### PR TITLE
Prepare and evidence-gate the BioRouter v1.88.0 release

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -1,0 +1,56 @@
+name: Release artifact smoke
+run-name: Release artifact smoke v${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the v prefix
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  windows-runtime:
+    runs-on: windows-latest
+    steps:
+      - name: Download Windows artifact from draft release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          New-Item -ItemType Directory -Force artifact | Out-Null
+          gh release download "v$env:VERSION" --repo $env:GITHUB_REPOSITORY `
+            --pattern "BioRouter-win32-x64-$env:VERSION.zip" --dir artifact
+          Expand-Archive "artifact/BioRouter-win32-x64-$env:VERSION.zip" artifact/unpacked
+
+      - name: Run packaged CLI, daemon, and desktop
+        shell: pwsh
+        env:
+          VERSION: ${{ inputs.version }}
+          BIOROUTER_DISABLE_KEYRING: "true"
+        run: |
+          $app = Resolve-Path "artifact/unpacked/BioRouter-win32-x64"
+          $cli = Join-Path $app "resources/bin/biorouter.exe"
+          $daemon = Join-Path $app "resources/bin/biorouterd.exe"
+          $desktop = Join-Path $app "BioRouter.exe"
+
+          $cliVersion = & $cli --version
+          if ($LASTEXITCODE -ne 0 -or $cliVersion -notmatch [regex]::Escape($env:VERSION)) {
+            throw "Packaged CLI did not report $env:VERSION"
+          }
+          $daemonVersion = & $daemon --version
+          if ($LASTEXITCODE -ne 0 -or $daemonVersion -notmatch [regex]::Escape($env:VERSION)) {
+            throw "Packaged daemon did not report $env:VERSION"
+          }
+          & $cli term --help | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "Packaged terminal help failed" }
+
+          $process = Start-Process $desktop -PassThru
+          Start-Sleep -Seconds 15
+          if ($process.HasExited) { throw "Packaged desktop exited during startup" }
+          Stop-Process -Id $process.Id -Force
+          Write-Host "Windows packaged runtime smoke passed for v$env:VERSION"

--- a/docs/release-notes/v1.88.0.md
+++ b/docs/release-notes/v1.88.0.md
@@ -1,71 +1,153 @@
-# Biorouter v1.88.0 Release Notes
+# BioRouter v1.88.0 Release Notes
 
-**Release Date:** July 2026
-**Repository:** [github.com/BaranziniLab/biorouter](https://github.com/BaranziniLab/biorouter)
+**Release date:** July 14, 2026
 
-This release is a polish-and-hardening pass over the chat surface. The whole
-GUI's **motion design** was reworked onto one coherent, faster animation
-vocabulary; a class of **text-overflow bugs** where long content bled out of
-chat bubbles, cards, and modals is fixed and hardened across the app; and the
-**Agent Drafter** picked up a batch of robustness fixes surfaced by a 100-app
-stress test. No breaking changes — existing installs upgrade in place, and your
-settings, sessions, extensions, and knowledge bases are preserved.
+**Repository:** [github.com/BaranziniLab/BioRouter](https://github.com/BaranziniLab/BioRouter)
+
+BioRouter v1.88.0 is a broad reliability, safety, performance, and interface
+release across the desktop app, terminal UI, agent runtime, Agent Drafter,
+headless server, and cross-platform distribution pipeline. It makes long-running
+agent work more controllable, reports usage more honestly, brings generated
+artifacts directly into chat, and gives every supported window size a complete,
+calmer workspace.
+
+There are no required configuration migrations. Existing settings, sessions,
+extensions, skills, workflows, knowledge bases, and usage history are preserved.
 
 ## Downloads
 
 | Platform | File | Install |
-| -------- | ---- | ------- |
-| **macOS** (Apple Silicon) | `BioRouter-1.88.0-arm64.dmg` | Open the DMG and drag `BioRouter.app` to `/Applications` |
-| **macOS** (Intel) | `BioRouter-1.88.0-x64.dmg` | Open the DMG and drag `BioRouter.app` to `/Applications` |
-| **Windows** (x64) | `BioRouter-win32-x64-1.88.0.zip` | Unzip and run `BioRouter.exe` |
-| **Linux** Ubuntu / Pop!_OS (x64) | `biorouter_1.88.0_amd64.deb` | `sudo dpkg -i biorouter_1.88.0_amd64.deb` |
-| **Linux** Fedora / RHEL (x64) | `BioRouter-1.88.0-1.x86_64.rpm` | `sudo rpm -i BioRouter-1.88.0-1.x86_64.rpm` |
+| --- | --- | --- |
+| **macOS** Apple Silicon | `BioRouter-1.88.0-arm64.dmg` | Open the DMG and drag `BioRouter.app` to `/Applications` |
+| **macOS** Intel | `BioRouter-1.88.0-x64.dmg` | Open the DMG and drag `BioRouter.app` to `/Applications` |
+| **Windows** x64 | `BioRouter-win32-x64-1.88.0.zip` | Unzip and run `BioRouter.exe` |
+| **Linux desktop** Debian / Ubuntu | `biorouter_1.88.0_amd64.deb` | `sudo apt install ./biorouter_1.88.0_amd64.deb` |
+| **Linux desktop** Fedora / RHEL | `BioRouter-1.88.0-1.x86_64.rpm` | `sudo dnf install ./BioRouter-1.88.0-1.x86_64.rpm` |
+| **Linux CLI only** Debian / Ubuntu | `biorouter-cli_1.88.0_amd64.deb` | `sudo apt install ./biorouter-cli_1.88.0_amd64.deb` |
+| **Linux CLI only** Fedora / RHEL | `biorouter-cli-1.88.0-1.x86_64.rpm` | `sudo dnf install ./biorouter-cli-1.88.0-1.x86_64.rpm` |
+| **Headless Linux** x64 | `biorouter-headless-linux-x64.tar.gz` | Extract and follow `docs/headless-linux.md` |
 
-macOS builds are signed and notarized with the UCSF Developer ID certificate.
-Users on v1.86.0 or later can update in place with the one-click **"Restart &
-Update"** button — no need to re-download the DMG.
+The macOS builds are signed and notarized with the UCSF Developer ID. The two
+signed updater ZIPs and `latest-mac.yml` are also included for in-app updates.
 
-## What's New
+## Highlights
 
-### Refined motion design
+### A steadier, more informative desktop
 
-Every animation surface — conversation loading, view/panel switching, the
-transition between streamed text and tool-call cards, the artifact side panel,
-app previews, sidebar collapse, hover/press feedback, and scrolling — was
-audited against a single motion rubric and tuned for a calmer, snappier feel:
+- Session history now appears immediately from a local cache and progressively
+  reconciles with the daemon instead of blocking the view on a full fetch.
+- Available updates live in a quiet sidebar action instead of interrupting work
+  with a modal. macOS users on v1.86.0 or newer still get one-click restart and
+  update.
+- Generated file paths and supported URLs open directly in BioRouter's artifact
+  preview, keeping the result and its originating conversation together.
+- Editing a past message now creates one canonical divergence at the correct
+  fork point, so branch lookup and replay remain consistent.
+- Bundled tools have a clearer Capabilities surface in Settings, including
+  permission inspection and configuration. Bundled local models also use names
+  that distinguish the built-in Llama Server from Ollama.
+- Usage Insights now includes durable per-model, per-day, cache-token, and
+  month-to-date accounting. Partial or unknown pricing is labeled as incomplete
+  rather than presented as a deceptively precise total.
+- The home screen, Knowledge workspace, chat greetings, panels, tool cards,
+  menus, tooltips, and compact window layouts were refined for quieter motion,
+  complete controls, predictable wrapping, and responsive resizing. System
+  Reduce Motion remains respected.
 
-- One shared timing + easing vocabulary (fast / base / slow, all ≤ 260 ms) so
-  motion is consistent everywhere instead of ad-hoc per component.
-- Buttons and interactive cards now give a subtle press response; overlays open
-  and close with correctly-paced, origin-aware transitions and quicker exits.
-- Top-level view switches crossfade instead of hard-cutting.
-- Streaming auto-scroll now tracks new content instantly instead of fighting it,
-  and the artifact panel animates on the GPU (no layout jank on open/resize).
-- All motion continues to honor the system **Reduce Motion** setting.
+### More controllable agent runs
 
-### Text no longer bleeds out of its container
+- Per-reply wall-clock, token, and dollar budgets provide explicit limits for
+  long agentic turns.
+- Repetition, oscillation, repeated failures, and no-progress stalls are
+  detected with staged soft-interrupt and hard-stop behavior instead of letting
+  a loop run indefinitely.
+- Reliable request-scoped cancellation, idempotent permission replies, and the
+  restored soft-interrupt path make active work easier to stop without corrupting
+  the session.
+- Structured success checks, optional reflection and post-edit diagnostics,
+  structured-output validation, persistent goals, living plans, active-work
+  tracking, background subagent results, and shadow-git checkpoints improve
+  recovery and make progress easier to inspect.
+- Hooks can match tool input, rewrite requests before execution, block results
+  afterward, and return aggregates. Permission rules can be scoped by directory
+  and command prefix with clearer risk grades and call previews.
+- Oversized messages and tool results use bounded previews and workspace-backed
+  handles; context preparation now ranks injected material, preserves recent
+  turns, validates compaction, and falls back progressively when a model window
+  is exceeded.
 
-Long unbroken content — a spaceless number list, a URL, a file path, a hash —
-could render wider than its chat bubble, card, or modal and spill past the
-rounded edge. This is fixed at the source and hardened across the app: user
-messages, the extension-install dialog, app cards, tool-call output, and
-knowledge-graph details all now wrap or scroll cleanly.
+### Security and cross-platform hardening
 
-### Agent Drafter hardening
+- A central secret-redaction boundary and tool-output scanning reduce accidental
+  credential, PII, and prompt-injection exposure.
+- Shell execution uses an auditable command policy plus OS isolation: macOS
+  Seatbelt and Linux Landlock/seccomp where available, with explicit behavior on
+  Windows.
+- ACP WebSocket authentication, app WebSocket origin checks, artifact-frame
+  origins, rate limiting, secret comparison, Electron navigation, and external
+  link handling were hardened.
+- Shell working directories are validated before execution, Windows background
+  processes receive graceful termination and PID-reuse protection, and native
+  tests now preserve platform-specific paths, shells, hooks, and dependencies.
+- One shared cross-compilation recipe now drives both CI and release builds.
+  Cross-target Cargo outputs are isolated so simultaneous Linux and Windows
+  builds cannot corrupt one another.
 
-A 100-app build stress test surfaced a batch of robustness fixes to the Agent
-Drafter app bundler, per-app control server, and vendored SDK, making app
-creation and export more reliable across a wider range of prompts.
+### Faster chat, knowledge, and terminal rendering
 
-### Chat & CLI reliability
+- Desktop streaming batches text deltas to animation frames, and the terminal UI
+  renders at a bounded frame rate instead of repainting for every token.
+- Conversation repair and compaction avoid repeated full-history scans, while
+  large transcripts share immutable data instead of copying it per turn.
+- Knowledge search caches BM25 indexes and tree-sitter queries. MCP processes can
+  be pooled across sessions, and desktop windows share a single daemon.
+- Startup work for first-run skills and Soul installation moves to the
+  background. Text-only replies skip unnecessary tool-response scans.
+- The CLI/TUI keeps the v1.88.0 feature set aligned with desktop, including
+  terminal chat, completion and model selection, usage reporting, diagnostics,
+  web access, file-drop path handling, and `biorouter doctor`.
 
-- The desktop app now recognizes backend-connection errors and surfaces a clear
-  message instead of a generic failure when a session can't start.
-- Auto Visualiser dashboard rendering was refined.
-- A round of CLI/TUI session improvements (input, completion, model selection,
-  doctor, web).
+### Agent Drafter and app SDK reliability
+
+- The Agent Drafter contract is enforced throughout generation, validation,
+  export, and runtime startup. Failures are visible, drag targets remain
+  reachable, and generated apps are exercised by an executable smoke harness.
+- The remediation work is grounded in a 100-app test drive and adds SDK
+  integration, quality gates, standalone control-server hardening, safer app
+  capabilities, and more dependable artifact previews.
+- App SDK v2 and structured app output handling improve how generated tools
+  declare capabilities, request permissions, and validate results.
+
+### Provider, model, and headless improvements
+
+- GPT-5.6 model-family metadata is included, and each model carries its own
+  context window so local and remote clients resolve capacity consistently.
+- Cache-token capture and cache-aware pricing now cover Claude and Claude on
+  Amazon Bedrock in addition to the broader usage-reporting pipeline.
+- The browser-served headless package correctly rewrites code-split JavaScript,
+  CSS, fonts, and other root-absolute assets when deployed behind a URL prefix.
+- CLI-only and headless Linux distributions remain independent of Electron for
+  server, HPC, container, and browser-only deployments.
+
+## Release verification
+
+Before publication, the release artifacts are built from the v1.88.0 source and
+run in their target environments. The gate covers:
+
+- signed, notarized, and stapled Apple Silicon and Intel apps mounted from their
+  DMGs, including packaged CLI/daemon version checks and desktop startup;
+- Debian and RPM desktop installation, packaged CLI/daemon execution, and GUI
+  startup under a virtual display;
+- CLI-only Debian and RPM installation plus terminal entry-point checks;
+- headless binary execution, browser bundle startup, health endpoint, and page
+  fetch in a clean Linux container;
+- Windows CLI, daemon, terminal entry point, and desktop startup on a native
+  Windows GitHub-hosted runner;
+- the complete desktop test suite, Rust CLI tests, version consistency, release
+  architecture checks, and updater-manifest validation.
 
 ## Upgrade notes
 
-No configuration changes are required. macOS users on v1.86.0+ can use in-app
-**Restart & Update**; others download the platform package above.
+No configuration changes are required. macOS users on v1.86.0 or later can use
+the in-app **Restart & Update** action. Everyone else can install the matching
+package above over the current version.

--- a/landing/about.html
+++ b/landing/about.html
@@ -232,6 +232,17 @@
       <h2>Latest updates</h2>
     </div>
     <div class="news-list">
+      <a href="https://github.com/BaranziniLab/BioRouter/releases/tag/v1.88.0" target="_blank" class="news-row">
+        <div class="news-date">
+          <div class="day">14</div>
+          <div class="mon">Jul</div>
+        </div>
+        <div class="news-body">
+          <h3>BioRouter v1.88.0: controllable agents, honest usage, faster workspaces</h3>
+          <p>BioRouter v1.88.0 strengthens every surface: agent runs gain budgets, loop and stall detection, reliable cancel and interrupt, persistent goals, structured success checks, checkpoints, scoped permissions, and safer hook execution; desktop and terminal streaming are faster; Knowledge and session history use progressive caches; and Usage Insights now preserves per-model, cache-token, daily, and month-to-date accounting while clearly labeling incomplete costs. The desktop adds direct previews for generated paths, canonical edited-message branches, configurable Capabilities, clearer local-model names, non-interruptive updates, and responsive compact workspaces. Security work adds secret and PII redaction, prompt-injection scanning, OS-level shell isolation, WebSocket and origin hardening, and a shared cross-platform CI/release recipe. Agent Drafter is hardened from a 100-app test drive, GPT-5.6 metadata is included, and desktop, CLI-only, and browser-headless builds ship across macOS, Windows, Debian/Ubuntu, and Fedora/RHEL.</p>
+          <div class="news-link">View the release notes →</div>
+        </div>
+      </a>
       <a href="baam.html" class="news-row">
         <div class="news-date">
           <div class="day">2</div>

--- a/landing/app-mockups.js
+++ b/landing/app-mockups.js
@@ -139,7 +139,7 @@
       '<span class="chip">' + svgI('skills') + '5</span>' +
       '<span class="chip">' + svgI('book') + '6 KBs visible</span>' +
       '<span class="chip">' + svgI('dollar') + '0.0000</span>' +
-      '<span class="chip">' + svgI('brain') + 'gpt-5.5</span>' +
+      '<span class="chip">' + svgI('brain') + 'gpt-5.6</span>' +
       '<span class="grow"></span>' + right + '</div></div>';
   }
 
@@ -313,11 +313,11 @@
       '<div class="bw-grp" style="margin:14px 0 2px"><i class="inst"></i>Built-in extensions (7)</div>' +
       erow('Developer', 'General development tools useful for software engineering.', true) +
       erow('Computer Controller', 'General computer control tools that don’t require you to be a developer or engineer.', true) +
-      erow('Auto Visualiser', 'Data visualization and UI generation tools.', false) +
+      erow('Auto Visualiser', 'Data visualization and UI generation tools.', true) +
       erow('Memory', 'Teach BioRouter your preferences as you go.', true) +
       erow('Tutorial', 'Access interactive tutorials and guides.', false) +
       erow('Knowledge', 'Personal, LLM-maintained knowledge bases backed by markdown folders and git history.', true) +
-      erow('Agent Drafter', 'Build interactive artifacts and export them as standalone projects.', false) +
+      erow('Agent Drafter', 'Build interactive artifacts and export them as standalone projects.', true) +
       '</div>';
     return win('extensions', {}, main);
   };
@@ -463,16 +463,16 @@
       '<h2>Provider Configuration</h2>' +
       '<div class="lead">Configure your AI model providers. API keys are encrypted and stored locally.</div>' +
       '<div class="bw-grp"><i class="local"></i>Local models</div>' +
-      prow('L', 'Llama Server', 'Bundled llama.cpp runtime. Default qwen3.5-4b; no external install required.', true) +
+      prow('L', 'Llama Server', 'Bundled llama.cpp runtime. Gemma 4 E4B laptop default; Qwen3.6 35B on 64 GiB systems.', true) +
       prow('O', 'Ollama', 'Local open source models. Default qwen3.', true) +
       '<div class="bw-grp"><i class="inst"></i>Institutional models</div>' +
-      prow('V', 'Versa API Azure', 'UCSF ChatGPT via Azure OpenAI. Default gpt-5.2-2025-12-11.', true) +
+      prow('V', 'Versa API Azure', 'UCSF ChatGPT via Azure OpenAI. Default gpt-5.5-2026-04-24.', true) +
       prow('V', 'Versa API Bedrock', 'UCSF Anthropic models via Amazon Bedrock. Default us.anthropic.claude-opus-4-6-v1.', true) +
       '<div class="bw-grp"><i class="comm"></i>Commercial models</div>' +
       prow('A', 'Azure OpenAI', 'Models through Azure OpenAI Service (uses Azure credential chain by default).', false) +
       prow('A', 'Amazon Bedrock', 'Run models through Amazon Bedrock.', true) +
       prow('A', 'Anthropic', 'Claude and other models from Anthropic.', true) +
-      prow('O', 'OpenAI', 'GPT-4 and other OpenAI models, including OpenAI compatible ones.', true) +
+      prow('O', 'OpenAI', 'OpenAI models with gpt-5.6 as the default, plus compatible endpoints.', true) +
       prow('G', 'Google Gemini', 'Gemini models from Google AI.', false) +
       prow('R', 'OpenRouter', 'Route to Claude, Gemini, Grok, DeepSeek, Qwen, and more.', false) +
       '</div>';

--- a/landing/assets/landing-site-content.md
+++ b/landing/assets/landing-site-content.md
@@ -34,7 +34,7 @@ GitHub: https://github.com/BaranziniLab/BioRouter
 
 ### Banner / Hero
 - BioRouter logo (icon.png) with glow animation
-- Version badge: "v1.20.0 Now Available"
+- Version badge: "v1.88.0 Now Available"
 - Headline: "UCSF BioRouter"
 - Subheading: AI-powered integrated research environment tagline
 - CTA buttons: Download, Documentation, GitHub
@@ -90,7 +90,7 @@ Chips for: UCSF Azure OpenAI (highlight), UCSF Amazon Bedrock (highlight), Anthr
 
 ### Bottom Links
 - About & Acknowledgements (→ about.html)
-- v1.20.0 Release Notes (https://github.com/BaranziniLab/BioRouter/releases/tag/v1.20.0)
+- v1.88.0 Release Notes (https://github.com/BaranziniLab/BioRouter/releases/tag/v1.88.0)
 - Baranzini Lab (https://baranzinilab.ucsf.edu/)
 
 ---
@@ -98,7 +98,7 @@ Chips for: UCSF Azure OpenAI (highlight), UCSF Amazon Bedrock (highlight), Anthr
 ## Tab 2 — Download (`download.html`)
 
 ### Hero
-- Version badge: "v1.20.0 — February 2026"
+- Version badge: "v1.88.0 — July 2026"
 - Title: "Download BioRouter"
 - Subtitle: "Native installers for every major platform. Open source and free."
 
@@ -112,20 +112,23 @@ JavaScript detects the visitor's OS and shows the recommended download button pr
 - Linux → amd64.deb (default for Linux)
 - Unknown/iOS/Android → show all options without a primary
 
-### Download Links (v1.20.0)
+### Download Links (v1.88.0)
 | Platform | File | URL |
 |---|---|---|
-| macOS Apple Silicon | BioRouter-1.20.0-arm64.dmg | https://github.com/BaranziniLab/BioRouter/releases/download/v1.20.0/BioRouter-1.20.0-arm64.dmg |
-| macOS Intel | BioRouter-1.20.0-x64.dmg | https://github.com/BaranziniLab/BioRouter/releases/download/v1.20.0/BioRouter-1.20.0-x64.dmg |
-| Windows x64 | BioRouter-win32-x64-1.20.0.zip | https://github.com/BaranziniLab/BioRouter/releases/download/v1.20.0/BioRouter-win32-x64-1.20.0.zip |
-| Linux Ubuntu/Pop!_OS | biorouter_1.20.0_amd64.deb | https://github.com/BaranziniLab/BioRouter/releases/download/v1.20.0/biorouter_1.20.0_amd64.deb |
-| Linux Fedora/RHEL | BioRouter-1.20.0-1.x86_64.rpm | https://github.com/BaranziniLab/BioRouter/releases/download/v1.20.0/BioRouter-1.20.0-1.x86_64.rpm |
+| macOS Apple Silicon | BioRouter-1.88.0-arm64.dmg | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-1.88.0-arm64.dmg |
+| macOS Intel | BioRouter-1.88.0-x64.dmg | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-1.88.0-x64.dmg |
+| Windows x64 | BioRouter-win32-x64-1.88.0.zip | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-win32-x64-1.88.0.zip |
+| Linux Ubuntu/Pop!_OS | biorouter_1.88.0_amd64.deb | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter_1.88.0_amd64.deb |
+| Linux Fedora/RHEL | BioRouter-1.88.0-1.x86_64.rpm | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-1.88.0-1.x86_64.rpm |
+| Linux CLI Debian/Ubuntu | biorouter-cli_1.88.0_amd64.deb | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter-cli_1.88.0_amd64.deb |
+| Linux CLI Fedora/RHEL | biorouter-cli-1.88.0-1.x86_64.rpm | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter-cli-1.88.0-1.x86_64.rpm |
+| Linux headless web | biorouter-headless-linux-x64.tar.gz | https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter-headless-linux-x64.tar.gz |
 
 ### Install Commands
 - macOS: Open DMG and drag BioRouter.app to /Applications
 - Windows: Unzip and run BioRouter.exe
-- Linux Debian: sudo dpkg -i biorouter_1.20.0_amd64.deb
-- Linux RPM: sudo rpm -i BioRouter-1.20.0-1.x86_64.rpm
+- Linux Debian: sudo apt install ./biorouter_1.88.0_amd64.deb
+- Linux RPM: sudo dnf install ./BioRouter-1.88.0-1.x86_64.rpm
 
 ### Setup Note / Info Box
 After installing, users should:
@@ -278,9 +281,9 @@ Each card contains:
 ## Tab 5 — About (`about.html`)
 
 ### News
-1. **BioRouter v1.20.0 Release** (February 2026)
-   - Link: https://github.com/BaranziniLab/BioRouter/releases/tag/v1.20.0
-   - What's new: multi-platform, updated models, new branding, simplified setup, full docs
+1. **BioRouter v1.88.0 Release** (July 2026)
+   - Link: https://github.com/BaranziniLab/BioRouter/releases/tag/v1.88.0
+   - What's new: controllable agent runs, honest usage accounting, faster desktop and TUI rendering, responsive workspaces, Agent Drafter hardening, cross-platform security, and desktop/CLI/headless packages
 
 2. **UCSF AI Research Day** (2026)
    - Link: https://ai.ucsf.edu/researchday

--- a/landing/docs.html
+++ b/landing/docs.html
@@ -360,7 +360,7 @@
       <!-- PROVIDERS -->
       <div class="doc-page" id="doc-providers">
         <h1>Providers and models</h1>
-        <p class="doc-intro">BioRouter connects to a range of LLM providers. Switch providers any time from Settings → Models without changing your workflows. Defaults below reflect <code>biorouter v1.87.0</code>.</p>
+        <p class="doc-intro">BioRouter connects to a range of LLM providers. Switch providers any time from Settings → Models without changing your workflows. Defaults below reflect <code>biorouter v1.88.0</code>.</p>
 
         <h2>UCSF institutional providers</h2>
         <table class="doc-table">
@@ -377,7 +377,7 @@
           <thead><tr><th>Provider</th><th>Env variable</th><th>Default model</th><th>Get API key</th></tr></thead>
           <tbody>
             <tr><td><strong>Anthropic</strong></td><td><code>ANTHROPIC_API_KEY</code></td><td><code>claude-opus-4-8</code></td><td><a href="https://platform.claude.com/" target="_blank">platform.claude.com</a></td></tr>
-            <tr><td><strong>OpenAI</strong></td><td><code>OPENAI_API_KEY</code></td><td><code>gpt-5.5</code></td><td><a href="https://platform.openai.com/api-keys" target="_blank">platform.openai.com</a></td></tr>
+            <tr><td><strong>OpenAI</strong></td><td><code>OPENAI_API_KEY</code></td><td><code>gpt-5.6</code></td><td><a href="https://platform.openai.com/api-keys" target="_blank">platform.openai.com</a></td></tr>
             <tr><td><strong>Azure OpenAI</strong> (own tenant)</td><td><code>AZURE_OPENAI_API_KEY</code></td><td><code>gpt-5.4-2026-03-05</code></td><td>Your Azure portal</td></tr>
             <tr><td><strong>Google Gemini</strong></td><td><code>GOOGLE_API_KEY</code></td><td><code>gemini-3.1-pro-preview</code></td><td><a href="https://aistudio.google.com" target="_blank">aistudio.google.com</a></td></tr>
             <tr><td><strong>X.AI (Grok)</strong></td><td><code>XAI_API_KEY</code></td><td><code>grok-4.3</code></td><td><a href="https://console.x.ai" target="_blank">console.x.ai</a></td></tr>
@@ -407,7 +407,7 @@
         <h3>Llama Server (bundled, recommended)</h3>
         <p>The desktop app ships a pinned <strong><a href="https://github.com/ggml-org/llama.cpp" target="_blank">llama.cpp</a> <code>llama-server</code></strong> binary and manages it as a sidecar process — so you can run capable local models <strong>without installing Ollama or anything else</strong>. Pick <strong>Llama Server</strong> in onboarding or Settings → Models, choose a model, and BioRouter downloads the weights from Hugging Face on first use and starts the server for you.</p>
         <ul>
-          <li><strong>Curated catalog</strong> of Qwen 3.5 and Gemma 4 models (Q4_K_M from verified <code>unsloth/*-GGUF</code> repos); default <code>qwen3.5-4b</code>. Any other model works too as a raw <code>owner/repo:QUANT</code> Hugging Face spec.</li>
+          <li><strong>Curated catalog</strong> of <strong>Gemma 4 E2B</strong>, <strong>Gemma 4 E4B</strong>, <strong>Gemma 4 12B</strong>, <strong>Gemma 4 26B</strong>, and <strong>Gemma 4 31B</strong>, plus <strong>Qwen3.6 27B</strong> and <strong>Qwen3.6 35B</strong>. BioRouter recommends Gemma 4 E4B on laptop-class machines and Qwen3.6 35B when at least 64 GiB of GPU-addressable memory is available. Any other model works as a raw <code>owner/repo:QUANT</code> Hugging Face spec.</li>
           <li><strong>Reasoning on by default</strong>, a model-native context window, and a q8_0 KV cache. Per-platform builds use Metal (macOS), Vulkan with CPU fallback (Windows), and CPU (Linux); CUDA is opt-in.</li>
           <li>Override anything with env vars — <code>LLAMACPP_CONTEXT_SIZE</code>, <code>LLAMACPP_ENABLE_THINKING</code>, <code>LLAMACPP_EXTRA_ARGS</code>, or point at your own server with <code>LLAMACPP_EXTERNAL_HOST</code>.</li>
         </ul>
@@ -426,7 +426,7 @@ ollama pull deepseek-r1     # Strong reasoning model</pre>
       <!-- EXTENSIONS -->
       <div class="doc-page" id="doc-extensions">
         <h1>Extensions, skills, and MCP</h1>
-        <p class="doc-intro">Extend BioRouter with built-in capabilities, third-party MCP servers, and reusable skill bundles. Defaults reflect <code>biorouter v1.87.0</code> (<code>ui/desktop/src/components/settings/extensions/bundled-extensions.json</code>).</p>
+        <p class="doc-intro">Extend BioRouter with built-in capabilities, third-party MCP servers, and reusable skill bundles. Defaults reflect <code>biorouter v1.88.0</code> (<code>ui/desktop/src/components/settings/extensions/bundled-extensions.json</code>).</p>
 
         <h2>Built-in extensions</h2>
         <p>Ship with BioRouter, no install needed. Enable or disable any of them from <strong>Settings → Extensions</strong>.</p>
@@ -435,10 +435,10 @@ ollama pull deepseek-r1     # Strong reasoning model</pre>
           <tbody>
             <tr><td><strong>Developer</strong></td><td>File operations, shell commands, code search, and text editing — the core agent toolkit</td><td><strong>On</strong></td></tr>
             <tr><td><strong>Knowledge</strong></td><td>Ingest / query / lint your personal knowledge bases (incl. the built-in <a href="#" onclick="showDoc('knowledge')">Soul</a> base) from within any chat</td><td><strong>On</strong></td></tr>
-            <tr><td>Auto Visualiser</td><td>Turns structured data into self-contained interactive HTML figures (33 chart, scientific, network, diagram, and geo tools) rendered inline in chat</td><td>Off</td></tr>
+            <tr><td>Auto Visualiser</td><td>Turns structured data into self-contained interactive HTML figures (33 chart, scientific, network, diagram, and geo tools) rendered inline in chat</td><td><strong>On</strong></td></tr>
             <tr><td><strong>Computer Controller</strong></td><td>General computer-control tools for non-developer workflows (web, automation, files)</td><td><strong>On</strong></td></tr>
             <tr><td><strong>Memory</strong></td><td>Persist preferences and context across sessions</td><td><strong>On</strong></td></tr>
-            <tr><td>Agent Drafter</td><td>Author BioRouter apps with the <a href="#" onclick="showDoc('agent-sdk')">Agent SDK</a>: TypeScript UIs, live per-app agents, widgets, resumable sessions, capability manifests, and standalone exports</td><td>Off</td></tr>
+            <tr><td>Agent Drafter</td><td>Author BioRouter apps with the <a href="#" onclick="showDoc('agent-sdk')">Agent SDK</a>: TypeScript UIs, live per-app agents, widgets, resumable sessions, capability manifests, and standalone exports</td><td><strong>On</strong></td></tr>
             <tr><td>Tutorial</td><td>Interactive in-app tutorials and guides</td><td>Off</td></tr>
           </tbody>
         </table>

--- a/landing/download.html
+++ b/landing/download.html
@@ -184,7 +184,7 @@
 <main class="page">
 
   <div class="download-hero">
-    <div class="version-badge" id="version-badge">v1.87.0 · July 2026</div>
+    <div class="version-badge" id="version-badge">v1.88.0 · July 2026</div>
     <h1>Download BioRouter</h1>
     <p>Native installers for every major platform. Each one now bundles the <code>biorouter</code> command-line interface. Open source, free to use.</p>
   </div>
@@ -219,45 +219,51 @@
       <tbody>
         <tr data-row="mac-arm">
           <td><div class="platform-os">macOS <small>Apple Silicon (M1/M2/M3/M4)</small></div></td>
-          <td><code class="file-name">BioRouter-1.87.0-arm64.dmg</code></td>
+          <td><code class="file-name">BioRouter-1.88.0-arm64.dmg</code></td>
           <td><span class="install-code">Drag to /Applications</span></td>
-          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.87.0/BioRouter-1.87.0-arm64.dmg">↓ .dmg</a></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-1.88.0-arm64.dmg">↓ .dmg</a></td>
         </tr>
         <tr data-row="mac-intel">
           <td><div class="platform-os">macOS <small>Intel (x86_64)</small></div></td>
-          <td><code class="file-name">BioRouter-1.87.0-x64.dmg</code></td>
+          <td><code class="file-name">BioRouter-1.88.0-x64.dmg</code></td>
           <td><span class="install-code">Drag to /Applications</span></td>
-          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.87.0/BioRouter-1.87.0-x64.dmg">↓ .dmg</a></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-1.88.0-x64.dmg">↓ .dmg</a></td>
         </tr>
         <tr data-row="windows">
           <td><div class="platform-os">Windows <small>x64</small></div></td>
-          <td><code class="file-name">BioRouter-win32-x64-1.87.0.zip</code></td>
+          <td><code class="file-name">BioRouter-win32-x64-1.88.0.zip</code></td>
           <td><span class="install-code">Unzip, run BioRouter.exe</span></td>
-          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.87.0/BioRouter-win32-x64-1.87.0.zip">↓ .zip</a></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-win32-x64-1.88.0.zip">↓ .zip</a></td>
         </tr>
         <tr data-row="linux-deb">
           <td><div class="platform-os">Linux <small>Ubuntu / Pop!_OS (x64)</small></div></td>
-          <td><code class="file-name">biorouter_1.87.0_amd64.deb</code></td>
+          <td><code class="file-name">biorouter_1.88.0_amd64.deb</code></td>
           <td><span class="install-code">sudo dpkg -i *.deb</span></td>
-          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.87.0/biorouter_1.87.0_amd64.deb">↓ .deb</a></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter_1.88.0_amd64.deb">↓ .deb</a></td>
         </tr>
         <tr data-row="linux-rpm">
           <td><div class="platform-os">Linux <small>Fedora / RHEL (x64)</small></div></td>
-          <td><code class="file-name">BioRouter-1.87.0-1.x86_64.rpm</code></td>
+          <td><code class="file-name">BioRouter-1.88.0-1.x86_64.rpm</code></td>
           <td><span class="install-code">sudo rpm -i *.rpm</span></td>
-          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.87.0/BioRouter-1.87.0-1.x86_64.rpm">↓ .rpm</a></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/BioRouter-1.88.0-1.x86_64.rpm">↓ .rpm</a></td>
         </tr>
         <tr data-row="linux-cli-deb">
           <td><div class="platform-os">Linux (CLI only) <small>Ubuntu / Debian (x64)</small></div></td>
-          <td><code class="file-name">biorouter-cli_1.87.0_amd64.deb</code></td>
+          <td><code class="file-name">biorouter-cli_1.88.0_amd64.deb</code></td>
           <td><span class="install-code">sudo apt install ./*.deb</span></td>
-          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.87.0/biorouter-cli_1.87.0_amd64.deb">↓ .deb</a></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter-cli_1.88.0_amd64.deb">↓ .deb</a></td>
         </tr>
         <tr data-row="linux-cli-rpm">
           <td><div class="platform-os">Linux (CLI only) <small>Fedora / RHEL (x64)</small></div></td>
-          <td><code class="file-name">biorouter-cli-1.87.0-1.x86_64.rpm</code></td>
+          <td><code class="file-name">biorouter-cli-1.88.0-1.x86_64.rpm</code></td>
           <td><span class="install-code">sudo dnf install ./*.rpm</span></td>
-          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.87.0/biorouter-cli-1.87.0-1.x86_64.rpm">↓ .rpm</a></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter-cli-1.88.0-1.x86_64.rpm">↓ .rpm</a></td>
+        </tr>
+        <tr data-row="linux-headless">
+          <td><div class="platform-os">Linux (headless web) <small>x64</small></div></td>
+          <td><code class="file-name">biorouter-headless-linux-x64.tar.gz</code></td>
+          <td><span class="install-code">Extract, follow the headless setup guide</span></td>
+          <td><a class="dl-chip dl-link" href="https://github.com/BaranziniLab/BioRouter/releases/download/v1.88.0/biorouter-headless-linux-x64.tar.gz">↓ .tar.gz</a></td>
         </tr>
       </tbody>
     </table>
@@ -269,7 +275,8 @@
       binaries (<code>biorouter</code> + the <code>biorouterd</code> server) to
       <code>/usr/bin</code> with no desktop GUI. They work well on servers, HPC nodes, and
       containers. Run <code>biorouter doctor</code> after install to check optional
-      prerequisites.
+      prerequisites. The <strong>headless web</strong> tarball adds the browser UI
+      and <code>biorouter-headless</code> launcher for remote or containerized use.
     </p>
   </div>
 
@@ -329,6 +336,7 @@
     'linux-rpm':     /^biorouter-[0-9].*x86_64\.rpm$/i,
     'linux-cli-deb': /^biorouter-cli_.*amd64\.deb$/i,
     'linux-cli-rpm': /^biorouter-cli-.*x86_64\.rpm$/i,
+    'linux-headless': /^biorouter-headless-linux-x64\.tar\.gz$/i,
   };
 
   const OS_TO_ROW = {

--- a/landing/index.html
+++ b/landing/index.html
@@ -262,7 +262,7 @@
 <main class="page">
 
   <div class="hero">
-    <div class="hero-badge"><span class="dot"></span> <span id="hero-version">v1.87.0</span> available now</div>
+    <div class="hero-badge"><span class="dot"></span> <span id="hero-version">v1.88.0</span> available now</div>
     <img src="icon.svg" class="hero-logo" alt="BioRouter" />
     <h1>UCSF BioRouter</h1>
     <p class="hero-sub">
@@ -614,7 +614,7 @@
   <div class="cta-strip">
     <div class="links">
       <a href="about.html" class="btn-ghost">About and acknowledgements</a>
-      <a href="https://github.com/BaranziniLab/BioRouter/releases/tag/v1.87.0" target="_blank" class="btn-ghost" id="release-notes-link"><span id="release-version">v1.87.0</span> release notes</a>
+      <a href="https://github.com/BaranziniLab/BioRouter/releases/tag/v1.88.0" target="_blank" class="btn-ghost" id="release-notes-link"><span id="release-version">v1.88.0</span> release notes</a>
       <a href="https://baranzinilab.ucsf.edu/" target="_blank" class="btn-ghost">Baranzini Lab</a>
     </div>
   </div>

--- a/landing/scripts/check-consistency.mjs
+++ b/landing/scripts/check-consistency.mjs
@@ -4,7 +4,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const BIOROUTER = resolve(process.env.BIOROUTER_REPO || join(ROOT, '..', 'BioRouter'));
+const BIOROUTER = resolve(process.env.BIOROUTER_REPO || join(ROOT, '..'));
 
 const read = (path) => readFileSync(path, 'utf8');
 const landing = (path) => read(join(ROOT, path));
@@ -47,16 +47,25 @@ const providerChecks = [
   ['crates/biorouter/src/providers/google.rs', /GOOGLE_DEFAULT_MODEL: &str = "([^"]+)"/, 'Google Gemini'],
   ['crates/biorouter/src/providers/xai.rs', /XAI_DEFAULT_MODEL: &str = "([^"]+)"/, 'X.AI'],
   ['crates/biorouter/src/providers/openrouter.rs', /OPENROUTER_DEFAULT_MODEL: &str = "([^"]+)"/, 'OpenRouter'],
-  ['crates/biorouter/src/providers/llamacpp.rs', /LLAMACPP_DEFAULT_MODEL: &str = "([^"]+)"/, 'Llama Server'],
   ['crates/biorouter/src/providers/ollama.rs', /OLLAMA_DEFAULT_MODEL: &str = "([^"]+)"/, 'Ollama'],
 ];
 
 for (const [path, re, name] of providerChecks) {
   const value = capture(source(path), re, name);
   includes(docs, value, `docs should include ${name} default ${value}`);
-  if (['OpenAI', 'Llama Server', 'Ollama', 'Versa Bedrock'].includes(name)) {
+  if (['OpenAI', 'Ollama', 'Versa Bedrock'].includes(name)) {
     includes(mockups, value, `mockups should include ${name} default ${value}`);
   }
+}
+
+const llamaSource = source('crates/biorouter/src/providers/llamacpp.rs');
+const llamaModels = [...llamaSource.matchAll(/display_name: "([^"]+)"/g)].map((match) => match[1]);
+check(llamaModels.length > 0, 'Llama Server catalog should contain display names');
+for (const model of llamaModels) {
+  includes(docs, model, `docs should include Llama Server model ${model}`);
+}
+for (const recommended of ['Gemma 4 E4B', 'Qwen3.6 35B']) {
+  includes(mockups, recommended, `mockups should include memory-tiered Llama Server recommendation ${recommended}`);
 }
 
 const appSidebar = source('ui/desktop/src/components/BioRouterSidebar/AppSidebar.tsx');

--- a/scripts/cross-env.sh
+++ b/scripts/cross-env.sh
@@ -29,8 +29,9 @@
 #   CROSS_REGISTRY_MOUNT            host path bound to the cargo registry cache
 #                                   instead of the docker named volume (CI:
 #                                   actions/cache persists it across runs)
-#   CROSS_TARGET_MOUNT              host path bound to /cross-target (pass
-#                                   /cross-target as the target-dir arg to use it)
+#   CROSS_TARGET_MOUNT              host path or Docker volume bound to
+#                                   /cross-target (pass /cross-target as the
+#                                   target-dir arg to use it)
 
 # ── The pins. THE GLIBC FLOOR LIVES HERE AND NOWHERE ELSE. ────────────────────
 # Pin the Linux cross-compile to an OLD-glibc base (Debian 11 "bullseye",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,8 +24,9 @@
 #   mac-manifest <ver>
 #                     Generate latest-mac.yml for electron-updater.
 #   verify <ver>      Verify all release artifacts (arch, notarization, dmg format).
-#   publish <ver>     Create the GitHub release with assets + notes.
-#   all <ver>         Run every phase in order (bump → … → publish).
+#   draft <ver>       Create a draft GitHub release with assets + notes.
+#   publish <ver>     Publish a verified draft after native Windows smoke passes.
+#   all <ver>         Run every build/verify phase and create the draft release.
 #
 # Hard-won invariants (see CLAUDE.md for the long version):
 #   * The macOS .dmg maker (macos-alias native module) only builds under
@@ -41,8 +42,8 @@
 #   * Every bundle writes ui/desktop/src/bin/ and clobbers the others — phases
 #     stage the correct binaries and run strictly one platform at a time.
 #   * The Linux docker package runs `npm ci` and leaves node_modules Linux-
-#     flavored, so it MUST be the last package phase; `verify`/`publish` and any
-#     later mac build need `cd ui/desktop && rm -rf node_modules && npm install`.
+#     flavored. Host-side browser, macOS, and headless builds must restore the
+#     native optional dependencies before they run.
 #   * Notarization credentials are read from notarization/APPLE_DEVELOPER_NOTES.md
 #     (gitignored). Override via APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD env vars.
 #
@@ -104,10 +105,24 @@ ensure_docker() {
 ensure_mac_dmg_deps() {
   ( cd "$DESK"
     if ! node -e "require.resolve('appdmg')" >/dev/null 2>&1; then
-      log "installing macOS dmg deps (appdmg)…"; npm install >/dev/null 2>&1
+      log "installing macOS dmg deps (appdmg)…"; npm install --package-lock=false >/dev/null 2>&1
     fi
     npm rebuild macos-alias ds-store >/dev/null 2>&1 || true
     node -e "require('appdmg')" >/dev/null 2>&1 || die "appdmg still not loadable — run: (cd ui/desktop && rm -rf node_modules && npm install)"
+  )
+}
+
+ensure_host_node_deps() {
+  activate_hermit
+  (
+    cd "$DESK"
+    if ! node -e "require('rollup')" >/dev/null 2>&1; then
+      log "restoring host-native desktop dependencies…"
+      rm -rf node_modules
+      npm install --package-lock=false >/dev/null
+    fi
+    node -e "require('rollup')" >/dev/null 2>&1 \
+      || die "host-native Rollup dependency is unavailable"
   )
 }
 
@@ -153,17 +168,27 @@ cmd_linux-backend() {
   log "cross-compiling linux-gnu backend (docker, $LINUX_RUST_IMG)"
   rm -rf "$ROOT/target/x86_64-unknown-linux-gnu/release/biorouter" \
          "$ROOT/target/x86_64-unknown-linux-gnu/release/biorouterd"
-  # The docker build compiles build.rs scripts for the container's host arch
-  # (aarch64-linux) into the shared target/release/build. A prior release built
-  # under a newer-glibc image leaves those ELF binaries behind, and reusing them
-  # under the pinned bullseye fails at build time with "GLIBC_2.3x not found".
-  # Drop only the Linux (ELF) build scripts so they recompile against bullseye's
-  # glibc; the mac (Mach-O) build scripts and final mac binaries are left intact.
-  # (The check-cross gate uses a per-triple target dir and never hits this.)
-  find "$ROOT/target/release/build" -name 'build-script-build' -type f 2>/dev/null \
-    | while read -r f; do file "$f" 2>/dev/null | grep -q ELF && rm -rf "$(dirname "$f")"; done
-  cross_linux "cargo build --release --bin biorouterd --bin biorouter"
+  run_cross_release \
+    cross_linux \
+    biorouter-linux-release-target \
+    "cargo build --release --bin biorouterd --bin biorouter" \
+    "mkdir -p /usr/src/myapp/target/x86_64-unknown-linux-gnu/release && \
+     cp -f /cross-target/x86_64-unknown-linux-gnu/release/biorouter \
+           /cross-target/x86_64-unknown-linux-gnu/release/biorouterd \
+           /usr/src/myapp/target/x86_64-unknown-linux-gnu/release/"
   log "linux backend compiled"
+}
+
+run_cross_release() { # <cross function> <target volume> <cargo command> <post command>
+  local cross_fn="$1" target_volume="$2" cargo_cmd="$3" post_cmd="$4" rc=0
+  docker volume rm -f "$target_volume" >/dev/null 2>&1 || true
+  docker volume create "$target_volume" >/dev/null
+  (
+    export CROSS_TARGET_MOUNT="$target_volume"
+    "$cross_fn" "$cargo_cmd" /cross-target "$post_cmd"
+  ) || rc=$?
+  docker volume rm -f "$target_volume" >/dev/null 2>&1 || true
+  return "$rc"
 }
 
 cmd_backends() {
@@ -176,7 +201,15 @@ cmd_backends() {
 
   ensure_docker
   log "cross-compiling windows-gnu backend (docker)"
-  cross_windows "cargo build --release --bin biorouterd --bin biorouter" "" "$WIN_DLL_STAGE"
+  run_cross_release \
+    cross_windows \
+    biorouter-windows-release-target \
+    "cargo build --release --bin biorouterd --bin biorouter" \
+    "mkdir -p /usr/src/myapp/target/x86_64-pc-windows-gnu/release && \
+     cp -f /cross-target/x86_64-pc-windows-gnu/release/biorouter.exe \
+           /cross-target/x86_64-pc-windows-gnu/release/biorouterd.exe \
+           /usr/src/myapp/target/x86_64-pc-windows-gnu/release/ && \
+     $WIN_DLL_STAGE"
 
   cmd_linux-backend
   log "all 4 backends compiled"
@@ -225,7 +258,7 @@ cmd_linux() {
   log "packaging Linux deb + rpm (docker)"
   docker volume create biorouter-linux-npm-cache >/dev/null 2>&1 || true
   docker run --rm --platform linux/amd64 -v "$ROOT":/ws -v biorouter-linux-npm-cache:/root/.npm \
-    node:20-bookworm bash /ws/ui/desktop/scripts/build-linux-deb.sh
+    node:24-bookworm bash /ws/ui/desktop/scripts/build-linux-deb.sh
   log "deb: $DESK/out/make/deb/x64/biorouter_${v}_amd64.deb"
   log "rpm: $DESK/out/make/rpm/x64/BioRouter-$v-1.x86_64.rpm"
   log "NOTE: node_modules is now Linux-flavored — run 'cd ui/desktop && rm -rf node_modules && npm install' before any further mac build."
@@ -248,7 +281,7 @@ cmd_cli-linux() {
 # used for Debian/Ubuntu deployments and verifies that no local profiles or
 # credential material were packaged.
 cmd_headless-linux() {
-  local v="$1"; ensure_docker
+  local v="$1"; ensure_docker; ensure_host_node_deps
   log "building headless Linux browser artifact"
   "$ROOT/scripts/package-headless-linux.sh"
   local tarball="$ROOT/dist/biorouter-headless-linux-x64.tar.gz"
@@ -288,6 +321,7 @@ cmd_verify() {
     file "$DESK/out/BioRouter-darwin-x64/BioRouter.app/Contents/Resources/bin/biorouterd" | grep -q x86_64 && log "intel bundled binary is x86_64 ✓" || { echo "intel binary WRONG ARCH"; ok=0; }
     xcrun stapler validate "$DESK/out/BioRouter-darwin-x64/BioRouter.app" >/dev/null 2>&1 && log "intel app stapled ✓" || { echo "intel NOT stapled"; ok=0; }
   fi
+  "$ROOT/scripts/smoke-test-release-artifacts.sh" "$v" || ok=0
   [ "$ok" = 1 ] || die "verification failed"
   log "all artifacts verified"
 }
@@ -312,14 +346,10 @@ cmd_mac-manifest() {
   log "latest-mac.yml: $DESK/out/make/latest-mac.yml"
 }
 
-# ── publish ───────────────────────────────────────────────────────────────────
-cmd_publish() {
+# ── draft + publish ───────────────────────────────────────────────────────────
+release_assets() {
   local v="$1"
-  local notes="$ROOT/docs/release-notes/v$v.md"
-  [ -f "$notes" ] || die "release notes missing: $notes"
-  cmd_mac-manifest "$v"
-  log "creating GitHub release v$v"
-  gh release create "v$v" --title "BioRouter v$v" --notes-file "$notes" \
+  printf '%s\n' \
     "$DESK/out/make/BioRouter-$v-arm64.dmg" \
     "$DESK/out/make/BioRouter-$v-x64.dmg" \
     "$DESK/out/make/$ARM64_ZIP_REL/BioRouter-darwin-arm64-$v.zip" \
@@ -331,6 +361,35 @@ cmd_publish() {
     "$ROOT/dist/cli/biorouter-cli_${v}_amd64.deb" \
     "$ROOT/dist/cli/biorouter-cli-${v}-1.x86_64.rpm" \
     "$ROOT/dist/biorouter-headless-linux-x64.tar.gz"
+}
+
+cmd_draft() {
+  local v="$1"
+  local notes="$ROOT/docs/release-notes/v$v.md"
+  [ -f "$notes" ] || die "release notes missing: $notes"
+  cmd_mac-manifest "$v"
+  local assets=()
+  while IFS= read -r asset; do
+    [ -f "$asset" ] || die "release asset missing: $asset"
+    assets+=("$asset")
+  done < <(release_assets "$v")
+  log "creating draft GitHub release v$v"
+  gh release create "v$v" --draft --target main --title "BioRouter v$v" \
+    --notes-file "$notes" "${assets[@]}"
+  log "draft ready: $(gh release view "v$v" --json url --jq .url)"
+}
+
+cmd_publish() {
+  local v="$1"
+  cmd_verify "$v"
+  local is_draft windows_smoke
+  is_draft="$(gh release view "v$v" --json isDraft --jq .isDraft 2>/dev/null || true)"
+  [ "$is_draft" = true ] || die "v$v must exist as a draft release before publication"
+  windows_smoke="$(gh run list --workflow release-artifact-smoke.yml --limit 30 \
+    --json displayTitle,conclusion \
+    --jq "[.[] | select(.displayTitle == \"Release artifact smoke v$v\" and .conclusion == \"success\")] | length")"
+  [ "$windows_smoke" -gt 0 ] || die "native Windows release smoke has not passed for v$v"
+  gh release edit "v$v" --draft=false
   log "published: $(gh release view "v$v" --json url --jq .url)"
 }
 
@@ -340,13 +399,14 @@ cmd_all() {
   cmd_mac-arm64 "$v"; cmd_mac-intel "$v"; cmd_windows "$v"; cmd_linux "$v"
   cmd_cli-linux "$v"                                                    # headless CLI deb/rpm
   cmd_headless-linux "$v"                                                # browser-served headless Linux
-  ( cd "$DESK" && rm -rf node_modules && npm install >/dev/null 2>&1 )  # un-Linux node_modules
-  cmd_verify "$v"; cmd_publish "$v"
+  ( cd "$DESK" && rm -rf node_modules && npm install --package-lock=false >/dev/null 2>&1 )  # un-Linux node_modules
+  cmd_verify "$v"; cmd_draft "$v"
+  log "draft created; run the native Windows smoke workflow, then: scripts/release.sh publish $v"
 }
 
 CMD="${1:-}"; VER="${2:-}"
 case "$CMD" in
-  bump|backends|linux-backend|mac-arm64|mac-intel|mac-manifest|windows|linux|cli-linux|headless-linux|verify|publish|all)
+  bump|backends|linux-backend|mac-arm64|mac-intel|mac-manifest|windows|linux|cli-linux|headless-linux|verify|draft|publish|all)
     need_version "$VER"; "cmd_${CMD}" "$VER" ;;
-  *) die "usage: scripts/release.sh {bump|backends|linux-backend|mac-arm64|mac-intel|mac-manifest|windows|linux|cli-linux|headless-linux|verify|publish|all} <version>" ;;
+  *) die "usage: scripts/release.sh {bump|backends|linux-backend|mac-arm64|mac-intel|mac-manifest|windows|linux|cli-linux|headless-linux|verify|draft|publish|all} <version>" ;;
 esac

--- a/scripts/smoke-test-release-artifacts.sh
+++ b/scripts/smoke-test-release-artifacts.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Execute the shipped vX.Y.Z artifacts in their target environments.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESK="$ROOT/ui/desktop"
+VERSION="${1:?usage: scripts/smoke-test-release-artifacts.sh <version> [all|mac|deb|rpm|cli|headless]}"
+TARGET="${2:-all}"
+
+log() { printf '\033[1;36m[release-smoke]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[release-smoke] %s\033[0m\n' "$*" >&2; exit 1; }
+
+require_file() {
+  [ -f "$1" ] || die "missing artifact: $1"
+}
+
+smoke_mac() {
+  local arch="$1" dmg="$2" mount tmp runner=(/usr/bin/env)
+  require_file "$dmg"
+  mount="$(mktemp -d "/tmp/biorouter-${arch}-mount.XXXXXX")"
+  tmp="$(mktemp -d "/tmp/biorouter-${arch}-smoke.XXXXXX")"
+  hdiutil attach -nobrowse -readonly -mountpoint "$mount" "$dmg" >/dev/null
+  local app="$mount/BioRouter.app"
+  [ -d "$app" ] || die "$arch DMG does not contain BioRouter.app"
+  codesign --verify --deep --strict --verbose=2 "$app"
+  spctl --assess --type execute --verbose "$app"
+  xcrun stapler validate "$app"
+  if [ "$arch" = x64 ]; then
+    arch -x86_64 /usr/bin/true >/dev/null 2>&1 || die "Rosetta is required for Intel runtime verification"
+    runner=(arch -x86_64)
+  fi
+  file "$app/Contents/Resources/bin/biorouter" | grep -q "${arch/x64/x86_64}" \
+    || die "$arch CLI architecture mismatch"
+  "${runner[@]}" "$app/Contents/Resources/bin/biorouter" --version | grep -q "$VERSION"
+  "${runner[@]}" "$app/Contents/Resources/bin/biorouterd" --version | grep -q "$VERSION"
+  HOME="$tmp" BIOROUTER_DISABLE_KEYRING=true \
+    "${runner[@]}" "$app/Contents/MacOS/BioRouter" --disable-gpu >"$tmp/app.log" 2>&1 &
+  local pid=$!
+  sleep 12
+  kill -0 "$pid" 2>/dev/null || { sed -n '1,160p' "$tmp/app.log" >&2; die "$arch desktop exited during startup"; }
+  kill "$pid" 2>/dev/null || true
+  sleep 1
+  kill -KILL "$pid" 2>/dev/null || true
+  pkill -KILL -f "$mount/BioRouter.app/Contents/" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  hdiutil detach "$mount" >/dev/null 2>&1 || {
+    sleep 2
+    hdiutil detach -force "$mount" >/dev/null
+  }
+  rm -rf "$mount" "$tmp"
+  log "macOS $arch DMG, CLI, daemon, and desktop startup passed"
+}
+
+smoke_deb() {
+  local deb="$DESK/out/make/deb/x64/biorouter_${VERSION}_amd64.deb"
+  require_file "$deb"
+  docker run --rm --platform linux/amd64 -e VERSION="$VERSION" \
+    -v "$deb":/pkg/biorouter.deb:ro debian:bookworm-slim bash -euxc '
+      apt-get update -qq
+      apt-get install -y -qq /pkg/biorouter.deb xvfb >/dev/null
+      /usr/lib/biorouter/resources/bin/biorouter --version | grep -q "$VERSION"
+      /usr/lib/biorouter/resources/bin/biorouterd --version | grep -q "$VERSION"
+      HOME=/tmp/biorouter-home BIOROUTER_DISABLE_KEYRING=true \
+        xvfb-run -a /usr/bin/biorouter --no-sandbox >/tmp/biorouter.log 2>&1 &
+      pid=$!
+      sleep 12
+      kill -0 "$pid"
+      kill "$pid" || true
+      sleep 1
+      kill -KILL "$pid" || true
+      wait "$pid" || true
+    '
+  log "Linux desktop DEB, CLI, daemon, and Xvfb startup passed"
+}
+
+smoke_rpm() {
+  local rpm="$DESK/out/make/rpm/x64/BioRouter-${VERSION}-1.x86_64.rpm"
+  require_file "$rpm"
+  docker run --rm --platform linux/amd64 -e VERSION="$VERSION" \
+    -v "$rpm":/pkg/biorouter.rpm:ro rockylinux:9 bash -euxc '
+      dnf install -y -q /pkg/biorouter.rpm xorg-x11-server-Xvfb >/dev/null
+      /usr/lib/BioRouter/resources/bin/biorouter --version | grep -q "$VERSION"
+      /usr/lib/BioRouter/resources/bin/biorouterd --version | grep -q "$VERSION"
+      Xvfb :99 -screen 0 1280x800x24 >/tmp/xvfb.log 2>&1 &
+      xvfb=$!
+      export DISPLAY=:99
+      HOME=/tmp/biorouter-home BIOROUTER_DISABLE_KEYRING=true \
+        /usr/bin/BioRouter --no-sandbox >/tmp/biorouter.log 2>&1 &
+      pid=$!
+      sleep 12
+      kill -0 "$pid"
+      kill "$pid" "$xvfb" || true
+      sleep 1
+      kill -KILL "$pid" "$xvfb" || true
+      wait "$pid" || true
+    '
+  log "Linux desktop RPM, CLI, daemon, and Xvfb startup passed"
+}
+
+smoke_cli_packages() {
+  local deb="$ROOT/dist/cli/biorouter-cli_${VERSION}_amd64.deb"
+  local rpm="$ROOT/dist/cli/biorouter-cli-${VERSION}-1.x86_64.rpm"
+  require_file "$deb"
+  require_file "$rpm"
+  docker run --rm --platform linux/amd64 -e VERSION="$VERSION" \
+    -v "$deb":/pkg/biorouter-cli.deb:ro debian:bookworm-slim bash -euxc '
+      apt-get update -qq
+      apt-get install -y -qq /pkg/biorouter-cli.deb >/dev/null
+      biorouter --version | grep -q "$VERSION"
+      biorouterd --version | grep -q "$VERSION"
+      biorouter term --help >/dev/null
+    '
+  docker run --rm --platform linux/amd64 -e VERSION="$VERSION" \
+    -v "$rpm":/pkg/biorouter-cli.rpm:ro rockylinux:9 bash -euxc '
+      dnf install -y -q /pkg/biorouter-cli.rpm >/dev/null
+      biorouter --version | grep -q "$VERSION"
+      biorouterd --version | grep -q "$VERSION"
+      biorouter term --help >/dev/null
+    '
+  log "CLI-only DEB/RPM version and terminal entry points passed"
+}
+
+smoke_headless() {
+  local tarball="$ROOT/dist/biorouter-headless-linux-x64.tar.gz"
+  require_file "$tarball"
+  docker run --rm --platform linux/amd64 -e VERSION="$VERSION" \
+    -v "$tarball":/pkg/biorouter-headless.tar.gz:ro debian:bookworm-slim bash -euxc '
+      apt-get update -qq
+      apt-get install -y -qq curl ca-certificates xvfb xauth >/dev/null
+      mkdir -p /app
+      tar -xzf /pkg/biorouter-headless.tar.gz -C /app
+      install=/app/headless-linux-x64
+      "$install/bin/biorouter" --version | grep -q "$VERSION"
+      "$install/bin/biorouterd" --version | grep -q "$VERSION"
+      "$install/bin/biorouter-headless" --version | grep -q "$VERSION"
+      HOME=/tmp/biorouter-home "$install/bin/biorouter-headless" serve \
+        --no-spawn --host 127.0.0.1 --port 18080 --web-dir "$install/web" >/tmp/headless.log 2>&1 &
+      pid=$!
+      for _ in $(seq 1 30); do
+        curl -fsS http://127.0.0.1:18080/headless/health >/tmp/health.json && break
+        sleep 1
+      done
+      grep -q "\"status\":\"ok\"" /tmp/health.json
+      curl -fsS http://127.0.0.1:18080/ | grep -qi "<!doctype html>"
+      kill "$pid"
+      wait "$pid" || true
+    '
+  log "headless tarball binaries, health endpoint, and web app passed"
+}
+
+case "$TARGET" in
+  all)
+    smoke_mac arm64 "$DESK/out/make/BioRouter-${VERSION}-arm64.dmg"
+    smoke_mac x64 "$DESK/out/make/BioRouter-${VERSION}-x64.dmg"
+    smoke_deb
+    smoke_rpm
+    smoke_cli_packages
+    smoke_headless
+    log "all locally executable release artifacts passed"
+    ;;
+  mac)
+    smoke_mac arm64 "$DESK/out/make/BioRouter-${VERSION}-arm64.dmg"
+    smoke_mac x64 "$DESK/out/make/BioRouter-${VERSION}-x64.dmg"
+    ;;
+  deb) smoke_deb ;;
+  rpm) smoke_rpm ;;
+  cli) smoke_cli_packages ;;
+  headless) smoke_headless ;;
+  *) die "unknown smoke target: $TARGET" ;;
+esac

--- a/scripts/verify-headless-artifact.sh
+++ b/scripts/verify-headless-artifact.sh
@@ -99,7 +99,7 @@ sed -n '1,20p' "$ARTIFACT/manifest.txt"
 if [ "$CREATE_TARBALL" = true ]; then
   tarball="$ROOT/dist/biorouter-headless-linux-x64.tar.gz"
   log "creating $tarball"
-  tar -C "$ROOT/dist" -czf "$tarball" "$(basename "$ARTIFACT")"
+  COPYFILE_DISABLE=1 tar --no-xattrs -C "$ROOT/dist" -czf "$tarball" "$(basename "$ARTIFACT")"
   shasum -a 256 "$tarball"
 fi
 

--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -224,7 +224,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -594,7 +593,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -635,7 +633,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1111,7 +1108,6 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -2718,7 +2714,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -6301,7 +6296,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6589,7 +6585,6 @@
       "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6631,7 +6626,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6642,7 +6636,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6783,7 +6776,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -7182,7 +7174,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -7455,7 +7446,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7537,7 +7527,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8151,7 +8140,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9273,7 +9261,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9707,7 +9694,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -9778,7 +9766,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -10483,6 +10470,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -10823,7 +10835,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11313,7 +11324,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -12642,7 +12652,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -13782,7 +13791,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -15054,6 +15062,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15089,7 +15098,6 @@
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -17549,7 +17557,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17661,6 +17668,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17676,6 +17684,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18043,7 +18052,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18053,7 +18061,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18083,7 +18090,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-kapsule": {
       "version": "2.5.7",
@@ -20037,8 +20045,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -20597,7 +20604,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21023,7 +21029,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -21114,7 +21119,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -21795,7 +21799,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

- isolate Linux and Windows cross-build outputs and package Linux with the supported Node 24 toolchain
- add executable release-artifact smoke coverage for macOS, Linux desktop, CLI-only, headless, and native Windows
- create releases as drafts and require local verification plus a successful version-specific Windows run before publication
- publish detailed v1.88.0 notes and align the landing page, downloads, provider defaults, bundled capabilities, and local-model catalog

## Release safety

This PR intentionally does **not** publish v1.88.0. After merge, the final headless manifest will be rebuilt from `main`, all local artifacts will pass `scripts/release.sh verify 1.88.0`, a draft release will be uploaded, and the Windows artifact workflow must succeed before the draft can be made public.

## Verification completed

- `bash -n` for the changed release scripts
- `./scripts/check-no-cross-drift.sh`
- `./scripts/check-version-consistency.sh 1.88.0`
- `node landing/scripts/check-consistency.mjs`
- Node 24 clean-install lockfile validation in Linux x64 Docker
- signed/notarized Apple Silicon and Intel DMG execution, including packaged CLI/daemon and Electron startup
- Debian desktop install + CLI/daemon + Electron startup under Xvfb
- RPM desktop install + CLI/daemon + Electron startup under Xvfb
- CLI-only DEB/RPM install + terminal entry point
- headless tarball binaries + HTTP health + browser bundle startup
