### PR TITLE
chore(dev): save/restore the machine-local git-worktree layout

### DIFF
--- a/scripts/worktrees.manifest
+++ b/scripts/worktrees.manifest
@@ -1,0 +1,6 @@
+/private/tmp/br-dashfix	main
+/private/tmp/br-integrate	integrate/docs-cleanup
+~/Desktop/biorouter-docs-cleanup	docs/comprehensive-cleanup
+.worktrees/icon-consistency	fix/titlebar-icon-consistency
+.worktrees/jupyter-ai-biorouter-persona	codex/jupyter-ai-biorouter-persona
+~/Desktop/br-toolcall	feat/streaming-tool-call-ui

--- a/scripts/worktrees.sh
+++ b/scripts/worktrees.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Save/restore this clone's git-worktree layout, so the same set of worktrees
+# can be recreated on another machine from the pushed branches.
+#
+#   scripts/worktrees.sh save      # snapshot the current layout into scripts/worktrees.manifest
+#   scripts/worktrees.sh restore   # recreate every missing worktree listed in the manifest
+#
+# Manifest format: one "path<TAB>branch" line per secondary worktree. Paths
+# inside the repo are stored relative to the repo root, paths under $HOME as
+# ~/..., anything else verbatim (e.g. /private/tmp scratch checkouts, which
+# macOS clears on reboot -- restore simply recreates them). The primary
+# checkout is never listed; detached worktrees are skipped.
+set -euo pipefail
+
+# The main worktree is always listed first, regardless of where we run from.
+top="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')"
+manifest="${WORKTREES_MANIFEST:-$top/scripts/worktrees.manifest}"
+
+save() {
+  local path="" branch="" tmp
+  tmp="$(mktemp)"
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) path="${line#worktree }" ;;
+      "branch refs/heads/"*) branch="${line#branch refs/heads/}" ;;
+      "")
+        if [ -n "$path" ] && [ -n "$branch" ] && [ "$path" != "$top" ]; then
+          case "$path" in
+            "$top"/*) path="${path#"$top"/}" ;;
+            "$HOME"/*) path="~/${path#"$HOME"/}" ;;
+          esac
+          printf '%s\t%s\n' "$path" "$branch" >>"$tmp"
+        fi
+        path="" branch=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain; echo)
+  mv "$tmp" "$manifest"
+  echo "saved $(wc -l <"$manifest" | tr -d ' ') worktree(s) to $manifest:"
+  sed 's/^/  /' "$manifest"
+}
+
+restore() {
+  [ -f "$manifest" ] || { echo "no manifest at $manifest" >&2; exit 1; }
+  git fetch origin --prune
+  local path branch dest failed=0
+  while IFS=$'\t' read -r path branch; do
+    [ -n "$path" ] && [ -n "$branch" ] || continue
+    case "$path" in
+      "~/"*) dest="$HOME/${path#\~/}" ;;
+      /*) dest="$path" ;;
+      *) dest="$top/$path" ;;
+    esac
+    if [ -e "$dest" ]; then
+      echo "skip (exists): $dest"
+      continue
+    fi
+    if ! git show-ref --verify -q "refs/heads/$branch"; then
+      git branch --track "$branch" "origin/$branch"
+    fi
+    if git worktree add "$dest" "$branch"; then
+      echo "restored: $dest -> $branch"
+    else
+      echo "FAILED: $dest -> $branch (branch may be checked out elsewhere)" >&2
+      failed=$((failed + 1))
+    fi
+  done <"$manifest"
+  [ "$failed" -eq 0 ] || exit 1
+}
+
+case "${1:-}" in
+  save) save ;;
+  restore) restore ;;
+  *) echo "usage: scripts/worktrees.sh {save|restore}" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
Git keeps worktree layout in `.git/worktrees/`, which never syncs — so after pushing every branch, a second machine still has to rebuild the worktree set by hand. This PR makes the layout data:

- **`scripts/worktrees.sh save`** snapshots the current layout into `scripts/worktrees.manifest` (one `path<TAB>branch` line per secondary worktree; in-repo paths stored relative, $HOME as `~`, scratch `/private/tmp` paths verbatim).
- **`scripts/worktrees.sh restore`** recreates every missing worktree on any clone, creating tracking branches from `origin` as needed. It warns and continues when a branch is already checked out (e.g. `main` in the primary checkout) instead of aborting.
- The committed manifest captures the current 6-worktree layout.

Smoke-tested with a save → remove → restore round-trip in a throwaway repo, including the fresh-clone case (local branch absent, only `origin/<branch>`).

Re-run `save` and commit whenever the layout changes.