### PR TITLE
Fix native Windows smoke for draft release assets

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   windows-runtime:
@@ -23,9 +23,28 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           New-Item -ItemType Directory -Force artifact | Out-Null
-          gh release download "v$env:VERSION" --repo $env:GITHUB_REPOSITORY `
-            --pattern "BioRouter-win32-x64-$env:VERSION.zip" --dir artifact
-          Expand-Archive "artifact/BioRouter-win32-x64-$env:VERSION.zip" artifact/unpacked
+          $tag = "v$env:VERSION"
+          $assetName = "BioRouter-win32-x64-$env:VERSION.zip"
+          $releases = gh api "repos/$env:GITHUB_REPOSITORY/releases?per_page=100" | ConvertFrom-Json
+          $matches = @($releases | Where-Object { $_.tag_name -eq $tag -and $_.draft })
+          if ($matches.Count -ne 1) {
+            throw "Expected one draft release for $tag, found $($matches.Count)"
+          }
+
+          $assets = gh api "repos/$env:GITHUB_REPOSITORY/releases/$($matches[0].id)/assets?per_page=100" | ConvertFrom-Json
+          $assetMatches = @($assets | Where-Object { $_.name -eq $assetName })
+          if ($assetMatches.Count -ne 1) {
+            throw "Expected one $assetName asset, found $($assetMatches.Count)"
+          }
+
+          $zip = "artifact/$assetName"
+          $headers = @{
+            Accept = "application/octet-stream"
+            Authorization = "Bearer $env:GH_TOKEN"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          Invoke-WebRequest $assetMatches[0].url -Headers $headers -OutFile $zip
+          Expand-Archive $zip artifact/unpacked
 
       - name: Run packaged CLI, daemon, and desktop
         shell: pwsh


### PR DESCRIPTION
## Summary

- resolve the private draft release through the GitHub Releases API instead of the tag endpoint, which intentionally returns 404 for drafts
- locate the exact Windows ZIP asset and download it through the authenticated asset API
- fail closed when the draft or asset is missing or ambiguous

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- the prior native Windows run reproduced the tag-endpoint failure before this fix

This is required before v1.88.0 can be published; the release remains a draft.