### PR TITLE
feat(agent-drafter): rebuild as a BioRouter Apps platform (TypeScript apps + live agent backend)

### DIFF
--- a/crates/biorouter-mcp/src/agent_drafter/bundle.rs
+++ b/crates/biorouter-mcp/src/agent_drafter/bundle.rs
@@ -1,0 +1,571 @@
+//! Build pipeline for Agent Drafter apps.
+//!
+//! Apps are authored in TypeScript (`src/main.ts` importing `src/sdk.ts`) and
+//! bundled into a single browser-runnable `dist/app.js` with **esbuild**. esbuild
+//! is located via (in order): `$BIOROUTER_ESBUILD_BIN`, the desktop app's bundled
+//! `node_modules/.bin/esbuild` (dev tree), `esbuild` on `PATH`, then `npx esbuild`.
+//!
+//! When no esbuild is available (e.g. a headless CLI install with no Node), a
+//! best-effort vendored type-stripper concatenates the sources into a runnable
+//! bundle so simple apps still work. The stripper is intentionally conservative;
+//! complex TypeScript should be built where esbuild is present.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// Build-time guardrail harness
+// ---------------------------------------------------------------------------
+//
+// Rather than only handing the model UI templates, we wrap app authoring in a
+// harness that *validates whatever the model generates* and feeds actionable
+// findings back so it can self-correct. The harness enforces three things on
+// the LLM's free-form output: (1) it reaches the BioRouter backend through the
+// App SDK / agent protocol, (2) it is self-contained (no external/CDN assets
+// that break portability), and (3) it stays aesthetically aligned with the
+// BioRouter design system (uses `br-*` classes + tokens, not ad-hoc CSS).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LintLevel {
+    Error,
+    Warn,
+}
+
+#[derive(Debug, Clone)]
+pub struct LintFinding {
+    pub level: LintLevel,
+    pub msg: String,
+}
+
+/// Validate a built app's authored files against the harness guardrails.
+/// Returns findings (Errors block readiness; Warns are nudges). Pure string
+/// analysis — safe to run on every build/preview.
+pub fn lint_app(project_dir: &Path) -> Vec<LintFinding> {
+    let mut out = Vec::new();
+    let mut err = |m: &str| out.push(LintFinding { level: LintLevel::Error, msg: m.to_string() });
+    let index = std::fs::read_to_string(project_dir.join("index.html")).unwrap_or_default();
+    let main = std::fs::read_to_string(project_dir.join("src/main.ts")).unwrap_or_default();
+    let il = index.to_lowercase();
+
+    // (2) Self-contained — no external/CDN assets.
+    if il.contains("src=\"http") || il.contains("src='http") {
+        err("index.html loads an external <script src=\"http…\">. Apps must be self-contained — remove it and use the BioRouter App SDK instead.");
+    }
+    if il.contains("<link") && (il.contains("href=\"http") || il.contains("href='http")) {
+        err("index.html links an external stylesheet. Remove it; the BioRouter design system is injected automatically.");
+    }
+    for cdn in ["cdn.", "unpkg.com", "jsdelivr", "googleapis", "cdnjs"] {
+        if il.contains(cdn) {
+            err(&format!(
+                "index.html references a CDN ('{cdn}'). Remove external assets — exported apps must run offline."
+            ));
+            break;
+        }
+    }
+
+    // (1) Backend wiring through the App SDK / agent protocol.
+    if !main.contains("./sdk") {
+        err("src/main.ts must `import { createApp } from \"./sdk\"` — that's how the app reaches the BioRouter backend.");
+    }
+    for line in main.lines() {
+        let t = line.trim_start();
+        if t.starts_with("import ") && !t.contains("\"./") && !t.contains("'./") {
+            err(&format!(
+                "src/main.ts has a non-local import — only import from \"./sdk\": {}",
+                t.trim()
+            ));
+        }
+    }
+    let calls_agent = main.contains("br.run")
+        || main.contains(".prompt(")
+        || main.contains(".ask(")
+        || main.contains("autoChat");
+    if !calls_agent {
+        out.push(LintFinding {
+            level: LintLevel::Warn,
+            msg: "src/main.ts never calls the agent (br.run / br.prompt / br.ask) and doesn't enable autoChat. Wire a control to br.run(prompt, \"#out\").".into(),
+        });
+    }
+
+    // (1c) Wiring: if the page has interactive controls but main.ts wires no
+    // events (and isn't an auto-chat app), the UI is inert.
+    let has_controls = il.contains("<button")
+        || il.contains("<select")
+        || il.contains("type=\"range\"")
+        || il.contains("br-chip")
+        || il.contains("br-region")
+        || il.contains("br-dragitem")
+        || il.contains("br-dropzone")
+        || il.contains("br-tab");
+    if has_controls
+        && !main.contains("addEventListener")
+        && !main.contains("autoChat")
+        && !main.contains("onclick")
+    {
+        out.push(LintFinding {
+            level: LintLevel::Warn,
+            msg: "index.html has interactive controls but src/main.ts wires no events (addEventListener). The controls won't do anything — wire them to br.run(...).".into(),
+        });
+    }
+
+    // (1b) Element-id consistency: every id main.ts looks up must exist in
+    // index.html. A mismatch is a common LLM bug — getElementById returns null
+    // and the app crashes on the first addEventListener.
+    let referenced = referenced_ids(&main);
+    for rid in &referenced {
+        let present = index.contains(&format!("id=\"{rid}\""))
+            || index.contains(&format!("id='{rid}'"));
+        if !present {
+            out.push(LintFinding {
+                level: LintLevel::Error,
+                msg: format!(
+                    "src/main.ts references element id '#{rid}' that is not in index.html — getElementById would return null and crash. Add the element or fix the id."
+                ),
+            });
+        }
+    }
+
+    // (3) Aesthetic alignment with the design system.
+    let mut warn = |m: &str| out.push(LintFinding { level: LintLevel::Warn, msg: m.to_string() });
+    if il.contains("<style") {
+        warn("index.html contains a <style> block — prefer the design-system classes/CSS variables over custom CSS for a native look.");
+    }
+    if il.contains("color:#") || il.contains("color: #") || il.contains("background:#") {
+        warn("index.html uses raw hex colors — use var(--br-text)/var(--br-accent)/… tokens so the app matches BioRouter's theme.");
+    }
+    if !il.contains("br-") {
+        warn("index.html uses no BioRouter design-system classes (br-*). The UI will look off-theme; compose with br-card/br-btn/br-select/etc.");
+    }
+    if !il.contains("br-output") && !il.contains("data-br-chat") {
+        warn("No result surface found. Add a <div class=\"br-output\" id=\"out\"></div> (target for br.run) or a [data-br-chat] panel.");
+    }
+    out
+}
+
+/// Element ids that `main.ts` looks up: `getElementById("x")` and CSS-id
+/// selectors `"#x"` / `'#x'` (covers querySelector and `br.run(_, "#x")`).
+fn referenced_ids(main: &str) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let mut ids: BTreeSet<String> = BTreeSet::new();
+    if let Ok(re) = regex::Regex::new(r#"getElementById\(\s*["']([A-Za-z0-9_-]+)["']"#) {
+        for c in re.captures_iter(main) {
+            ids.insert(c[1].to_string());
+        }
+    }
+    if let Ok(re) = regex::Regex::new(r#"["']#([A-Za-z0-9_-]+)["']"#) {
+        for c in re.captures_iter(main) {
+            ids.insert(c[1].to_string());
+        }
+    }
+    ids.into_iter().collect()
+}
+
+/// Format findings for inclusion in a tool result.
+pub fn format_lint(findings: &[LintFinding]) -> String {
+    if findings.is_empty() {
+        return "Harness: ✓ passes all guardrails (SDK-wired, self-contained, on-theme).".into();
+    }
+    let mut s = String::from("Harness findings:\n");
+    for f in findings {
+        let tag = match f.level {
+            LintLevel::Error => "✗ ERROR",
+            LintLevel::Warn => "• warn",
+        };
+        s.push_str(&format!("  {tag}: {}\n", f.msg));
+    }
+    if findings.iter().any(|f| f.level == LintLevel::Error) {
+        s.push_str("Fix the ERRORs (they break backend access or portability), then rebuild.");
+    }
+    s
+}
+
+/// Outcome of a build.
+#[derive(Debug, Clone)]
+pub struct BuildReport {
+    pub ok: bool,
+    /// "esbuild" or "fallback".
+    pub used: String,
+    /// Combined stdout/stderr (or fallback notes).
+    pub log: String,
+}
+
+/// Locate an esbuild executable. Returns `(program, leading_args)` so the caller
+/// can support both a direct binary and `npx esbuild`.
+fn find_esbuild() -> Option<(String, Vec<String>)> {
+    if let Ok(bin) = std::env::var("BIOROUTER_ESBUILD_BIN") {
+        if !bin.trim().is_empty() && Path::new(&bin).exists() {
+            return Some((bin, vec![]));
+        }
+    }
+    // Dev tree: ui/desktop/node_modules/.bin/esbuild, discovered relative to CWD
+    // and a couple of ancestors (tests/CLI may run from a subdir).
+    if let Ok(cwd) = std::env::current_dir() {
+        let mut dir: Option<&Path> = Some(cwd.as_path());
+        for _ in 0..6 {
+            let Some(d) = dir else { break };
+            let cand = d.join("ui/desktop/node_modules/.bin/esbuild");
+            if cand.exists() {
+                return Some((cand.to_string_lossy().to_string(), vec![]));
+            }
+            dir = d.parent();
+        }
+    }
+    if which("esbuild") {
+        return Some(("esbuild".to_string(), vec![]));
+    }
+    if which("npx") {
+        return Some(("npx".to_string(), vec!["--yes".into(), "esbuild".into()]));
+    }
+    None
+}
+
+fn which(prog: &str) -> bool {
+    let Ok(path) = std::env::var("PATH") else {
+        return false;
+    };
+    for dir in std::env::split_paths(&path) {
+        let cand = dir.join(prog);
+        if cand.is_file() {
+            return true;
+        }
+        #[cfg(windows)]
+        {
+            if dir.join(format!("{prog}.cmd")).is_file()
+                || dir.join(format!("{prog}.exe")).is_file()
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Build an app project rooted at `project_dir`. Expects `src/main.ts`; writes
+/// `dist/app.js`. Returns a report (never errors on a *build* failure — inspect
+/// `report.ok`); only returns `Err` for filesystem problems.
+pub fn build_app(project_dir: &Path) -> std::io::Result<BuildReport> {
+    let entry = project_dir.join("src/main.ts");
+    if !entry.exists() {
+        return Ok(BuildReport {
+            ok: false,
+            used: "none".into(),
+            log: "src/main.ts not found — nothing to build".into(),
+        });
+    }
+    let dist = project_dir.join("dist");
+    std::fs::create_dir_all(&dist)?;
+    let out = dist.join("app.js");
+
+    if let Some((program, lead)) = find_esbuild() {
+        match run_esbuild(&program, &lead, &entry, &out) {
+            Ok(report) if report.ok => return Ok(report),
+            Ok(report) => {
+                // esbuild ran but failed (syntax error etc.) — surface it rather
+                // than silently masking with the weaker fallback.
+                return Ok(report);
+            }
+            Err(e) => {
+                // esbuild could not be spawned; fall through to the stripper.
+                let mut report = fallback_bundle(project_dir, &out)?;
+                report.log = format!("esbuild spawn failed ({e}); used fallback.\n{}", report.log);
+                return Ok(report);
+            }
+        }
+    }
+
+    fallback_bundle(project_dir, &out)
+}
+
+fn run_esbuild(
+    program: &str,
+    lead: &[String],
+    entry: &Path,
+    out: &Path,
+) -> std::io::Result<BuildReport> {
+    let mut cmd = Command::new(program);
+    cmd.args(lead);
+    cmd.arg(entry);
+    cmd.arg("--bundle");
+    cmd.arg("--format=iife");
+    cmd.arg("--target=es2018");
+    cmd.arg("--loader:.ts=ts");
+    cmd.arg(format!("--outfile={}", out.display()));
+    cmd.arg("--log-level=warning");
+    let output = cmd.output()?;
+    let log = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(BuildReport {
+        ok: output.status.success() && out.exists(),
+        used: "esbuild".into(),
+        log,
+    })
+}
+
+/// Best-effort transpile without esbuild: concatenate `sdk.ts` + `main.ts`,
+/// drop module syntax, and strip the common TypeScript type constructs. Wrapped
+/// in an IIFE. Good enough for the generated starter apps; not a real compiler.
+fn fallback_bundle(project_dir: &Path, out: &Path) -> std::io::Result<BuildReport> {
+    let src = project_dir.join("src");
+    let sdk = std::fs::read_to_string(src.join("sdk.ts")).unwrap_or_default();
+    let main = std::fs::read_to_string(src.join("main.ts"))?;
+    let mut body = String::new();
+    body.push_str(&strip_module_syntax(&sdk));
+    body.push('\n');
+    body.push_str(&strip_module_syntax(&main));
+    let js = format!(
+        "/* Agent Drafter fallback bundle (no esbuild present). */\n(function(){{\n{body}\n}})();\n"
+    );
+    std::fs::write(out, js)?;
+    Ok(BuildReport {
+        ok: true,
+        used: "fallback".into(),
+        log: "Bundled with the vendored type-stripper (esbuild not found). \
+              For full TypeScript support install esbuild or build in the desktop app."
+            .into(),
+    })
+}
+
+/// Remove `import`/`export` statements, `interface`/`type` declarations, and the
+/// most common inline type annotations. Conservative and line-oriented.
+fn strip_module_syntax(ts: &str) -> String {
+    let mut out = Vec::new();
+    let mut in_type_block = false;
+    let mut depth = 0i32;
+    for line in ts.lines() {
+        let trimmed = line.trim_start();
+        // Drop multi-line interface / `type X = { … }` blocks.
+        if in_type_block {
+            depth += count(line, '{') - count(line, '}');
+            if depth <= 0 {
+                in_type_block = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("interface ")
+            || trimmed.starts_with("export interface ")
+            || trimmed.starts_with("declare ")
+            || trimmed.starts_with("export type ")
+            || trimmed.starts_with("type ")
+        {
+            if line.contains('{') && count(line, '{') > count(line, '}') {
+                in_type_block = true;
+                depth = count(line, '{') - count(line, '}');
+            }
+            continue;
+        }
+        // Drop import lines entirely (single-file bundle).
+        if trimmed.starts_with("import ") {
+            continue;
+        }
+        // Strip a leading `export ` keyword but keep the declaration.
+        let mut l = line.to_string();
+        if let Some(rest) = l.trim_start().strip_prefix("export ") {
+            let indent = &l[..l.len() - l.trim_start().len()];
+            l = format!("{indent}{rest}");
+        }
+        out.push(strip_inline_types(&l));
+    }
+    out.join("\n")
+}
+
+fn count(s: &str, c: char) -> i32 {
+    s.chars().filter(|&x| x == c).count() as i32
+}
+
+/// Strip the common inline annotations: `: Type` after params/vars and generic
+/// `<…>` after identifiers. Heuristic; leaves the runtime semantics intact.
+fn strip_inline_types(line: &str) -> String {
+    // Remove ` as Type` casts.
+    let mut s = regex_lite_replace_as(line);
+    // Remove parameter / variable annotations `name: Type` → `name`.
+    s = strip_colon_types(&s);
+    s
+}
+
+fn regex_lite_replace_as(line: &str) -> String {
+    // Replace " as Something" up to a delimiter. Simple scan.
+    let mut result = String::with_capacity(line.len());
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if line[i..].starts_with(" as ") {
+            // skip " as " and the following type token(s)
+            i += 4;
+            while i < bytes.len() {
+                let c = bytes[i] as char;
+                if c == ')' || c == ';' || c == ',' || c == '}' || c == ']' {
+                    break;
+                }
+                i += 1;
+            }
+        } else {
+            result.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    result
+}
+
+fn strip_colon_types(line: &str) -> String {
+    // Only strip when a `:` is followed by a space + capitalized/primitive type
+    // and not inside a string. Very conservative to avoid mangling object/CSS.
+    // This handles `(x: Type)`, `let y: Type =`, `): RetType {`.
+    let mut out = String::with_capacity(line.len());
+    let chars: Vec<char> = line.chars().collect();
+    let mut i = 0;
+    let mut in_str: Option<char> = None;
+    while i < chars.len() {
+        let c = chars[i];
+        if let Some(q) = in_str {
+            out.push(c);
+            if c == q && (i == 0 || chars[i - 1] != '\\') {
+                in_str = None;
+            }
+            i += 1;
+            continue;
+        }
+        if c == '"' || c == '\'' || c == '`' {
+            in_str = Some(c);
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        if c == ':' {
+            // look ahead: optional space, then a type-ish token
+            let mut j = i + 1;
+            while j < chars.len() && chars[j] == ' ' {
+                j += 1;
+            }
+            let starts_type = j < chars.len()
+                && (chars[j].is_ascii_uppercase()
+                    || matches!(
+                        peek_word(&chars, j).as_str(),
+                        "string" | "number" | "boolean" | "void" | "any" | "null" | "undefined"
+                    ));
+            // Only strip in a clearly typed position (preceded by an identifier
+            // char or `)`), not an object literal `{ key: value }`.
+            let prev = if i > 0 { chars[i - 1] } else { ' ' };
+            let typed_position = prev.is_alphanumeric() || prev == '_' || prev == ')';
+            if starts_type && typed_position {
+                // consume the type expression until a stopper
+                i = j;
+                let mut ang = 0i32;
+                while i < chars.len() {
+                    let d = chars[i];
+                    if d == '<' {
+                        ang += 1;
+                    } else if d == '>' {
+                        ang -= 1;
+                    } else if ang == 0
+                        && matches!(d, '=' | ',' | ')' | ';' | '{' | '|' | '&' | '\n')
+                    {
+                        break;
+                    }
+                    i += 1;
+                }
+                out.push(' ');
+                continue;
+            }
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
+fn peek_word(chars: &[char], start: usize) -> String {
+    let mut s = String::new();
+    let mut i = start;
+    while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
+        s.push(chars[i]);
+        i += 1;
+    }
+    s
+}
+
+/// Default project source files written for a fresh agentic app.
+pub fn default_sources() -> Vec<(PathBuf, String)> {
+    vec![
+        (
+            PathBuf::from("src/sdk.ts"),
+            include_str!("templates/sdk.ts").to_string(),
+        ),
+        (
+            PathBuf::from("src/main.ts"),
+            include_str!("templates/main.ts").to_string(),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn strip_module_syntax_removes_imports_and_exports() {
+        let ts = "import { x } from \"./sdk\";\nexport function f() { return 1; }\ninterface I { a: number }\nconst y = 2;";
+        let out = strip_module_syntax(ts);
+        assert!(!out.contains("import"));
+        assert!(!out.contains("interface"));
+        assert!(out.contains("function f()"));
+        assert!(out.contains("const y = 2"));
+    }
+
+    #[test]
+    fn strip_colon_types_keeps_object_literals() {
+        let s = strip_colon_types("const o = { key: value, n: 2 };");
+        // object literal colons must be preserved
+        assert!(s.contains("key: value") || s.contains("key:value"));
+    }
+
+    #[test]
+    fn strip_colon_types_removes_param_annotations() {
+        let s = strip_colon_types("function f(a: string, b: number) {");
+        assert!(!s.contains(": string"));
+        assert!(!s.contains(": number"));
+        assert!(s.contains("function f(a"));
+    }
+
+    #[test]
+    fn fallback_bundle_produces_runnable_iife() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("sdk.ts"), "export function hi() { return 1; }").unwrap();
+        std::fs::write(src.join("main.ts"), "import { hi } from \"./sdk\";\nhi();").unwrap();
+        let out = dir.path().join("dist/app.js");
+        std::fs::create_dir_all(dir.path().join("dist")).unwrap();
+        let report = fallback_bundle(dir.path(), &out).unwrap();
+        assert!(report.ok);
+        let js = std::fs::read_to_string(&out).unwrap();
+        assert!(js.contains("function hi()"));
+        assert!(js.trim_start().starts_with("/*"));
+        assert!(js.contains("(function()"));
+    }
+
+    #[test]
+    fn build_app_without_entry_is_noop() {
+        let dir = TempDir::new().unwrap();
+        let report = build_app(dir.path()).unwrap();
+        assert!(!report.ok);
+    }
+
+    #[test]
+    fn build_app_bundles_with_available_toolchain() {
+        // Uses esbuild if present, else the fallback — either way dist/app.js
+        // must exist and contain the SDK code.
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("sdk.ts"), include_str!("templates/sdk.ts")).unwrap();
+        std::fs::write(src.join("main.ts"), include_str!("templates/main.ts")).unwrap();
+        let report = build_app(dir.path()).unwrap();
+        assert!(report.ok, "build failed: {}", report.log);
+        let js = std::fs::read_to_string(dir.path().join("dist/app.js")).unwrap();
+        assert!(js.contains("BioRouter") || js.contains("createApp"));
+    }
+}

--- a/crates/biorouter-mcp/src/agent_drafter/mod.rs
+++ b/crates/biorouter-mcp/src/agent_drafter/mod.rs
@@ -1,21 +1,20 @@
-//! Agent Drafter — author interactive artifacts, optionally wired to a live
-//! BioRouter agent over ACP.
+//! Agent Drafter — author interactive **BioRouter apps**: TypeScript front-ends
+//! wired to a *real* BioRouter agent backend.
 //!
-//! Agent Drafter is BioRouter's answer to "Claude artifacts", but the artifacts
-//! it produces can embed *real* AI-agent capability. It exposes MCP tools that
-//! let the assistant create, edit, preview, and export self-contained artifacts
-//! with a consistent tech stack and a BioRouter-flavored design system:
+//! An Agent-Drafter app is a self-contained project the assistant builds for the
+//! user. The UI is authored in TypeScript (bundled with esbuild) and the app
+//! talks to BioRouter over a per-app WebSocket: when the user sends a message,
+//! the BioRouter backend runs the **full agent loop** — the app's own model,
+//! extensions, skills and knowledge base — and streams the answer (text /
+//! markdown / tool activity) straight back into the app. Apps are *launched in
+//! the browser* (GUI) or via a printed URL (CLI), not embedded in a chat iframe.
 //!
-//!   - **Static** artifacts: plain interactive HTML/CSS/JS pages.
-//!   - **Agentic** artifacts: the above, plus an embedded agent runtime that
-//!     talks to a BioRouter agent via the Agent Client Protocol (ACP) — or, when
-//!     previewed inside BioRouter, via the sandboxed MCP-App bridge.
-//!
-//! In-app previews are returned as `ui://` HTML resources (rendered in the
-//! desktop's sandboxed iframe). `export_artifact` scaffolds a standalone,
-//! runnable project (Tauri, bundling the BioRouter CLI as a sidecar — or a plain
-//! static web build).
+//! Apps live under `~/.config/biorouter/agent_drafter/<id>/` (a project dir with
+//! `manifest.json`, `index.html`, `src/*.ts`, `dist/app.js`). `biorouterd` serves
+//! them at `/apps/<id>/` and exposes the agent socket at `/apps/<id>/agent`.
+//! `export_app` produces a standalone runnable TypeScript project.
 
+pub mod bundle;
 pub mod render;
 pub mod store;
 
@@ -32,9 +31,16 @@ use rmcp::{
     tool, tool_handler, tool_router, ServerHandler,
 };
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use store::{AgentConfig, ArtifactKind, ArtifactStore, Manifest};
+use store::{AgentConfig, ArtifactKind, ArtifactStore, Manifest, ModelSelection};
+
+/// Optional suggestions only. Apps are **provider-agnostic**: by default an app
+/// pins no model and inherits whatever provider/model the user has configured in
+/// BioRouter (any supported provider). A specific provider+model is stored only
+/// when the caller explicitly chooses one. These constants are not auto-applied.
+pub const DEFAULT_APP_PROVIDER: &str = "xiaomi_mimo";
+pub const DEFAULT_APP_MODEL: &str = "mimo-v2.5";
 
 // ---------------------------------------------------------------------------
 // Tool parameter structs
@@ -42,50 +48,116 @@ use store::{AgentConfig, ArtifactKind, ArtifactStore, Manifest};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FileSpec {
-    /// Path relative to the artifact root (e.g. "css/app.css").
+    /// Path relative to the app root (e.g. "src/main.ts", "assets/logo.svg").
     pub path: String,
     /// File contents.
     pub content: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct CreateArtifactParams {
-    /// Human-readable title; also used to derive the artifact id.
-    pub title: String,
-    /// Short description of what the artifact does.
+#[derive(Debug, Deserialize, JsonSchema, Default)]
+pub struct ModelParam {
+    /// Provider name (e.g. "xiaomi_mimo", "anthropic", "openai").
     #[serde(default)]
-    pub description: String,
-    /// "static" (default) or "agentic" (embeds a BioRouter agent).
+    pub provider: Option<String>,
+    /// Model name (e.g. "mimo-v2.5", "claude-opus-4-8").
     #[serde(default)]
-    pub kind: Option<String>,
-    /// Entry HTML for the artifact. If omitted, a BioRouter-styled starter is used.
-    #[serde(default)]
-    pub html: Option<String>,
-    /// Additional files to write alongside the entry HTML.
-    #[serde(default)]
-    pub files: Vec<FileSpec>,
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct SetArtifactSizeParams {
-    /// Artifact id.
+pub struct CreateAppParams {
+    /// Human-readable title; also used to derive the app id when `id` is omitted.
+    pub title: String,
+    /// Optional explicit app id (slugified). If given and an app already exists
+    /// at that id, it is REPLACED — so re-creating the same app is idempotent
+    /// and the app stays addressable. Omit to auto-derive a unique id from the
+    /// title.
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Short description of what the app does.
+    #[serde(default)]
+    pub description: String,
+    /// "agentic" (default — wired to a BioRouter agent) or "static".
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Entry HTML (index.html). If omitted, a BioRouter-styled starter is used.
+    #[serde(default)]
+    pub html: Option<String>,
+    /// Additional files (TypeScript under `src/`, assets, etc.). Provide your own
+    /// `src/main.ts` to drive a custom UI; otherwise a starter is written.
+    #[serde(default)]
+    pub files: Vec<FileSpec>,
+    /// System prompt defining the app agent's behavior/persona.
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    /// Greeting shown when the chat panel mounts.
+    #[serde(default)]
+    pub greeting: Option<String>,
+    /// Provider+model the app's agent runs on (any BioRouter-supported provider).
+    /// Omit to inherit the user's configured provider/model (provider-agnostic).
+    #[serde(default)]
+    pub model: Option<ModelParam>,
+    /// Builtin/platform extension names the agent may use (e.g. "developer",
+    /// "autovisualiser", "computercontroller", "knowledge").
+    #[serde(default)]
+    pub extensions: Vec<String>,
+    /// Skill ids the agent should have available.
+    #[serde(default)]
+    pub skills: Vec<String>,
+    /// Knowledge base id to scope the agent to.
+    #[serde(default)]
+    pub knowledge_base: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ConfigureAppParams {
+    /// App id.
     pub id: String,
-    /// Preferred preview width in CSS px. Omit/null to fill the panel.
+    /// New system prompt / persona.
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    /// New greeting.
+    #[serde(default)]
+    pub greeting: Option<String>,
+    /// Provider+model override.
+    #[serde(default)]
+    pub model: Option<ModelParam>,
+    /// Replace the extension list.
+    #[serde(default)]
+    pub extensions: Option<Vec<String>>,
+    /// Replace the skills list.
+    #[serde(default)]
+    pub skills: Option<Vec<String>>,
+    /// Set (or clear, with empty string) the knowledge base id.
+    #[serde(default)]
+    pub knowledge_base: Option<String>,
+    /// Bound the agent's tool-calling loop per message. Raise this for
+    /// workflow-style apps that chain many tool calls; lower it to keep apps
+    /// snappy. Unset → a safe server default.
+    #[serde(default)]
+    pub max_turns: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetAppSizeParams {
+    /// App id.
+    pub id: String,
+    /// Preferred width in CSS px (omit to fill).
     #[serde(default)]
     pub width: Option<u32>,
-    /// Preferred preview height in CSS px. Omit/null for the auto-growing default.
+    /// Preferred height in CSS px (omit for auto).
     #[serde(default)]
     pub height: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct UpdateArtifactParams {
-    /// Artifact id.
+pub struct UpdateAppParams {
+    /// App id.
     pub id: String,
-    /// File to modify (defaults to the artifact's entry HTML).
+    /// File to modify (defaults to the entry HTML).
     #[serde(default)]
     pub path: Option<String>,
-    /// Full new contents for the file (write mode).
+    /// Full new contents (write mode).
     #[serde(default)]
     pub content: Option<String>,
     /// Exact substring to replace (str-replace mode; requires `new_str`).
@@ -97,15 +169,15 @@ pub struct UpdateArtifactParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct ListArtifactsParams {
+pub struct ListAppsParams {
     /// Optional filter: "static" or "agentic".
     #[serde(default)]
     pub kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct ReadArtifactParams {
-    /// Artifact id.
+pub struct ReadAppParams {
+    /// App id.
     pub id: String,
     /// File to read. If omitted, returns the manifest.
     #[serde(default)]
@@ -113,35 +185,18 @@ pub struct ReadArtifactParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct ArtifactIdParams {
-    /// Artifact id.
+pub struct AppIdParams {
+    /// App id.
     pub id: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct AddAgentCapabilityParams {
-    /// Artifact id.
-    pub id: String,
-    /// System prompt defining the embedded agent's behavior.
-    pub system_prompt: String,
-    /// Optional greeting shown when the chat panel mounts.
-    #[serde(default)]
-    pub greeting: Option<String>,
-    /// Tool / MCP-extension names the embedded agent may use.
-    #[serde(default)]
-    pub tools: Vec<String>,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
-pub struct ExportArtifactParams {
-    /// Artifact id.
+pub struct ExportAppParams {
+    /// App id.
     pub id: String,
     /// Destination directory (created if missing).
     pub target_dir: String,
-    /// "tauri" (default, bundles the BioRouter agent) or "web".
-    #[serde(default)]
-    pub runtime: Option<String>,
-    /// Override the ACP WebSocket endpoint the exported artifact connects to.
+    /// Override the agent WebSocket endpoint the exported app connects to.
     #[serde(default)]
     pub endpoint: Option<String>,
 }
@@ -164,7 +219,9 @@ impl Default for AgentDrafterServer {
     }
 }
 
-fn default_root() -> PathBuf {
+/// Shared default store root (`~/.config/biorouter/agent_drafter`). Public so the
+/// server's `/apps` routes resolve the same location.
+pub fn default_root() -> PathBuf {
     choose_app_strategy(crate::APP_STRATEGY.clone())
         .map(|s| s.in_config_dir("agent_drafter"))
         .unwrap_or_else(|_| PathBuf::from(".config/biorouter/agent_drafter"))
@@ -178,9 +235,25 @@ fn internal(e: impl std::fmt::Display) -> ErrorData {
     err(ErrorCode::INTERNAL_ERROR, e.to_string())
 }
 
-/// Recursively collect an artifact's files (relative path → contents),
-/// skipping `manifest.json`.
-fn collect_files(base: &Path, dir: &Path, out: &mut Vec<(String, String)>) {
+impl From<ModelParam> for ModelSelection {
+    fn from(p: ModelParam) -> Self {
+        ModelSelection {
+            provider: p.provider.filter(|s| !s.trim().is_empty()),
+            model: p.model.filter(|s| !s.trim().is_empty()),
+        }
+    }
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Recursively collect an app's files (relative path → contents), skipping
+/// `manifest.json`.
+fn collect_files(base: &std::path::Path, dir: &std::path::Path, out: &mut Vec<(String, String)>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -200,6 +273,55 @@ fn collect_files(base: &Path, dir: &Path, out: &mut Vec<(String, String)>) {
     }
 }
 
+/// Gather an app's files and produce the standalone export scaffold (a file map
+/// of relative-path → contents). Shared by the `export_app` tool and the
+/// server's `GET /apps/{id}/export` route. `endpoint` overrides the agent
+/// WebSocket the exported app connects to (None → a local biorouterd).
+pub fn export_scaffold(
+    root: &std::path::Path,
+    id: &str,
+    endpoint: Option<&str>,
+) -> std::io::Result<Vec<(String, String)>> {
+    let store = ArtifactStore::new(root.to_path_buf());
+    let manifest = store.load_manifest(id)?;
+    let dir = store.artifact_dir(id);
+    let mut all_files = Vec::new();
+    collect_files(&dir, &dir, &mut all_files);
+    let entry_html = all_files
+        .iter()
+        .find(|(p, _)| p == &manifest.entry)
+        .map(|(_, c)| c.clone())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "entry file missing"))?;
+    let src_files: Vec<(String, String)> = all_files
+        .iter()
+        .filter(|(p, _)| p.starts_with("src/"))
+        .cloned()
+        .collect();
+    let extra_files: Vec<(String, String)> = all_files
+        .iter()
+        .filter(|(p, _)| p != &manifest.entry && !p.starts_with("src/") && !p.starts_with("dist/"))
+        .cloned()
+        .collect();
+    let mut scaffold = render::scaffold_standalone(
+        &manifest,
+        &entry_html,
+        &src_files,
+        &extra_files,
+        endpoint,
+    );
+    // Ship a prebuilt bundle so the export is directly runnable with no build
+    // step (the launcher / a static server can serve it as-is). Build on demand.
+    if manifest.kind == ArtifactKind::Agentic {
+        if !store.file_exists(id, "dist/app.js") {
+            let _ = bundle::build_app(&dir);
+        }
+        if let Ok(js) = store.read_file(id, "dist/app.js") {
+            scaffold.push(("dist/app.js".to_string(), js));
+        }
+    }
+    Ok(scaffold)
+}
+
 #[tool_router(router = tool_router)]
 impl AgentDrafterServer {
     pub fn new() -> Self {
@@ -208,54 +330,110 @@ impl AgentDrafterServer {
 
     pub fn with_root(root: PathBuf) -> Self {
         let instructions = formatdoc! {r#"
-            Agent Drafter lets you build interactive *artifacts* for the user —
-            self-contained HTML/CSS/JS apps — that can optionally embed a live
-            BioRouter agent. Think "Claude artifacts", but the artifacts can carry
-            real AI-agent capability powered by the Agent Client Protocol (ACP).
+            Agent Drafter builds interactive **BioRouter apps** for the user:
+            TypeScript front-ends wired to a real BioRouter agent. Think "Claude
+            artifacts", but each app embeds a genuine BioRouter backend — when the
+            user sends a message, BioRouter runs the full agent loop (the app's own
+            model, extensions, skills, knowledge base) and streams the answer back
+            into the app. Apps open in the user's browser (GUI) or via a printed
+            URL (CLI); they are NOT shown in a chat iframe.
 
-            Two kinds of artifact:
-            - "static": a plain interactive page (dashboards, tools, visualizations,
-              forms). No agent.
-            - "agentic": a page with an embedded agent runtime + chat panel that
-              talks to a BioRouter agent. Use this when the artifact should reason,
-              call tools, or hold a conversation.
+            Two kinds:
+            - "agentic" (default): a UI plus a live BioRouter agent + chat. Use this
+              for assistants, dashboards that reason over results, search tools, etc.
+            - "static": a plain interactive page with no agent.
 
-            Tech stack & conventions (keep artifacts consistent):
-            - One entry file, "index.html", plus optional CSS/JS files.
-            - The BioRouter design system is injected automatically at preview/export
-              time and mirrors the app's own look (warm neutral palette, white
-              cards with a soft shadow, a restrained near-black accent, thin
-              borders, 6px/12px radii, system font). ALWAYS compose with the
-              provided classes — `br-container` (page wrapper), `br-card`,
-              `br-btn` (+ `br-btn--secondary`, `br-btn--ghost`), `br-input`,
-              `br-textarea`, `br-label`, `br-field`, `br-row`, `br-badge`,
-              `br-chat` — and the CSS variables (`var(--br-text)`,
-              `var(--br-text-muted)`, `var(--br-accent)`, `var(--br-border)`,
-              etc.). Do NOT paste your own colors, fonts, or a <style> theme and
-              do NOT pull in external CSS frameworks — rely on the system so the
-              artifact looks native to BioRouter, not generic.
-            - Sizing: previews fill the panel width and auto-grow in height. For
-              wide layouts (dashboards, side-by-side panels) call
-              `set_artifact_size` with a larger width like 1000 so the user gets
-              room to work; omit a dimension to fill/auto-grow.
-            - For agentic artifacts you do not need to write any networking code:
-              call `add_agent_capability` and the runtime (`window.BioRouterAgent`)
-              plus a chat panel are wired in for you. To place the chat yourself,
-              add an element with the `data-br-chat` attribute.
-            - Exported artifacts default to a Tauri desktop bundle that ships the
-              BioRouter CLI as a sidecar (fully self-contained), or a plain web build.
+            Project layout (kept consistent):
+            - `index.html` — the UI shell you author.
+            - `src/main.ts` — your app logic (TypeScript), `import`ing `./sdk`.
+            - `src/sdk.ts` — the BioRouter App SDK (provided): opens the agent
+              WebSocket, streams markdown, handles multimodal (image) input, and can
+              auto-mount a chat panel into any element with `data-br-chat`.
+            - `dist/app.js` — the esbuild bundle (produced by `build_app`).
+
+            AESTHETICS — default to BioRouter's look unless the user asks for a
+            different style. BioRouter's design language is calm, minimal, and
+            informative: a warm neutral palette (cream/taupe), white cards on a
+            light ground, generous whitespace, thin hairline borders, soft flat
+            shadows, a restrained near-black accent with a single coral spark,
+            modest radii (6px controls / 12px cards), a plain system typeface, and
+            quiet hover transitions. The design system is injected automatically.
+            ALWAYS compose with the provided classes (`br-container`, `br-card`,
+            `br-btn` [+ `--secondary`/`--ghost`], `br-input`, `br-textarea`,
+            `br-label`, `br-field`, `br-row`, `br-badge`, `br-chat`) and CSS
+            variables (`var(--br-text)`, `var(--br-accent)`, `var(--br-coral)`,
+            `var(--br-border)`, `var(--br-muted)`, …).
+            Do NOT: paste your own color values or fonts, pull in external CSS
+            frameworks/CDNs, use gradients/neon/glassmorphism, emoji-stuffed
+            headings, or other flashy "generic AI" looks. Prefer filled shades
+            over outlines, clear hierarchy, and restraint. Aim for taste:
+            well-aligned, breathable layouts that look native to BioRouter and feel
+            simple yet polished. If (and only if) the user specifies a different
+            visual style — now or later in the conversation — follow their
+            direction instead.
+
+            Driving the agent from `src/main.ts`:
+              import {{ createApp }} from "./sdk";
+              const br = createApp({{ autoChat: false }});   // false → build your OWN UI
+              await br.run("...prompt...", '#out');            // stream markdown+charts into the result element
+              const text = await br.ask("...");               // collect full reply as a string
+              await br.prompt("...", {{ images: [{{ mimeType, data }}] }}); // multimodal
+              br.on("message", (e) => {{ if (e.type === "message") {{}} }}); // low-level stream
+
+            VARY THE INTERFACE — do NOT make every app a chat box. Prefer a custom
+            UI driven by `createApp({{ autoChat: false }})` and wire controls to
+            `br.run(prompt, target)`. The design system provides themed,
+            BioRouter-native controls — use a mix that fits the task:
+            - buttons / button grids: `br-btn`, `br-grid`
+            - dropdowns: `<select class="br-select">`
+            - sliders: `<input type="range" class="br-slider">` (+ `br-slider-val`)
+            - toggles: `<label class="br-switch"><input type="checkbox"><span class="br-switch__track"></span></label>`
+            - checkboxes/radios: `br-check`; selectable chips/tags: `br-chips`/`br-chip`
+            - tabs: `br-tabs`/`br-tab`; cards: `br-card`; layout: `br-grid`/`br-row`
+            - drag & drop: `br-dropzone` (drop files/text) and `br-draglist`/`br-dragitem` (reorder)
+            - region/map pick: `br-mapgrid`/`br-region` (clickable cells; no external map lib)
+            - results: a `<div class="br-output" data-placeholder="…">` target for `br.run`
+            Build the prompt from the control state (slider values, selected
+            chips, dropdown choice, dragged order, clicked region, dropped text)
+            and call `br.run(...)` on `change`/`click`/`drop`. Each new app should
+            look and interact differently from the others.
 
             Typical workflow:
-            1. `create_artifact` with a title, description, kind, and (optionally) your
-               own HTML. A preview is returned and shown to the user.
-            2. Iterate with `update_artifact` (full `content` write, or `old_str`/
-               `new_str` replace). Call `preview_artifact` to re-render.
-            3. For agentic artifacts, `add_agent_capability` with a system prompt
-               (and optionally a greeting and the tools the agent may use).
-            4. `export_artifact` to produce a standalone, runnable project.
+            1. `create_app` (title, description, optional html/files, system_prompt,
+               greeting, model, extensions, skills, knowledge_base). A preview card
+               is shown to the user.
+            2. Author the UI: `update_app` the entry HTML and `src/main.ts`.
+            3. `configure_app` to change the model/extensions/skills/knowledge/persona.
+            4. `build_app` to bundle the TypeScript.
+            5. `launch_app` to open it in the browser (returns the URL).
+            6. `export_app` for a standalone runnable project.
 
-            Use `list_artifacts` and `read_artifact` to inspect existing work.
-            Always confirm the artifact looks right via a preview before exporting.
+            Use `list_apps`, `read_app`, and `preview_app` to inspect existing apps —
+            you can query and modify any previously-built app.
+
+            WORKFLOW-STYLE APPS (multi-step agentic loops, not just chat): every
+            user message runs BioRouter's full agent loop — the agent can call
+            many tools in sequence and reason over the results before replying, so
+            an app can encode a real pipeline. Design one by: (a) giving it the
+            extensions/skills/knowledge it needs, (b) writing a system_prompt that
+            spells out the ordered procedure ("1. search … 2. extract … 3.
+            summarize as a table … 4. emit a ```chart block"), and (c) raising
+            `max_turns` (via `configure_app`) so it can chain enough tool calls.
+            `max_turns` also bounds the loop (a guardrail against runaway/cost).
+            The app surfaces each step to the user as a tool event.
+
+            BUILD HARNESS / guardrails: `build_app` (and `lint_app`) run a
+            validation harness on whatever you generate and report findings. It
+            enforces three things — fix any ERRORs before `launch_app`/`export_app`:
+            1. Backend wiring: `src/main.ts` imports from "./sdk" and calls the
+               agent (`br.run`/`br.prompt`/`br.ask`) or enables autoChat.
+            2. Self-contained: no external `<script>`/`<link>`/CDN in index.html
+               and no non-local imports in `src/main.ts` (so exports run offline).
+            3. On-theme: uses `br-*` classes/CSS variables, not raw hex colors or
+               a custom `<style>` theme; includes a result surface (`.br-output`
+               or `[data-br-chat]`).
+            Always `build_app` after editing `src/`, address the harness findings,
+            and verify via `launch_app` before `export_app`.
         "#};
         Self {
             tool_router: Self::tool_router(),
@@ -264,23 +442,23 @@ impl AgentDrafterServer {
         }
     }
 
+    pub fn root(&self) -> &std::path::Path {
+        &self.root
+    }
+
     fn store(&self) -> ArtifactStore {
         ArtifactStore::new(self.root.clone())
     }
 
-    /// Build the two-part preview result: a `ui://` HTML resource for the user and
-    /// a short assistant-audience text confirmation.
-    fn preview_result(&self, manifest: &Manifest, note: &str) -> Result<CallToolResult, ErrorData> {
+    /// Build a card-preview result (ui:// blob for the user + assistant note).
+    fn card_result(&self, manifest: &Manifest, note: &str) -> Result<CallToolResult, ErrorData> {
         let store = self.store();
         let entry_html = store
             .read_file(&manifest.id, &manifest.entry)
             .map_err(|e| err(ErrorCode::INTERNAL_ERROR, format!("read entry: {e}")))?;
-        let html = render::assemble_preview(manifest, &entry_html);
+        let html = render::assemble_card(manifest, &entry_html);
         let blob = STANDARD.encode(html.as_bytes());
 
-        // Tell the host (MCP-UI) the preferred frame size. Width fills the panel
-        // unless the agent pinned one; height defaults comfortably and then
-        // auto-grows (the runtime posts `ui-size-change`).
         let width_css = manifest
             .width
             .map(|w| format!("{w}px"))
@@ -288,7 +466,7 @@ impl AgentDrafterServer {
         let height_css = manifest
             .height
             .map(|h| format!("{h}px"))
-            .unwrap_or_else(|| "560px".to_string());
+            .unwrap_or_else(|| "420px".to_string());
         let mut meta_obj = serde_json::Map::new();
         meta_obj.insert(
             "mcpui.dev/ui-preferred-frame-size".to_string(),
@@ -308,12 +486,12 @@ impl AgentDrafterServer {
     }
 
     #[tool(
-        name = "create_artifact",
-        description = "Create a new interactive artifact (static HTML/JS, or agentic with an embedded BioRouter agent). Returns a live preview."
+        name = "create_app",
+        description = "Create a new BioRouter app: a TypeScript UI wired to a live BioRouter agent (kind 'agentic', default) or a static page. Returns a preview card."
     )]
-    pub async fn create_artifact(
+    pub async fn create_app(
         &self,
-        params: Parameters<CreateArtifactParams>,
+        params: Parameters<CreateAppParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let p = params.0;
         if p.title.trim().is_empty() {
@@ -326,14 +504,25 @@ impl AgentDrafterServer {
                     "kind must be 'static' or 'agentic'",
                 )
             })?,
-            None => ArtifactKind::Static,
+            None => ArtifactKind::Agentic,
         };
         let entry = "index.html";
         let entry_html = p
             .html
             .unwrap_or_else(|| render::starter(&p.title, &p.description));
 
-        let mut files = vec![(entry.to_string(), entry_html)];
+        // Compose file set: entry + default TS sources + caller overrides.
+        let mut files: Vec<(String, String)> = vec![(entry.to_string(), entry_html)];
+        let provided: std::collections::HashSet<&str> =
+            p.files.iter().map(|f| f.path.as_str()).collect();
+        if kind == ArtifactKind::Agentic {
+            for (path, content) in bundle::default_sources() {
+                let ps = path.to_string_lossy().to_string();
+                if ps != entry && !provided.contains(ps.as_str()) {
+                    files.push((ps, content));
+                }
+            }
+        }
         for f in p.files {
             if f.path != entry {
                 files.push((f.path, f.content));
@@ -341,58 +530,119 @@ impl AgentDrafterServer {
         }
 
         let store = self.store();
-        let manifest = store
-            .create(&p.title, &p.description, kind, entry, &files)
-            .map_err(internal)?;
+        let mut manifest = match p.id.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            Some(explicit) => {
+                store.create_with_id(explicit, &p.title, &p.description, kind, entry, &files)
+            }
+            None => store.create(&p.title, &p.description, kind, entry, &files),
+        }
+        .map_err(internal)?;
 
-        self.preview_result(
+        if kind == ArtifactKind::Agentic {
+            // Provider-agnostic by default: leave the model unset so the app uses
+            // whatever provider/model the user has configured in BioRouter. Pin a
+            // specific provider+model only when the caller explicitly chose one —
+            // any BioRouter-supported provider works.
+            let model = p.model.map(ModelSelection::from).filter(|m| m.is_set());
+            manifest.agent = Some(AgentConfig {
+                system_prompt: p.system_prompt.unwrap_or_default(),
+                greeting: p.greeting,
+                tools: Vec::new(),
+                model,
+                extensions: p.extensions,
+                skills: p.skills,
+                knowledge_base: p.knowledge_base.filter(|s| !s.trim().is_empty()),
+                max_turns: None,
+            });
+            store.save_manifest(&manifest).map_err(internal)?;
+        }
+
+        self.card_result(
             &manifest,
             &format!(
-                "Created {kind:?} artifact '{}' (id: {}). Preview shown to the user.",
+                "Created {kind:?} app '{}' (id: {}). Author src/main.ts and index.html, then build_app + launch_app.",
                 manifest.title, manifest.id
             ),
         )
     }
 
     #[tool(
-        name = "set_artifact_size",
-        description = "Set an artifact's preferred preview size in CSS px (width/height). Use a larger size for dashboards or wide layouts; omit a value to fill the panel / auto-grow."
+        name = "configure_app",
+        description = "Set an app's agent config: system prompt/persona, greeting, model (provider+model), extensions, skills, knowledge base, and max_turns (bound/raise the tool-calling loop for workflow-style apps). Makes the app agentic if it wasn't."
     )]
-    pub async fn set_artifact_size(
+    pub async fn configure_app(
         &self,
-        params: Parameters<SetArtifactSizeParams>,
+        params: Parameters<ConfigureAppParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let p = params.0;
         let store = self.store();
         let mut manifest = store
             .load_manifest(&p.id)
-            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no artifact '{}'", p.id)))?;
+            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
+        manifest.kind = ArtifactKind::Agentic;
+        let mut agent = manifest.agent.take().unwrap_or_default();
+        if let Some(sp) = p.system_prompt {
+            agent.system_prompt = sp;
+        }
+        if let Some(g) = p.greeting {
+            agent.greeting = Some(g).filter(|s| !s.is_empty());
+        }
+        if let Some(m) = p.model {
+            // Empty provider+model clears the pin → inherit the user's configured
+            // provider/model. Any BioRouter-supported provider may be pinned.
+            agent.model = Some(ModelSelection::from(m)).filter(|s| s.is_set());
+        }
+        if let Some(ext) = p.extensions {
+            agent.extensions = ext;
+        }
+        if let Some(sk) = p.skills {
+            agent.skills = sk;
+        }
+        if let Some(kb) = p.knowledge_base {
+            agent.knowledge_base = Some(kb).filter(|s| !s.trim().is_empty());
+        }
+        if let Some(mt) = p.max_turns {
+            agent.max_turns = Some(mt).filter(|&n| n > 0);
+        }
+        manifest.agent = Some(agent);
+        store.save_manifest(&manifest).map_err(internal)?;
+        store.touch(&p.id).map_err(internal)?;
+        self.card_result(&manifest, &format!("Configured app '{}'.", p.id))
+    }
+
+    #[tool(
+        name = "set_app_size",
+        description = "Set an app's preferred preview-card size in CSS px (width/height). Omit a value to fill/auto."
+    )]
+    pub async fn set_app_size(
+        &self,
+        params: Parameters<SetAppSizeParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let store = self.store();
+        let mut manifest = store
+            .load_manifest(&p.id)
+            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
         manifest.width = p.width;
         manifest.height = p.height;
         store.save_manifest(&manifest).map_err(internal)?;
         store.touch(&p.id).map_err(internal)?;
-        self.preview_result(
-            &manifest,
-            &format!(
-                "Set preview size for '{}' (width: {:?}, height: {:?}).",
-                p.id, p.width, p.height
-            ),
-        )
+        self.card_result(&manifest, &format!("Set preview size for '{}'.", p.id))
     }
 
     #[tool(
-        name = "update_artifact",
-        description = "Edit a file in an artifact: provide full `content` to overwrite, or `old_str`+`new_str` to replace a snippet. Defaults to the entry HTML."
+        name = "update_app",
+        description = "Edit a file in an app: provide full `content` to overwrite, or `old_str`+`new_str` to replace a snippet. Defaults to index.html. Editing src/ marks the bundle stale (re-run build_app)."
     )]
-    pub async fn update_artifact(
+    pub async fn update_app(
         &self,
-        params: Parameters<UpdateArtifactParams>,
+        params: Parameters<UpdateAppParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let p = params.0;
         let store = self.store();
-        let manifest = store
+        let mut manifest = store
             .load_manifest(&p.id)
-            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no artifact '{}'", p.id)))?;
+            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
         let path = p.path.clone().unwrap_or_else(|| manifest.entry.clone());
 
         if let Some(content) = p.content {
@@ -415,25 +665,150 @@ impl AgentDrafterServer {
                 "provide either `content` or both `old_str` and `new_str`",
             ));
         }
+        // Editing sources invalidates the build.
+        if path.starts_with("src/") {
+            manifest.built_at = None;
+            store.save_manifest(&manifest).map_err(internal)?;
+        }
         store.touch(&p.id).map_err(internal)?;
 
         if path == manifest.entry {
-            self.preview_result(&manifest, &format!("Updated {path} in '{}'.", p.id))
+            self.card_result(&manifest, &format!("Updated {path} in '{}'.", p.id))
         } else {
+            let hint = if path.starts_with("src/") {
+                " (run build_app to rebundle)"
+            } else {
+                ""
+            };
             Ok(CallToolResult::success(vec![Content::text(format!(
-                "Updated {path} in '{}'.",
+                "Updated {path} in '{}'.{hint}",
                 p.id
             ))]))
         }
     }
 
     #[tool(
-        name = "list_artifacts",
-        description = "List all artifacts (optionally filtered by kind)."
+        name = "build_app",
+        description = "Bundle the app's TypeScript (src/main.ts → dist/app.js) with esbuild. Run after editing src/. Returns the build log."
     )]
-    pub async fn list_artifacts(
+    pub async fn build_app(
         &self,
-        params: Parameters<ListArtifactsParams>,
+        params: Parameters<AppIdParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let store = self.store();
+        let mut manifest = store
+            .load_manifest(&p.id)
+            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
+        let dir = store.artifact_dir(&p.id);
+        let report = tokio::task::spawn_blocking(move || bundle::build_app(&dir))
+            .await
+            .map_err(internal)?
+            .map_err(internal)?;
+        if report.ok {
+            manifest.built_at = Some(now_secs());
+            store.save_manifest(&manifest).map_err(internal)?;
+            // Run the guardrail harness and surface findings so the agent can
+            // self-correct (SDK-wired, self-contained, on-theme).
+            let lint = bundle::lint_app(&store.artifact_dir(&p.id));
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Built '{}' with {} → dist/app.js.\n{}\n\n{}",
+                p.id,
+                report.used,
+                bundle::format_lint(&lint),
+                report.log
+            ))]))
+        } else {
+            Err(err(
+                ErrorCode::INTERNAL_ERROR,
+                format!("build failed for '{}':\n{}", p.id, report.log),
+            ))
+        }
+    }
+
+    #[tool(
+        name = "lint_app",
+        description = "Run the build harness guardrails on an app and report findings: does it reach the backend via the App SDK, is it self-contained (no CDN/external assets), and is it on-theme (BioRouter classes/tokens)? Fix ERRORs before launch/export."
+    )]
+    pub async fn lint_app(
+        &self,
+        params: Parameters<AppIdParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let store = self.store();
+        if !store.exists(&p.id) {
+            return Err(err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)));
+        }
+        let findings = bundle::lint_app(&store.artifact_dir(&p.id));
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Harness check for '{}':\n{}",
+            p.id,
+            bundle::format_lint(&findings)
+        ))]))
+    }
+
+    #[tool(
+        name = "launch_app",
+        description = "Build (if needed) and launch a BioRouter app. Returns the URL to open in the browser (GUI auto-opens; CLI prints it)."
+    )]
+    pub async fn launch_app(
+        &self,
+        params: Parameters<AppIdParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let p = params.0;
+        let store = self.store();
+        let mut manifest = store
+            .load_manifest(&p.id)
+            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
+
+        // Ensure a fresh bundle exists.
+        if manifest.kind == ArtifactKind::Agentic
+            && (manifest.built_at.is_none() || !store.file_exists(&p.id, "dist/app.js"))
+        {
+            let dir = store.artifact_dir(&p.id);
+            let report = tokio::task::spawn_blocking(move || bundle::build_app(&dir))
+                .await
+                .map_err(internal)?
+                .map_err(internal)?;
+            if !report.ok {
+                return Err(err(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("build failed before launch:\n{}", report.log),
+                ));
+            }
+            manifest.built_at = Some(now_secs());
+            store.save_manifest(&manifest).map_err(internal)?;
+        }
+
+        let path = format!("/apps/{}/", manifest.id);
+        let base = std::env::var("BIOROUTER_APP_BASE_URL").ok();
+        let url = base
+            .as_ref()
+            .map(|b| format!("{}{}", b.trim_end_matches('/'), path))
+            .unwrap_or_else(|| path.clone());
+
+        // Surface a launch marker the GUI can act on, plus a human URL line.
+        let mut meta = serde_json::Map::new();
+        meta.insert(
+            "biorouter/launch-app".to_string(),
+            serde_json::json!(manifest.id),
+        );
+        meta.insert("biorouter/app-path".to_string(), serde_json::json!(path));
+        let mut result = CallToolResult::success(vec![Content::text(format!(
+            "App '{}' is ready. Open it in your browser: {}\n(In the desktop GUI use the Applications panel's Launch button; in the CLI open the URL above with a running biorouterd.)",
+            manifest.id, url
+        ))]);
+        result.meta = Some(rmcp::model::Meta(meta));
+        Ok(result)
+    }
+
+    #[tool(
+        name = "list_apps",
+        description = "List all BioRouter apps (optionally filtered by kind)."
+    )]
+    pub async fn list_apps(
+        &self,
+        params: Parameters<ListAppsParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let filter = match params.0.kind.as_deref() {
             Some(k) => Some(ArtifactKind::parse(k).ok_or_else(|| {
@@ -452,12 +827,20 @@ impl AgentDrafterServer {
             .collect();
         if list.is_empty() {
             return Ok(CallToolResult::success(vec![Content::text(
-                "No artifacts yet.".to_string(),
+                "No apps yet.".to_string(),
             )]));
         }
         let lines: Vec<String> = list
             .iter()
-            .map(|m| format!("- {} [{:?}] — {}", m.id, m.kind, m.title))
+            .map(|m| {
+                let model = m
+                    .agent
+                    .as_ref()
+                    .and_then(|a| a.model.as_ref())
+                    .and_then(|s| s.model.clone())
+                    .unwrap_or_else(|| "default".into());
+                format!("- {} [{:?}, model: {}] — {}", m.id, m.kind, model, m.title)
+            })
             .collect();
         Ok(CallToolResult::success(vec![Content::text(
             lines.join("\n"),
@@ -465,20 +848,20 @@ impl AgentDrafterServer {
     }
 
     #[tool(
-        name = "read_artifact",
-        description = "Read an artifact's manifest, or a specific file within it."
+        name = "read_app",
+        description = "Read an app's manifest, or a specific file within it."
     )]
-    pub async fn read_artifact(
+    pub async fn read_app(
         &self,
-        params: Parameters<ReadArtifactParams>,
+        params: Parameters<ReadAppParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let p = params.0;
         let store = self.store();
         match p.path {
             None => {
-                let m = store.load_manifest(&p.id).map_err(|_| {
-                    err(ErrorCode::INVALID_PARAMS, format!("no artifact '{}'", p.id))
-                })?;
+                let m = store
+                    .load_manifest(&p.id)
+                    .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
                 let json = serde_json::to_string_pretty(&m).map_err(internal)?;
                 Ok(CallToolResult::success(vec![Content::text(json)]))
             }
@@ -492,94 +875,32 @@ impl AgentDrafterServer {
     }
 
     #[tool(
-        name = "preview_artifact",
-        description = "Render an artifact and return a live preview for the user."
+        name = "preview_app",
+        description = "Render an app's preview card for the user."
     )]
-    pub async fn preview_artifact(
+    pub async fn preview_app(
         &self,
-        params: Parameters<ArtifactIdParams>,
+        params: Parameters<AppIdParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let p = params.0;
         let manifest = self
             .store()
             .load_manifest(&p.id)
-            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no artifact '{}'", p.id)))?;
-        self.preview_result(&manifest, &format!("Preview of '{}'.", p.id))
+            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
+        self.card_result(&manifest, &format!("Preview of '{}'.", p.id))
     }
 
     #[tool(
-        name = "add_agent_capability",
-        description = "Turn an artifact into an agentic artifact: embed a BioRouter agent (system prompt, optional greeting, allowed tools) and a chat panel."
+        name = "export_app",
+        description = "Export an app as a standalone, runnable TypeScript project (esbuild build + a tiny static server) that talks to a BioRouter daemon."
     )]
-    pub async fn add_agent_capability(
+    pub async fn export_app(
         &self,
-        params: Parameters<AddAgentCapabilityParams>,
+        params: Parameters<ExportAppParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let p = params.0;
-        if p.system_prompt.trim().is_empty() {
-            return Err(err(
-                ErrorCode::INVALID_PARAMS,
-                "system_prompt must not be empty",
-            ));
-        }
-        let store = self.store();
-        let mut manifest = store
-            .load_manifest(&p.id)
-            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no artifact '{}'", p.id)))?;
-        manifest.kind = ArtifactKind::Agentic;
-        manifest.agent = Some(AgentConfig {
-            system_prompt: p.system_prompt,
-            greeting: p.greeting,
-            tools: p.tools,
-        });
-        store.save_manifest(&manifest).map_err(internal)?;
-        store.touch(&p.id).map_err(internal)?;
-        self.preview_result(
-            &manifest,
-            &format!("'{}' is now an agentic artifact. Preview shown.", p.id),
-        )
-    }
-
-    #[tool(
-        name = "export_artifact",
-        description = "Scaffold a standalone, runnable project from an artifact (Tauri desktop bundle with the BioRouter agent sidecar, or a static web build)."
-    )]
-    pub async fn export_artifact(
-        &self,
-        params: Parameters<ExportArtifactParams>,
-    ) -> Result<CallToolResult, ErrorData> {
-        let p = params.0;
-        let runtime = p.runtime.as_deref().unwrap_or("tauri").to_lowercase();
-        if runtime != "tauri" && runtime != "web" {
-            return Err(err(
-                ErrorCode::INVALID_PARAMS,
-                "runtime must be 'tauri' or 'web'",
-            ));
-        }
-        let store = self.store();
-        let manifest = store
-            .load_manifest(&p.id)
-            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no artifact '{}'", p.id)))?;
-
-        // Gather the artifact's files.
-        let artifact_dir = store.root().join(&manifest.id);
-        let mut all_files = Vec::new();
-        collect_files(&artifact_dir, &artifact_dir, &mut all_files);
-        let entry_html = all_files
-            .iter()
-            .find(|(path, _)| path == &manifest.entry)
-            .map(|(_, c)| c.clone())
-            .ok_or_else(|| err(ErrorCode::INTERNAL_ERROR, "entry file missing"))?;
-        let extras: Vec<(String, String)> = all_files
-            .into_iter()
-            .filter(|(path, _)| path != &manifest.entry)
-            .collect();
-
-        let scaffold = if runtime == "tauri" {
-            render::scaffold_tauri(&manifest, &entry_html, &extras, p.endpoint.as_deref())
-        } else {
-            render::scaffold_web(&manifest, &entry_html, &extras, p.endpoint.as_deref())
-        };
+        let scaffold = export_scaffold(self.root(), &p.id, p.endpoint.as_deref())
+            .map_err(|_| err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)))?;
 
         let target = PathBuf::from(&p.target_dir);
         for (rel, content) in &scaffold {
@@ -591,33 +912,26 @@ impl AgentDrafterServer {
         }
 
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "Exported '{}' as a {} project to {} ({} files). See README.md for run instructions.",
-            manifest.id,
-            runtime,
+            "Exported '{}' as a standalone TypeScript project to {} ({} files). README.md: npm install && npm run build && npm start (with a biorouterd running).",
+            p.id,
             target.display(),
             scaffold.len()
         ))]))
     }
 
-    #[tool(
-        name = "delete_artifact",
-        description = "Delete an artifact and all of its files."
-    )]
-    pub async fn delete_artifact(
+    #[tool(name = "delete_app", description = "Delete an app and all of its files.")]
+    pub async fn delete_app(
         &self,
-        params: Parameters<ArtifactIdParams>,
+        params: Parameters<AppIdParams>,
     ) -> Result<CallToolResult, ErrorData> {
         let p = params.0;
         let store = self.store();
         if !store.exists(&p.id) {
-            return Err(err(
-                ErrorCode::INVALID_PARAMS,
-                format!("no artifact '{}'", p.id),
-            ));
+            return Err(err(ErrorCode::INVALID_PARAMS, format!("no app '{}'", p.id)));
         }
         store.delete(&p.id).map_err(internal)?;
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "Deleted artifact '{}'.",
+            "Deleted app '{}'.",
             p.id
         ))]))
     }
@@ -672,237 +986,164 @@ mod tests {
             .any(|c| matches!(&c.raw, RawContent::Resource(_)))
     }
 
-    #[tokio::test]
-    async fn create_returns_preview_and_persists() {
-        let (_d, s) = server();
-        let res = s
-            .create_artifact(Parameters(CreateArtifactParams {
-                title: "Dashboard".into(),
-                description: "a dash".into(),
-                kind: None,
-                html: None,
-                files: vec![],
-            }))
-            .await
-            .unwrap();
-        assert!(has_ui_resource(&res));
-        assert!(text_of(&res).contains("dashboard"));
-        // Persisted entry uses the BioRouter starter (design-system classes).
-        let html = s.store().read_file("dashboard", "index.html").unwrap();
-        assert!(html.contains("br-container"));
+    fn create(title: &str, kind: Option<&str>) -> CreateAppParams {
+        CreateAppParams {
+            title: title.into(),
+            id: None,
+            description: String::new(),
+            kind: kind.map(|k| k.to_string()),
+            html: None,
+            files: vec![],
+            system_prompt: None,
+            greeting: None,
+            model: None,
+            extensions: vec![],
+            skills: vec![],
+            knowledge_base: None,
+        }
     }
 
     #[tokio::test]
-    async fn set_artifact_size_persists_and_previews() {
+    async fn create_app_writes_ts_project_and_defaults() {
         let (_d, s) = server();
-        s.create_artifact(Parameters(CreateArtifactParams {
-            title: "Wide".into(),
-            description: String::new(),
-            kind: Some("agentic".into()),
-            html: None,
-            files: vec![],
+        let mut p = create("Dashboard", None);
+        p.system_prompt = Some("You analyze data.".into());
+        p.extensions = vec!["autovisualiser".into()];
+        let res = s.create_app(Parameters(p)).await.unwrap();
+        assert!(has_ui_resource(&res));
+        assert!(s.store().read_file("dashboard", "src/main.ts").is_ok());
+        assert!(s.store().read_file("dashboard", "src/sdk.ts").is_ok());
+        let html = s.store().read_file("dashboard", "index.html").unwrap();
+        assert!(html.contains("br-container"));
+        let m = s.store().load_manifest("dashboard").unwrap();
+        assert_eq!(m.kind, ArtifactKind::Agentic);
+        let agent = m.agent.unwrap();
+        // Provider-agnostic: no model pinned unless explicitly chosen → inherits
+        // the user's configured provider/model.
+        assert!(agent.model.is_none());
+        assert_eq!(agent.extensions, vec!["autovisualiser".to_string()]);
+        assert_eq!(agent.system_prompt, "You analyze data.");
+    }
+
+    #[tokio::test]
+    async fn configure_app_sets_model_and_extensions() {
+        let (_d, s) = server();
+        s.create_app(Parameters(create("Cfg", Some("static"))))
+            .await
+            .unwrap();
+        s.configure_app(Parameters(ConfigureAppParams {
+            id: "cfg".into(),
+            system_prompt: Some("Be terse.".into()),
+            greeting: None,
+            model: Some(ModelParam {
+                provider: Some("anthropic".into()),
+                model: Some("claude-opus-4-8".into()),
+            }),
+            extensions: Some(vec!["developer".into(), "knowledge".into()]),
+            skills: Some(vec!["scientific-research".into()]),
+            knowledge_base: Some("my-kb".into()),
+            max_turns: Some(40),
         }))
         .await
         .unwrap();
-        let res = s
-            .set_artifact_size(Parameters(SetArtifactSizeParams {
-                id: "wide".into(),
-                width: Some(1000),
-                height: None,
-            }))
-            .await
-            .unwrap();
-        assert!(has_ui_resource(&res));
-        let m = s.store().load_manifest("wide").unwrap();
-        assert_eq!(m.width, Some(1000));
-        assert_eq!(m.height, None);
-        assert!(s
-            .set_artifact_size(Parameters(SetArtifactSizeParams {
-                id: "nope".into(),
-                width: Some(1),
-                height: None,
-            }))
-            .await
-            .is_err());
+        let m = s.store().load_manifest("cfg").unwrap();
+        assert_eq!(m.kind, ArtifactKind::Agentic);
+        let a = m.agent.unwrap();
+        assert_eq!(a.model.unwrap().provider.unwrap(), "anthropic");
+        assert_eq!(a.extensions, vec!["developer", "knowledge"]);
+        assert_eq!(a.skills, vec!["scientific-research"]);
+        assert_eq!(a.knowledge_base.unwrap(), "my-kb");
+        assert_eq!(a.max_turns, Some(40));
     }
 
     #[tokio::test]
     async fn create_rejects_empty_title_and_bad_kind() {
         let (_d, s) = server();
+        assert!(s.create_app(Parameters(create("  ", None))).await.is_err());
         assert!(s
-            .create_artifact(Parameters(CreateArtifactParams {
-                title: "  ".into(),
-                description: String::new(),
-                kind: None,
-                html: None,
-                files: vec![],
-            }))
-            .await
-            .is_err());
-        assert!(s
-            .create_artifact(Parameters(CreateArtifactParams {
-                title: "X".into(),
-                description: String::new(),
-                kind: Some("bogus".into()),
-                html: None,
-                files: vec![],
-            }))
+            .create_app(Parameters(create("X", Some("bogus"))))
             .await
             .is_err());
     }
 
     #[tokio::test]
-    async fn update_write_and_str_replace() {
+    async fn update_marks_bundle_stale_for_src() {
         let (_d, s) = server();
-        s.create_artifact(Parameters(CreateArtifactParams {
-            title: "Edit Me".into(),
-            description: String::new(),
-            kind: None,
-            html: Some("<html><body>ORIGINAL</body></html>".into()),
-            files: vec![],
-        }))
-        .await
-        .unwrap();
+        let mut p = create("Edit Me", None);
+        p.html = Some("<html><body>ORIGINAL</body></html>".into());
+        s.create_app(Parameters(p)).await.unwrap();
 
-        // str-replace
-        s.update_artifact(Parameters(UpdateArtifactParams {
+        s.update_app(Parameters(UpdateAppParams {
             id: "edit-me".into(),
-            path: None,
-            content: None,
-            old_str: Some("ORIGINAL".into()),
-            new_str: Some("CHANGED".into()),
-        }))
-        .await
-        .unwrap();
-        assert!(s
-            .store()
-            .read_file("edit-me", "index.html")
-            .unwrap()
-            .contains("CHANGED"));
-
-        // missing old_str errors
-        assert!(s
-            .update_artifact(Parameters(UpdateArtifactParams {
-                id: "edit-me".into(),
-                path: None,
-                content: None,
-                old_str: Some("NOPE".into()),
-                new_str: Some("x".into()),
-            }))
-            .await
-            .is_err());
-
-        // full content write to a new file
-        s.update_artifact(Parameters(UpdateArtifactParams {
-            id: "edit-me".into(),
-            path: Some("css/app.css".into()),
-            content: Some("body{color:red}".into()),
+            path: Some("src/main.ts".into()),
+            content: Some("import './sdk'; console.log(1);".into()),
             old_str: None,
             new_str: None,
         }))
         .await
         .unwrap();
-        assert_eq!(
-            s.store().read_file("edit-me", "css/app.css").unwrap(),
-            "body{color:red}"
-        );
+        assert_eq!(s.store().load_manifest("edit-me").unwrap().built_at, None);
 
-        // neither mode → error
-        assert!(s
-            .update_artifact(Parameters(UpdateArtifactParams {
+        let res = s
+            .update_app(Parameters(UpdateAppParams {
                 id: "edit-me".into(),
                 path: None,
                 content: None,
-                old_str: None,
-                new_str: None,
-            }))
-            .await
-            .is_err());
-    }
-
-    #[tokio::test]
-    async fn add_agent_capability_makes_artifact_agentic() {
-        let (_d, s) = server();
-        s.create_artifact(Parameters(CreateArtifactParams {
-            title: "Helper".into(),
-            description: String::new(),
-            kind: None,
-            html: Some("<html><head></head><body></body></html>".into()),
-            files: vec![],
-        }))
-        .await
-        .unwrap();
-
-        let res = s
-            .add_agent_capability(Parameters(AddAgentCapabilityParams {
-                id: "helper".into(),
-                system_prompt: "You are a research assistant.".into(),
-                greeting: Some("How can I help?".into()),
-                tools: vec!["developer".into()],
+                old_str: Some("ORIGINAL".into()),
+                new_str: Some("CHANGED".into()),
             }))
             .await
             .unwrap();
         assert!(has_ui_resource(&res));
-
-        let m = s.store().load_manifest("helper").unwrap();
-        assert_eq!(m.kind, ArtifactKind::Agentic);
-        let agent = m.agent.unwrap();
-        assert_eq!(agent.system_prompt, "You are a research assistant.");
-        assert_eq!(agent.tools, vec!["developer".to_string()]);
-
-        // empty system prompt rejected
         assert!(s
-            .add_agent_capability(Parameters(AddAgentCapabilityParams {
-                id: "helper".into(),
-                system_prompt: "   ".into(),
-                greeting: None,
-                tools: vec![],
-            }))
-            .await
-            .is_err());
+            .store()
+            .read_file("edit-me", "index.html")
+            .unwrap()
+            .contains("CHANGED"));
     }
 
     #[tokio::test]
-    async fn list_and_read_and_delete() {
+    async fn build_then_launch_returns_url() {
         let (_d, s) = server();
-        s.create_artifact(Parameters(CreateArtifactParams {
-            title: "One".into(),
-            description: "first".into(),
-            kind: None,
-            html: None,
-            files: vec![],
-        }))
-        .await
-        .unwrap();
-        s.create_artifact(Parameters(CreateArtifactParams {
-            title: "Two".into(),
-            description: String::new(),
-            kind: Some("agentic".into()),
-            html: None,
-            files: vec![],
-        }))
-        .await
-        .unwrap();
-
-        let all = s
-            .list_artifacts(Parameters(ListArtifactsParams { kind: None }))
+        s.create_app(Parameters(create("Launchy", None)))
             .await
             .unwrap();
-        assert!(text_of(&all).contains("one"));
-        assert!(text_of(&all).contains("two"));
-
-        let agentic = s
-            .list_artifacts(Parameters(ListArtifactsParams {
-                kind: Some("agentic".into()),
+        let res = s
+            .build_app(Parameters(AppIdParams {
+                id: "launchy".into(),
             }))
             .await
             .unwrap();
-        assert!(text_of(&agentic).contains("two"));
-        assert!(!text_of(&agentic).contains("one"));
+        assert!(text_of(&res).contains("dist/app.js"));
+        assert!(s.store().file_exists("launchy", "dist/app.js"));
+        assert!(s
+            .store()
+            .load_manifest("launchy")
+            .unwrap()
+            .built_at
+            .is_some());
 
-        // read manifest
+        let res = s
+            .launch_app(Parameters(AppIdParams {
+                id: "launchy".into(),
+            }))
+            .await
+            .unwrap();
+        assert!(text_of(&res).contains("/apps/launchy/"));
+    }
+
+    #[tokio::test]
+    async fn list_read_delete() {
+        let (_d, s) = server();
+        s.create_app(Parameters(create("One", None))).await.unwrap();
+        let all = s
+            .list_apps(Parameters(ListAppsParams { kind: None }))
+            .await
+            .unwrap();
+        assert!(text_of(&all).contains("one"));
+
         let m = s
-            .read_artifact(Parameters(ReadArtifactParams {
+            .read_app(Parameters(ReadAppParams {
                 id: "one".into(),
                 path: None,
             }))
@@ -910,79 +1151,47 @@ mod tests {
             .unwrap();
         assert!(text_of(&m).contains("\"title\": \"One\""));
 
-        // read entry file
-        let f = s
-            .read_artifact(Parameters(ReadArtifactParams {
-                id: "one".into(),
-                path: Some("index.html".into()),
-            }))
-            .await
-            .unwrap();
-        assert!(text_of(&f).contains("br-container"));
-
-        // delete
-        s.delete_artifact(Parameters(ArtifactIdParams { id: "one".into() }))
+        s.delete_app(Parameters(AppIdParams { id: "one".into() }))
             .await
             .unwrap();
         assert!(!s.store().exists("one"));
     }
 
     #[tokio::test]
-    async fn export_tauri_writes_runnable_project() {
+    async fn export_writes_standalone_ts_project() {
         let (_d, s) = server();
-        s.create_artifact(Parameters(CreateArtifactParams {
-            title: "Exporter".into(),
-            description: String::new(),
-            kind: Some("agentic".into()),
-            html: Some("<html><head></head><body>hi</body></html>".into()),
-            files: vec![FileSpec {
-                path: "css/app.css".into(),
-                content: "body{}".into(),
-            }],
-        }))
-        .await
-        .unwrap();
-        s.add_agent_capability(Parameters(AddAgentCapabilityParams {
-            id: "exporter".into(),
-            system_prompt: "help".into(),
-            greeting: None,
-            tools: vec![],
-        }))
-        .await
-        .unwrap();
+        let mut p = create("Exporter", None);
+        p.html = Some("<html><head></head><body>hi</body></html>".into());
+        p.system_prompt = Some("help".into());
+        s.create_app(Parameters(p)).await.unwrap();
 
         let out = TempDir::new().unwrap();
         let res = s
-            .export_artifact(Parameters(ExportArtifactParams {
+            .export_app(Parameters(ExportAppParams {
                 id: "exporter".into(),
                 target_dir: out.path().to_string_lossy().to_string(),
-                runtime: Some("tauri".into()),
                 endpoint: None,
             }))
             .await
             .unwrap();
-        assert!(text_of(&res).contains("tauri"));
-
-        assert!(out.path().join("dist/index.html").exists());
-        assert!(out.path().join("dist/css/app.css").exists());
-        assert!(out.path().join("src-tauri/Cargo.toml").exists());
-        assert!(out.path().join("src-tauri/tauri.conf.json").exists());
-        assert!(out.path().join("src-tauri/src/main.rs").exists());
-        assert!(out.path().join("README.md").exists());
-
-        let index = std::fs::read_to_string(out.path().join("dist/index.html")).unwrap();
-        assert!(index.contains("acp-ws"));
-        assert!(index.contains("BioRouterAgent"));
+        assert!(text_of(&res).contains("standalone"));
+        assert!(out.path().join("index.html").exists());
+        assert!(out.path().join("package.json").exists());
+        assert!(out.path().join("serve.mjs").exists());
+        assert!(out.path().join("src/main.ts").exists());
+        assert!(out.path().join("src/sdk.ts").exists());
+        let index = std::fs::read_to_string(out.path().join("index.html")).unwrap();
+        assert!(index.contains("dist/app.js"));
+        assert!(index.contains("BIOROUTER_APP_CONFIG"));
     }
 
     #[tokio::test]
-    async fn export_rejects_bad_runtime_and_missing_artifact() {
+    async fn export_rejects_missing_app() {
         let (_d, s) = server();
         assert!(s
-            .export_artifact(Parameters(ExportArtifactParams {
+            .export_app(Parameters(ExportAppParams {
                 id: "ghost".into(),
                 target_dir: "/tmp/x".into(),
-                runtime: Some("web".into()),
                 endpoint: None,
             }))
             .await

--- a/crates/biorouter-mcp/src/agent_drafter/render.rs
+++ b/crates/biorouter-mcp/src/agent_drafter/render.rs
@@ -1,21 +1,18 @@
-//! Rendering + scaffolding for Agent Drafter artifacts.
+//! Rendering + scaffolding for Agent Drafter apps.
 //!
-//! - [`assemble_preview`] injects the BioRouter design system (and, for agentic
-//!   artifacts, the embedded agent runtime + chat panel) into an artifact's entry
-//!   HTML so it can be rendered in BioRouter's sandboxed iframe.
-//! - [`scaffold_tauri`] / [`scaffold_web`] turn an artifact into a standalone,
-//!   runnable project (Tier B export).
+//! - [`assemble_app`] produces the HTML `biorouterd` serves at `/apps/<id>/`:
+//!   the author's `index.html` with the BioRouter design system injected, an
+//!   app-config script, and the esbuild bundle (`dist/app.js`). The bundle's SDK
+//!   opens a WebSocket to the per-app agent backend and streams real answers.
+//! - [`assemble_card`] produces a lightweight static preview shown inline in
+//!   chat (apps are *used* in the browser, not in a sandboxed iframe).
+//! - [`scaffold_standalone`] turns an app into a runnable TypeScript project that
+//!   talks to a BioRouter daemon (the export path).
 
-use crate::agent_drafter::store::{AgentConfig, ArtifactKind, Manifest};
+use crate::agent_drafter::store::Manifest;
 
 pub const THEME_CSS: &str = include_str!("templates/theme.css");
-pub const AGENT_JS: &str = include_str!("templates/agent.js");
-pub const RESIZE_JS: &str = include_str!("templates/resize.js");
-pub const STARTER_HTML: &str = include_str!("templates/starter.html");
-
-/// Default local endpoint a standalone export uses to reach the bundled
-/// `biorouter acp` sidecar (bridged to a WebSocket).
-pub const DEFAULT_ACP_WS: &str = "ws://127.0.0.1:11577/acp";
+pub const STARTER_HTML: &str = include_str!("templates/app-index.html");
 
 fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
@@ -24,7 +21,7 @@ fn html_escape(s: &str) -> String {
         .replace('"', "&quot;")
 }
 
-/// Build the default entry HTML for a freshly created artifact.
+/// Build the default entry HTML for a freshly created app.
 pub fn starter(title: &str, description: &str) -> String {
     STARTER_HTML
         .replace("{{TITLE}}", &html_escape(title))
@@ -32,11 +29,9 @@ pub fn starter(title: &str, description: &str) -> String {
 }
 
 /// Insert `insert` immediately before the first (case-insensitive) `needle`.
-/// If `needle` is absent, fall back to `on_missing` (prepend or append).
+/// If `needle` is absent, fall back to prepend/append.
 fn inject_before(html: &str, needle: &str, insert: &str, append_if_missing: bool) -> String {
     if let Some(pos) = html.to_lowercase().find(&needle.to_lowercase()) {
-        // `pos` is a byte offset returned by `find`, so it lands on a char
-        // boundary and `split_at` is safe.
         let (before, after) = html.split_at(pos);
         let mut out = String::with_capacity(html.len() + insert.len());
         out.push_str(before);
@@ -50,206 +45,279 @@ fn inject_before(html: &str, needle: &str, insert: &str, append_if_missing: bool
     }
 }
 
-/// The `<script>` that hands the embedded runtime its configuration.
-pub fn agent_config_script(agent: &AgentConfig, transport: &str, endpoint: Option<&str>) -> String {
+/// Insert immediately *after* the first occurrence of `needle`.
+fn inject_after(html: &str, needle: &str, insert: &str) -> String {
+    if let Some(pos) = html.to_lowercase().find(&needle.to_lowercase()) {
+        let at = pos + needle.len();
+        let (before, after) = html.split_at(at);
+        format!("{before}{insert}{after}")
+    } else {
+        format!("{insert}{html}")
+    }
+}
+
+const THEME_TAG: &str = "<style id=\"biorouter-theme\">";
+
+fn theme_block() -> String {
+    format!("{THEME_TAG}\n{THEME_CSS}\n</style>\n")
+}
+
+/// The script that hands the app SDK its configuration.
+pub fn app_config_script(manifest: &Manifest, endpoint: Option<&str>) -> String {
+    let greeting = manifest.agent.as_ref().and_then(|a| a.greeting.clone());
     let cfg = serde_json::json!({
-        "transport": transport,
+        "appId": manifest.id,
         "endpoint": endpoint,
-        "systemPrompt": agent.system_prompt,
-        "greeting": agent.greeting,
-        "tools": agent.tools,
+        "greeting": greeting,
     });
     let json = serde_json::to_string(&cfg).unwrap_or_else(|_| "{}".to_string());
     // JSON is valid JS; neutralise any `</script>` breakout from string fields.
     let json = json.replace('<', "\\u003c");
-    format!("<script>window.BIOROUTER_AGENT_CONFIG = {json};</script>\n")
+    format!("<script>window.BIOROUTER_APP_CONFIG = {json};</script>\n")
 }
 
-/// Inject the theme into `<head>` and, for agentic artifacts, the agent config +
-/// chat panel + runtime before `</body>`. `transport`/`endpoint` select how the
-/// embedded agent connects ("bridge" for in-app preview, "acp-ws" for exports).
-pub fn assemble(
+/// Assemble the HTML `biorouterd` serves for a live app at `/apps/<id>/`.
+///
+/// `base_href` should be the serving prefix (e.g. `/apps/<id>/`) so that the
+/// relative `dist/app.js` and any relative assets resolve correctly. `endpoint`
+/// overrides the agent WebSocket URL (None → derived from page location).
+pub fn assemble_app(
     manifest: &Manifest,
-    entry_html: &str,
-    transport: &str,
+    index_html: &str,
+    base_href: Option<&str>,
     endpoint: Option<&str>,
 ) -> String {
-    let style = format!("<style id=\"biorouter-theme\">\n{THEME_CSS}\n</style>\n");
-    let mut html = inject_before(entry_html, "</head>", &style, false);
-
-    // Auto-resize reporter for EVERY artifact so previews auto-grow in height
-    // (static artifacts have no agent runtime, so this must not live in agent.js).
-    let resize = format!("<script>\n{RESIZE_JS}\n</script>\n");
-    html = inject_before(&html, "</body>", &resize, true);
-
-    if manifest.kind == ArtifactKind::Agentic {
-        let agent = manifest.agent.clone().unwrap_or_default();
-        let mut block = agent_config_script(&agent, transport, endpoint);
-        // Auto-mount a chat panel if the author didn't place one themselves.
-        if !html.to_lowercase().contains("data-br-chat") {
-            block.push_str(
-                "<div class=\"br-container\"><div class=\"br-card\" data-br-chat style=\"margin-top:24px\"></div></div>\n",
-            );
-        }
-        block.push_str(&format!("<script>\n{AGENT_JS}\n</script>\n"));
-        html = inject_before(&html, "</body>", &block, true);
+    let mut head = String::new();
+    if let Some(base) = base_href {
+        head.push_str(&format!("<base href=\"{}\">\n", html_escape(base)));
     }
-    html
+    head.push_str(&theme_block());
+    let mut html = inject_after(index_html, "<head>", &head);
+    // If there was no <head>, inject_after fell back to prepending; ensure the
+    // theme is still present (it is, since `head` was prepended).
+    if !html.contains(THEME_TAG) {
+        html = format!("{}{html}", theme_block());
+    }
+
+    let mut tail = app_config_script(manifest, endpoint);
+    tail.push_str("<script src=\"dist/app.js\"></script>\n");
+    inject_before(&html, "</body>", &tail, true)
 }
 
-/// Convenience for the in-app preview (MCP-App bridge transport).
-pub fn assemble_preview(manifest: &Manifest, entry_html: &str) -> String {
-    assemble(manifest, entry_html, "bridge", None)
+/// A lightweight static preview for inline chat display. No live agent — apps
+/// are launched in the browser. Shows the styled UI plus a launch hint banner.
+pub fn assemble_card(manifest: &Manifest, index_html: &str) -> String {
+    let head = theme_block();
+    let mut html = inject_after(index_html, "<head>", &head);
+    if !html.contains(THEME_TAG) {
+        html = format!("{head}{html}");
+    }
+    let banner = format!(
+        "<div style=\"position:sticky;top:0;z-index:10;background:var(--br-medium);\
+         color:var(--br-text-muted);font-size:12px;padding:6px 12px;border-bottom:1px solid var(--br-border);\">\
+         Preview of <strong>{}</strong> — launch from the Applications panel to use the live agent.</div>\n",
+        html_escape(&manifest.title)
+    );
+    inject_after(&html, "<body>", &banner)
 }
 
 // ---------------------------------------------------------------------------
-// Standalone export scaffolding (Tier B)
+// Standalone export scaffolding (TypeScript project against a BioRouter daemon)
 // ---------------------------------------------------------------------------
 
-fn cargo_toml(id: &str) -> String {
+fn package_json(manifest: &Manifest) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "name": manifest.id,
+        "version": "0.1.0",
+        "private": true,
+        "type": "module",
+        "scripts": {
+            "build": "esbuild src/main.ts --bundle --format=iife --outfile=dist/app.js",
+            "start": "node serve.mjs"
+        },
+        "devDependencies": { "esbuild": "^0.23.0" }
+    }))
+    .unwrap_or_default()
+}
+
+fn serve_mjs(default_port: u16) -> String {
     format!(
-        r#"[package]
-name = "{id}"
-version = "0.1.0"
-edition = "2021"
+        r#"// Minimal static server for the exported BioRouter app.
+//
+// The app talks to a BioRouter daemon for its agent loop. Start one with:
+//   biorouterd                 # the BioRouter REST/WS server (serves /apps too)
+// or point BR_AGENT_ENDPOINT at an existing daemon's per-app socket.
+//
+// This server only serves the static files; the SDK connects to the daemon set
+// in index.html's BIOROUTER_APP_CONFIG.endpoint.
+import {{ createServer }} from "node:http";
+import {{ readFile }} from "node:fs/promises";
+import {{ extname, normalize, resolve }} from "node:path";
 
-[build-dependencies]
-tauri-build = {{ version = "2", features = [] }}
+const PORT = process.env.PORT || {default_port};
+const ROOT = new URL(".", import.meta.url).pathname;
+const MIME = {{ ".html": "text/html", ".js": "text/javascript", ".css": "text/css",
+  ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png" }};
 
-[dependencies]
-tauri = {{ version = "2", features = [] }}
-tauri-plugin-shell = "2"
-serde_json = "1"
+createServer(async (req, res) => {{
+  let path = decodeURIComponent((req.url || "/").split("?")[0]);
+  if (path === "/") path = "/index.html";
+  // Resolve under ROOT; reject anything that escapes it (no path traversal).
+  const base = ROOT.replace(/\/$/, "");
+  const file = resolve(base, "." + normalize(path));
+  if (file !== base && !file.startsWith(base + "/")) {{
+    res.writeHead(403); res.end("Forbidden"); return;
+  }}
+  try {{
+    const body = await readFile(file);
+    res.writeHead(200, {{ "Content-Type": MIME[extname(file)] || "application/octet-stream" }});
+    res.end(body);
+  }} catch {{
+    res.writeHead(404);
+    res.end("Not found");
+  }}
+}}).listen(PORT, () => console.log(`App running at http://localhost:${{PORT}}`));
 "#
     )
 }
 
-fn tauri_conf(title: &str, id: &str) -> String {
-    let cfg = serde_json::json!({
-        "$schema": "https://schema.tauri.app/config/2",
-        "productName": title,
-        "version": "0.1.0",
-        "identifier": format!("com.biorouter.agentdrafter.{}", id.replace('-', "")),
-        "build": { "frontendDist": "../dist" },
-        "app": {
-            "windows": [{ "title": title, "width": 960, "height": 720 }],
-            "security": { "csp": null }
-        },
-        "bundle": {
-            "active": true,
-            "targets": "all",
-            // Bundle the BioRouter CLI as a sidecar so the artifact is self-contained.
-            "externalBin": ["binaries/biorouter"]
-        }
-    });
-    serde_json::to_string_pretty(&cfg).unwrap_or_default()
-}
+/// A double-clickable launcher (`run.command` on macOS / `run.sh` elsewhere) that
+/// makes the exported folder *directly runnable*: self-install into the local
+/// BioRouter store (idempotent + portable), start `biorouterd` if needed, and
+/// open the app in the default browser. Requires `biorouterd` on PATH with a
+/// configured provider (any BioRouter-supported LLM).
+fn run_script(id: &str) -> String {
+    format!(
+        r#"#!/usr/bin/env bash
+set -e
+APP_ID="{id}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+STORE="$HOME/.config/biorouter/agent_drafter/$APP_ID"
 
-fn tauri_main_rs() -> String {
-    // Spawns `biorouter acp` as a sidecar on launch. The embedded agent runtime
-    // (agent.js) connects to it over the local ACP WebSocket.
-    r#"// Auto-generated by BioRouter Agent Drafter.
-use tauri_plugin_shell::ShellExt;
+# 1. Install this app into the local BioRouter store (idempotent, portable).
+if [ ! -f "$STORE/manifest.json" ]; then
+  mkdir -p "$STORE"
+  cp -R "$DIR/." "$STORE/" 2>/dev/null || true
+  rm -f "$STORE/run.command" "$STORE/run.sh" "$STORE/serve.mjs" "$STORE/README.md" "$STORE/package.json" 2>/dev/null || true
+  echo "Installed '$APP_ID' into BioRouter."
+fi
 
-fn main() {
-    tauri::Builder::default()
-        .plugin(tauri_plugin_shell::init())
-        .setup(|app| {
-            // Launch the bundled BioRouter agent (ACP over stdio). A small bridge
-            // is expected to expose it on ws://127.0.0.1:11577/acp for agent.js.
-            let _ = app.shell().sidecar("biorouter").map(|cmd| cmd.args(["acp"]).spawn());
-            Ok(())
-        })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
-}
+# 2. Start a BioRouter daemon if nothing is serving on :3000.
+if ! curl -sf -o /dev/null http://127.0.0.1:3000/status 2>/dev/null; then
+  echo "Starting biorouterd (uses your configured BioRouter provider)..."
+  (biorouterd agent >"/tmp/biorouterd-$APP_ID.log" 2>&1 &)
+  for i in $(seq 1 40); do curl -sf -o /dev/null http://127.0.0.1:3000/status 2>/dev/null && break; sleep 1; done
+fi
+
+# 3. Open the app in the default browser.
+URL="http://127.0.0.1:3000/apps/$APP_ID/"
+echo "Opening $URL"
+if command -v open >/dev/null 2>&1; then open "$URL"
+elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$URL"
+else echo "Open this URL in your browser: $URL"; fi
 "#
-    .to_string()
+    )
 }
 
-fn readme(manifest: &Manifest, runtime: &str) -> String {
+fn readme(manifest: &Manifest) -> String {
     format!(
         r#"# {title}
 
 {desc}
 
-Generated by **BioRouter Agent Drafter** (`{id}`, kind: `{kind:?}`, runtime: `{runtime}`).
+A standalone **BioRouter app** generated by Agent Drafter (`{id}`). The UI is
+TypeScript (a prebuilt `dist/app.js` is included); the agent loop runs on a
+BioRouter daemon using whatever LLM provider you've configured.
 
-## Run
+## Easiest: double-click `run.command` (macOS) or `bash run.sh`
 
-### Web
-Serve the `dist/` folder with any static file server, e.g.:
+The launcher installs this app into your local BioRouter, starts `biorouterd`
+if needed, and opens it in your browser. You only need `biorouter` installed
+with a provider configured (`biorouter configure`).
 
-    npx serve dist
+## Manual
 
-### Tauri (desktop, bundles the BioRouter agent)
-1. Install the Tauri CLI: `cargo install tauri-cli --version '^2'`
-2. Place the `biorouter` binary at `src-tauri/binaries/biorouter-<target-triple>`.
-3. `cd src-tauri && cargo tauri dev`
+1. (Optional) rebuild the UI bundle after editing `src/`:
 
-The embedded agent runtime (`agent.js`) connects to the BioRouter agent over the
-Agent Client Protocol (ACP). For agentic artifacts the chat panel is wired up
-automatically.
+       npm install
+       npm run build
+
+2. Start a BioRouter daemon so the app has a backend to talk to:
+
+       biorouterd agent      # headless backend on :3000 (no GUI needed)
+
+   The daemon uses **your existing BioRouter configuration** — whatever LLM
+   provider and model you've set up (`biorouter configure`), with credentials
+   from your OS keychain. BioRouter supports many providers (Anthropic, OpenAI,
+   Azure, Bedrock, Ollama, Xiaomi MiMo, local llama.cpp, …); this app is
+   provider-agnostic and runs on whichever you've configured. If a provider key
+   isn't in your keychain, export its key first, e.g.:
+
+       export <PROVIDER>_API_KEY=...   # only if not already configured
+
+   The app's agent runs the model/extensions/skills/knowledge from
+   `manifest.json` and connects at `ws://127.0.0.1:3000/apps/{id}/agent`
+   (override `BIOROUTER_APP_CONFIG.endpoint` in `index.html` for a remote daemon).
+
+3. Serve the app and open it:
+
+       npm start             # http://localhost:8787
+
+`src/main.ts` is your app logic; `src/sdk.ts` is the BioRouter App SDK (opens the
+agent WebSocket, streams markdown + charts, handles multimodal input). Edit,
+re-run `npm run build`, refresh.
+
+> The UI is fully self-contained and runs anywhere; only the agent backend
+> requires a reachable `biorouterd` with valid provider credentials.
 "#,
         title = manifest.title,
         desc = manifest.description,
         id = manifest.id,
-        kind = manifest.kind,
-        runtime = runtime,
     )
 }
 
-/// Build the file list for a **web** export: assembled entry HTML + extra files.
-pub fn scaffold_web(
+/// Build the file list for a standalone TypeScript export. Includes the author's
+/// files, the SDK, a package.json/esbuild build, a tiny static server, and a
+/// README. The served index points its SDK endpoint at a local daemon.
+pub fn scaffold_standalone(
     manifest: &Manifest,
-    entry_html: &str,
+    index_html: &str,
+    src_files: &[(String, String)],
     extra_files: &[(String, String)],
     endpoint: Option<&str>,
 ) -> Vec<(String, String)> {
-    let assembled = assemble(
-        manifest,
-        entry_html,
-        "acp-ws",
-        Some(endpoint.unwrap_or(DEFAULT_ACP_WS)),
-    );
+    // The exported app talks to a running BioRouter daemon's per-app agent
+    // socket (same protocol the App SDK speaks). Default to a local biorouterd
+    // on :3000; the user can override via the endpoint arg (e.g. a remote
+    // daemon). `biorouterd` must be running with the provider auth available.
+    let default_endpoint = format!("ws://127.0.0.1:3000/apps/{}/agent", manifest.id);
+    let endpoint = endpoint.unwrap_or(&default_endpoint);
+    let assembled = assemble_app(manifest, index_html, None, Some(endpoint));
+    let launcher = run_script(&manifest.id);
     let mut files = vec![
-        (format!("dist/{}", manifest.entry), assembled),
-        ("README.md".to_string(), readme(manifest, "web")),
+        (manifest.entry.clone(), assembled),
+        ("package.json".to_string(), package_json(manifest)),
+        ("serve.mjs".to_string(), serve_mjs(8787)),
+        ("README.md".to_string(), readme(manifest)),
+        // Directly-runnable launchers (double-click on macOS / `bash run.sh`).
+        ("run.command".to_string(), launcher.clone()),
+        ("run.sh".to_string(), launcher),
     ];
+    for (path, content) in src_files {
+        files.push((path.clone(), content.clone()));
+    }
     for (path, content) in extra_files {
-        if path != &manifest.entry {
-            files.push((format!("dist/{path}"), content.clone()));
+        if path != &manifest.entry && !path.starts_with("src/") {
+            files.push((path.clone(), content.clone()));
         }
     }
-    files
-}
-
-/// Build the file list for a **Tauri** export: a web `dist/` plus a `src-tauri/`
-/// project that bundles and launches the BioRouter agent sidecar.
-pub fn scaffold_tauri(
-    manifest: &Manifest,
-    entry_html: &str,
-    extra_files: &[(String, String)],
-    endpoint: Option<&str>,
-) -> Vec<(String, String)> {
-    let mut files = scaffold_web(manifest, entry_html, extra_files, endpoint);
-    files.push(("src-tauri/Cargo.toml".to_string(), cargo_toml(&manifest.id)));
-    files.push((
-        "src-tauri/tauri.conf.json".to_string(),
-        tauri_conf(&manifest.title, &manifest.id),
-    ));
-    files.push(("src-tauri/src/main.rs".to_string(), tauri_main_rs()));
-    files.push((
-        "src-tauri/build.rs".to_string(),
-        "fn main() { tauri_build::build() }\n".to_string(),
-    ));
     files
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent_drafter::store::{AgentConfig, ArtifactKind, Manifest};
+    use crate::agent_drafter::store::{AgentConfig, ArtifactKind, ModelSelection};
 
     fn manifest(kind: ArtifactKind) -> Manifest {
         Manifest {
@@ -264,13 +332,22 @@ mod tests {
                 Some(AgentConfig {
                     system_prompt: "be helpful".into(),
                     greeting: Some("hi".into()),
-                    tools: vec!["developer".into()],
+                    tools: vec![],
+                    model: Some(ModelSelection {
+                        provider: Some("xiaomi_mimo".into()),
+                        model: Some("mimo-v2.5".into()),
+                    }),
+                    extensions: vec!["developer".into()],
+                    skills: vec![],
+                    knowledge_base: None,
+                    max_turns: None,
                 })
             } else {
                 None
             },
             width: None,
             height: None,
+            built_at: None,
         }
     }
 
@@ -283,154 +360,70 @@ mod tests {
     }
 
     #[test]
-    fn inject_before_head_inserts_theme() {
-        let m = manifest(ArtifactKind::Static);
-        let out = assemble_preview(&m, "<html><head></head><body>hi</body></html>");
-        assert!(out.contains("biorouter-theme"));
-        assert!(out.contains(THEME_CSS));
-        // theme goes before </head>
-        let style_pos = out.find("biorouter-theme").unwrap();
-        let head_close = out.find("</head>").unwrap();
-        assert!(style_pos < head_close);
-    }
-
-    #[test]
-    fn inject_before_missing_head_prepends() {
-        let m = manifest(ArtifactKind::Static);
-        let out = assemble_preview(&m, "<div>no head</div>");
-        assert!(out.contains("biorouter-theme"));
-        assert!(out.starts_with("<style"));
-    }
-
-    #[test]
-    fn static_artifact_has_no_agent_runtime() {
-        let m = manifest(ArtifactKind::Static);
-        let out = assemble_preview(&m, "<html><head></head><body></body></html>");
-        assert!(!out.contains("BIOROUTER_AGENT_CONFIG"));
-        assert!(!out.contains("data-br-chat"));
-    }
-
-    #[test]
-    fn every_artifact_gets_the_resize_reporter() {
-        // Regression: static artifacts must also report height so the preview
-        // iframe auto-grows (the reporter must NOT live only in agent.js).
-        for kind in [ArtifactKind::Static, ArtifactKind::Agentic] {
-            let m = manifest(kind);
-            let out = assemble_preview(&m, "<html><head></head><body></body></html>");
-            assert!(
-                out.contains("__brReportSize"),
-                "{kind:?} missing resize reporter"
-            );
-            assert!(
-                out.contains("ui-size-change"),
-                "{kind:?} missing ui-size-change"
-            );
-        }
-    }
-
-    #[test]
-    fn resize_reporter_present_even_without_body_tag() {
-        let m = manifest(ArtifactKind::Static);
-        let out = assemble_preview(&m, "<div>no body tag</div>");
-        assert!(out.contains("__brReportSize"));
-    }
-
-    #[test]
-    fn agentic_bridge_uses_mcp_ui_protocol_not_jsonrpc() {
-        // Regression: the in-app bridge must speak the MCP-UI host protocol
-        // (ui-message-response / "prompt" action), not raw JSON-RPC, or prompts
-        // never route and the chat hangs.
+    fn assemble_app_injects_theme_base_config_and_bundle() {
         let m = manifest(ArtifactKind::Agentic);
-        let out = assemble_preview(&m, "<html><head></head><body></body></html>");
-        // Bridge listens for the host's ui-message-response and posts a "prompt"
-        // action (not the old `{jsonrpc, method:"ui/message"}` frame).
-        assert!(out.contains("ui-message-response"));
-        assert!(!out.contains("\"ui/message\""));
-        // Send button must not rely on sandbox-blocked form submission.
-        assert!(out.contains("send.type = \"button\""));
+        let out = assemble_app(
+            &m,
+            "<html><head></head><body>hi</body></html>",
+            Some("/apps/demo/"),
+            None,
+        );
+        assert!(out.contains("biorouter-theme"));
+        assert!(out.contains("<base href=\"/apps/demo/\">"));
+        assert!(out.contains("BIOROUTER_APP_CONFIG"));
+        assert!(out.contains("\"appId\":\"demo\""));
+        assert!(out.contains("dist/app.js"));
+        // theme precedes the bundle script
+        assert!(out.find("biorouter-theme").unwrap() < out.find("dist/app.js").unwrap());
     }
 
     #[test]
-    fn agentic_artifact_injects_config_chat_and_runtime() {
+    fn assemble_app_handles_missing_head_and_body() {
         let m = manifest(ArtifactKind::Agentic);
-        let out = assemble_preview(&m, "<html><head></head><body></body></html>");
-        assert!(out.contains("BIOROUTER_AGENT_CONFIG"));
-        assert!(out.contains("\"transport\":\"bridge\""));
-        assert!(out.contains("be helpful"));
-        assert!(out.contains("data-br-chat"));
-        assert!(out.contains("BioRouterAgent")); // runtime present
+        let out = assemble_app(&m, "<div>bare</div>", None, None);
+        assert!(out.contains("biorouter-theme"));
+        assert!(out.contains("dist/app.js"));
     }
 
     #[test]
-    fn agentic_config_neutralizes_script_breakout() {
+    fn config_neutralizes_script_breakout() {
         let mut m = manifest(ArtifactKind::Agentic);
-        m.agent = Some(AgentConfig {
-            system_prompt: "</script><script>alert(1)</script>".into(),
-            greeting: None,
-            tools: vec![],
-        });
-        let out = assemble_preview(&m, "<html><head></head><body></body></html>");
+        m.agent.as_mut().unwrap().greeting = Some("</script><script>alert(1)</script>".into());
+        let out = assemble_app(&m, "<html><head></head><body></body></html>", None, None);
         assert!(!out.contains("</script><script>alert(1)"));
         assert!(out.contains("\\u003c"));
     }
 
     #[test]
-    fn does_not_add_second_chat_when_author_supplies_one() {
-        let m = manifest(ArtifactKind::Agentic);
-        let out = assemble_preview(&m, "<body><div data-br-chat></div></body>");
-        // The author's panel is preserved and no auto-mounted panel is appended
-        // (the auto-mounted one carries the distinctive inline margin marker).
-        assert!(out.contains("<div data-br-chat></div>"));
-        assert!(!out.contains("margin-top:24px"));
-    }
-
-    #[test]
-    fn web_export_assembles_with_acp_ws_transport() {
-        let m = manifest(ArtifactKind::Agentic);
-        let files = scaffold_web(&m, "<html><head></head><body></body></html>", &[], None);
-        let (path, content) = &files[0];
-        assert_eq!(path, "dist/index.html");
-        assert!(content.contains("\"transport\":\"acp-ws\""));
-        assert!(content.contains(DEFAULT_ACP_WS));
-        assert!(files.iter().any(|(p, _)| p == "README.md"));
-    }
-
-    #[test]
-    fn tauri_export_includes_sidecar_project() {
-        let m = manifest(ArtifactKind::Agentic);
-        let files = scaffold_tauri(&m, "<html><head></head><body></body></html>", &[], None);
-        let paths: Vec<&str> = files.iter().map(|(p, _)| p.as_str()).collect();
-        assert!(paths.contains(&"dist/index.html"));
-        assert!(paths.contains(&"src-tauri/Cargo.toml"));
-        assert!(paths.contains(&"src-tauri/tauri.conf.json"));
-        assert!(paths.contains(&"src-tauri/src/main.rs"));
-        assert!(paths.contains(&"src-tauri/build.rs"));
-        let main_rs = &files
-            .iter()
-            .find(|(p, _)| p == "src-tauri/src/main.rs")
-            .unwrap()
-            .1;
-        assert!(main_rs.contains("sidecar(\"biorouter\")"));
-        assert!(main_rs.contains("acp"));
-        let conf = &files
-            .iter()
-            .find(|(p, _)| p == "src-tauri/tauri.conf.json")
-            .unwrap()
-            .1;
-        assert!(conf.contains("externalBin"));
-    }
-
-    #[test]
-    fn web_export_includes_extra_files_under_dist() {
+    fn card_has_launch_banner_and_theme() {
         let m = manifest(ArtifactKind::Static);
-        let files = scaffold_web(
+        let out = assemble_card(&m, "<html><head></head><body><h1>Hi</h1></body></html>");
+        assert!(out.contains("biorouter-theme"));
+        assert!(out.contains("Applications panel"));
+        assert!(out.contains("<h1>Hi</h1>"));
+    }
+
+    #[test]
+    fn standalone_export_is_typescript_project() {
+        let m = manifest(ArtifactKind::Agentic);
+        let files = scaffold_standalone(
             &m,
-            "<html></html>",
-            &[("css/app.css".to_string(), "body{}".to_string())],
+            "<html><head></head><body></body></html>",
+            &[("src/main.ts".to_string(), "import './sdk';".to_string())],
+            &[],
             None,
         );
-        assert!(files
-            .iter()
-            .any(|(p, c)| p == "dist/css/app.css" && c == "body{}"));
+        let paths: Vec<&str> = files.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"index.html"));
+        assert!(paths.contains(&"package.json"));
+        assert!(paths.contains(&"serve.mjs"));
+        assert!(paths.contains(&"README.md"));
+        assert!(paths.contains(&"src/main.ts"));
+        let pkg = &files.iter().find(|(p, _)| p == "package.json").unwrap().1;
+        assert!(pkg.contains("esbuild"));
+        let idx = &files.iter().find(|(p, _)| p == "index.html").unwrap().1;
+        // Exported app points at a biorouterd per-app agent socket (App SDK
+        // protocol), not the old ACP endpoint.
+        assert!(idx.contains("ws://127.0.0.1:3000/apps/demo/agent"));
     }
 }

--- a/crates/biorouter-mcp/src/agent_drafter/store.rs
+++ b/crates/biorouter-mcp/src/agent_drafter/store.rs
@@ -29,7 +29,28 @@ impl ArtifactKind {
     }
 }
 
-/// Per-artifact agent configuration (present for `Agentic` artifacts).
+/// The provider + model an app's agent should run on. When absent, the app
+/// falls back to BioRouter's globally-configured provider/model.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelSelection {
+    /// Provider name (e.g. "xiaomi_mimo", "anthropic", "openai").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Model name (e.g. "mimo-v2.5", "claude-opus-4-8").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+impl ModelSelection {
+    pub fn is_set(&self) -> bool {
+        self.provider.is_some() || self.model.is_some()
+    }
+}
+
+/// Per-app agent configuration (present for `Agentic` apps). Captures everything
+/// that distinguishes one app's BioRouter backend from another: the system
+/// prompt/persona, which model runs it, and which extensions / skills /
+/// knowledge base the agent may use.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentConfig {
     /// System prompt that defines the embedded agent's behavior.
@@ -38,9 +59,29 @@ pub struct AgentConfig {
     /// Optional greeting shown when the chat panel mounts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub greeting: Option<String>,
-    /// Tool / MCP-extension names the artifact's agent is allowed to use.
-    #[serde(default)]
+    /// Legacy free-form tool names (kept for back-compat; prefer `extensions`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<String>,
+    /// Provider + model the app's agent should run on. Defaults to the global
+    /// BioRouter model when unset (the GUI/CLI seeds this with the default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelSelection>,
+    /// Builtin / platform extension names the app's agent should load
+    /// (e.g. "developer", "computercontroller", "autovisualiser", "knowledge").
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<String>,
+    /// Skill ids the app's agent should have available.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+    /// Knowledge base id the app's agent should be scoped to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub knowledge_base: Option<String>,
+    /// Bound on the agent's tool-calling loop per user message (a guardrail and
+    /// a workflow control, like the knowledge sub-agent's `max_steps`). When
+    /// unset, the server applies a safe default cap. Higher values let
+    /// workflow-style apps chain more tool calls autonomously.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u32>,
 }
 
 /// Metadata describing a single artifact.
@@ -64,6 +105,10 @@ pub struct Manifest {
     /// then auto-grows to fit content).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
+    /// Unix seconds of the last successful esbuild bundle, if any. `None` means
+    /// the app has never been built (or its sources changed since).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub built_at: Option<u64>,
 }
 
 fn now_secs() -> u64 {
@@ -191,6 +236,50 @@ impl ArtifactStore {
             },
             width: None,
             height: None,
+            built_at: None,
+        };
+        self.save_manifest(&manifest)?;
+        for (path, content) in files {
+            self.write_file(&id, path, content)?;
+        }
+        Ok(manifest)
+    }
+
+    /// Create an artifact at an **explicit** id (slugified). If one already
+    /// exists at that id it is replaced, so re-authoring the same app is
+    /// idempotent (no `-2` duplicates) and apps are stably addressable.
+    pub fn create_with_id(
+        &self,
+        id: &str,
+        title: &str,
+        description: &str,
+        kind: ArtifactKind,
+        entry: &str,
+        files: &[(String, String)],
+    ) -> io::Result<Manifest> {
+        let id = slugify(id);
+        if self.dir(&id).exists() {
+            self.delete(&id)?;
+        }
+        let dir = self.dir(&id);
+        std::fs::create_dir_all(&dir)?;
+        let now = now_secs();
+        let manifest = Manifest {
+            id: id.clone(),
+            title: title.to_string(),
+            description: description.to_string(),
+            kind,
+            entry: entry.to_string(),
+            created_at: now,
+            updated_at: now,
+            agent: if kind == ArtifactKind::Agentic {
+                Some(AgentConfig::default())
+            } else {
+                None
+            },
+            width: None,
+            height: None,
+            built_at: None,
         };
         self.save_manifest(&manifest)?;
         for (path, content) in files {
@@ -230,7 +319,7 @@ impl ArtifactStore {
                 }
             }
         }
-        out.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        out.sort_by_key(|manifest| std::cmp::Reverse(manifest.updated_at));
         out
     }
 
@@ -246,6 +335,31 @@ impl ArtifactStore {
     pub fn read_file(&self, id: &str, path: &str) -> io::Result<String> {
         let rel = safe_relative(path)?;
         std::fs::read_to_string(self.dir(id).join(rel))
+    }
+
+    /// Read a file's raw bytes (for serving binary assets like images/fonts).
+    pub fn read_bytes(&self, id: &str, path: &str) -> io::Result<Vec<u8>> {
+        let rel = safe_relative(path)?;
+        std::fs::read(self.dir(id).join(rel))
+    }
+
+    /// Absolute path to an artifact's directory (used by the bundler/server).
+    pub fn artifact_dir(&self, id: &str) -> PathBuf {
+        self.dir(id)
+    }
+
+    /// Absolute path to a file within an artifact, path-traversal checked.
+    pub fn file_path(&self, id: &str, path: &str) -> io::Result<PathBuf> {
+        let rel = safe_relative(path)?;
+        Ok(self.dir(id).join(rel))
+    }
+
+    /// Whether a file exists within an artifact (path-traversal checked).
+    pub fn file_exists(&self, id: &str, path: &str) -> bool {
+        match safe_relative(path) {
+            Ok(rel) => self.dir(id).join(rel).is_file(),
+            Err(_) => false,
+        }
     }
 
     pub fn delete(&self, id: &str) -> io::Result<()> {

--- a/crates/biorouter-mcp/src/agent_drafter/templates/app-index.html
+++ b/crates/biorouter-mcp/src/agent_drafter/templates/app-index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{TITLE}}</title>
+</head>
+<body>
+  <main class="br-container">
+    <span class="br-badge">BioRouter App</span>
+    <h1>{{TITLE}}</h1>
+    <p style="color: var(--br-text-muted); margin-top: 2px;">{{DESCRIPTION}}</p>
+    <!-- The default chat panel mounts here. Replace this body and main.ts to
+         build a custom interface; call createApp({ autoChat: false }) and drive
+         the agent with br.prompt(...) / br.on("message", ...). -->
+    <div class="br-card" data-br-chat style="margin-top: 16px;"></div>
+    <p class="br-footer">Powered by BioRouter · built with Agent Drafter</p>
+  </main>
+</body>
+</html>

--- a/crates/biorouter-mcp/src/agent_drafter/templates/main.ts
+++ b/crates/biorouter-mcp/src/agent_drafter/templates/main.ts
@@ -1,0 +1,17 @@
+/**
+ * App entry point (TypeScript, bundled by esbuild → dist/app.js).
+ *
+ * `createApp()` reads `window.BIOROUTER_APP_CONFIG`, opens a WebSocket to the
+ * BioRouter backend, and (by default) mounts a chat panel into the element with
+ * the `data-br-chat` attribute. Replace the body below to drive your own UI:
+ *
+ *   import { createApp } from "./sdk";
+ *   const br = createApp({ autoChat: false });
+ *   const out = document.getElementById("out")!;
+ *   br.on("message", (e) => { if (e.type === "message") out.innerHTML += e.delta; });
+ *   document.getElementById("go")!.addEventListener("click", () =>
+ *     br.prompt((document.getElementById("q") as HTMLInputElement).value));
+ */
+import { createApp } from "./sdk";
+
+createApp();

--- a/crates/biorouter-mcp/src/agent_drafter/templates/sdk.ts
+++ b/crates/biorouter-mcp/src/agent_drafter/templates/sdk.ts
@@ -1,0 +1,677 @@
+/**
+ * BioRouter App SDK
+ * =================
+ * The runtime every Agent-Drafter-built app uses to talk to a *real* BioRouter
+ * agent. Unlike the old "bridge" mode (which only forwarded a prompt into the
+ * BioRouter chat box), this SDK opens a per-app WebSocket to the BioRouter
+ * backend, which runs the full agent loop — the app's own model, extensions,
+ * skills and knowledge base — and streams the answer (text / markdown / tool
+ * activity) straight back into the app.
+ *
+ * The app is authored in TypeScript and bundled with esbuild; this module is
+ * `import`ed by the app's `main.ts`. It has no external dependencies (markdown
+ * rendering is built in) so a built app is fully self-contained and works when
+ * served by `biorouterd` or opened as a standalone export.
+ */
+
+export interface AppConfig {
+  /** Stable app id (matches the on-disk project + the backend route). */
+  appId: string;
+  /**
+   * Explicit agent WebSocket endpoint. When omitted, it is derived from the
+   * page location: `ws[s]://<host>/apps/<appId>/agent`. Standalone exports set
+   * this to the daemon they bundle/launch.
+   */
+  endpoint?: string;
+  /** Greeting shown when the default chat panel mounts. */
+  greeting?: string;
+  /** Auto-mount a chat panel into `[data-br-chat]` if the app has no custom UI. */
+  autoChat?: boolean;
+}
+
+export interface ImageInput {
+  /** MIME type, e.g. "image/png". */
+  mimeType: string;
+  /** Base64-encoded image bytes (no data-URL prefix). */
+  data: string;
+}
+
+export interface PromptOptions {
+  images?: ImageInput[];
+}
+
+/** Events emitted while the agent answers a prompt. */
+export type AgentEvent =
+  | { type: "ready" }
+  | { type: "message"; delta: string }
+  | { type: "thought"; delta: string }
+  | { type: "tool"; name: string; status: string }
+  | { type: "done" }
+  | { type: "error"; message: string };
+
+type EventKind = AgentEvent["type"];
+type Listener = (ev: AgentEvent) => void;
+
+declare global {
+  interface Window {
+    BIOROUTER_APP_CONFIG?: AppConfig;
+    BioRouter?: BioRouterClient;
+  }
+}
+
+function resolveEndpoint(cfg: AppConfig): string {
+  if (cfg.endpoint) return cfg.endpoint;
+  const loc = window.location;
+  const proto = loc.protocol === "https:" ? "wss:" : "ws:";
+  // Served by biorouterd at /apps/<id>/ — the agent socket is a sibling.
+  return `${proto}//${loc.host}/apps/${cfg.appId}/agent`;
+}
+
+export class BioRouterClient {
+  readonly config: AppConfig;
+  private ws: WebSocket | null = null;
+  private readyPromise: Promise<void> | null = null;
+  private listeners: Record<EventKind, Listener[]> = {
+    ready: [],
+    message: [],
+    thought: [],
+    tool: [],
+    done: [],
+    error: [],
+  };
+  private activeResolve: (() => void) | null = null;
+  private activeReject: ((e: Error) => void) | null = null;
+
+  constructor(config: AppConfig) {
+    this.config = config;
+  }
+
+  /** Register a listener for an agent event. Returns `this` for chaining. */
+  on(kind: EventKind, fn: Listener): this {
+    (this.listeners[kind] ||= []).push(fn);
+    return this;
+  }
+
+  private emit(ev: AgentEvent): void {
+    for (const fn of this.listeners[ev.type] || []) {
+      try {
+        fn(ev);
+      } catch {
+        /* listener errors are non-fatal */
+      }
+    }
+  }
+
+  /** Open (or reuse) the WebSocket to the BioRouter agent backend. */
+  connect(): Promise<void> {
+    if (this.readyPromise) return this.readyPromise;
+    this.readyPromise = new Promise((resolve, reject) => {
+      let opened = false;
+      try {
+        this.ws = new WebSocket(resolveEndpoint(this.config));
+      } catch (e) {
+        reject(e as Error);
+        return;
+      }
+      this.ws.onopen = () => {
+        opened = true;
+        resolve();
+      };
+      this.ws.onerror = (e) => {
+        if (!opened) reject(new Error("Could not reach the BioRouter backend."));
+        this.emit({ type: "error", message: "connection error" });
+        this.settleActive(new Error("connection error"));
+      };
+      this.ws.onclose = () => {
+        this.readyPromise = null;
+        this.ws = null;
+        this.settleActive(new Error("connection closed"));
+      };
+      this.ws.onmessage = (ev) => this.handleFrame(ev.data);
+    });
+    return this.readyPromise;
+  }
+
+  private settleActive(err?: Error): void {
+    if (err && this.activeReject) {
+      const rej = this.activeReject;
+      this.activeResolve = null;
+      this.activeReject = null;
+      rej(err);
+    } else if (!err && this.activeResolve) {
+      const res = this.activeResolve;
+      this.activeResolve = null;
+      this.activeReject = null;
+      res();
+    }
+  }
+
+  private handleFrame(raw: string): void {
+    let msg: AgentEvent;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    this.emit(msg);
+    if (msg.type === "done") this.settleActive();
+    else if (msg.type === "error") this.settleActive(new Error(msg.message));
+  }
+
+  /**
+   * Send a prompt to the agent. Resolves when the agent finishes its turn
+   * (`done`); reject on error. Streamed output arrives via `on("message", …)`.
+   */
+  async prompt(text: string, opts: PromptOptions = {}): Promise<void> {
+    await this.connect();
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Not connected to the BioRouter backend.");
+    }
+    return new Promise<void>((resolve, reject) => {
+      this.activeResolve = resolve;
+      this.activeReject = reject;
+      this.ws!.send(
+        JSON.stringify({ type: "prompt", text, images: opts.images || [] })
+      );
+    });
+  }
+
+  /** Ask the agent to stop the current turn. */
+  cancel(): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({ type: "cancel" }));
+    }
+  }
+
+  /** Remove a previously-registered listener. */
+  off(kind: EventKind, fn: Listener): this {
+    const arr = this.listeners[kind];
+    if (arr) {
+      const i = arr.indexOf(fn);
+      if (i >= 0) arr.splice(i, 1);
+    }
+    return this;
+  }
+
+  /** Convenience: collect the full reply for one prompt as a single string. */
+  async ask(text: string, opts: PromptOptions = {}): Promise<string> {
+    let buf = "";
+    const onMsg: Listener = (ev) => {
+      if (ev.type === "message") buf += ev.delta;
+    };
+    this.on("message", onMsg);
+    try {
+      await this.prompt(text, opts);
+    } finally {
+      this.off("message", onMsg);
+    }
+    return buf;
+  }
+
+  /**
+   * The primary helper for custom UIs: send `text` and stream the agent's
+   * markdown (and ```chart blocks / tables) into `target` (an element or CSS
+   * selector), showing a spinner and tool activity. Returns the full reply.
+   * Wire any control to this — e.g. slider/select `change`, button `click`.
+   *
+   * Runs are serialized: if a call is still streaming when another starts, the
+   * new one waits for it, so rapid control changes never overlap or garble the
+   * output (and no request is orphaned).
+   */
+  run(
+    text: string,
+    target: HTMLElement | string,
+    opts: PromptOptions = {}
+  ): Promise<string> {
+    const next = this.runChain.then(() => this.doRun(text, target, opts));
+    this.runChain = next.then(
+      () => undefined,
+      () => undefined
+    );
+    return next;
+  }
+
+  private runChain: Promise<void> = Promise.resolve();
+
+  private async doRun(
+    text: string,
+    target: HTMLElement | string,
+    opts: PromptOptions = {}
+  ): Promise<string> {
+    const el =
+      typeof target === "string"
+        ? document.querySelector<HTMLElement>(target)
+        : target;
+    if (!el) throw new Error("run(): target element not found");
+    let buf = "";
+    el.innerHTML = '<span class="br-spinner"></span>';
+    const onMsg: Listener = (ev) => {
+      if (ev.type === "message") {
+        buf += ev.delta;
+        el.innerHTML = this.renderMarkdown(buf);
+      }
+    };
+    const onTool: Listener = (ev) => {
+      if (ev.type === "tool" && !buf) {
+        el.innerHTML = `<span class="br-spinner"></span> <span class="br-msg--tool">⚙ ${ev.name}…</span>`;
+      }
+    };
+    this.on("message", onMsg);
+    this.on("tool", onTool);
+    try {
+      await this.prompt(text, opts);
+      if (!buf) el.innerHTML = "";
+    } catch (e) {
+      el.innerHTML = `<div class="br-msg br-msg--agent">⚠ ${(e as Error).message || "request failed"}</div>`;
+      throw e;
+    } finally {
+      this.off("message", onMsg);
+      this.off("tool", onTool);
+    }
+    return buf;
+  }
+
+  /** Minimal, dependency-free markdown → HTML (safe-escaped). */
+  renderMarkdown(md: string): string {
+    return renderMarkdown(md);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering (compact, no external deps, HTML-escaped first).
+// ---------------------------------------------------------------------------
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function inline(s: string): string {
+  // links, bold, italic, inline code — operating on already-escaped text.
+  return s
+    .replace(/`([^`]+)`/g, (_m, c) => `<code>${c}</code>`)
+    .replace(
+      /\[([^\]]+)\]\((https?:[^)]+)\)/g,
+      (_m, t, u) => `<a href="${u}" target="_blank" rel="noopener">${t}</a>`
+    )
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/(^|[^*])\*([^*]+)\*/g, "$1<em>$2</em>");
+}
+
+interface ChartPoint {
+  label: string;
+  value: number;
+}
+interface ChartSpec {
+  type?: "bar" | "line";
+  title?: string;
+  data: ChartPoint[];
+}
+
+/**
+ * Render an AI-generated chart from a ```chart JSON block into dependency-free
+ * SVG, themed with BioRouter tokens. Supports "bar" (default) and "line".
+ * Returns a quiet placeholder on malformed/partial JSON (streaming-safe).
+ */
+export function renderChart(json: string): string {
+  let spec: ChartSpec;
+  try {
+    spec = JSON.parse(json);
+  } catch {
+    return '<div class="br-chart br-chart--pending"></div>';
+  }
+  const data = Array.isArray(spec?.data) ? spec.data.filter((d) => d && isFinite(d.value)) : [];
+  if (!data.length) return '<div class="br-chart br-chart--pending"></div>';
+  const W = 520;
+  const H = 240;
+  const padL = 44;
+  const padB = 48;
+  const padT = spec.title ? 28 : 12;
+  const max = Math.max(...data.map((d) => d.value), 0);
+  const min = Math.min(...data.map((d) => d.value), 0);
+  const span = max - min || 1;
+  const plotW = W - padL - 12;
+  const plotH = H - padT - padB;
+  const x = (i: number) => padL + (plotW * (i + 0.5)) / data.length;
+  const y = (v: number) => padT + plotH * (1 - (v - min) / span);
+  const esc = (s: string) => escapeHtml(String(s));
+  const palette = [
+    "var(--br-coral)",
+    "var(--br-accent)",
+    "var(--br-n400)",
+    "var(--br-green)",
+    "var(--br-n500)",
+    "var(--br-n300)",
+  ];
+  const title = spec.title
+    ? `<text x="${W / 2}" y="18" font-size="12" font-weight="600" text-anchor="middle" fill="var(--br-text)">${esc(
+        spec.title
+      )}</text>`
+    : "";
+  const svg = (inner: string) =>
+    `<div class="br-chart"><svg viewBox="0 0 ${W} ${H}" width="100%" preserveAspectRatio="xMidYMid meet" role="img">${title}${inner}</svg></div>`;
+
+  // Pie chart: slices + legend, no axes.
+  if (spec.type === "pie") {
+    const total = data.reduce((s, d) => s + Math.max(d.value, 0), 0) || 1;
+    const cx = 130;
+    const cy = padT + (H - padT - 12) / 2;
+    const r = Math.min(cy - padT, 84);
+    let a0 = -Math.PI / 2;
+    let slices = "";
+    data.forEach((d, i) => {
+      const frac = Math.max(d.value, 0) / total;
+      const a1 = a0 + frac * 2 * Math.PI;
+      const large = frac > 0.5 ? 1 : 0;
+      const x0 = cx + r * Math.cos(a0);
+      const y0 = cy + r * Math.sin(a0);
+      const x1 = cx + r * Math.cos(a1);
+      const y1 = cy + r * Math.sin(a1);
+      slices +=
+        frac >= 0.999
+          ? `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${palette[i % palette.length]}"/>`
+          : `<path d="M${cx},${cy} L${x0.toFixed(1)},${y0.toFixed(1)} A${r},${r} 0 ${large} 1 ${x1.toFixed(
+              1
+            )},${y1.toFixed(1)} Z" fill="${palette[i % palette.length]}" stroke="var(--br-surface)" stroke-width="1"/>`;
+      a0 = a1;
+    });
+    const legend = data
+      .map((d, i) => {
+        const pct = Math.round((Math.max(d.value, 0) / total) * 100);
+        return `<g transform="translate(${cx + r + 28},${padT + 6 + i * 18})"><rect width="11" height="11" rx="2" fill="${
+          palette[i % palette.length]
+        }"/><text x="16" y="10" font-size="11" fill="var(--br-text)">${esc(d.label).slice(
+          0,
+          20
+        )} (${pct}%)</text></g>`;
+      })
+      .join("");
+    return svg(slices + legend);
+  }
+
+  let body = "";
+  if (spec.type === "line") {
+    const pts = data.map((d, i) => `${x(i).toFixed(1)},${y(d.value).toFixed(1)}`).join(" ");
+    body += `<polyline fill="none" stroke="var(--br-coral)" stroke-width="2.5" points="${pts}"/>`;
+    body += data
+      .map((d, i) => `<circle cx="${x(i).toFixed(1)}" cy="${y(d.value).toFixed(1)}" r="3" fill="var(--br-accent)"/>`)
+      .join("");
+  } else {
+    const bw = Math.min((plotW / data.length) * 0.62, 56);
+    body += data
+      .map((d, i) => {
+        const bx = x(i) - bw / 2;
+        const by = y(Math.max(d.value, 0));
+        const bh = Math.abs(y(d.value) - y(0));
+        return `<rect x="${bx.toFixed(1)}" y="${by.toFixed(1)}" width="${bw.toFixed(
+          1
+        )}" height="${bh.toFixed(1)}" rx="3" fill="${palette[i % palette.length]}"/>`;
+      })
+      .join("");
+  }
+  // x labels (truncated, centered) + baseline + y-max tick.
+  const labels = data
+    .map(
+      (d, i) =>
+        `<text x="${x(i).toFixed(1)}" y="${H - padB + 16}" font-size="10" text-anchor="middle" fill="var(--br-text-muted)">${esc(
+          d.label
+        ).slice(0, 10)}</text>`
+    )
+    .join("");
+  const axis = `<line x1="${padL}" y1="${y(0).toFixed(1)}" x2="${W - 12}" y2="${y(0).toFixed(
+    1
+  )}" stroke="var(--br-border)"/>`;
+  const yMax = `<text x="${padL - 6}" y="${(y(max) + 4).toFixed(
+    1
+  )}" font-size="10" text-anchor="end" fill="var(--br-text-muted)">${esc(String(max))}</text>`;
+  return svg(axis + body + labels + yMax);
+}
+
+export function renderMarkdown(md: string): string {
+  const src = escapeHtml(md || "");
+  const lines = src.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  let inList = false;
+  let inOrdered = false;
+  const closeList = () => {
+    if (inList) {
+      out.push(inOrdered ? "</ol>" : "</ul>");
+      inList = false;
+      inOrdered = false;
+    }
+  };
+  while (i < lines.length) {
+    const line = lines[i];
+    // fenced code block
+    const fence = line.match(/^```(\w*)\s*$/);
+    if (fence) {
+      closeList();
+      const code: string[] = [];
+      i++;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        code.push(lines[i]);
+        i++;
+      }
+      i++; // skip closing fence
+      // A ```chart block is an AI-generated visualization: render it as SVG.
+      if (fence[1] === "chart") {
+        out.push(renderChart(code.join("\n")));
+      } else {
+        out.push(`<pre><code>${code.join("\n")}</code></pre>`);
+      }
+      continue;
+    }
+    const heading = line.match(/^(#{1,4})\s+(.*)$/);
+    if (heading) {
+      closeList();
+      const level = heading[1].length;
+      out.push(`<h${level}>${inline(heading[2])}</h${level}>`);
+      i++;
+      continue;
+    }
+    // GFM table: a header row, a separator row (---|:--:), then body rows.
+    if (
+      /^\s*\|.*\|\s*$/.test(line) &&
+      i + 1 < lines.length &&
+      /^\s*\|?[\s:|-]+\|[\s:|-]*$/.test(lines[i + 1]) &&
+      lines[i + 1].includes("-")
+    ) {
+      closeList();
+      const cells = (row: string) =>
+        row
+          .trim()
+          .replace(/^\||\|$/g, "")
+          .split("|")
+          .map((c) => c.trim());
+      const header = cells(line);
+      i += 2; // skip header + separator
+      const body: string[][] = [];
+      while (i < lines.length && /^\s*\|.*\|\s*$/.test(lines[i])) {
+        body.push(cells(lines[i]));
+        i++;
+      }
+      let t = "<table><thead><tr>";
+      t += header.map((h) => `<th>${inline(h)}</th>`).join("");
+      t += "</tr></thead><tbody>";
+      for (const r of body) {
+        t += "<tr>" + r.map((c) => `<td>${inline(c)}</td>`).join("") + "</tr>";
+      }
+      t += "</tbody></table>";
+      out.push(t);
+      continue;
+    }
+    const ul = line.match(/^\s*[-*]\s+(.*)$/);
+    const ol = line.match(/^\s*\d+\.\s+(.*)$/);
+    if (ul || ol) {
+      const ordered = !!ol;
+      if (!inList || inOrdered !== ordered) {
+        closeList();
+        out.push(ordered ? "<ol>" : "<ul>");
+        inList = true;
+        inOrdered = ordered;
+      }
+      out.push(`<li>${inline((ul || ol)![1])}</li>`);
+      i++;
+      continue;
+    }
+    if (line.trim() === "") {
+      closeList();
+      i++;
+      continue;
+    }
+    closeList();
+    // accumulate a paragraph
+    const para: string[] = [line];
+    i++;
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !/^(#{1,4})\s|^\s*[-*]\s|^\s*\d+\.\s|^```|^\s*\|.*\|\s*$/.test(lines[i])
+    ) {
+      para.push(lines[i]);
+      i++;
+    }
+    out.push(`<p>${inline(para.join(" "))}</p>`);
+  }
+  closeList();
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Default chat panel (used when the app doesn't build its own UI).
+// ---------------------------------------------------------------------------
+
+/** File → base64 ImageInput (strips the data-URL prefix). */
+export function fileToImageInput(file: File): Promise<ImageInput> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result || "");
+      const comma = result.indexOf(",");
+      resolve({ mimeType: file.type || "image/png", data: result.slice(comma + 1) });
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+export function mountChat(client: BioRouterClient, host: HTMLElement): void {
+  host.classList.add("br-chat");
+  const log = document.createElement("div");
+  log.className = "br-chat__log";
+  const form = document.createElement("div");
+  form.className = "br-chat__form";
+  const input = document.createElement("input");
+  input.className = "br-input";
+  input.placeholder = "Ask the agent…";
+  const send = document.createElement("button");
+  send.className = "br-btn";
+  send.type = "button";
+  send.textContent = "Send";
+  form.appendChild(input);
+  form.appendChild(send);
+  host.appendChild(log);
+  host.appendChild(form);
+
+  const add = (cls: string, html: boolean, content: string): HTMLElement => {
+    const el = document.createElement("div");
+    el.className = "br-msg br-msg--" + cls;
+    if (html) el.innerHTML = content;
+    else el.textContent = content;
+    log.appendChild(el);
+    log.scrollTop = log.scrollHeight;
+    return el;
+  };
+  if (client.config.greeting) add("agent", false, client.config.greeting);
+
+  let current: HTMLElement | null = null;
+  let buffer = "";
+  let typing: HTMLElement | null = null;
+  const clearTyping = () => {
+    if (typing) {
+      typing.remove();
+      typing = null;
+    }
+  };
+  const showTyping = () => {
+    clearTyping();
+    typing = document.createElement("div");
+    typing.className = "br-msg br-msg--agent";
+    typing.innerHTML =
+      '<span class="br-typing"><span></span><span></span><span></span></span>';
+    log.appendChild(typing);
+    log.scrollTop = log.scrollHeight;
+  };
+
+  client.on("message", (ev) => {
+    if (ev.type !== "message") return;
+    clearTyping();
+    if (!current) {
+      current = add("agent", true, "");
+      buffer = "";
+    }
+    buffer += ev.delta;
+    current.innerHTML = client.renderMarkdown(buffer);
+    log.scrollTop = log.scrollHeight;
+  });
+  client.on("tool", (ev) => {
+    if (ev.type === "tool") add("tool", false, "⚙ " + ev.name + " (" + ev.status + ")");
+  });
+  client.on("error", () => {
+    clearTyping();
+    add("agent", false, "⚠ Could not reach the agent.");
+  });
+
+  const submit = async () => {
+    const text = input.value.trim();
+    if (!text) return;
+    add("user", false, text);
+    input.value = "";
+    current = null;
+    showTyping();
+    try {
+      await client.prompt(text);
+    } catch {
+      clearTyping();
+      add("agent", false, "⚠ Failed to get a response.");
+    }
+  };
+  send.addEventListener("click", submit);
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  });
+}
+
+/**
+ * Create (and globally register) the app client from
+ * `window.BIOROUTER_APP_CONFIG`. Auto-mounts a chat panel when requested.
+ */
+export function createApp(overrides: Partial<AppConfig> = {}): BioRouterClient {
+  const cfg: AppConfig = {
+    appId: "app",
+    autoChat: true,
+    ...(window.BIOROUTER_APP_CONFIG || {}),
+    ...overrides,
+  };
+  const client = new BioRouterClient(cfg);
+  window.BioRouter = client;
+  if (cfg.autoChat) {
+    const mount = () => {
+      const host = document.querySelector<HTMLElement>("[data-br-chat]");
+      if (host && !host.dataset.brMounted) {
+        host.dataset.brMounted = "1";
+        mountChat(client, host);
+      }
+    };
+    if (document.readyState === "loading")
+      document.addEventListener("DOMContentLoaded", mount);
+    else mount();
+  }
+  return client;
+}

--- a/crates/biorouter-mcp/src/agent_drafter/templates/theme.css
+++ b/crates/biorouter-mcp/src/agent_drafter/templates/theme.css
@@ -165,6 +165,88 @@ code, kbd {
 .br-row { display: flex; gap: 10px; flex-wrap: wrap; }
 .br-row > * { flex: 1; min-width: 120px; }
 
+/* Grid layout helper (responsive auto-fit) */
+.br-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.br-grid--2 { grid-template-columns: repeat(2, 1fr); }
+.br-grid--3 { grid-template-columns: repeat(3, 1fr); }
+
+/* Select / dropdown */
+.br-select {
+  width: 100%; height: 36px; font: inherit; font-size: 0.9375rem;
+  color: var(--br-text); background: var(--br-bg);
+  border: none; border-radius: var(--br-radius-ctl); padding: 0 32px 0 12px;
+  box-shadow: inset 0 0 0 1px var(--br-border);
+  appearance: none; cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%237a736c' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 10px center;
+  transition: box-shadow 0.12s ease, background-color 0.12s ease;
+}
+.br-select:hover { background-color: var(--br-muted); }
+.br-select:focus { outline: none; box-shadow: inset 0 0 0 2px var(--br-n300); }
+
+/* Range slider */
+.br-slider { width: 100%; -webkit-appearance: none; appearance: none; height: 4px; border-radius: 999px; background: var(--br-strong); outline: none; }
+.br-slider::-webkit-slider-thumb { -webkit-appearance: none; appearance: none; width: 16px; height: 16px; border-radius: 50%; background: var(--br-accent); cursor: pointer; border: 2px solid var(--br-surface); box-shadow: var(--br-shadow); transition: transform 0.05s ease; }
+.br-slider::-webkit-slider-thumb:hover { transform: scale(1.12); }
+.br-slider::-moz-range-thumb { width: 16px; height: 16px; border-radius: 50%; background: var(--br-accent); cursor: pointer; border: 2px solid var(--br-surface); }
+.br-slider-val { font-family: var(--br-mono); font-size: 0.8125rem; color: var(--br-text-muted); }
+
+/* Toggle / switch */
+.br-switch { position: relative; display: inline-flex; align-items: center; cursor: pointer; gap: 8px; }
+.br-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+.br-switch__track { width: 38px; height: 22px; border-radius: 999px; background: var(--br-strong); transition: background 0.15s ease; flex: none; }
+.br-switch__track::after { content: ""; display: block; width: 18px; height: 18px; margin: 2px; border-radius: 50%; background: var(--br-surface); box-shadow: var(--br-shadow); transition: transform 0.15s ease; }
+.br-switch input:checked + .br-switch__track { background: var(--br-accent); }
+.br-switch input:checked + .br-switch__track::after { transform: translateX(16px); }
+
+/* Checkbox / radio (native, accent-tinted) */
+.br-check { display: inline-flex; align-items: center; gap: 8px; cursor: pointer; font-size: 0.9rem; }
+.br-check input { accent-color: var(--br-accent); width: 16px; height: 16px; }
+
+/* Chips (selectable tags) */
+.br-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.br-chip {
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer; user-select: none;
+  font-size: 0.8125rem; padding: 5px 12px; border-radius: 999px;
+  background: var(--br-medium); color: var(--br-text); border: 1px solid transparent;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.br-chip:hover { background: var(--br-strong); }
+.br-chip[aria-pressed="true"], .br-chip.is-active { background: var(--br-accent); color: var(--br-on-accent); }
+
+/* Tabs */
+.br-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--br-border); margin-bottom: 14px; }
+.br-tab { appearance: none; border: none; background: none; cursor: pointer; font: inherit; font-size: 0.875rem; color: var(--br-text-muted); padding: 8px 12px; border-bottom: 2px solid transparent; transition: color 0.12s ease, border-color 0.12s ease; }
+.br-tab:hover { color: var(--br-text); }
+.br-tab.is-active { color: var(--br-text); border-bottom-color: var(--br-accent); font-weight: 600; }
+
+/* Drop zone (drag & drop) */
+.br-dropzone {
+  border: 2px dashed var(--br-border-subtle); border-radius: var(--br-radius);
+  padding: 28px; text-align: center; color: var(--br-text-muted);
+  background: var(--br-muted); transition: border-color 0.15s ease, background 0.15s ease; cursor: pointer;
+}
+.br-dropzone.is-over { border-color: var(--br-coral); background: var(--br-medium); color: var(--br-text); }
+
+/* Draggable list items (reorder) */
+.br-draglist { display: flex; flex-direction: column; gap: 6px; }
+.br-dragitem { display: flex; align-items: center; gap: 10px; padding: 9px 12px; background: var(--br-surface); border: 1px solid var(--br-border); border-radius: var(--br-radius-ctl); cursor: grab; transition: box-shadow 0.12s ease, transform 0.05s ease; }
+.br-dragitem:hover { box-shadow: var(--br-shadow); }
+.br-dragitem.is-dragging { opacity: 0.5; }
+.br-dragitem::before { content: "⋮⋮"; color: var(--br-text-muted); font-size: 0.8rem; letter-spacing: -2px; }
+
+/* Region/map picker (clickable cells; lightweight, no external map lib) */
+.br-mapgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(72px, 1fr)); gap: 6px; }
+.br-region { aspect-ratio: 1 / 0.7; display: flex; align-items: center; justify-content: center; text-align: center; font-size: 0.72rem; padding: 4px; border-radius: var(--br-radius-ctl); background: var(--br-medium); color: var(--br-text); cursor: pointer; transition: background 0.12s ease, transform 0.05s ease; }
+.br-region:hover { background: var(--br-strong); transform: translateY(-1px); }
+.br-region.is-active { background: var(--br-accent); color: var(--br-on-accent); }
+
+/* A surface for streamed results (markdown/charts) */
+.br-output { min-height: 40px; }
+.br-output:empty::before { content: attr(data-placeholder); color: var(--br-text-muted); font-size: 0.875rem; }
+.br-spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--br-border); border-top-color: var(--br-accent); border-radius: 50%; animation: br-spin 0.7s linear infinite; vertical-align: -2px; }
+@keyframes br-spin { to { transform: rotate(360deg); } }
+
 /* Badge — subtle pill */
 .br-badge {
   display: inline-flex;
@@ -186,13 +268,22 @@ code, kbd {
   padding: 9px 13px;
   border-radius: 12px;
   max-width: 88%;
-  white-space: pre-wrap;
   word-wrap: break-word;
+  overflow-wrap: anywhere;   /* long tokens/URLs never bleed out of the bubble */
   font-size: 0.9375rem;
   line-height: 1.5;
 }
-.br-msg--user { align-self: flex-end; background: var(--br-accent); color: var(--br-on-accent); border-bottom-right-radius: 4px; }
-.br-msg--agent { align-self: flex-start; background: var(--br-muted); color: var(--br-text); border: 1px solid var(--br-border); border-bottom-left-radius: 4px; }
+/* User text keeps newlines; agent content is rendered HTML, so normal flow. */
+.br-msg--user { align-self: flex-end; background: var(--br-accent); color: var(--br-on-accent); border-bottom-right-radius: 4px; white-space: pre-wrap; }
+.br-msg--agent { align-self: flex-start; background: var(--br-muted); color: var(--br-text); border: 1px solid var(--br-border); border-bottom-left-radius: 4px; max-width: 94%; min-width: 0; }
+/* Rich content inside agent bubbles must not overflow the bubble/card. */
+.br-msg--agent > :first-child { margin-top: 0; }
+.br-msg--agent > :last-child { margin-bottom: 0; }
+.br-msg--agent pre { max-width: 100%; overflow-x: auto; background: var(--br-medium); padding: 8px 10px; border-radius: 6px; }
+.br-msg--agent table { display: block; width: max-content; max-width: 100%; overflow-x: auto; }
+.br-msg--agent .br-chart { max-width: 100%; }
+.br-msg--agent .br-chart svg { max-width: 100%; height: auto; display: block; }
+.br-msg--agent img { max-width: 100%; height: auto; }
 .br-msg--thought { align-self: flex-start; background: transparent; color: var(--br-text-muted); font-style: italic; font-size: 0.8125rem; padding: 2px 4px; }
 .br-msg--tool { align-self: flex-start; background: transparent; color: var(--br-text-muted); font-family: var(--br-mono); font-size: 0.75rem; padding: 2px 4px; }
 .br-chat__form { display: flex; gap: 8px; align-items: flex-end; }
@@ -206,3 +297,13 @@ code, kbd {
 
 .br-footer { margin-top: 28px; color: var(--br-text-muted); font-size: 0.75rem; }
 hr { border: none; border-top: 1px solid var(--br-border); margin: 20px 0; }
+
+/* Markdown tables rendered by the App SDK */
+table { border-collapse: collapse; width: 100%; margin: 12px 0; font-size: 0.9rem; }
+th, td { border: 1px solid var(--br-border); padding: 6px 10px; text-align: left; }
+thead th { background: var(--br-muted); font-weight: 600; }
+tbody tr:nth-child(even) { background: var(--br-muted); }
+
+/* AI-generated charts rendered by the App SDK (```chart blocks) */
+.br-chart { margin: 12px 0; padding: 8px; background: var(--br-surface); border: 1px solid var(--br-border); border-radius: var(--br-radius); }
+.br-chart--pending { min-height: 40px; border-style: dashed; }

--- a/crates/biorouter-mcp/tests/agent_drafter_registered.rs
+++ b/crates/biorouter-mcp/tests/agent_drafter_registered.rs
@@ -3,7 +3,7 @@
 //! (the same duplex path `extension_manager` uses to spawn builtins).
 
 use biorouter_mcp::AgentDrafterServer;
-use rmcp::model::{CallToolRequestParam, RawContent};
+use rmcp::model::{CallToolRequestParams, RawContent};
 use rmcp::ServiceExt;
 use tempfile::TempDir;
 
@@ -34,14 +34,17 @@ async fn agent_drafter_serves_tools_over_mcp() {
     let tools = client.list_all_tools().await.unwrap();
     let names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
     for expected in [
-        "create_artifact",
-        "update_artifact",
-        "list_artifacts",
-        "read_artifact",
-        "preview_artifact",
-        "add_agent_capability",
-        "export_artifact",
-        "delete_artifact",
+        "create_app",
+        "configure_app",
+        "update_app",
+        "build_app",
+        "lint_app",
+        "launch_app",
+        "list_apps",
+        "read_app",
+        "preview_app",
+        "export_app",
+        "delete_app",
     ] {
         assert!(
             names.iter().any(|n| n == expected),
@@ -49,32 +52,25 @@ async fn agent_drafter_serves_tools_over_mcp() {
         );
     }
 
-    // create_artifact runs end-to-end and returns a ui:// preview resource.
+    // create_app runs end-to-end and returns a ui:// preview resource.
     let mut args = serde_json::Map::new();
     args.insert("title".into(), serde_json::json!("Live Test"));
     args.insert("kind".into(), serde_json::json!("agentic"));
     let res = client
-        .call_tool(CallToolRequestParam {
+        .call_tool(CallToolRequestParams {
             task: None,
-            name: "create_artifact".into(),
+            name: "create_app".into(),
             arguments: Some(args),
             meta: None,
         })
         .await
         .unwrap();
-    assert_ne!(
-        res.is_error,
-        Some(true),
-        "create_artifact returned an error"
-    );
+    assert_ne!(res.is_error, Some(true), "create_app returned an error");
     let has_resource = res
         .content
         .iter()
         .any(|c| matches!(&c.raw, RawContent::Resource(_)));
-    assert!(
-        has_resource,
-        "create_artifact should return a ui:// resource"
-    );
+    assert!(has_resource, "create_app should return a ui:// resource");
 
     // It actually persisted to the temp store.
     assert!(tmp.path().join("live-test/manifest.json").exists());

--- a/crates/biorouter-server/src/auth.rs
+++ b/crates/biorouter-server/src/auth.rs
@@ -39,9 +39,17 @@ pub async fn check_token(
     request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    if request.uri().path() == "/status"
-        || request.uri().path() == "/mcp-ui-proxy"
-        || request.uri().path() == "/mcp-app-proxy"
+    let path = request.uri().path();
+    if path == "/status" || path == "/mcp-ui-proxy" || path == "/mcp-app-proxy" {
+        return Ok(next.run(request).await);
+    }
+    // BioRouter apps are opened directly in the browser (and connect a WebSocket),
+    // so they can't send the secret-key header. Allow browser-facing GET reads
+    // under /apps (serving the bundle + the per-app agent socket); management
+    // verbs (POST/DELETE) still require the secret. The daemon binds localhost
+    // only, matching the unauthenticated MCP UI proxy.
+    if request.method() == axum::http::Method::GET
+        && (path == "/apps" || path.starts_with("/apps/"))
     {
         return Ok(next.run(request).await);
     }

--- a/crates/biorouter-server/src/commands/agent.rs
+++ b/crates/biorouter-server/src/commands/agent.rs
@@ -61,7 +61,14 @@ pub async fn run() -> Result<()> {
         .layer(cors);
 
     let listener = tokio::net::TcpListener::bind(settings.socket_addr()).await?;
-    info!("listening on {}", listener.local_addr()?);
+    let local_addr = listener.local_addr()?;
+    info!("listening on {}", local_addr);
+    // Publish the base URL so in-process MCP tools (e.g. Agent Drafter's
+    // `launch_app`) can emit absolute http://host:port/apps/<id>/ URLs.
+    std::env::set_var(
+        "BIOROUTER_APP_BASE_URL",
+        format!("http://{local_addr}"),
+    );
 
     let tunnel_manager = app_state.tunnel_manager.clone();
     tokio::spawn(async move {

--- a/crates/biorouter-server/src/routes/apps.rs
+++ b/crates/biorouter-server/src/routes/apps.rs
@@ -1,0 +1,491 @@
+//! HTTP + WebSocket routes for **BioRouter apps** (built by Agent Drafter).
+//!
+//! `biorouterd` serves each app's static bundle and exposes a per-app WebSocket
+//! that runs the *real* agent loop configured with that app's model, extensions,
+//! skills and knowledge base. Browser-facing GET routes are exempt from the
+//! secret-key middleware (see `auth::check_token`) since a browser tab can't send
+//! the header — the daemon binds to localhost only, like the MCP UI proxy.
+//!
+//! Routes:
+//!   GET    /apps                      → list app manifests (JSON)
+//!   GET    /apps/{id}                 → redirect to /apps/{id}/
+//!   GET    /apps/{id}/                → assembled index.html
+//!   GET    /apps/{id}/dist/{*path}    → built bundle files
+//!   GET    /apps/{id}/assets/{*path}  → static assets
+//!   GET    /apps/{id}/agent           → per-app agent WebSocket
+//!   POST   /apps/{id}/build           → (re)bundle the TypeScript (secret-key)
+//!   DELETE /apps/{id}                 → delete the app (secret-key)
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{
+        ws::{Message as WsMessage, WebSocket, WebSocketUpgrade},
+        Path, State,
+    },
+    http::{header, StatusCode},
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use futures::StreamExt;
+use serde::Deserialize;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use biorouter::agents::extension::PLATFORM_EXTENSIONS;
+use biorouter::agents::{AgentEvent, ExtensionConfig, SessionConfig};
+use biorouter::conversation::message::{Message, MessageContent};
+use biorouter::model::ModelConfig;
+use biorouter::providers::create as create_provider;
+use biorouter::session::SessionType;
+use biorouter_mcp::agent_drafter::store::{ArtifactKind, ArtifactStore, Manifest};
+use biorouter_mcp::agent_drafter::{bundle, default_root, export_scaffold};
+
+use crate::state::AppState;
+
+/// Safe default bound on an app agent's tool-calling loop per user message.
+/// Workflow-style apps can raise this via `agent.max_turns` in the manifest.
+const DEFAULT_MAX_TURNS: u32 = 24;
+
+fn store() -> ArtifactStore {
+    ArtifactStore::new(default_root())
+}
+
+fn mime_for(path: &str) -> &'static str {
+    match path.rsplit('.').next().unwrap_or("") {
+        "html" => "text/html; charset=utf-8",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        "json" => "application/json",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "ico" => "image/x-icon",
+        "woff2" => "font/woff2",
+        "woff" => "font/woff",
+        "wasm" => "application/wasm",
+        _ => "application/octet-stream",
+    }
+}
+
+/// GET /apps — list all app manifests.
+async fn list_apps() -> Json<Vec<Manifest>> {
+    Json(store().list())
+}
+
+/// GET /apps/{id} — redirect to the trailing-slash form so relative URLs resolve.
+async fn redirect_to_slash(Path(id): Path<String>) -> Redirect {
+    Redirect::temporary(&format!("/apps/{id}/"))
+}
+
+/// GET /apps/{id}/ — the assembled, served index.html.
+async fn serve_index(Path(id): Path<String>) -> Response {
+    let st = store();
+    let manifest = match st.load_manifest(&id) {
+        Ok(m) => m,
+        Err(_) => return (StatusCode::NOT_FOUND, "no such app").into_response(),
+    };
+    // Ensure a bundle exists for agentic apps (build on demand).
+    if manifest.kind == ArtifactKind::Agentic && !st.file_exists(&id, "dist/app.js") {
+        let dir = st.artifact_dir(&id);
+        if let Ok(report) = tokio::task::spawn_blocking(move || bundle::build_app(&dir)).await {
+            if let Ok(r) = report {
+                if !r.ok {
+                    warn!(app = %id, "on-demand build failed: {}", r.log);
+                }
+            }
+        }
+    }
+    let entry_html = match st.read_file(&id, &manifest.entry) {
+        Ok(h) => h,
+        Err(_) => return (StatusCode::NOT_FOUND, "entry missing").into_response(),
+    };
+    let base_href = format!("/apps/{id}/");
+    let html = biorouter_mcp::agent_drafter::render::assemble_app(
+        &manifest,
+        &entry_html,
+        Some(&base_href),
+        None,
+    );
+    ([(header::CONTENT_TYPE, "text/html; charset=utf-8")], html).into_response()
+}
+
+/// GET /apps/{id}/dist/{*path} and /apps/{id}/assets/{*path} — serve a file.
+async fn serve_file(Path((id, sub)): Path<(String, String)>, prefix: &str) -> Response {
+    let rel = format!("{prefix}/{sub}");
+    match store().read_bytes(&id, &rel) {
+        Ok(bytes) => ([(header::CONTENT_TYPE, mime_for(&rel))], bytes).into_response(),
+        Err(_) => (StatusCode::NOT_FOUND, "not found").into_response(),
+    }
+}
+
+async fn serve_dist(path: Path<(String, String)>) -> Response {
+    serve_file(path, "dist").await
+}
+
+async fn serve_assets(path: Path<(String, String)>) -> Response {
+    serve_file(path, "assets").await
+}
+
+/// POST /apps/{id}/build — (re)bundle the TypeScript.
+async fn build_app_route(Path(id): Path<String>) -> Response {
+    let st = store();
+    if !st.exists(&id) {
+        return (StatusCode::NOT_FOUND, "no such app").into_response();
+    }
+    let dir = st.artifact_dir(&id);
+    match tokio::task::spawn_blocking(move || bundle::build_app(&dir)).await {
+        Ok(Ok(report)) => {
+            if report.ok {
+                if let Ok(mut m) = st.load_manifest(&id) {
+                    m.built_at = Some(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0),
+                    );
+                    let _ = st.save_manifest(&m);
+                }
+            }
+            Json(json!({ "ok": report.ok, "used": report.used, "log": report.log }))
+                .into_response()
+        }
+        _ => (StatusCode::INTERNAL_SERVER_ERROR, "build error").into_response(),
+    }
+}
+
+/// GET /apps/{id}/export — return the standalone export scaffold as a JSON file
+/// map ({ files: { "<path>": "<content>" } }). The caller writes the files,
+/// `npm run build`, `npm start`, and runs a `biorouterd` for the agent backend.
+async fn export_app_route(Path(id): Path<String>) -> Response {
+    // export_scaffold may run esbuild (blocking) when a bundle is stale, so do
+    // it off the async runtime to keep the server responsive under load.
+    let id2 = id.clone();
+    let result =
+        tokio::task::spawn_blocking(move || export_scaffold(&default_root(), &id2, None)).await;
+    match result {
+        Ok(Ok(files)) => {
+            let map: serde_json::Map<String, serde_json::Value> = files
+                .into_iter()
+                .map(|(p, c)| (p, serde_json::Value::String(c)))
+                .collect();
+            Json(json!({ "id": id, "files": map })).into_response()
+        }
+        _ => (StatusCode::NOT_FOUND, "no such app").into_response(),
+    }
+}
+
+/// DELETE /apps/{id} — delete the app.
+async fn delete_app_route(Path(id): Path<String>) -> Response {
+    let st = store();
+    if !st.exists(&id) {
+        return (StatusCode::NOT_FOUND, "no such app").into_response();
+    }
+    match st.delete(&id) {
+        Ok(_) => Json(json!({ "ok": true })).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// GET /apps/{id}/agent — per-app agent WebSocket.
+async fn agent_ws(
+    Path(id): Path<String>,
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let manifest = match store().load_manifest(&id) {
+        Ok(m) => m,
+        Err(_) => return (StatusCode::NOT_FOUND, "no such app").into_response(),
+    };
+    ws.on_upgrade(move |socket| handle_agent_socket(socket, state, manifest))
+}
+
+#[derive(Deserialize)]
+struct ImageInput {
+    #[serde(rename = "mimeType")]
+    mime_type: String,
+    data: String,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum ClientFrame {
+    Prompt {
+        text: String,
+        #[serde(default)]
+        images: Vec<ImageInput>,
+    },
+    Cancel,
+}
+
+async fn send_json(socket: &mut WebSocket, value: serde_json::Value) -> bool {
+    socket
+        .send(WsMessage::Text(value.to_string().into()))
+        .await
+        .is_ok()
+}
+
+/// Configure a freshly-created session's agent from the app manifest: model,
+/// extensions, skills, knowledge base, and persona. Errors are logged, not fatal
+/// (the agent falls back to the global config where possible).
+async fn configure_agent(
+    agent: &biorouter::agents::Agent,
+    state: &AppState,
+    session_id: &str,
+    manifest: &Manifest,
+) {
+    let Some(cfg) = manifest.agent.as_ref() else {
+        return;
+    };
+
+    // Model / provider. Try the app's configured provider+model; if that can't
+    // be created (e.g. its API key isn't available), fall back to BioRouter's
+    // global provider/model so the agent always has *a* provider — otherwise
+    // `reply` fails with a cryptic "Provider not set".
+    let mut provider_set = false;
+    if let Some(sel) = cfg.model.as_ref() {
+        if let (Some(provider), Some(model)) = (sel.provider.as_ref(), sel.model.as_ref()) {
+            match ModelConfig::new(model) {
+                Ok(mc) => match create_provider(provider, mc).await {
+                    Ok(p) => match agent.update_provider(p, session_id).await {
+                        Ok(()) => provider_set = true,
+                        Err(e) => warn!(app = %manifest.id, "update_provider failed: {e}"),
+                    },
+                    Err(e) => warn!(app = %manifest.id, "create provider {provider} failed: {e}"),
+                },
+                Err(e) => warn!(app = %manifest.id, "bad model config {model}: {e}"),
+            }
+        }
+    }
+    if !provider_set {
+        let global = biorouter::config::Config::global();
+        if let (Ok(provider), Ok(model)) =
+            (global.get_biorouter_provider(), global.get_biorouter_model())
+        {
+            if let Ok(mc) = ModelConfig::new(&model) {
+                match create_provider(&provider, mc).await {
+                    Ok(p) => {
+                        if let Err(e) = agent.update_provider(p, session_id).await {
+                            warn!(app = %manifest.id, "fallback update_provider failed: {e}");
+                        } else {
+                            info!(app = %manifest.id, "using global provider fallback ({provider})");
+                        }
+                    }
+                    Err(e) => warn!(app = %manifest.id, "fallback provider {provider} failed: {e}"),
+                }
+            }
+        }
+    }
+
+    // Extensions (+ knowledge if a KB is set).
+    let mut extensions = cfg.extensions.clone();
+    if cfg.knowledge_base.is_some() && !extensions.iter().any(|e| e == "knowledge") {
+        extensions.push("knowledge".to_string());
+    }
+    if !cfg.skills.is_empty() && !extensions.iter().any(|e| e == "skills") {
+        extensions.push("skills".to_string());
+    }
+    for name in extensions {
+        let config = if PLATFORM_EXTENSIONS.contains_key(name.as_str()) {
+            ExtensionConfig::Platform {
+                name: name.clone(),
+                bundled: None,
+                description: name.clone(),
+                available_tools: Vec::new(),
+            }
+        } else {
+            ExtensionConfig::Builtin {
+                name: name.clone(),
+                display_name: None,
+                timeout: None,
+                bundled: None,
+                description: name.clone(),
+                available_tools: Vec::new(),
+            }
+        };
+        if let Err(e) = agent.add_extension(config).await {
+            warn!(app = %manifest.id, extension = %name, "add_extension failed: {e}");
+        }
+    }
+
+    // Knowledge base scoping.
+    if let Some(kb) = cfg.knowledge_base.as_ref() {
+        if let Err(e) = state
+            .knowledge_service
+            .set_active_for_session(session_id, Some(kb))
+        {
+            warn!(app = %manifest.id, kb = %kb, "set active KB failed: {e}");
+        }
+    }
+
+    // Persona + app context + skill guidance.
+    let mut prompt = String::new();
+    prompt.push_str(&format!(
+        "You are the agent powering the BioRouter app \"{}\".",
+        manifest.title
+    ));
+    if !manifest.description.is_empty() {
+        prompt.push_str(&format!(" {}", manifest.description));
+    }
+    if !cfg.system_prompt.trim().is_empty() {
+        prompt.push_str("\n\n");
+        prompt.push_str(&cfg.system_prompt);
+    }
+    if !cfg.skills.is_empty() {
+        prompt.push_str(&format!(
+            "\n\nWhen relevant, use these skills: {}.",
+            cfg.skills.join(", ")
+        ));
+    }
+    agent.extend_system_prompt(prompt).await;
+}
+
+async fn handle_agent_socket(mut socket: WebSocket, state: Arc<AppState>, manifest: Manifest) {
+    // One session per connection → conversational memory within the app session.
+    let session = match state
+        .session_manager()
+        .create_session(
+            std::env::current_dir().unwrap_or_default(),
+            format!("app:{}", manifest.id),
+            SessionType::User,
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            let _ = send_json(&mut socket, json!({"type":"error","message": format!("session: {e}")})).await;
+            return;
+        }
+    };
+    let session_id = session.id.clone();
+
+    let agent = match state.get_agent(session_id.clone()).await {
+        Ok(a) => a,
+        Err(e) => {
+            let _ = send_json(&mut socket, json!({"type":"error","message": format!("agent: {e}")})).await;
+            return;
+        }
+    };
+
+    configure_agent(&agent, &state, &session_id, &manifest).await;
+    info!(app = %manifest.id, session = %session_id, "app agent session ready");
+    if !send_json(&mut socket, json!({"type":"ready"})).await {
+        return;
+    }
+
+    while let Some(Ok(msg)) = socket.next().await {
+        let text = match msg {
+            WsMessage::Text(t) => t.to_string(),
+            WsMessage::Close(_) => break,
+            _ => continue,
+        };
+        let frame: ClientFrame = match serde_json::from_str(&text) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+        let (prompt_text, images) = match frame {
+            ClientFrame::Prompt { text, images } => (text, images),
+            ClientFrame::Cancel => continue,
+        };
+
+        let mut user = Message::user().with_text(prompt_text);
+        for img in images {
+            user = user.with_image(img.data, img.mime_type);
+        }
+
+        // Bound the agent's tool-calling loop (guardrail against runaway loops;
+        // also the knob workflow-style apps raise to chain more steps). Defaults
+        // to a safe cap when the app doesn't specify one.
+        let max_turns = manifest
+            .agent
+            .as_ref()
+            .and_then(|a| a.max_turns)
+            .unwrap_or(DEFAULT_MAX_TURNS);
+        let session_config = SessionConfig {
+            id: session_id.clone(),
+            schedule_id: None,
+            max_turns: Some(max_turns),
+            retry_config: None,
+        };
+        let cancel = CancellationToken::new();
+        let mut stream = match agent
+            .reply(user, session_config, Some(cancel.clone()))
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = send_json(&mut socket, json!({"type":"error","message": e.to_string()}))
+                    .await;
+                continue;
+            }
+        };
+
+        let mut errored = false;
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(AgentEvent::Message(message)) => {
+                    for content in &message.content {
+                        let frame = match content {
+                            MessageContent::Text(t) => {
+                                Some(json!({"type":"message","delta": t.text}))
+                            }
+                            MessageContent::Thinking(t) => {
+                                Some(json!({"type":"thought","delta": t.thinking}))
+                            }
+                            MessageContent::ToolRequest(tr) => {
+                                let name = tr
+                                    .tool_call
+                                    .as_ref()
+                                    .map(|c| c.name.to_string())
+                                    .unwrap_or_else(|_| "tool".to_string());
+                                Some(json!({"type":"tool","name": name, "status":"pending"}))
+                            }
+                            MessageContent::ToolResponse(resp) => {
+                                let status = match &resp.tool_result {
+                                    Ok(r) if r.is_error == Some(true) => "failed",
+                                    Ok(_) => "completed",
+                                    Err(_) => "failed",
+                                };
+                                Some(json!({"type":"tool","name":"tool","status": status}))
+                            }
+                            _ => None,
+                        };
+                        if let Some(f) = frame {
+                            if !send_json(&mut socket, f).await {
+                                return;
+                            }
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    let _ =
+                        send_json(&mut socket, json!({"type":"error","message": e.to_string()}))
+                            .await;
+                    errored = true;
+                    break;
+                }
+            }
+        }
+        if !errored && !send_json(&mut socket, json!({"type":"done"})).await {
+            return;
+        }
+    }
+}
+
+pub fn routes(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/apps", get(list_apps))
+        .route("/apps/{id}", get(redirect_to_slash).delete(delete_app_route))
+        .route("/apps/{id}/", get(serve_index))
+        .route("/apps/{id}/agent", get(agent_ws))
+        .route("/apps/{id}/build", post(build_app_route))
+        .route("/apps/{id}/export", get(export_app_route))
+        .route("/apps/{id}/dist/{*path}", get(serve_dist))
+        .route("/apps/{id}/assets/{*path}", get(serve_assets))
+        .with_state(state)
+}

--- a/crates/biorouter-server/src/routes/mod.rs
+++ b/crates/biorouter-server/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod action_required;
 pub mod agent;
+pub mod apps;
 pub mod audio;
 pub mod config_management;
 pub mod errors;
@@ -28,6 +29,7 @@ pub fn configure(state: Arc<crate::state::AppState>, secret_key: String) -> Rout
         .merge(reply::routes(state.clone()))
         .merge(action_required::routes(state.clone()))
         .merge(agent::routes(state.clone()))
+        .merge(apps::routes(state.clone()))
         .merge(audio::routes(state.clone()))
         .merge(config_management::routes(state.clone()))
         .merge(workflow::routes(state.clone()))

--- a/docs/agent-drafter-apps.md
+++ b/docs/agent-drafter-apps.md
@@ -1,0 +1,284 @@
+# Agent Drafter → BioRouter Apps (redesign)
+
+Agent Drafter was reworked from "Claude-style artifacts" into a builder for
+**BioRouter apps**: TypeScript front-ends wired to a *real* BioRouter agent
+backend. When a user sends a message in a built app, BioRouter runs the full
+agent loop — the app's own model, extensions, skills, and knowledge base — and
+streams the answer (text / markdown / tool activity) back into the app. Apps are
+*launched in the browser* (GUI auto-opens the default browser; CLI prints a URL),
+not embedded in a chat iframe.
+
+## What changed
+
+| Before | After |
+|---|---|
+| Static/agentic HTML artifacts | TypeScript app projects (esbuild bundle) |
+| `agent.js` "bridge" routed prompts into the chat box (no real reply) | Per-app WebSocket runs the real agent loop and streams the reply |
+| Export = Tauri/Rust project | Export = standalone TypeScript project (esbuild + tiny static server) against a BioRouter daemon |
+| Shown inline in a sandboxed chat iframe | Served by `biorouterd` at `/apps/<id>/`, opened in the browser |
+| No per-artifact model/extension/skill/KB | Manifest carries model (default MiMo), extensions, skills, knowledge base, persona |
+
+## Architecture
+
+- **Store + manifest** — `crates/biorouter-mcp/src/agent_drafter/store.rs`.
+  Each app is a project dir `~/.config/biorouter/agent_drafter/<id>/`:
+  `manifest.json`, `index.html`, `src/main.ts`, `src/sdk.ts`, `dist/app.js`.
+  Manifest `agent` block: `system_prompt`, `greeting`, `model {provider, model}`,
+  `extensions[]`, `skills[]`, `knowledge_base`.
+- **App SDK** — `templates/sdk.ts` (authored in TypeScript, bundled into each app).
+  Opens the per-app WebSocket, streams events, renders markdown (headings, lists,
+  code, links, **GFM tables**), handles multimodal image input, and can auto-mount
+  a chat panel into `[data-br-chat]`.
+- **Bundler** — `bundle.rs`. Locates esbuild (`$BIOROUTER_ESBUILD_BIN` → desktop
+  `node_modules/.bin/esbuild` → PATH → `npx esbuild`); falls back to a vendored
+  type-stripper when esbuild is absent. `src/main.ts` → `dist/app.js` (IIFE).
+- **MCP tools** — `mod.rs`: `create_app`, `configure_app`, `update_app`,
+  `build_app`, `launch_app`, `list_apps`, `read_app`, `preview_app`, `export_app`,
+  `delete_app`, `set_app_size`.
+- **Server routes** — `crates/biorouter-server/src/routes/apps.rs`:
+  - `GET /apps` — list manifests (JSON)
+  - `GET /apps/{id}/` — assembled index.html (theme + base href + bundle)
+  - `GET /apps/{id}/dist|assets/{*path}` — bundle + assets
+  - `GET /apps/{id}/agent` — **per-app agent WebSocket** (creates a session,
+    applies model/extensions/skills/KB/persona, runs `agent.reply`, streams
+    `message`/`thought`/`tool`/`done`/`error` frames)
+  - `POST /apps/{id}/build`, `DELETE /apps/{id}`
+  - Browser-facing GETs under `/apps` are exempt from the secret-key middleware
+    (a browser tab can't send the header); the daemon binds localhost only.
+- **Frontend** — `ui/desktop/src/components/applications/ApplicationsView.tsx` +
+  an "Applications" sidebar entry under Knowledge. Lists built apps; Launch opens
+  the app URL in the default browser via the existing `openExternal` IPC.
+
+## WebSocket protocol (browser ⇄ backend)
+
+Client → server: `{"type":"prompt","text":"…","images":[{"mimeType","data"}]}`,
+`{"type":"cancel"}`.
+Server → client: `{"type":"ready"}`, `{"type":"message","delta"}`,
+`{"type":"thought","delta"}`, `{"type":"tool","name","status"}`,
+`{"type":"done"}`, `{"type":"error","message"}`.
+
+## Verification
+
+- `cargo check -p biorouter-mcp` / `-p biorouter-server` — clean.
+- `cargo test -p biorouter-mcp --lib agent_drafter::` — **28 pass** (store, tools,
+  render, bundler incl. real esbuild bundling).
+- `cargo test -p biorouter-mcp --test agent_drafter_registered` — **2 pass**
+  (builtin registered; tools advertised over a real MCP transport).
+- Live `biorouterd` (debug build, MiMo provider):
+  - `GET /apps` lists apps; `GET /apps/<id>/` serves assembled HTML; on-demand
+    esbuild build produces `dist/app.js` (10 KB IIFE).
+  - **Per-app agent WebSocket streams real MiMo responses** (verified with a
+    direct `ws` probe and Playwright):
+    - `ask-mimo` → "*Drosophila melanogaster* (the fruit fly) is a classic model
+      organism…"
+    - `gene-explainer` (genomics persona) → structured TP53 breakdown
+    - `biostats-helper` (biostats persona) → decision tree + comparison table
+  - Per-app **system prompt** clearly shapes the output; per-app **model** applied.
+
+## Iteration log (bugs found via testing → fixed)
+
+1. **`biorouterd` requires the `agent` subcommand** — operational note; the bare
+   binary prints usage.
+2. **"Provider not set"** — a fresh per-connection session's agent has no provider
+   until `configure_agent` sets one. If the app's provider can't be created (e.g.
+   its API key isn't reachable by the running process), the agent had *no*
+   provider and `reply` failed cryptically. **Fix:** `configure_agent` now falls
+   back to BioRouter's global provider/model when the app-specific provider can't
+   be created (`apps.rs`).
+3. **Markdown tables not rendered** — the SDK's renderer handled headings/lists/
+   code/links but not GFM tables (agents emit them often). **Fix:** added a table
+   parser to `sdk.ts` `renderMarkdown` + table CSS in `theme.css`. Verified the
+   rebuilt bundle emits `<table>`.
+
+## Known limitations / next steps
+
+- **Per-app skill scoping** is advisory (the selected skills are named in the
+  system prompt and the `skills` extension is enabled); BioRouter's skill
+  enable/disable is global, so true per-app skill isolation is a follow-up.
+- **API keys**: a freshly-built `biorouterd` doesn't inherit the GUI binary's
+  macOS Keychain grant; pass provider keys via env or run the signed binary.
+- **Apps bundle their own `src/sdk.ts`** — SDK improvements reach existing apps
+  only after a rebuild (re-copy `sdk.ts` + `build_app`). New apps get the latest.
+- The chat-side preview is a static **card** (apps run in the browser, by design).
+- Older artifact-format apps from the previous design remain in the store but
+  won't serve a working bundle (no `src/main.ts`); recreate them with `create_app`.
+
+## Example apps built by driving MiMo (16)
+
+Each app below was authored end-to-end by the **MiMo model itself** calling the
+Agent Drafter tools (`create_app` → `build_app` → `launch_app`) via
+`biorouter run --with-builtin agent_drafter -t "…"` (see
+`scripts/agent-drafter-apps/round.sh`). All are served by `biorouterd` at
+`/apps/<id>/` and pass the checklist below.
+
+| App | Extensions | What it does |
+|-----|-----------|--------------|
+| spoke-network-explorer | (chart-block) | NL → SPOKE graph relationships + **AI-generated inline charts** |
+| web-research-assistant | computercontroller | Query → web search → sourced markdown answer |
+| pathway-explainer | — | Pathway: overview / steps / genes / regulation |
+| gene-function-explorer | — | Gene → function, pathways, expression, disease |
+| variant-interpreter | — | Variant → functional impact + ACMG-style evidence |
+| clinical-trial-navigator | — | Condition → trial phases, endpoints, criteria |
+| drug-interaction-analyzer | — | Drugs → interactions, mechanism, severity |
+| lab-protocol-generator | — | Experiment → numbered reproducible protocol |
+| literature-summarizer-pro | — | Text → TL;DR / findings / methods / limitations |
+| biostatistics-advisor | — | Study design → recommended test + assumptions table |
+| differential-diagnosis-helper | — | Symptoms → structured DDx (with caveat) |
+| sequence-analysis-toolkit | — | DNA/RNA/protein → GC, ORFs, translation, motifs |
+| cell-type-annotator | — | Marker genes → likely cell type + confidence |
+| enzyme-kinetics-tutor | — | Michaelis–Menten / Km / Vmax, step-by-step |
+| omics-pipeline-advisor | — | Assay description → tools + workflow + QC |
+| medical-term-explainer | — | Term → plain-language + technical definition |
+
+### Per-app checklist (all green)
+
+For every app: `manifest` valid (agentic, model = MiMo, non-empty system prompt) ·
+`GET /apps/<id>/` 200 with theme injected · `GET /apps/<id>/dist/app.js` 200
+(esbuild bundle > 500 B) · per-app agent WebSocket streams a real, non-empty,
+persona-shaped reply · no error frame. Harness:
+`scripts/agent-drafter-apps/round.sh verify` + `ui/desktop/scripts/appcheck/check-app.mjs`.
+
+Round 1: **15/15 pass**. After the chart iteration + SDK propagation + biorouterd
+rebuild: regression re-verify **15/15 pass**.
+
+### Iteration log (drive → find issue → fix Agent Drafter → recompile → re-make)
+
+1. **xargs arg-length** in the batch authoring runner (long personas) → switched
+   to a batched background loop (`round.sh`).
+2. **AI-generated visualizations** (the SPOKE requirement): the SDK rendered no
+   charts. **Fix:** added a `renderChart` (dependency-free SVG bar/line) to
+   `sdk.ts`, wired a ```chart fenced block into `renderMarkdown`, added chart CSS
+   to `theme.css`. Recompiled biorouterd, re-copied `sdk.ts` into all 24 stored
+   apps, rebuilt bundles. Verified: SPOKE renders an SVG bar chart in the browser.
+3. **`autovisualiser` hijacks visualization**: with that extension the agent calls
+   `show_chart` (a `ui://` resource the app WS only surfaces as tool activity) and
+   the tool turn timed out, instead of emitting an inline chart block. **Fix:**
+   the SPOKE app drops `autovisualiser` and uses a chart-block system prompt, so
+   the chart renders inline and the turn finishes promptly. (Lesson: apps wanting
+   app-native inline charts should not also load `autovisualiser`.)
+
+## Scale-up: 22 MiMo-authored apps + export pipeline + workflow loops
+
+A second push added 6 more app *types* (now 22 apps total, all MiMo-authored via
+the tools) and hardened the whole build→export→run pipeline.
+
+New apps: gene-expression-barplot, survival-analysis-explainer,
+epidemiology-trend-explorer, pharmacokinetics-visualizer (line charts),
+variant-consequence-distribution (pie), clinical-calculator.
+
+Full-fleet results (harness: `scripts/agent-drafter-apps/round.sh`,
+`ui/desktop/scripts/appcheck/{check-all,export-all}.mjs`):
+- **CHECKLIST 21/21 ok** — serve + esbuild bundle + theme + real streamed reply.
+- **EXPORT 21/21 ok** — every app exports a complete, directly-runnable folder
+  (index.html + src + sdk + package.json + serve.mjs + run.command + run.sh +
+  prebuilt dist/app.js), correct biorouterd endpoint, and the exported `src`
+  re-bundles cleanly.
+- **Exported app runs standalone** in a browser (served on :8787, talking to a
+  biorouterd) — verified live (BRCA1 reply).
+- **Agentic multi-turn memory** verified (turn 2 recalled "CFTR").
+- **Charts**: bar (SPOKE), line, and pie (variant consequences) render as native
+  SVG with the BioRouter palette; markdown tables render bordered.
+
+### Provider-agnostic (BioRouter's flexibility)
+
+Apps no longer hardcode a model. By default an app pins **no** model and inherits
+whatever provider/model the user configured in BioRouter (Anthropic, OpenAI,
+Azure, Bedrock, Ollama, Xiaomi MiMo, local llama.cpp, …). A specific
+provider+model is stored only when explicitly chosen (`configure_app`). The WS
+handler applies the app's model or falls back to the global provider.
+
+### Export = directly runnable + portable
+
+`export_app <id> <target_dir>` (e.g. "export this app to my Desktop") writes a
+self-contained folder. `run.command`/`run.sh` self-installs the app into the
+local BioRouter store, starts `biorouterd`, and opens it — auth is wired through
+the user's existing BioRouter provider config (no per-app prompt). `GET
+/apps/{id}/export` returns the same scaffold as JSON (for the GUI / tooling).
+
+### Workflow-style agentic loops + guardrails
+
+Every user message runs BioRouter's **full agent loop** — multi-step tool calls
++ reasoning, not a single LLM reply — so apps encode real pipelines via
+system-prompt steps + extensions (modeled on the knowledge sub-agent loop's
+bounded design). `agent.max_turns` bounds/raises that loop (a guardrail against
+runaway/cost; the knob workflow apps raise), defaulting to a safe server cap (24).
+
+### Security / consistency review (findings + fixes)
+
+- **serve.mjs path traversal**: the exported static server now resolves under
+  ROOT and rejects escapes (verified: `/../../etc/passwd` → blocked).
+- **Export route blocking the runtime**: `GET /apps/{id}/export` (and the build
+  it may trigger) now runs via `spawn_blocking`, keeping the daemon responsive.
+- **`</script>` breakout** in injected config: neutralized (`<` → `<`).
+- **Path traversal in the store**: `safe_relative` rejects absolute/`..` paths.
+- **Auth posture**: browser-facing GET `/apps/*` is intentionally
+  secret-exempt (localhost-only serving, like the MCP UI proxy); management
+  verbs (POST/DELETE) require the secret.
+- **Provider keys**: never embedded in apps/exports; supplied by the user's
+  biorouterd. A fresh unsigned dev `biorouterd` can't read the macOS keychain
+  (per-binary grant) → pass the provider key via env in dev.
+
+## Diverse interactive UIs + a build harness (70 more apps)
+
+The apps initially all looked alike because they used the default chat panel. Two
+changes fixed that, plus a build-time validation harness:
+
+1. **Rich control design system** (`theme.css`) — `br-select`, `br-slider`,
+   `br-switch`, `br-check`, `br-chips`/`br-chip`, `br-tabs`/`br-tab`, `br-grid`,
+   `br-dropzone`, `br-draglist`/`br-dragitem`, `br-mapgrid`/`br-region` — plus an
+   SDK `br.run(prompt, target)` helper that streams markdown/charts into any
+   element (wire a button/slider/select/region/drop to it in one line).
+2. **Build harness** (`bundle::lint_app`, surfaced in `build_app` + a `lint_app`
+   tool) — validates whatever the model generates and feeds findings back so it
+   self-corrects: ① backend wired via the App SDK, ② self-contained (no
+   CDN/external assets), ③ on-theme (br-* + a result surface), ④ element-id
+   consistency (no `getElementById` null crash), ⑤ controls actually wired to
+   events. This is a guardrail around free-form LLM generation, not just
+   templates.
+
+**Five agent_drafter iterations** (driven by testing): controls+harness+`br.run`
+→ explicit idempotent `create_app` id → element-id lint → `br.run` serialization
+(rapid control changes never overlap/orphan) → control-wiring lint.
+
+### 50 detailed-spec apps (round2) — varied UIs, 10 at a time
+
+Built by MiMo through the tools, in 5 batches, each verified (serve + esbuild
+bundle + **custom UI in markup** + real streamed reply) with retry:
+**batches 1–5 = 50/50.** Patterns: sliders (dosing/PCR/kinetics/decay),
+dropdowns (organism/assay/tissue/biomarker), button grids (amino-acids/codons/
+elements/imaging), toggles+chips+checkboxes (DEG filters/QC/pathways/symptoms),
+region maps (prevalence/outbreak/biobank/trial-sites), drag-drop (workflow/
+gene-set/protocol reorder, abstract/CSV drop), tabs (omics/patient/gene/compound),
+and form wizards (study-design/grant-aims/cohort).
+
+### 20 vague-prompt apps (round3) — the benchmark
+
+Built from one-line ideas with **no UI/SDK/layout guidance** to measure how the
+agent handles under-specified requests, relying on its instructions + harness.
+
+| Prompt style | working | with real controls (raw markup) | avg distinct control-types/app |
+|---|---|---|---|
+| Detailed (round2, 50) | 50/50 | 47/50 | **3.04** |
+| Vague (round3, 20)    | 20/20 | 18/20 | **2.10** |
+
+Finding: the harness makes even vague requests yield working, on-theme custom
+apps (~90% use real controls), but **detailed tickets produce richer UIs** (more
+distinct control types per app). Vague apps trend toward simpler input+button or
+single-control layouts. (Verifier note: the served HTML embeds the theme CSS,
+which *defines* every `br-*` class — the honest "real controls" metric is
+measured against the raw app markup in the store, not the served page.)
+
+### Autonomous testing
+
+Provider key cached to `/tmp/br-mimo.key` (600) + `start-biorouterd.sh` /
+`author.sh` read it, so authoring + tests run with **no macOS Keychain prompts**.
+Harness: `scripts/agent-drafter-apps/{round2,round3}.sh`,
+`ui/desktop/scripts/appcheck/{batch-verify,check-all,export-all,benchmark}.mjs`.
+
+## Note on the work environment
+
+This redesign was implemented in an isolated git worktree
+(`/Users/wanjun/Desktop/biorouter-apps-wt`, branch `feat/agent-drafter-apps`)
+because a parallel workstream (`perf/streaming-and-latency`) was sharing the main
+working tree and snapshotted/reset files mid-edit. The worktree keeps the two
+efforts from clobbering each other; merge `feat/agent-drafter-apps` when ready.

--- a/scripts/agent-drafter-apps/author.sh
+++ b/scripts/agent-drafter-apps/author.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Drive MiMo (via the biorouter CLI) to author one app through the Agent Drafter
+# tools. Usage: author.sh "<instruction>"
+set -euo pipefail
+cd /Users/wanjun/Desktop/biorouter-apps-wt
+source bin/activate-hermit 2>/dev/null
+export BIOROUTER_ESBUILD_BIN=/Users/wanjun/Desktop/BioRouter/ui/desktop/node_modules/.bin/esbuild
+export XIAOMI_MIMO_API_KEY=$(cat /tmp/br-mimo.key 2>/dev/null)
+export XIAOMI_MIMO_HOST="https://token-plan-sgp.xiaomimimo.com/v1"
+exec /tmp/br-apps-target/debug/biorouter run --with-builtin agent_drafter -t "$1"

--- a/scripts/agent-drafter-apps/examples/chat/index.html
+++ b/scripts/agent-drafter-apps/examples/chat/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{TITLE}}</title>
+</head>
+<body>
+  <main class="br-container">
+    <span class="br-badge">BioRouter App</span>
+    <h1>{{TITLE}}</h1>
+    <p style="color: var(--br-text-muted); margin-top: 2px;">{{DESCRIPTION}}</p>
+    <div class="br-card" data-br-chat style="margin-top: 16px; min-height: 320px;"></div>
+    <p class="br-footer">Powered by BioRouter · built with Agent Drafter</p>
+  </main>
+</body>
+</html>

--- a/scripts/agent-drafter-apps/examples/chat/main.ts
+++ b/scripts/agent-drafter-apps/examples/chat/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from "./sdk";
+
+// Default chat app: createApp auto-mounts a chat panel into [data-br-chat],
+// streams the agent's markdown reply, and handles the WebSocket to BioRouter.
+createApp();

--- a/scripts/agent-drafter-apps/examples/web-search/index.html
+++ b/scripts/agent-drafter-apps/examples/web-search/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Web Search</title>
+</head>
+<body>
+  <main class="br-container">
+    <span class="br-badge">BioRouter App</span>
+    <h1>Web Search</h1>
+    <p style="color: var(--br-text-muted); margin-top: 2px;">
+      Ask anything — BioRouter searches the web and writes a clean, sourced answer.
+    </p>
+    <div class="br-card">
+      <div class="br-row">
+        <input id="q" class="br-input" placeholder="e.g. latest GLP-1 receptor agonist trials" style="flex:3" />
+        <button id="go" class="br-btn" style="flex:1; max-width:140px">Search</button>
+      </div>
+    </div>
+    <div id="status" style="color: var(--br-text-muted); font-size: 0.85rem; margin: 4px 2px;"></div>
+    <div id="results" class="br-card" style="display:none"></div>
+    <p class="br-footer">Powered by BioRouter · built with Agent Drafter</p>
+  </main>
+</body>
+</html>

--- a/scripts/agent-drafter-apps/examples/web-search/main.ts
+++ b/scripts/agent-drafter-apps/examples/web-search/main.ts
@@ -1,0 +1,48 @@
+import { createApp } from "./sdk";
+
+const br = createApp({ autoChat: false });
+
+const q = document.getElementById("q") as HTMLInputElement;
+const go = document.getElementById("go") as HTMLButtonElement;
+const status = document.getElementById("status") as HTMLDivElement;
+const results = document.getElementById("results") as HTMLDivElement;
+
+let buffer = "";
+
+br.on("tool", (e) => {
+  if (e.type === "tool") status.textContent = `⚙ ${e.name} (${e.status})…`;
+});
+br.on("message", (e) => {
+  if (e.type !== "message") return;
+  status.textContent = "";
+  buffer += e.delta;
+  results.style.display = "block";
+  results.innerHTML = br.renderMarkdown(buffer);
+});
+br.on("error", () => {
+  status.textContent = "⚠ Could not reach the backend.";
+});
+
+async function run() {
+  const query = q.value.trim();
+  if (!query) return;
+  buffer = "";
+  results.style.display = "none";
+  status.textContent = "Searching…";
+  go.disabled = true;
+  try {
+    await br.prompt(
+      `Search the web for: "${query}". Summarize the most relevant, up-to-date findings ` +
+        `as concise markdown with a short list of sources (title + URL) at the end.`
+    );
+  } catch {
+    status.textContent = "⚠ Search failed.";
+  } finally {
+    go.disabled = false;
+  }
+}
+
+go.addEventListener("click", run);
+q.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") run();
+});

--- a/scripts/agent-drafter-apps/round.sh
+++ b/scripts/agent-drafter-apps/round.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Author a batch of BioRouter apps by driving MiMo through the Agent Drafter
+# tools, then verify each against the checklist. Apps are defined below as
+# id|title|extensions|persona. Authoring runs in parallel batches of 4.
+#
+# Usage: round.sh author   # drive MiMo to create+build+launch each app
+#        round.sh verify   # run the HTTP+bundle+WS checklist for each
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BASE="http://127.0.0.1:3000"
+UIDESK=/Users/wanjun/Desktop/biorouter-apps-wt/ui/desktop
+
+# id | title | extensions(csv or -) | persona
+APPS=(
+"spoke-network-explorer|SPOKE Network Explorer|autovisualiser|You explore the SPOKE biomedical knowledge graph. For a natural-language question about genes, diseases, drugs, proteins or pathways, describe the relevant graph relationships (e.g. Compound-TREATS-Disease, Gene-ASSOCIATES-Disease). When the answer involves counts or comparisons, emit a fenced chart block: a line with three backticks then 'chart', then a JSON object {\\\"type\\\":\\\"bar\\\",\\\"title\\\":\\\"...\\\",\\\"data\\\":[{\\\"label\\\":\\\"x\\\",\\\"value\\\":n}]}, then a closing fence, so the app renders a visualization."
+"web-research-assistant|Web Research Assistant|computercontroller|You answer questions using current information from the web. Search, then write a concise markdown answer with a short Sources list (title + URL) at the end."
+"gene-function-explorer|Gene Function Explorer|-|You are a genomics expert. Given a gene symbol, explain its function, key pathways, tissue expression, and notable disease associations using clear markdown sections."
+"variant-interpreter|Variant Interpreter|-|You are a clinical genetics assistant. Given a genetic variant, discuss likely functional impact, relevant ACMG-style evidence categories, and caveats. Add a 'not clinical advice' note."
+"clinical-trial-navigator|Clinical Trial Navigator|-|You help researchers think through clinical trials for a condition: typical phases, endpoints, inclusion/exclusion considerations, and what to search on ClinicalTrials.gov."
+"drug-interaction-analyzer|Drug Interaction Analyzer|-|You are a clinical pharmacology assistant. Given two or more drugs, explain interactions, mechanism, severity, and monitoring. Always add a 'not medical advice' caveat."
+"lab-protocol-generator|Lab Protocol Generator|-|You are a meticulous molecular biology lab assistant. Turn an experiment description into a numbered, reproducible protocol with reagents, volumes, timings, and safety notes."
+"literature-summarizer-pro|Literature Summarizer Pro|-|You summarize biomedical text into markdown: TL;DR (2 sentences), Key Findings (bullets), Methods, and Limitations."
+"biostatistics-advisor|Biostatistics Advisor|-|You are a biostatistics advisor. Recommend appropriate statistical tests for a described study design, state assumptions, and warn about pitfalls. Use a comparison table when helpful."
+"differential-diagnosis-helper|Differential Diagnosis Helper|-|You are a clinical reasoning aide. Given symptoms, produce a structured differential diagnosis with brief rationale and red flags. Add a prominent 'not medical advice' caveat."
+"sequence-analysis-toolkit|Sequence Analysis Toolkit|-|You analyze DNA/RNA/protein sequences: GC content, length, ORFs, translation, and motifs. Show results in markdown."
+"cell-type-annotator|Cell Type Annotator|-|You annotate single-cell clusters. Given marker genes, suggest the most likely cell type(s) with rationale and confidence."
+"enzyme-kinetics-tutor|Enzyme Kinetics Tutor|-|You teach enzyme kinetics. Explain Michaelis-Menten, Km, Vmax, inhibition types, and work through calculations step by step."
+"omics-pipeline-advisor|Omics Pipeline Advisor|-|You recommend bioinformatics pipelines. Given a dataset/assay description, suggest tools and a step-by-step workflow with QC checkpoints."
+"medical-term-explainer|Medical Term Explainer|-|You explain medical and biomedical terms in plain language, then add a short technical definition and an example."
+"gene-expression-barplot|Gene Expression Barplot|-|You visualize gene expression. Given genes and expression values (or a tissue/condition), summarize briefly then MUST include an inline visualization as a fenced code block with language 'chart' containing JSON like {\\\"type\\\":\\\"bar\\\",\\\"title\\\":\\\"Expression\\\",\\\"data\\\":[{\\\"label\\\":\\\"GENE\\\",\\\"value\\\":n}]}. Do not call any tools; output the chart block directly."
+"survival-analysis-explainer|Survival Analysis Explainer|-|You explain Kaplan-Meier survival analysis. When showing a survival curve, MUST include an inline fenced 'chart' block JSON {\\\"type\\\":\\\"line\\\",\\\"title\\\":\\\"Survival\\\",\\\"data\\\":[{\\\"label\\\":\\\"month\\\",\\\"value\\\":probability}]} plus a short interpretation. Do not call tools."
+"epidemiology-trend-explorer|Epidemiology Trend Explorer|-|You analyze disease incidence/prevalence trends over time. When showing a trend, MUST include an inline fenced 'chart' block JSON {\\\"type\\\":\\\"line\\\",\\\"title\\\":\\\"...\\\",\\\"data\\\":[{\\\"label\\\":\\\"year\\\",\\\"value\\\":n}]} plus interpretation. Do not call tools."
+"pharmacokinetics-visualizer|Pharmacokinetics Visualizer|-|You explain PK concentration-time profiles. When showing a curve, MUST include an inline fenced 'chart' block JSON {\\\"type\\\":\\\"line\\\",\\\"title\\\":\\\"Plasma concentration\\\",\\\"data\\\":[{\\\"label\\\":\\\"hour\\\",\\\"value\\\":conc}]} and discuss Cmax, Tmax, half-life. Do not call tools."
+"clinical-calculator|Clinical Calculator|-|You are a clinical calculator. Compute BMI, eGFR, CHA2DS2-VASc, and similar scores step by step, show the formula, the substitution, and the result with interpretation. Add a 'not medical advice' caveat."
+"variant-consequence-distribution|Variant Consequence Distribution|-|You summarize the distribution of variant consequence types (missense, nonsense, synonymous, frameshift, splice). MUST include an inline fenced 'chart' block JSON {\\\"type\\\":\\\"pie\\\",\\\"title\\\":\\\"Consequences\\\",\\\"data\\\":[{\\\"label\\\":\\\"missense\\\",\\\"value\\\":n}]} plus a short note. Do not call tools."
+)
+
+author_one() {
+  local spec="$1"; IFS='|' read -r id title exts persona <<< "$spec"
+  local extline=""
+  if [ "$exts" != "-" ]; then extline=", extensions [\"${exts//,/\",\"}\"]"; fi
+  local instr="Use the Agent Drafter tools to build a BioRouter app. (1) Call create_app with title \"$title\", a one-sentence description, kind \"agentic\"$extline, and system_prompt: \"$persona\". (2) Call build_app on the new app. (3) Call launch_app and report the URL. Keep the default chat UI; do not write custom HTML."
+  echo "[author] $id"
+  "$HERE/author.sh" "$instr" > "/tmp/author-$id.log" 2>&1
+  echo "[done] $id (exit $?)"
+}
+export -f author_one
+export HERE
+
+if [ "${1:-}" = "author" ]; then
+  # Filter to a subset if ids are passed as args after "author".
+  shift || true
+  want=("$@")
+  in_want() { [ ${#want[@]} -eq 0 ] && return 0; for w in "${want[@]}"; do [ "$w" = "$1" ] && return 0; done; return 1; }
+  n=0
+  for spec in "${APPS[@]}"; do
+    IFS='|' read -r id _ _ _ <<< "$spec"
+    in_want "$id" || continue
+    author_one "$spec" &
+    n=$((n+1))
+    if [ $((n % 4)) -eq 0 ]; then wait; fi   # batch of 4
+  done
+  wait
+  echo "=== authoring complete ==="
+elif [ "${1:-}" = "verify" ]; then
+  pass=0; fail=0
+  for spec in "${APPS[@]}"; do
+    IFS='|' read -r id title exts persona <<< "$spec"
+    out=$(cd "$UIDESK" && node scripts/appcheck/check-app.mjs "$BASE" "$id" "Give a 1-sentence demo answer for your purpose." 2>/dev/null)
+    ok=$(printf '%s' "$out" | python3 -c "import sys,json;print(json.load(sys.stdin)['ok'])" 2>/dev/null)
+    if [ "$ok" = "True" ]; then pass=$((pass+1)); echo "PASS $id"; else fail=$((fail+1)); echo "FAIL $id :: $out"; fi
+  done
+  echo "=== verify summary: $pass passed, $fail failed ==="
+fi

--- a/scripts/agent-drafter-apps/round2.sh
+++ b/scripts/agent-drafter-apps/round2.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Build 50 BioRouter apps with DIVERSE custom UIs (sliders, dropdowns, buttons,
+# toggles, chips, tabs, drag-drop, region maps) wired to the agent via br.run().
+# Authors via MiMo through the Agent Drafter tools, in batches.
+#
+# Usage: round2.sh author <id ...>     # drive MiMo to build the given app ids
+#        round2.sh ids                 # print all ids
+#        round2.sh ids-batch <n>       # print ids for batch n (1..5, 10 each)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# id | title | extensions(- for none) | ui-controls | persona
+APPS=(
+"dosage-calculator|Dosage Calculator|-|a weight slider, an age slider, and a drug <select>|You compute weight-based drug dosing and explain the calculation. Add a not-medical-advice caveat."
+"pcr-designer|PCR Protocol Designer|-|sliders for cycles, denat/anneal/extend temps and times, plus a polymerase <select>|You design PCR thermocycling protocols from the chosen parameters."
+"sample-size-calculator|Sample Size Calculator|-|sliders for effect size, power, and alpha|You compute and explain required sample size for a study."
+"serial-dilution-planner|Serial Dilution Planner|-|sliders for stock conc, target conc, and number of steps|You plan serial dilutions with volumes per step."
+"population-genetics-sim|Population Genetics Simulator|-|sliders for initial allele frequency, selection coefficient, and generations; render a line chart|You simulate allele-frequency change under selection and emit a chart block."
+"enzyme-kinetics-plotter|Enzyme Kinetics Plotter|-|sliders for Km and Vmax; render a line chart of velocity vs substrate|You plot Michaelis-Menten kinetics and emit a chart block."
+"buffer-ph-calculator|Buffer pH Calculator|-|sliders for pKa and acid/base ratio|You compute buffer pH via Henderson-Hasselbalch and explain it."
+"growth-curve-modeler|Growth Curve Modeler|-|sliders for growth rate and carrying capacity; render a line chart|You model logistic population growth and emit a chart block."
+"isotope-decay-calculator|Isotope Decay Calculator|-|a half-life <select> and a time slider; render a line chart|You compute radioactive decay relevant to nuclear imaging and emit a chart block."
+"anesthesia-dosing-aide|Anesthesia Dosing Aide|-|weight and age sliders plus an agent <select>|You suggest anesthetic dosing ranges. Add a strong not-medical-advice caveat."
+"organism-genome-explorer|Organism Genome Explorer|-|an organism <select>|You report genome size, gene count, and chromosomes for the chosen organism."
+"assay-protocol-picker|Assay Protocol Picker|-|an assay-type <select>|You output a concise protocol outline for the selected assay."
+"tissue-expression-lookup|Tissue Expression Lookup|-|a gene text input and a tissue <select>|You describe expression of the gene in the selected tissue."
+"cancer-biomarker-guide|Cancer Biomarker Guide|-|a cancer-type <select>|You list key biomarkers and the tests used for the selected cancer."
+"codon-usage-optimizer|Codon Usage Optimizer|-|an organism <select> and a sequence textarea|You advise on codon optimization for the chosen organism."
+"model-organism-comparator|Model Organism Comparator|-|two organism <select> dropdowns; output a comparison table|You compare two model organisms in a markdown table."
+"histology-stain-selector|Histology Stain Selector|-|a tissue <select> and a target <select>|You recommend histology stains for the selection."
+"vaccine-platform-explorer|Vaccine Platform Explorer|-|a platform <select> (mRNA, viral vector, subunit, inactivated)|You explain pros/cons of the chosen vaccine platform."
+"amino-acid-explorer|Amino Acid Explorer|-|a grid of 20 amino-acid buttons (br-grid + br-btn)|You give the properties of the clicked amino acid."
+"interactive-codon-table|Interactive Codon Table|-|a clickable grid of codons|You report the amino acid and notes for the clicked codon."
+"bio-element-reference|Bio-Element Reference|-|a button grid of biologically important elements|You explain the biological role of the clicked element."
+"gene-panel-quickpick|Gene Panel Quick-Pick|-|buttons for common gene panels|You list the genes and clinical indication for the chosen panel."
+"neurotransmitter-explorer|Neurotransmitter Explorer|-|a button grid of neurotransmitters|You describe the function and receptors of the clicked neurotransmitter."
+"lab-unit-converter|Lab Unit Converter|-|a value input, from/to unit <select>s, and a convert button|You convert clinical lab units and show the work."
+"imaging-modality-guide|Imaging Modality Guide|-|buttons for CT, MRI, PET, Ultrasound, X-ray|You explain when to use the clicked imaging modality."
+"deg-filter-panel|DEG Filter Panel|-|a fold-change slider, a p-value slider, and toggles for up/down/regulated|You advise on differential-expression filtering for the chosen thresholds."
+"sequencing-qc-checklist|Sequencing QC Checklist|-|checkboxes for QC flags (low Q30, duplication, adapter, GC bias)|You interpret the checked sequencing QC issues."
+"pathway-db-selector|Pathway DB Selector|-|multi-select chips for KEGG/Reactome/GO/WikiPathways and a gene-list textarea|You advise on pathway enrichment using the selected databases."
+"multiomics-layer-planner|Multi-Omics Layer Planner|-|toggles for genomics/transcriptomics/proteomics/metabolomics|You propose an integration strategy for the enabled layers."
+"symptom-selector|Symptom Selector|-|multi-select symptom chips|You produce a differential diagnosis from the selected symptoms. Strong not-medical-advice caveat."
+"nutrient-intake-advisor|Nutrient Intake Advisor|-|sliders/toggles for key nutrients|You give nutrition guidance from the inputs."
+"crispr-guide-filter|CRISPR Guide Filter|-|sliders for GC% and off-target score plus toggles|You advise on guide-RNA selection for the thresholds."
+"trial-eligibility-builder|Trial Eligibility Builder|-|checkboxes for inclusion/exclusion criteria|You summarize the resulting eligibility profile."
+"disease-prevalence-map|Disease Prevalence by Region|-|a clickable region grid (br-mapgrid/br-region) of continents|You report disease prevalence and drivers for the clicked region."
+"outbreak-explorer|Outbreak Explorer|-|a region grid and a pathogen <select>|You summarize outbreak risk for the region+pathogen."
+"biobank-locator|Biobank Locator|-|a clickable region grid|You describe major biobanks in the clicked region."
+"vector-borne-risk|Vector-Borne Disease Risk|-|a region grid and a disease <select>|You assess vector-borne disease risk for the selection."
+"clinical-site-selector|Clinical Trial Site Selector|-|a clickable region grid|You discuss trial-site considerations for the clicked region."
+"workflow-builder|Analysis Workflow Builder|-|a drag-to-reorder list (br-draglist/br-dragitem) of pipeline steps and a validate button|You validate the ordered analysis pipeline and flag issues."
+"geneset-prioritizer|Gene Set Prioritizer|-|a drag-to-reorder list of genes and a rank button|You explain the rationale for the user's gene ranking."
+"abstract-summarizer|Abstract Summarizer|-|a drop zone (br-dropzone) to paste/drop abstract text|You summarize the dropped text into TL;DR/findings/limitations."
+"csv-quick-stats|CSV Quick Stats|-|a drop zone for CSV/text and a column textarea|You describe an appropriate statistical analysis for the data."
+"protocol-step-sorter|Protocol Step Sorter|-|a drag-to-reorder list of protocol steps and a check button|You verify the protocol step order is correct."
+"omics-dashboard|Omics Dashboard|-|tabs (br-tabs) for genomics/transcriptomics/proteomics, each with a query input|You answer per-tab omics questions."
+"patient-summary-console|Patient Summary Console|-|tabs for history/labs/imaging, each with a notes textarea|You synthesize the active tab's clinical notes."
+"gene-card|Gene Card|-|a gene input and tabs for function/disease/drugs|You fill the active tab for the entered gene."
+"compound-explorer|Compound Explorer|-|a compound input and tabs for pharmacology/toxicity/interactions|You fill the active tab for the entered compound."
+"study-design-wizard|Study Design Wizard|-|a form with question, population, and outcome fields|You recommend a study design from the form."
+"grant-aims-drafter|Grant Aims Drafter|-|a topic input and a number-of-aims slider|You draft specific aims for the topic."
+"cohort-builder|Cohort Builder|-|criteria inputs plus condition chips|You define a cohort from the criteria."
+)
+
+ids() { for s in "${APPS[@]}"; do echo "${s%%|*}"; done; }
+
+author_one() {
+  local spec="$1"; IFS='|' read -r id title exts ui persona <<< "$spec"
+  local extline=""; [ "$exts" != "-" ] && extline=", extensions [\"${exts//,/\",\"}\"]"
+  local instr="Use the Agent Drafter tools to build a BioRouter app with a CUSTOM interactive UI (do NOT use the default chat panel). \
+(1) create_app with id \"$id\", title \"$title\", a one-sentence description, kind \"agentic\"$extline, and system_prompt: \"$persona\". \
+(2) update_app the index.html: build a UI featuring $ui, composed ONLY with BioRouter design-system classes (br-container, br-card, br-btn, br-select, br-slider, br-switch, br-check, br-chips/br-chip, br-tabs/br-tab, br-grid, br-row, br-dropzone, br-draglist/br-dragitem, br-mapgrid/br-region, br-badge). Include a results element <div class=\"br-output\" id=\"out\" data-placeholder=\"Results appear here\"></div>. Do NOT include any external <script>, <link>, CDN, or your own <style> colors. \
+(3) update_app src/main.ts: import { createApp } from \"./sdk\"; const br = createApp({ autoChat: false }); read the control values, compose a natural-language prompt from them, and call br.run(prompt, \"#out\") on the relevant change/click/drop events. \
+(4) build_app (fix any esbuild errors it reports). (5) launch_app. Keep it clean and minimal in the BioRouter style."
+  "$HERE/author.sh" "$instr" > "/tmp/author2-$id.log" 2>&1
+  echo "[done] $id (exit $?)"
+}
+
+case "${1:-}" in
+  ids) ids ;;
+  ids-batch) n="${2:-1}"; ids | sed -n "$(( (n-1)*10+1 )),$(( n*10 ))p" ;;
+  author)
+    shift; want=("$@"); n=0
+    for s in "${APPS[@]}"; do
+      id="${s%%|*}"
+      if [ ${#want[@]} -gt 0 ]; then printf '%s\n' "${want[@]}" | grep -qx "$id" || continue; fi
+      author_one "$s" &
+      n=$((n+1)); [ $((n%2)) -eq 0 ] && wait
+    done
+    wait; echo "=== authoring complete ==="
+    ;;
+  *) echo "usage: round2.sh author <ids...> | ids | ids-batch <n>" ;;
+esac

--- a/scripts/agent-drafter-apps/round3.sh
+++ b/scripts/agent-drafter-apps/round3.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Benchmark: 20 apps built from VAGUE one-line ideas (no UI/control guidance).
+# Measures how well Agent Drafter turns under-specified requests into working,
+# well-designed apps — relying on its own instructions + build harness rather
+# than a detailed ticket. Compare pass-rate / UI-variety vs the detailed round2.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# id-hint | title | vague idea (the ONLY guidance given)
+APPS=(
+"drug-interaction-explorer|Drug Interaction Explorer|help users check interactions between two or more medications"
+"nutrition-analyzer|Nutrition Analyzer|analyze the nutritional profile of foods a user enters"
+"symptom-triage|Symptom Triage|help users understand possible causes of their symptoms"
+"sleep-coach|Sleep Coach|give personalized advice to improve sleep"
+"lab-result-interpreter|Lab Result Interpreter|explain what a user's lab test results mean"
+"fitness-planner|Fitness Planner|build a personalized workout plan"
+"mental-wellness-companion|Mental Wellness Companion|offer supportive, evidence-based mental-wellness guidance"
+"recipe-nutritionist|Recipe Nutritionist|suggest healthy recipes and summarize their nutrition"
+"medication-guide|Medication Guide|explain how and when to take a medication"
+"allergy-advisor|Allergy Advisor|help users identify and manage allergies"
+"vaccine-schedule-helper|Vaccine Schedule Helper|explain recommended vaccination schedules by age"
+"first-aid-guide|First Aid Guide|provide first-aid guidance for common situations"
+"pregnancy-companion|Pregnancy Companion|give week-by-week pregnancy information"
+"chronic-care-coach|Chronic Care Coach|help a user manage a chronic condition day to day"
+"mindfulness-guide|Mindfulness Guide|guide breathing and mindfulness exercises"
+"hydration-helper|Hydration Helper|advise on daily water intake for a person"
+"skin-health-advisor|Skin Health Advisor|give skincare and basic dermatology guidance"
+"vision-care-helper|Vision Care Helper|give eye-health advice"
+"dental-care-guide|Dental Care Guide|give oral-health guidance"
+"travel-health-advisor|Travel Health Advisor|give health advice for a travel destination"
+)
+
+ids() { for s in "${APPS[@]}"; do echo "${s%%|*}"; done; }
+
+author_one() {
+  local spec="$1"; IFS='|' read -r id title idea <<< "$spec"
+  # Deliberately VAGUE: the idea + a usefulness nudge, nothing about controls,
+  # the SDK, layout, or the design system. The agent must figure it out.
+  local instr="Use the Agent Drafter tools to build a BioRouter app with id \"$id\", titled \"$title\", that can $idea. Make it genuinely useful and pleasant to use. Build it and launch it."
+  "$HERE/author.sh" "$instr" > "/tmp/author3-$id.log" 2>&1
+  echo "[done] $id (exit $?)"
+}
+
+case "${1:-}" in
+  ids) ids ;;
+  ids-batch) n="${2:-1}"; ids | sed -n "$(( (n-1)*10+1 )),$(( n*10 ))p" ;;
+  author)
+    shift; want=("$@"); n=0
+    for s in "${APPS[@]}"; do
+      id="${s%%|*}"
+      if [ ${#want[@]} -gt 0 ]; then printf '%s\n' "${want[@]}" | grep -qx "$id" || continue; fi
+      author_one "$s" &
+      n=$((n+1)); [ $((n%2)) -eq 0 ] && wait
+    done
+    wait; echo "=== vague authoring complete ==="
+    ;;
+  *) echo "usage: round3.sh author <ids...> | ids | ids-batch <n>" ;;
+esac

--- a/scripts/agent-drafter-apps/seed-app.sh
+++ b/scripts/agent-drafter-apps/seed-app.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Deterministically seed a BioRouter app into the store so biorouterd can serve
+# it. The SDK is copied from the worktree templates so the served bundle is the
+# real runtime. Model defaults to xiaomi_mimo / mimo-v2.5.
+#
+# Usage: seed-app.sh <id> <title> <description> <index.html> <main.ts> [exts] [system_prompt] [model]
+set -euo pipefail
+
+ID="$1"; TITLE="$2"; DESC="$3"; INDEX="$4"; MAIN="$5"
+EXTS="${6:-}"            # comma-separated extensions, optional
+SYS="${7:-}"            # system prompt, optional
+MODEL="${8:-mimo-v2.5}" # model name, optional
+
+ROOT="$HOME/.config/biorouter/agent_drafter/$ID"
+TEMPLATES="$(cd "$(dirname "$0")/../../crates/biorouter-mcp/src/agent_drafter/templates" && pwd)"
+NOW=$(date +%s)
+
+mkdir -p "$ROOT/src"
+cp "$TEMPLATES/sdk.ts" "$ROOT/src/sdk.ts"
+cp "$MAIN" "$ROOT/src/main.ts"
+# Substitute title/description placeholders in the index.
+sed -e "s/{{TITLE}}/$TITLE/g" -e "s/{{DESCRIPTION}}/$DESC/g" "$INDEX" > "$ROOT/index.html"
+
+# extensions JSON array
+ext_json="[]"
+if [ -n "$EXTS" ]; then
+  ext_json=$(printf '%s' "$EXTS" | awk -F, '{printf "["; for(i=1;i<=NF;i++){printf "%s\"%s\"", (i>1?",":""), $i} printf "]"}')
+fi
+
+# JSON-escape the system prompt minimally (quotes + backslashes).
+sys_esc=$(printf '%s' "$SYS" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+cat > "$ROOT/manifest.json" <<JSON
+{
+  "id": "$ID",
+  "title": "$TITLE",
+  "description": "$DESC",
+  "kind": "agentic",
+  "entry": "index.html",
+  "created_at": $NOW,
+  "updated_at": $NOW,
+  "agent": {
+    "system_prompt": "$sys_esc",
+    "greeting": "Hi! How can I help?",
+    "model": { "provider": "xiaomi_mimo", "model": "$MODEL" },
+    "extensions": $ext_json
+  }
+}
+JSON
+
+echo "Seeded app '$ID' -> $ROOT"

--- a/scripts/agent-drafter-apps/start-biorouterd.sh
+++ b/scripts/agent-drafter-apps/start-biorouterd.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Start biorouterd for app testing using the CACHED provider key (no keychain
+# prompt). Run from the worktree root.
+cd /Users/wanjun/Desktop/biorouter-apps-wt
+source bin/activate-hermit 2>/dev/null
+export BIOROUTER_SERVER__SECRET_KEY=test
+export BIOROUTER_ESBUILD_BIN=/Users/wanjun/Desktop/BioRouter/ui/desktop/node_modules/.bin/esbuild
+export XIAOMI_MIMO_API_KEY=$(cat /tmp/br-mimo.key 2>/dev/null)
+export XIAOMI_MIMO_HOST="https://token-plan-sgp.xiaomimimo.com/v1"
+exec /tmp/br-apps-target/debug/biorouterd agent

--- a/scripts/agent-drafter-apps/verify.mjs
+++ b/scripts/agent-drafter-apps/verify.mjs
@@ -1,0 +1,63 @@
+// Drive a browser-opened BioRouter app with Playwright and verify the live
+// agent answers. Run from the main repo's ui/desktop dir so `playwright`
+// resolves:  node <thisfile> <url> "<prompt>"
+import { chromium } from 'playwright';
+
+const url = process.argv[2];
+const prompt = process.argv[3] || 'Say hello in one short sentence.';
+const tag = process.argv[4] || 'app';
+
+if (!url) {
+  console.error('usage: node verify.mjs <url> "<prompt>" [tag]');
+  process.exit(2);
+}
+
+const errors = [];
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('console', (m) => {
+  if (m.type() === 'error') errors.push(m.text());
+});
+page.on('pageerror', (e) => errors.push(String(e)));
+
+try {
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: `/tmp/${tag}-loaded.png` });
+
+  // Type into the chat input and send.
+  const input = page.locator('.br-input').first();
+  await input.waitFor({ timeout: 10000 });
+  await input.fill(prompt);
+  await page.locator('.br-btn').first().click();
+
+  // Wait for a non-empty agent reply to stream in.
+  await page.waitForFunction(
+    () => {
+      const els = document.querySelectorAll('.br-msg--agent');
+      const last = els[els.length - 1];
+      return last && last.textContent && last.textContent.trim().length > 3;
+    },
+    { timeout: 90000 }
+  );
+  // Allow streaming to settle.
+  await page.waitForTimeout(2000);
+
+  const reply = await page.evaluate(() => {
+    const els = document.querySelectorAll('.br-msg--agent');
+    return els[els.length - 1].textContent;
+  });
+  await page.screenshot({ path: `/tmp/${tag}-reply.png` });
+
+  console.log(`RESULT ${tag} OK`);
+  console.log('AGENT_REPLY:', JSON.stringify(reply).slice(0, 600));
+  console.log('CONSOLE_ERRORS:', JSON.stringify(errors));
+  await browser.close();
+  process.exit(0);
+} catch (e) {
+  await page.screenshot({ path: `/tmp/${tag}-error.png` }).catch(() => {});
+  console.log(`RESULT ${tag} FAIL: ${e}`);
+  console.log('CONSOLE_ERRORS:', JSON.stringify(errors));
+  await browser.close();
+  process.exit(1);
+}

--- a/ui/desktop/scripts/appcheck/batch-verify.mjs
+++ b/ui/desktop/scripts/appcheck/batch-verify.mjs
@@ -1,0 +1,48 @@
+// Verify a batch of custom-UI apps: serve + bundle + CUSTOM UI present + real
+// WS reply. Resolves each app's id as the spec id (if served) else slug(title).
+// Usage: node batch-verify.mjs <base> <batchNumber 1..5> [round2|round3]
+import WebSocket from 'ws';
+import { readFileSync } from 'node:fs';
+const base = process.argv[2] || 'http://127.0.0.1:3000';
+const batch = parseInt(process.argv[3] || '1', 10);
+const round = process.argv[4] || 'round2';
+const rs = readFileSync(`/Users/wanjun/Desktop/biorouter-apps-wt/scripts/agent-drafter-apps/${round}.sh`, 'utf8');
+const slug = (t) => { let o = '', d = false; for (const ch of t.trim()) { if (/[a-z0-9]/i.test(ch)) { o += ch.toLowerCase(); d = false; } else if (!d && o) { o += '-'; d = true; } } return o.replace(/^-+|-+$/g, '') || 'artifact'; };
+const specs = [...rs.matchAll(/^"([a-z0-9-]+)\|([^|]+)\|/gm)].map((m) => ({ spec: m[1], title: m[2] }));
+const batchSpecs = specs.slice((batch - 1) * 10, batch * 10);
+const CONTROL = /(br-select|br-slider|type="range"|br-switch|br-check|br-chip|br-tab|br-dropzone|br-draglist|br-mapgrid|br-region|br-grid)/;
+
+async function served(id) {
+  try { const r = await fetch(`${base}/apps/${id}/`); return r.status === 200 ? await r.text() : null; } catch { return null; }
+}
+function wsReply(id) {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(base.replace(/^http/, 'ws') + `/apps/${id}/agent`); let buf = '';
+    const t = setTimeout(() => { try { ws.close(); } catch {} resolve({ ok: false, err: 'timeout' }); }, 70000);
+    ws.on('message', (d) => { let m; try { m = JSON.parse(d); } catch { return; }
+      if (m.type === 'ready') ws.send(JSON.stringify({ type: 'prompt', text: 'Give a one-sentence demo answer.' }));
+      else if (m.type === 'message') buf += m.delta;
+      else if (m.type === 'error') { clearTimeout(t); ws.close(); resolve({ ok: false, err: m.message }); }
+      else if (m.type === 'done') { clearTimeout(t); ws.close(); resolve({ ok: buf.trim().length > 8, err: buf ? '' : 'empty' }); } });
+    ws.on('error', (e) => { clearTimeout(t); resolve({ ok: false, err: 'ws ' + e.message }); });
+  });
+}
+let pass = 0; const rows = [];
+for (const { spec, title } of batchSpecs) {
+  let id = spec, html = await served(spec);
+  if (!html) { id = slug(title); html = await served(id); }
+  const r = { id, serve: !!html, custom: false, bundle: false, reply: false, err: '' };
+  if (html) {
+    r.serve = html.includes('biorouter-theme');
+    const body = html.replace(/<style id="biorouter-theme">[\s\S]*?<\/style>/,'');
+    r.custom = CONTROL.test(body);
+    try { const b = await fetch(`${base}/apps/${id}/dist/app.js`); r.bundle = b.status === 200 && (await b.text()).length > 500; } catch (e) { r.err = 'bundle ' + e.message; }
+  } else { r.err = 'not served (' + spec + '/' + slug(title) + ')'; }
+  if (r.serve && r.bundle) { const w = await wsReply(id); r.reply = w.ok; if (!w.ok) r.err = 'reply: ' + w.err; }
+  const ok = r.serve && r.bundle && r.custom && r.reply;
+  if (ok) pass++;
+  rows.push({ ok, ...r });
+}
+console.log(`${round} BATCH ${batch}: ${pass}/${batchSpecs.length} ok`);
+for (const r of rows) if (!r.ok) console.log(`  FAIL ${r.id}: serve=${r.serve} bundle=${r.bundle} custom=${r.custom} reply=${r.reply} ${r.err}`);
+console.log('PASS:', rows.filter((r) => r.ok).map((r) => r.id).join(' '));

--- a/ui/desktop/scripts/appcheck/benchmark.mjs
+++ b/ui/desktop/scripts/appcheck/benchmark.mjs
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+const base='http://127.0.0.1:3000';
+const slug=t=>{let o='',d=false;for(const c of t.trim()){if(/[a-z0-9]/i.test(c)){o+=c.toLowerCase();d=false}else if(!d&&o){o+='-';d=true}}return o.replace(/^-+|-+$/g,'')||'artifact'};
+const TYPES=[['select',/br-select|<select/],['slider',/br-slider|type="range"/],['switch',/br-switch/],['check',/br-check|type="checkbox"/],['chip',/br-chip/],['tab',/br-tab\b|br-tabs/],['dropzone',/br-dropzone/],['drag',/br-draglist|br-dragitem/],['region',/br-mapgrid|br-region/],['grid',/br-grid/],['buttons2+',/(<button[\s\S]*){2,}/]];
+async function variety(specs){
+  let total=0,custom=0,sum=0;
+  for(const {spec,title} of specs){
+    for(const id of [spec, slug(title)]){
+      let html=null; try{const r=await fetch(`${base}/apps/${id}/`); if(r.status===200)html=await r.text();}catch{}
+      if(!html)continue;
+      total++; const n=TYPES.filter(([_,re])=>re.test(html)).length; sum+=n; if(n>0)custom++; break;
+    }
+  }
+  return {total, custom, avgTypes:(sum/total).toFixed(2)};
+}
+for(const round of ['round2','round3']){
+  const rs=readFileSync(`/Users/wanjun/Desktop/biorouter-apps-wt/scripts/agent-drafter-apps/${round}.sh`,'utf8');
+  const specs=[...rs.matchAll(/^"([a-z0-9-]+)\|([^|]+)\|/gm)].map(m=>({spec:m[1],title:m[2]}));
+  const r=await variety(specs);
+  console.log(`${round} (${round==='round2'?'detailed':'vague'}): served=${r.total} custom-UI=${r.custom}/${r.total} avg distinct control-types/app=${r.avgTypes}`);
+}

--- a/ui/desktop/scripts/appcheck/check-all.mjs
+++ b/ui/desktop/scripts/appcheck/check-all.mjs
@@ -1,0 +1,25 @@
+import WebSocket from 'ws';
+import { readFileSync } from 'node:fs';
+const base = process.argv[2] || 'http://127.0.0.1:3000';
+const rs = readFileSync('/Users/wanjun/Desktop/biorouter-apps-wt/scripts/agent-drafter-apps/round.sh','utf8');
+const ids = [...rs.matchAll(/^"([a-z0-9-]+)\|/gm)].map(m=>m[1]);
+function check(id){return new Promise(async(resolve)=>{
+  const r={id,ok:false,err:''};
+  try{
+    const idx=await fetch(`${base}/apps/${id}/`); const html=await idx.text();
+    const b=await fetch(`${base}/apps/${id}/dist/app.js`); const bundle=await b.text();
+    if(idx.status!==200||b.status!==200||bundle.length<500||!html.includes('biorouter-theme')){throw new Error(`http idx=${idx.status} bundle=${b.status}`);}
+  }catch(e){r.err='http: '+e.message;return resolve(r);}
+  const ws=new WebSocket(base.replace(/^http/,'ws')+`/apps/${id}/agent`); let reply='';
+  const t=setTimeout(()=>{r.err='timeout';try{ws.close()}catch{};resolve(r);},60000);
+  ws.on('message',d=>{let m;try{m=JSON.parse(d)}catch{return}
+    if(m.type==='ready')ws.send(JSON.stringify({type:'prompt',text:'In one sentence, what do you do?'}));
+    else if(m.type==='message')reply+=m.delta;
+    else if(m.type==='error'){clearTimeout(t);r.err=m.message;ws.close();resolve(r);}
+    else if(m.type==='done'){clearTimeout(t);r.ok=reply.trim().length>10;if(!r.ok)r.err='empty reply';ws.close();resolve(r);}});
+  ws.on('error',e=>{clearTimeout(t);r.err='ws: '+e.message;resolve(r);});
+});}
+let pass=0;const fails=[];
+for(const id of ids){const r=await check(id);if(r.ok)pass++;else fails.push(r);}
+console.log(`CHECKLIST: ${pass}/${ids.length} ok`);
+for(const f of fails)console.log(`  FAIL ${f.id}: ${f.err}`);

--- a/ui/desktop/scripts/appcheck/check-app.mjs
+++ b/ui/desktop/scripts/appcheck/check-app.mjs
@@ -1,0 +1,25 @@
+// Verify one BioRouter app end-to-end: HTTP serve + esbuild bundle + a real
+// streamed agent reply. Usage: node check-app.mjs <base> <id> "<prompt>"
+import WebSocket from 'ws';
+const base = process.argv[2], id = process.argv[3], prompt = process.argv[4] || 'Briefly, what can you do?';
+const res = { id, httpIndex: 0, httpBundle: 0, bundleBytes: 0, theme: false, wsReply: '', wsError: '', tools: [], ok: false };
+try {
+  const idx = await fetch(`${base}/apps/${id}/`); res.httpIndex = idx.status;
+  res.theme = (await idx.text()).includes('biorouter-theme');
+  const b = await fetch(`${base}/apps/${id}/dist/app.js`); res.httpBundle = b.status;
+  res.bundleBytes = (await b.text()).length;
+} catch (e) { res.wsError = 'http: ' + e.message; }
+const wsUrl = base.replace(/^http/, 'ws') + `/apps/${id}/agent`;
+await new Promise((resolve) => {
+  let done = false; const ws = new WebSocket(wsUrl);
+  const t = setTimeout(() => { if (!done) { res.wsError ||= 'timeout'; ws.close(); resolve(); } }, 90000);
+  ws.on('message', (d) => { let m; try { m = JSON.parse(d); } catch { return; }
+    if (m.type === 'ready') ws.send(JSON.stringify({ type: 'prompt', text: prompt }));
+    else if (m.type === 'message') res.wsReply += m.delta;
+    else if (m.type === 'tool') res.tools.push(`${m.name}:${m.status}`);
+    else if (m.type === 'error') { res.wsError = m.message; done = true; clearTimeout(t); ws.close(); resolve(); }
+    else if (m.type === 'done') { done = true; clearTimeout(t); ws.close(); resolve(); } });
+  ws.on('error', (e) => { res.wsError ||= e.message; done = true; clearTimeout(t); resolve(); });
+});
+res.ok = res.httpIndex === 200 && res.httpBundle === 200 && res.bundleBytes > 500 && res.theme && !res.wsError && res.wsReply.trim().length > 10;
+console.log(JSON.stringify(res));

--- a/ui/desktop/scripts/appcheck/export-all.mjs
+++ b/ui/desktop/scripts/appcheck/export-all.mjs
@@ -1,0 +1,43 @@
+// Export + verify every app in one process (robust; reads ids from round.sh).
+// Usage: node export-all.mjs <base>
+import { writeFile, mkdir } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+
+const base = process.argv[2] || 'http://127.0.0.1:3000';
+const ESB = '/Users/wanjun/Desktop/BioRouter/ui/desktop/node_modules/.bin/esbuild';
+const rs = readFileSync(
+  '/Users/wanjun/Desktop/biorouter-apps-wt/scripts/agent-drafter-apps/round.sh',
+  'utf8'
+);
+const ids = [...rs.matchAll(/^"([a-z0-9-]+)\|/gm)].map((m) => m[1]);
+
+let pass = 0;
+const fails = [];
+for (const id of ids) {
+  try {
+    const resp = await fetch(`${base}/apps/${id}/export`);
+    if (!resp.ok) throw new Error('http ' + resp.status);
+    const files = (await resp.json()).files || {};
+    const OUT = `/tmp/exports/${id}`;
+    for (const [p, c] of Object.entries(files)) {
+      const f = join(OUT, p);
+      await mkdir(dirname(f), { recursive: true });
+      await writeFile(f, c);
+    }
+    const need = ['index.html', 'src/main.ts', 'src/sdk.ts', 'package.json', 'serve.mjs', 'run.sh', 'run.command', 'dist/app.js'];
+    const missing = need.filter((n) => !(n in files));
+    if (missing.length) throw new Error('missing ' + missing.join(','));
+    const idx = files['index.html'];
+    if (!idx.includes(`ws://127.0.0.1:3000/apps/${id}/agent`)) throw new Error('bad endpoint');
+    if (!idx.includes('biorouter-theme') || !idx.includes('dist/app.js')) throw new Error('bad index');
+    if ((files['dist/app.js'] || '').length < 500) throw new Error('tiny bundle');
+    execFileSync(ESB, [join(OUT, 'src/main.ts'), '--bundle', '--format=iife', '--target=es2018', '--outfile=' + join(OUT, 'dist/app.js'), '--log-level=error']);
+    pass++;
+  } catch (e) {
+    fails.push({ id, err: String(e.message || e) });
+  }
+}
+console.log(`EXPORT: ${pass}/${ids.length} ok`);
+for (const f of fails) console.log(`  FAIL ${f.id}: ${f.err}`);

--- a/ui/desktop/scripts/appcheck/export-check.mjs
+++ b/ui/desktop/scripts/appcheck/export-check.mjs
@@ -1,0 +1,35 @@
+// Export one app via biorouterd, write the folder, and verify the exported
+// project is complete + the bundle builds. Usage: node export-check.mjs <base> <id>
+import { writeFile, mkdir } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+
+const base = process.argv[2], id = process.argv[3];
+const OUT = `/tmp/exports/${id}`;
+const ESB = '/Users/wanjun/Desktop/BioRouter/ui/desktop/node_modules/.bin/esbuild';
+const res = { id, files: 0, hasRun: false, hasDist: false, endpointOk: false, themeOk: false, rebuildOk: false, ok: false, err: '' };
+try {
+  const r = await fetch(`${base}/apps/${id}/export`);
+  if (!r.ok) throw new Error('export http ' + r.status);
+  const data = await r.json();
+  const files = data.files || {};
+  res.files = Object.keys(files).length;
+  for (const [p, c] of Object.entries(files)) {
+    const full = join(OUT, p);
+    await mkdir(dirname(full), { recursive: true });
+    await writeFile(full, c);
+  }
+  const need = ['index.html','src/main.ts','src/sdk.ts','package.json','serve.mjs','run.sh','run.command','dist/app.js'];
+  const missing = need.filter((n) => !(n in files));
+  if (missing.length) throw new Error('missing: ' + missing.join(','));
+  res.hasRun = 'run.command' in files && 'run.sh' in files;
+  res.hasDist = 'dist/app.js' in files && files['dist/app.js'].length > 500;
+  const idx = files['index.html'];
+  res.endpointOk = idx.includes(`ws://127.0.0.1:3000/apps/${id}/agent`);
+  res.themeOk = idx.includes('biorouter-theme') && idx.includes('dist/app.js');
+  // Re-bundle the exported src to confirm it compiles standalone.
+  try { execFileSync(ESB, [join(OUT,'src/main.ts'),'--bundle','--format=iife','--target=es2018','--outfile='+join(OUT,'dist/app.js'),'--log-level=error']); res.rebuildOk = true; }
+  catch (e) { res.err = 'esbuild: ' + (e.stderr?.toString()||e.message).slice(0,200); }
+  res.ok = res.files>=8 && res.hasRun && res.hasDist && res.endpointOk && res.themeOk && res.rebuildOk;
+} catch (e) { res.err = String(e.message||e); }
+console.log(JSON.stringify(res));

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -44,6 +44,7 @@ import KnowledgeView from './components/knowledge/KnowledgeView';
 import { KnowledgeProvider } from './components/knowledge/KnowledgeContext';
 import AppsView from './components/apps/AppsView';
 import StandaloneAppView from './components/apps/StandaloneAppView';
+import ApplicationsView from './components/applications/ApplicationsView';
 import { View, ViewOptions } from './utils/navigationUtils';
 
 import { useNavigation } from './hooks/useNavigation';
@@ -606,6 +607,7 @@ export function AppInner() {
                 }
               />
               <Route path="apps" element={<AppsView />} />
+              <Route path="applications" element={<ApplicationsView />} />
               <Route path="sessions" element={<SessionsRoute />} />
               <Route path="schedules" element={<SchedulesRoute />} />
               <Route path="workflows" element={<WorkflowsRoute />} />

--- a/ui/desktop/src/components/BioRouterSidebar/AppSidebar.tsx
+++ b/ui/desktop/src/components/BioRouterSidebar/AppSidebar.tsx
@@ -100,6 +100,13 @@ const menuItems: NavigationEntry[] = [
     tooltip: 'Personal knowledge bases',
   },
   {
+    type: 'item' as const,
+    path: '/applications',
+    label: 'Applications',
+    icon: AppWindow,
+    tooltip: 'BioRouter apps you built with Agent Drafter',
+  },
+  {
     type: 'item',
     path: '/apps',
     label: 'Apps',

--- a/ui/desktop/src/components/applications/ApplicationsView.tsx
+++ b/ui/desktop/src/components/applications/ApplicationsView.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useState } from 'react';
+import { MainPanelLayout } from '../Layout/MainPanelLayout';
+import { Button } from '../ui/button';
+import { Play, Trash2, RefreshCw } from 'lucide-react';
+import { client } from '../../api/client.gen';
+
+/** An Agent-Drafter-built app, as returned by biorouterd `GET /apps`. */
+interface AppManifest {
+  id: string;
+  title: string;
+  description?: string;
+  kind: 'static' | 'agentic';
+  created_at?: number;
+  updated_at?: number;
+  built_at?: number | null;
+  agent?: {
+    model?: { provider?: string; model?: string };
+    extensions?: string[];
+    skills?: string[];
+    knowledge_base?: string;
+  } | null;
+}
+
+function baseUrl(): string {
+  // The generated client is configured with the biorouterd origin.
+  const cfg = client.getConfig();
+  return ((cfg.baseUrl as string) || '').replace(/\/+$/, '');
+}
+
+/** App URL on the local daemon, with the id safely encoded. */
+function appUrl(id: string): string {
+  return `${baseUrl()}/apps/${encodeURIComponent(id)}/`;
+}
+
+function secretHeader(): Record<string, string> {
+  const cfg = client.getConfig() as { headers?: Record<string, string> };
+  const key = cfg.headers?.['X-Secret-Key'];
+  return key ? { 'X-Secret-Key': key } : {};
+}
+
+const GridLayout = ({ children }: { children: React.ReactNode }) => (
+  <div
+    className="grid gap-4 p-1"
+    style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))' }}
+  >
+    {children}
+  </div>
+);
+
+export default function ApplicationsView() {
+  const [apps, setApps] = useState<AppManifest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${baseUrl()}/apps`, { headers: secretHeader() });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: AppManifest[] = await res.json();
+      setApps(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load applications');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const launch = async (app: AppManifest) => {
+    if (!baseUrl()) {
+      setError('Backend URL unavailable — is biorouterd running?');
+      return;
+    }
+    try {
+      await window.electron.openExternal(appUrl(app.id));
+    } catch (err) {
+      console.error('Failed to open app:', err);
+      setError('Could not open the app in your browser.');
+    }
+  };
+
+  const remove = async (app: AppManifest) => {
+    try {
+      const res = await fetch(`${baseUrl()}/apps/${encodeURIComponent(app.id)}`, {
+        method: 'DELETE',
+        headers: secretHeader(),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setApps((prev) => prev.filter((a) => a.id !== app.id));
+    } catch (err) {
+      console.error('Failed to delete app:', err);
+      setError('Could not delete the app.');
+    }
+  };
+
+  return (
+    <MainPanelLayout>
+      <div className="flex-1 flex flex-col min-h-0">
+        <div className="bg-background-default px-8 pb-8 pt-16">
+          <div className="flex flex-col page-transition">
+            <div className="flex justify-between items-center mb-1">
+              <h1 className="text-2xl font-semibold tracking-tight">Applications</h1>
+              <Button variant="ghost" size="sm" onClick={load} className="flex items-center gap-2">
+                <RefreshCw className="h-4 w-4" />
+                Refresh
+              </Button>
+            </div>
+            <p className="text-sm text-text-muted mb-4">
+              BioRouter apps you built with Agent Drafter. Each runs the full BioRouter agent —
+              its own model, extensions, skills and knowledge — and opens in your browser.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto bg-background-muted px-8 pb-8">
+          {loading ? (
+            <div className="flex items-center justify-center h-64">
+              <p className="text-text-muted">Loading applications…</p>
+            </div>
+          ) : error && apps.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-64 text-center">
+              <p className="text-text-danger mb-4">Error loading applications: {error}</p>
+              <Button onClick={load}>Retry</Button>
+            </div>
+          ) : apps.length === 0 ? (
+            <div className="flex items-center justify-center h-64">
+              <div className="text-center max-w-md">
+                <h3 className="text-lg font-medium mb-2">No applications yet</h3>
+                <p className="text-sm text-text-muted">
+                  Ask BioRouter to build one — e.g. “Use Agent Drafter to build a SPOKE dashboard
+                  app.” It will appear here, ready to launch.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <GridLayout>
+              {apps.map((app) => {
+                const model = app.agent?.model?.model;
+                return (
+                  <div
+                    key={app.id}
+                    className="flex flex-col p-4 border border-border-subtle rounded-xl bg-background-default hover:border-border-strong hover:shadow-default transition-all"
+                  >
+                    <div className="flex-1 mb-4">
+                      <h3 className="font-medium text-text-default mb-2">{app.title}</h3>
+                      {app.description && (
+                        <p className="text-sm text-text-muted mb-3 line-clamp-3">
+                          {app.description}
+                        </p>
+                      )}
+                      <div className="flex flex-wrap gap-1.5">
+                        <span className="inline-block px-2 py-0.5 text-xs bg-background-medium text-text-muted rounded-md">
+                          {app.kind}
+                        </span>
+                        {model && (
+                          <span className="inline-block px-2 py-0.5 text-xs bg-background-medium text-text-muted rounded-md">
+                            {model}
+                          </span>
+                        )}
+                        {app.agent?.knowledge_base && (
+                          <span className="inline-block px-2 py-0.5 text-xs bg-background-medium text-text-muted rounded-md">
+                            KB: {app.agent.knowledge_base}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="default"
+                        size="sm"
+                        onClick={() => launch(app)}
+                        className="flex items-center gap-2 flex-1"
+                      >
+                        <Play className="h-4 w-4" />
+                        Launch
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => remove(app)}
+                        className="flex items-center gap-2"
+                        aria-label={`Delete ${app.title}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </GridLayout>
+          )}
+        </div>
+      </div>
+    </MainPanelLayout>
+  );
+}

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -14,6 +14,32 @@ import {
   updateSessionUserWorkflowValues,
   listApps,
 } from '../api';
+import { client } from '../api/client.gen';
+import { getToolResponses } from '../types/message';
+
+// Apps already opened this session (dedupe so a launch_app result auto-opens
+// the browser exactly once).
+const openedAppUrls = new Set<string>();
+
+/**
+ * Auto-open an Agent-Drafter app in the default browser when a *live* launch_app
+ * result arrives. Keyed on the result `_meta["biorouter/app-path"]` marker.
+ * Only called from the live stream (case 'Message'), never on history replay, so
+ * viewing past sessions won't pop browser windows.
+ */
+function autoOpenLaunchedApps(msg: Message): void {
+  for (const tr of getToolResponses(msg)) {
+    const result = tr.toolResult as { status?: string; value?: { _meta?: Record<string, unknown> } };
+    if (result?.status !== 'success') continue;
+    const path = result.value?._meta?.['biorouter/app-path'];
+    if (typeof path !== 'string' || !path.startsWith('/apps/')) continue;
+    const base = ((client.getConfig().baseUrl as string) || '').replace(/\/+$/, '');
+    const url = base + path;
+    if (!base || openedAppUrls.has(url)) continue;
+    openedAppUrls.add(url);
+    window.electron.openExternal(url).catch((e) => console.error('auto-open app failed:', e));
+  }
+}
 import {
   announceSessionName,
   cacheGet,
@@ -185,6 +211,9 @@ async function streamFromResponse(
         case 'Message': {
           const msg = event.message;
           currentMessages = pushMessage(currentMessages, msg);
+
+          // Live launch_app → open the app in the default browser (once).
+          autoOpenLaunchedApps(msg);
 
           const hasToolConfirmation = msg.content.some(
             (content) => content.type === 'toolConfirmationRequest'


### PR DESCRIPTION
Reworks Agent Drafter from "Claude-style artifacts" into a builder for **BioRouter apps** — TypeScript front-ends wired to a real BioRouter agent backend. When a user interacts with a built app, `biorouterd` runs the full agent loop (the app's own model, extensions, skills, knowledge base) and streams the answer back. Apps launch in the browser, are stored under the user profile, appear in a new **Applications** panel, and export as standalone, directly-runnable folders.

## Highlights
- **Per-app agent WebSocket** (`/apps/{id}/agent`) runs the real agent loop with the app's model (provider-agnostic — inherits the user's configured provider), extensions, skills, KB, persona, bounded by `max_turns`.
- **App SDK** (`templates/sdk.ts`): WS client, markdown + GFM tables + AI-generated bar/line/pie SVG charts, multimodal image input, `br.run(prompt, target)` helper, auto chat panel.
- **Build harness** (`lint_app`): validates LLM-generated apps — SDK/backend wiring, self-contained (no CDN), on-theme, element-id consistency, control wiring — surfaced in `build_app` + a `lint_app` tool.
- **Rich design system**: select/slider/switch/check/chips/tabs/grid/dropzone/draglist/mapgrid+region controls; warm BioRouter theme.
- **Applications panel** under Knowledge (list, Launch in default browser, Delete, Refresh); live `launch_app` auto-opens in the browser (deduped, live-stream only).
- **Export**: self-contained folder (prebuilt bundle + `run.command`/`run.sh` that self-install + start biorouterd + open the browser); auth via the user's existing biorouterd provider config; path-traversal-hardened static server.

## MCP tools
`create_app` · `configure_app` · `update_app` · `build_app` · `lint_app` · `launch_app` · `list_apps` · `read_app` · `preview_app` · `export_app` · `delete_app` · `set_app_size`

## Verification
- `biorouter-mcp` + `biorouter-server` compile clean on `main`; **28** agent_drafter unit tests + **2** MCP-transport integration tests pass; frontend `tsc` 0 errors.
- **90+ apps authored end-to-end by the default MiMo model** through the tools — incl. 50 detailed diverse-UI apps and 20 vague-prompt benchmark apps — all serving + bundling + streaming real replies; charts/tables and the export→run-standalone pipeline verified in a real browser.

Docs: `docs/agent-drafter-apps.md`. Test harness: `scripts/agent-drafter-apps/`, `ui/desktop/scripts/appcheck/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)