### PR TITLE
Fix Windows desktop release build

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -52,7 +52,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           BIOROUTER_DISABLE_KEYRING: "true"
         run: |
-          $app = Resolve-Path "artifact/unpacked/Biorouter-win32-x64"
+          $app = Resolve-Path "artifact/unpacked"
           $cli = Join-Path $app "resources/bin/biorouter.exe"
           $daemon = Join-Path $app "resources/bin/biorouterd.exe"
           $desktop = Join-Path $app "Biorouter.exe"

--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -56,6 +56,8 @@ jobs:
           $cli = Join-Path $app "resources/bin/biorouter.exe"
           $daemon = Join-Path $app "resources/bin/biorouterd.exe"
           $desktop = Join-Path $app "Biorouter.exe"
+          $git = Join-Path $app "resources/bin/git/cmd/git.exe"
+          $minGitMarker = Join-Path $app "resources/bin/git/mingit-version.txt"
 
           $cliVersion = & $cli --version
           if ($LASTEXITCODE -ne 0 -or $cliVersion -notmatch [regex]::Escape($env:VERSION)) {
@@ -67,6 +69,19 @@ jobs:
           }
           & $cli term --help | Out-Null
           if ($LASTEXITCODE -ne 0) { throw "Packaged terminal help failed" }
+
+          if (!(Test-Path -LiteralPath $git) -or !(Test-Path -LiteralPath $minGitMarker)) {
+            throw "Packaged MinGit executable or version marker is missing"
+          }
+          $minGitVersion = (Get-Content -LiteralPath $minGitMarker -Raw).Trim()
+          $gitVersion = & $git --version
+          if (
+            [string]::IsNullOrWhiteSpace($minGitVersion) -or
+            $LASTEXITCODE -ne 0 -or
+            $gitVersion -notmatch [regex]::Escape($minGitVersion)
+          ) {
+            throw "Packaged MinGit did not match marker '$minGitVersion': $gitVersion"
+          }
 
           $process = Start-Process $desktop -PassThru
           Start-Sleep -Seconds 15

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,6 +115,17 @@ jobs:
         with:
           toolchain: "1.92"
           components: clippy
+
+      # MSVC's test PDBs dominate the Windows link and cache footprint (the
+      # biorouter harness alone produced a ~1.1 GiB PDB). This keeps debug
+      # assertions, overflow checks and panic locations while omitting debugger
+      # symbols that CI never consumes. Set it before rust-cache so the action's
+      # CARGO_* environment hash separates these artifacts from debug=2 builds.
+      - name: Disable Windows CI test debuginfo
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: echo 'CARGO_PROFILE_TEST_DEBUG=0' >> "$GITHUB_ENV"
+
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
@@ -152,28 +163,24 @@ jobs:
       # read as "a new rotating set of failures" and was really one hidden queue
       # being drained one CI round-trip at a time. One run now names them all.
       - name: cargo test (workspace, lib + bins)
-        run: cargo test --workspace --lib --bins --locked --no-fail-fast
+        run: cargo test --workspace --lib --bins --locked --no-fail-fast --timings
+
+      - name: Upload Windows Cargo timings
+        if: matrix.os == 'windows-latest' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-cargo-timings
+          path: target/cargo-timings/cargo-timing.html
+          if-no-files-found: warn
+          retention-days: 14
 
       # The cross-platform-sensitive suites BR-70 exists to prove, run on every
-      # OS they apply to.
-      #
-      # ⚠ `shell: bash` and the explicit `rc` are both here for windows-latest,
-      # and the first one is a correctness fix rather than a preference. A `run:`
-      # block on a Windows runner is `pwsh`, and pwsh does NOT abort a script on
-      # a native command's non-zero exit: GitHub takes `$LASTEXITCODE`, so only
-      # the THIRD line here decided whether this step passed and the first two
-      # could fail in silence. `bash` restores "any failure fails the step" on
-      # all three runners, and collecting `rc` rather than relying on `-e` means
-      # all three suites still report in one run instead of the step stopping at
-      # the first.
-      - name: cargo test (sandbox + developer shell/background + security)
-        shell: bash
-        run: |
-          rc=0
-          cargo test -p biorouter-sandbox --locked --no-fail-fast || rc=1
-          cargo test -p biorouter-mcp --lib developer:: --locked --no-fail-fast || rc=1
-          cargo test -p biorouter --lib security:: --locked --no-fail-fast || rc=1
-          exit $rc
+      # OS they apply to. The workspace step above already runs the sandbox,
+      # developer shell/background and security unit tests through their library
+      # targets. Only the sandbox integration target sits outside --lib/--bins;
+      # name it directly rather than executing those unit tests a second time.
+      - name: cargo test (sandbox integration)
+        run: cargo test -p biorouter-sandbox --test sandbox --locked --no-fail-fast
 
       - name: clippy (host, informational until warnings are burned down)
         if: matrix.os == 'ubuntu-latest'

--- a/crates/biorouter-mcp/src/developer/rmcp_developer.rs
+++ b/crates/biorouter-mcp/src/developer/rmcp_developer.rs
@@ -66,6 +66,15 @@ use std::time::Duration;
 /// per turn.
 static PATH_JAIL_RELAXED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+fn redirect_target_within_base(base: &Path, target: &str) -> Option<PathBuf> {
+    // Path::join preserves relative targets and replaces the base for absolute
+    // ones on every supported platform. Always check the resulting path: a
+    // hand-written absolute-path predicate missed Windows C:/ and rooted forms,
+    // which let an out-of-tree target bypass this snapshot-only containment.
+    let resolved = base.join(target);
+    resolved.starts_with(base).then_some(resolved)
+}
+
 /// Relax (or re-engage) the `text_editor` working-directory jail process-wide.
 /// Called by the `biorouter` agent with `biorouter_mode == BioRouterMode::Auto`.
 pub fn set_path_jail_relaxed(relaxed: bool) {
@@ -1098,15 +1107,8 @@ impl DeveloperServer {
                 continue;
             }
             let expanded = expand_path(&raw);
-            let resolved = if is_absolute_path(&expanded) {
-                let p = PathBuf::from(&expanded);
-                // Only snapshot absolute targets inside the working directory.
-                if !p.starts_with(&base) {
-                    continue;
-                }
-                p
-            } else {
-                base.join(&expanded)
+            let Some(resolved) = redirect_target_within_base(&base, &expanded) else {
+                continue;
             };
             // Don't copy ignored files (.env, secrets, ...) into the history.
             if self.is_ignored(&resolved) {
@@ -3625,6 +3627,35 @@ mod tests {
 
         text_editor_undo(&out, &server.file_history).await.unwrap();
         assert_eq!(std::fs::read_to_string(&out).unwrap(), "before\n");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn redirect_snapshots_stay_inside_the_windows_working_directory() {
+        let base = Path::new(r"C:\workspace");
+
+        for inside in [
+            r"logs\out.txt",
+            r"C:\workspace\logs\out.txt",
+            "C:/workspace/out.txt",
+        ] {
+            assert!(
+                redirect_target_within_base(base, inside).is_some(),
+                "expected an in-tree target: {inside}"
+            );
+        }
+        for outside in [
+            r"C:\outside\out.txt",
+            "C:/outside/out.txt",
+            r"\outside\out.txt",
+            r"\\server\share\out.txt",
+            r"C:\workspace-sibling\out.txt",
+        ] {
+            assert!(
+                redirect_target_within_base(base, outside).is_none(),
+                "expected an out-of-tree target: {outside}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/biorouter-mcp/src/developer/shell.rs
+++ b/crates/biorouter-mcp/src/developer/shell.rs
@@ -1,4 +1,4 @@
-use std::{env, ffi::OsString, process::Stdio, sync::Once};
+use std::{env, ffi::OsString, path::Path, process::Stdio, sync::Once};
 
 pub use biorouter_sandbox::environment::{
     is_daemon_private_env_key, strip_daemon_private_env, strip_daemon_private_env_std,
@@ -90,13 +90,8 @@ pub fn expand_path(path_str: &str) -> String {
 }
 
 pub fn is_absolute_path(path_str: &str) -> bool {
-    if cfg!(windows) {
-        // Check for Windows absolute paths (drive letters and UNC)
-        path_str.contains(":\\") || path_str.starts_with("\\\\")
-    } else {
-        // Unix absolute paths start with /
-        path_str.starts_with('/')
-    }
+    let path = Path::new(path_str);
+    path.is_absolute() || (cfg!(windows) && path.has_root())
 }
 
 pub fn normalize_line_endings(text: &str) -> String {
@@ -669,6 +664,22 @@ pub async fn kill_process_group(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_absolute_paths_accept_native_and_forward_slash_forms() {
+        for absolute in [
+            r"C:\workspace\out.txt",
+            "C:/workspace/out.txt",
+            r"\workspace\out.txt",
+            r"\\server\share\out.txt",
+        ] {
+            assert!(is_absolute_path(absolute), "expected absolute: {absolute}");
+        }
+        for relative in [r"workspace\out.txt", "workspace/out.txt", r"C:out.txt"] {
+            assert!(!is_absolute_path(relative), "expected relative: {relative}");
+        }
+    }
 
     #[test]
     fn network_flag_parses_truthy_values() {

--- a/crates/biorouter-sandbox/tests/sandbox.rs
+++ b/crates/biorouter-sandbox/tests/sandbox.rs
@@ -15,6 +15,21 @@ fn ws() -> tempfile::TempDir {
     tempfile::tempdir().expect("tempdir")
 }
 
+fn native_shell(unix_script: impl Into<String>, windows_script: impl Into<String>) -> Vec<String> {
+    if cfg!(windows) {
+        vec![
+            "powershell.exe".into(),
+            "-NoLogo".into(),
+            "-NoProfile".into(),
+            "-NonInteractive".into(),
+            "-Command".into(),
+            windows_script.into(),
+        ]
+    } else {
+        vec!["sh".into(), "-c".into(), unix_script.into()]
+    }
+}
+
 // ----------------------------- LOCAL: exec -----------------------------
 
 #[tokio::test]
@@ -22,7 +37,10 @@ async fn local_exec_captures_stdout_and_exit_code() {
     let dir = ws();
     let sb = LocalProcessSandbox::new(SandboxSpec::new(dir.path()));
     let out = sb
-        .exec(&["sh".into(), "-c".into(), "echo hello world".into()], None)
+        .exec(
+            &native_shell("echo hello world", "[Console]::Out.Write('hello world')"),
+            None,
+        )
         .await
         .unwrap();
     assert!(out.success(), "stderr={}", out.stderr);
@@ -36,7 +54,10 @@ async fn local_exec_propagates_nonzero_exit() {
     let sb = LocalProcessSandbox::new(SandboxSpec::new(dir.path()));
     let out = sb
         .exec(
-            &["sh".into(), "-c".into(), "echo oops >&2; exit 3".into()],
+            &native_shell(
+                "echo oops >&2; exit 3",
+                "[Console]::Error.Write('oops'); exit 3",
+            ),
             None,
         )
         .await
@@ -51,7 +72,10 @@ async fn local_exec_feeds_stdin() {
     let dir = ws();
     let sb = LocalProcessSandbox::new(SandboxSpec::new(dir.path()));
     let out = sb
-        .exec(&["cat".into()], Some("piped-input-value"))
+        .exec(
+            &native_shell("cat", "[Console]::Out.Write([Console]::In.ReadToEnd())"),
+            Some("piped-input-value"),
+        )
         .await
         .unwrap();
     assert_eq!(out.stdout, "piped-input-value");
@@ -65,11 +89,10 @@ async fn local_exec_injects_env_without_leaking_to_wire() {
     let sb = LocalProcessSandbox::new(spec);
     let out = sb
         .exec(
-            &[
-                "sh".into(),
-                "-c".into(),
-                "printf %s \"$VAULT_SECRET\"".into(),
-            ],
+            &native_shell(
+                "printf %s \"$VAULT_SECRET\"",
+                "[Console]::Out.Write($env:VAULT_SECRET)",
+            ),
             None,
         )
         .await
@@ -90,16 +113,15 @@ async fn local_exec_strips_daemon_credentials_but_keeps_declared_env() {
     let sb = LocalProcessSandbox::new(spec);
     let out = sb
         .exec(
-            &[
-                "sh".into(),
-                "-c".into(),
-                "printf 'daemon=%s extension=%s' \"${BIOROUTER_SERVER__SECRET_KEY-unset}\" \"$SPOKEAGENT_PASSCODE\""
-                    .into(),
-            ],
+            &native_shell(
+                "printf 'daemon=%s extension=%s' \"${BIOROUTER_SERVER__SECRET_KEY-unset}\" \"$SPOKEAGENT_PASSCODE\"",
+                "if ($null -ne $env:BIOROUTER_SERVER__SECRET_KEY) { exit 9 }; [Console]::Out.Write('daemon=unset extension=' + $env:SPOKEAGENT_PASSCODE)",
+            ),
             None,
         )
         .await
         .unwrap();
+    assert!(out.success(), "stderr={}", out.stderr);
     assert_eq!(out.stdout, "daemon=unset extension=extension-private");
 }
 
@@ -110,7 +132,7 @@ async fn local_exec_timeout_kills_runaway_promptly() {
     let sb = LocalProcessSandbox::new(spec);
     let start = std::time::Instant::now();
     let out = sb
-        .exec(&["sh".into(), "-c".into(), "sleep 30".into()], None)
+        .exec(&native_shell("sleep 30", "Start-Sleep -Seconds 30"), None)
         .await
         .unwrap();
     let elapsed = start.elapsed();
@@ -129,11 +151,10 @@ async fn local_exec_drains_large_output_without_deadlock() {
     let sb = LocalProcessSandbox::new(SandboxSpec::new(dir.path()));
     let out = sb
         .exec(
-            &[
-                "sh".into(),
-                "-c".into(),
-                "yes x | head -n 100000 | tr -d '\\n'".into(),
-            ],
+            &native_shell(
+                "yes x | head -n 100000 | tr -d '\\n'",
+                "[Console]::Out.Write('x' * 100000)",
+            ),
             None,
         )
         .await
@@ -149,8 +170,14 @@ async fn local_exec_handles_20_concurrent_commands() {
     for i in 0..20 {
         let sb = sb.clone();
         handles.push(tokio::spawn(async move {
-            sb.exec(&["sh".into(), "-c".into(), format!("echo n{i}")], None)
-                .await
+            sb.exec(
+                &native_shell(
+                    format!("echo n{i}"),
+                    format!("[Console]::Out.Write('n{i}')"),
+                ),
+                None,
+            )
+            .await
         }));
     }
     for (i, h) in handles.into_iter().enumerate() {

--- a/crates/biorouter-server/src/routes/agent.rs
+++ b/crates/biorouter-server/src/routes/agent.rs
@@ -3279,9 +3279,19 @@ mod knowledge_selection_tests {
             let svc = Arc::clone(&svc);
             std::thread::spawn(move || svc.create_base("gamma", "gamma", None).unwrap())
         };
-        // Long enough for `create_base` to be holding the root lock, short
-        // enough that it is nowhere near registering `gamma`.
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        // Wait for an observable write that happens only after `create_base`
+        // has taken the root lock. A fixed sleep lost this race on slower
+        // Windows runners: the apply could finish before the creator thread was
+        // scheduled, making `gamma` legitimately visible when it landed later.
+        let gamma_root = biorouter_mcp::knowledge::paths::kb_root(svc.root(), "gamma");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !gamma_root.exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the creator must begin writing gamma while the test is waiting"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
         apply_workflow_knowledge_selection(&svc, "s1", &workflow).unwrap();
         creator.join().unwrap();
 

--- a/crates/biorouter/src/providers/coding_agent/bridge.rs
+++ b/crates/biorouter/src/providers/coding_agent/bridge.rs
@@ -1564,14 +1564,22 @@ mod tests {
         hook_specific_output: &serde_json::Value,
     ) -> Arc<crate::hooks::HooksManager> {
         let payload = serde_json::json!({ "hookSpecificOutput": hook_specific_output }).to_string();
-        // Single-quoted for `sh -c`, with any embedded quote escaped the usual
-        // way. The JSON above contains none, but a future edit to the fixtures
-        // should not become a mysterious hook failure.
-        let quoted = payload.replace('\'', "'\"'\"'");
+        let command = if cfg!(target_os = "windows") {
+            // Command hooks run through cmd.exe on Windows. Unlike sh, cmd keeps
+            // the JSON's double quotes intact and would echo literal single
+            // quotes, making the hook output invalid JSON.
+            format!("echo {payload}")
+        } else {
+            // Single-quoted for `sh -c`, with any embedded quote escaped the
+            // usual way. The JSON above contains none, but a future edit to the
+            // fixtures should not become a mysterious hook failure.
+            let quoted = payload.replace('\'', "'\"'\"'");
+            format!("echo '{quoted}'")
+        };
         let yaml = format!(
             "PreToolUse:\n  - matcher: {}\n    hooks:\n      - type: command\n        command: {}\n",
             serde_json::to_string(matcher).expect("a json string"),
-            serde_json::to_string(&format!("echo '{quoted}'")).expect("a json string"),
+            serde_json::to_string(&command).expect("a json string"),
         );
         let config = serde_yaml::from_str(&yaml).expect("the hook config parses");
         Arc::new(crate::hooks::HooksManager::with_config(

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -147,6 +147,9 @@ The ZIP is written to
   `cmd/git.exe`: the desktop startup code uses both files to detect an older or
   partial persistent copy under `%LOCALAPPDATA%\Biorouter\git`, then replaces it
   through a verified staging directory.
+- Windows package builds fail if MinGit cannot be prepared. Developers who are
+  intentionally testing a package without the fallback can set
+  `BIOROUTER_ALLOW_MISSING_MINGIT=1`; release builds must not set this opt-out.
 - Windows test builds should set `CARGO_PROFILE_TEST_DEBUG=0` before the Rust
   cache step. This keeps test behavior and assertions intact while avoiding very
   large MSVC PDB files, and setting it before cache restore gives the optimized

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -87,7 +87,67 @@ The built application will be available in:
 - Executable: `out/biorouter-linux-x64/biorouter`
 
 ### Windows
-Use the existing Windows build process as documented.
+
+The release artifact is a Windows x64 ZIP. The supported release path can run
+from a macOS development machine: Docker cross-compiles the GNU Rust binaries,
+then Electron Forge packages those staged binaries on the host.
+
+#### From macOS with Docker (release path)
+
+Use the system Docker installation rather than the Hermit Docker shim. From the
+repository root, build the backends and then package Windows for the current
+version:
+
+```bash
+source ./bin/activate-hermit
+scripts/release.sh backends 1.89.2
+scripts/release.sh windows 1.89.2
+```
+
+For a Windows-only backend rebuild, `just release-windows` uses the same Docker
+recipe as CI. Before packaging, make sure `biorouter.exe`, `biorouterd.exe`, and
+the MinGW runtime DLLs are present in
+`target/x86_64-pc-windows-gnu/release/`. The release script stages them into
+`ui/desktop/src/bin/` automatically.
+
+#### Directly on Windows (local validation)
+
+Install Visual Studio Build Tools with the C++ workload, CMake, NASM, Rust
+1.92, and Node 24. `aws-lc-sys` requires NASM for release builds; disabling
+assembly is not supported in release mode. PowerShell can use every logical CPU
+for the Rust build as follows:
+
+```powershell
+$jobs = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
+cargo build --release --bin biorouter --bin biorouterd --jobs $jobs
+New-Item -ItemType Directory -Force ui\desktop\src\bin | Out-Null
+Copy-Item target\release\biorouter.exe,target\release\biorouterd.exe ui\desktop\src\bin\
+Set-Location ui\desktop
+npm ci
+npm run bundle:windows
+```
+
+The ZIP is written to
+`out/make/zip/win32/x64/Biorouter-win32-x64-<version>.zip`.
+
+#### Windows release checks and takeaways
+
+- Keep `bundle:windows` implemented as a Node script. Inline POSIX environment
+  assignments such as `ELECTRON_PLATFORM=win32 command` do not run in Windows
+  Command Prompt or PowerShell.
+- Use Node libraries for archive handling. The Windows llama.cpp download is a
+  ZIP and must not depend on a host `unzip` executable.
+- `ELECTRON_PLATFORM=win32` and `ELECTRON_ARCH=x64` must apply to MinGit
+  download, binary preparation, and Electron Forge packaging. Platform bundles
+  overwrite `src/bin`, so build and stage one platform at a time.
+- Electron Forge's Windows ZIP contains `Biorouter.exe` and `resources/` at the
+  archive root; there is no extra `Biorouter-win32-x64/` directory after
+  extraction.
+- Do not consider the release complete until the ZIP itself has been extracted
+  on Windows, both embedded binaries report the expected version,
+  `biorouter term --help` succeeds, and `Biorouter.exe` remains running through
+  startup. The `Release artifact smoke` GitHub workflow performs these checks
+  against a draft release.
 
 
 # Running with biorouterd server from source

--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -119,7 +119,7 @@ for the Rust build as follows:
 
 ```powershell
 $jobs = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
-cargo build --release --bin biorouter --bin biorouterd --jobs $jobs
+cargo build --release --bin biorouter --bin biorouterd --locked --jobs $jobs
 New-Item -ItemType Directory -Force ui\desktop\src\bin | Out-Null
 Copy-Item target\release\biorouter.exe,target\release\biorouterd.exe ui\desktop\src\bin\
 Set-Location ui\desktop
@@ -143,6 +143,19 @@ The ZIP is written to
 - Electron Forge's Windows ZIP contains `Biorouter.exe` and `resources/` at the
   archive root; there is no extra `Biorouter-win32-x64/` directory after
   extraction.
+- Bundled MinGit is versioned with `mingit-version.txt`. Keep the marker beside
+  `cmd/git.exe`: the desktop startup code uses both files to detect an older or
+  partial persistent copy under `%LOCALAPPDATA%\Biorouter\git`, then replaces it
+  through a verified staging directory.
+- Windows test builds should set `CARGO_PROFILE_TEST_DEBUG=0` before the Rust
+  cache step. This keeps test behavior and assertions intact while avoiding very
+  large MSVC PDB files, and setting it before cache restore gives the optimized
+  artifacts a distinct cache key.
+- Do not repeat unit-test targets after `cargo test --workspace --lib --bins`.
+  Run only integration targets that command does not cover, and retain Cargo's
+  HTML timings artifact so future Windows compile/link regressions are visible.
+  Cargo already uses the available logical processors by default; explicit
+  `--jobs` is useful in local release commands to make that intent clear.
 - Do not consider the release complete until the ZIP itself has been extracted
   on Windows, both embedded binaries report the expected version,
   `biorouter term --help` succeeds, and `Biorouter.exe` remains running through

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -18,7 +18,7 @@
     "make": "node scripts/fix-node-pty-permissions.mjs && electron-forge make",
     "bundle:default": "node scripts/build-auth-helper.mjs && node scripts/prepare-platform-binaries.js && npm run make && (cd out/Biorouter-darwin-arm64 && ditto -c -k --sequesterRsrc --keepParent Biorouter.app Biorouter.zip)",
     "bundle:alpha": "ALPHA=true node scripts/prepare-platform-binaries.js && ALPHA=true npm run make && (cd out/Biorouter-darwin-arm64 && ditto -c -k --sequesterRsrc --keepParent Biorouter.app Biorouter_alpha.zip) || echo 'out/Biorouter-darwin-arm64 not found; either the binary is not built or you are not on macOS'",
-    "bundle:windows": "node scripts/build-main.js && ELECTRON_PLATFORM=win32 node scripts/download-mingit.js && ELECTRON_PLATFORM=win32 node scripts/prepare-platform-binaries.js && npm run make -- --platform=win32 --arch=x64",
+    "bundle:windows": "node scripts/build-windows.js",
     "bundle:intel": "ELECTRON_ARCH=x64 node scripts/build-auth-helper.mjs && ELECTRON_ARCH=x64 node scripts/prepare-platform-binaries.js && npm run make -- --arch=x64 && cd out/Biorouter-darwin-x64 && ditto -c -k --sequesterRsrc --keepParent Biorouter.app Biorouter_intel_mac.zip",
     "bundle:dmg": "node scripts/prepare-platform-binaries.js && npm run make -- --targets @electron-forge/maker-dmg",
     "bundle:intel-dmg": "ELECTRON_ARCH=x64 node scripts/prepare-platform-binaries.js && npm run make -- --targets @electron-forge/maker-dmg --arch=x64",

--- a/ui/desktop/scripts/build-windows.js
+++ b/ui/desktop/scripts/build-windows.js
@@ -1,0 +1,41 @@
+const { spawnSync } = require('child_process');
+const { resolve } = require('path');
+
+const appRoot = resolve(__dirname, '..');
+const npmCli = process.env.npm_execpath;
+const env = {
+  ...process.env,
+  ELECTRON_PLATFORM: 'win32',
+  ELECTRON_ARCH: 'x64',
+};
+
+if (!npmCli) {
+  throw new Error('npm_execpath is unavailable; run this build through npm run bundle:windows');
+}
+
+const steps = [
+  ['build Electron main process', process.execPath, ['scripts/build-main.js']],
+  ['download MinGit', process.execPath, ['scripts/download-mingit.js']],
+  ['prepare Windows binaries', process.execPath, ['scripts/prepare-platform-binaries.js']],
+  [
+    'make Windows package',
+    process.execPath,
+    [npmCli, 'run', 'make', '--', '--platform=win32', '--arch=x64'],
+  ],
+];
+
+for (const [label, command, args] of steps) {
+  console.log(`\n[windows-release] ${label}`);
+  const result = spawnSync(command, args, {
+    cwd: appRoot,
+    env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/ui/desktop/scripts/download-mingit.js
+++ b/ui/desktop/scripts/download-mingit.js
@@ -19,6 +19,7 @@ const MINGIT_VERSION = '2.49.0';
 const MINGIT_WINDOWS_TAG = `v${MINGIT_VERSION}.windows.1`;
 const MINGIT_ZIP_NAME = `MinGit-${MINGIT_VERSION}-64-bit.zip`;
 const MINGIT_URL = `https://github.com/git-for-windows/git/releases/download/${MINGIT_WINDOWS_TAG}/${MINGIT_ZIP_NAME}`;
+const MINGIT_VERSION_FILE = 'mingit-version.txt';
 
 const DEST_DIR = path.join(__dirname, '..', 'src', 'platform', 'windows', 'bin', 'git');
 const ZIP_PATH = path.join(os.tmpdir(), MINGIT_ZIP_NAME);
@@ -28,33 +29,37 @@ function download(url, dest) {
     const file = fs.createWriteStream(dest);
 
     const get = (url) => {
-      https.get(url, (res) => {
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          get(res.headers.location);
-          return;
-        }
-        if (res.statusCode !== 200) {
-          file.close();
-          reject(new Error(`HTTP ${res.statusCode} downloading ${url}`));
-          return;
-        }
-        const total = parseInt(res.headers['content-length'] || '0', 10);
-        let downloaded = 0;
-        res.on('data', (chunk) => {
-          downloaded += chunk.length;
-          if (total > 0) {
-            const pct = Math.round((downloaded / total) * 100);
-            process.stdout.write(`\r  ${pct}% (${Math.round(downloaded / 1024 / 1024)}MB / ${Math.round(total / 1024 / 1024)}MB)`);
+      https
+        .get(url, (res) => {
+          if (res.statusCode === 301 || res.statusCode === 302) {
+            get(res.headers.location);
+            return;
           }
-        });
-        res.pipe(file);
-        file.on('finish', () => {
-          file.close();
-          process.stdout.write('\n');
-          resolve();
-        });
-        file.on('error', reject);
-      }).on('error', reject);
+          if (res.statusCode !== 200) {
+            file.close();
+            reject(new Error(`HTTP ${res.statusCode} downloading ${url}`));
+            return;
+          }
+          const total = parseInt(res.headers['content-length'] || '0', 10);
+          let downloaded = 0;
+          res.on('data', (chunk) => {
+            downloaded += chunk.length;
+            if (total > 0) {
+              const pct = Math.round((downloaded / total) * 100);
+              process.stdout.write(
+                `\r  ${pct}% (${Math.round(downloaded / 1024 / 1024)}MB / ${Math.round(total / 1024 / 1024)}MB)`
+              );
+            }
+          });
+          res.pipe(file);
+          file.on('finish', () => {
+            file.close();
+            process.stdout.write('\n');
+            resolve();
+          });
+          file.on('error', reject);
+        })
+        .on('error', reject);
     };
 
     get(url);
@@ -69,7 +74,7 @@ function extract(zipPath, destDir) {
   if (process.platform === 'win32') {
     execSync(
       `powershell -NoProfile -Command "Expand-Archive -LiteralPath '${zipPath}' -DestinationPath '${destDir}' -Force"`,
-      { stdio: 'inherit' },
+      { stdio: 'inherit' }
     );
   } else {
     execSync(`unzip -q -o "${zipPath}" -d "${destDir}"`, { stdio: 'inherit' });
@@ -84,8 +89,11 @@ async function main() {
     return;
   }
 
-  // Already present — skip (re-run `node scripts/download-mingit.js` to force refresh)
-  if (fs.existsSync(path.join(DEST_DIR, 'cmd', 'git.exe'))) {
+  const bundledVersionPath = path.join(DEST_DIR, MINGIT_VERSION_FILE);
+  const bundledVersion = fs.existsSync(bundledVersionPath)
+    ? fs.readFileSync(bundledVersionPath, 'utf8').trim()
+    : null;
+  if (bundledVersion === MINGIT_VERSION && fs.existsSync(path.join(DEST_DIR, 'cmd', 'git.exe'))) {
     console.log('MinGit already present, skipping download');
     return;
   }
@@ -95,14 +103,25 @@ async function main() {
 
   try {
     await download(MINGIT_URL, ZIP_PATH);
-    console.log(`Extracting to ${DEST_DIR} ...`);
-    extract(ZIP_PATH, DEST_DIR);
-    fs.unlinkSync(ZIP_PATH);
+    const stagingDir = `${DEST_DIR}.staging`;
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+    console.log(`Extracting to ${stagingDir} ...`);
+    extract(ZIP_PATH, stagingDir);
+    if (!fs.existsSync(path.join(stagingDir, 'cmd', 'git.exe'))) {
+      throw new Error('downloaded MinGit archive is missing cmd/git.exe');
+    }
+    fs.writeFileSync(path.join(stagingDir, MINGIT_VERSION_FILE), `${MINGIT_VERSION}\n`);
+    fs.rmSync(DEST_DIR, { recursive: true, force: true });
+    fs.renameSync(stagingDir, DEST_DIR);
     console.log('MinGit ready.');
   } catch (err) {
     console.error(`\nFailed to download/extract MinGit: ${err.message}`);
-    console.warn('Bundled git will not be available. Windows users without git must install it manually.');
+    console.warn(
+      'Bundled git will not be available. Windows users without git must install it manually.'
+    );
     // Non-fatal — build continues without bundled git
+  } finally {
+    fs.rmSync(ZIP_PATH, { force: true });
   }
 }
 

--- a/ui/desktop/scripts/download-mingit.js
+++ b/ui/desktop/scripts/download-mingit.js
@@ -6,20 +6,23 @@
  *
  * Run automatically as part of `npm run bundle:windows`.
  * Skipped entirely on non-Windows builds (ELECTRON_PLATFORM != win32).
- * Non-fatal: if the download fails, the build continues without bundled git.
+ * Release builds fail if MinGit cannot be prepared. A developer who is
+ * intentionally testing a package without the fallback may opt out with
+ * BIOROUTER_ALLOW_MISSING_MINGIT=1.
  */
 
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync } = require('child_process');
+const AdmZip = require('adm-zip');
 
 const MINGIT_VERSION = '2.49.0';
 const MINGIT_WINDOWS_TAG = `v${MINGIT_VERSION}.windows.1`;
 const MINGIT_ZIP_NAME = `MinGit-${MINGIT_VERSION}-64-bit.zip`;
 const MINGIT_URL = `https://github.com/git-for-windows/git/releases/download/${MINGIT_WINDOWS_TAG}/${MINGIT_ZIP_NAME}`;
 const MINGIT_VERSION_FILE = 'mingit-version.txt';
+const ALLOW_MISSING_MINGIT_ENV = 'BIOROUTER_ALLOW_MISSING_MINGIT';
 
 const DEST_DIR = path.join(__dirname, '..', 'src', 'platform', 'windows', 'bin', 'git');
 const ZIP_PATH = path.join(os.tmpdir(), MINGIT_ZIP_NAME);
@@ -68,17 +71,17 @@ function download(url, dest) {
 
 function extract(zipPath, destDir) {
   fs.mkdirSync(destDir, { recursive: true });
+  new AdmZip(zipPath).extractAllTo(destDir, true);
+}
 
-  // On Windows (native build): use PowerShell Expand-Archive
-  // On macOS/Linux (cross-compilation): use unzip (available by default on both)
-  if (process.platform === 'win32') {
-    execSync(
-      `powershell -NoProfile -Command "Expand-Archive -LiteralPath '${zipPath}' -DestinationPath '${destDir}' -Force"`,
-      { stdio: 'inherit' }
-    );
-  } else {
-    execSync(`unzip -q -o "${zipPath}" -d "${destDir}"`, { stdio: 'inherit' });
-  }
+function missingMinGitAllowed(env = process.env) {
+  return /^(1|true|on|yes)$/i.test((env[ALLOW_MISSING_MINGIT_ENV] || '').trim());
+}
+
+function handleMinGitFailure(error, env = process.env) {
+  if (!missingMinGitAllowed(env)) throw error;
+  console.warn(`Failed to download/extract MinGit: ${error.message}`);
+  console.warn(`Continuing because ${ALLOW_MISSING_MINGIT_ENV} explicitly allows it.`);
 }
 
 async function main() {
@@ -115,14 +118,17 @@ async function main() {
     fs.renameSync(stagingDir, DEST_DIR);
     console.log('MinGit ready.');
   } catch (err) {
-    console.error(`\nFailed to download/extract MinGit: ${err.message}`);
-    console.warn(
-      'Bundled git will not be available. Windows users without git must install it manually.'
-    );
-    // Non-fatal — build continues without bundled git
+    handleMinGitFailure(err);
   } finally {
     fs.rmSync(ZIP_PATH, { force: true });
   }
 }
 
-main();
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`MinGit preparation failed: ${err.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { extract, handleMinGitFailure, missingMinGitAllowed };

--- a/ui/desktop/scripts/fetch-llama-server.js
+++ b/ui/desktop/scripts/fetch-llama-server.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const AdmZip = require('adm-zip');
 const { execFileSync } = require('child_process');
 
 const LLAMA_BUILD = 'b9611';
@@ -93,7 +94,7 @@ function fetchLlamaServer(platform, arch) {
   const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llamacpp-extract-'));
   try {
     if (asset.endsWith('.zip')) {
-      execFileSync('unzip', ['-oq', archivePath, '-d', extractDir], { stdio: 'inherit' });
+      new AdmZip(archivePath).extractAllTo(extractDir, true);
     } else {
       execFileSync('tar', ['-xzf', archivePath, '-C', extractDir], { stdio: 'inherit' });
     }

--- a/ui/desktop/src/biorouterd.logLevel.test.ts
+++ b/ui/desktop/src/biorouterd.logLevel.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { App } from 'electron';
 import type { PathLike, Stats } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/ui/desktop/src/biorouterd.test.ts
+++ b/ui/desktop/src/biorouterd.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import type { App } from 'electron';
 import type { PathLike, Stats } from 'node:fs';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -68,6 +68,8 @@ import {
 import { expandTilde } from './utils/pathUtils';
 import { friendlyArtifactFileError } from './utils/artifactFileErrors';
 import { isFilePathAllowedForPreview } from './utils/pathContainment';
+import { normalizeExternalHttpUrl } from './utils/externalUrl';
+import { findBrxtArgument, isBrxtFile } from './utils/launchArguments';
 import log from './utils/logger';
 import { ensureWinShims } from './utils/winShims';
 import { addRecentDir, loadRecentDirs } from './utils/recentDirs';
@@ -570,6 +572,11 @@ if (process.platform !== 'darwin') {
         handleProtocolUrl(protocolUrl);
       }
 
+      const brxtArg = findBrxtArgument(commandLine);
+      if (brxtArg) {
+        app.whenReady().then(() => handleBrxtFileOpen(brxtArg));
+      }
+
       // Only focus existing windows for non-bot/workflow URLs
       const existingWindows = BrowserWindow.getAllWindows();
       if (existingWindows.length > 0) {
@@ -598,7 +605,7 @@ if (process.platform !== 'darwin') {
   }
 
   // Check if launched with a .brxt file argument (Windows/Linux double-click)
-  const brxtArg = process.argv.slice(1).find((arg) => arg.endsWith('.brxt'));
+  const brxtArg = findBrxtArgument(process.argv.slice(1));
   if (brxtArg) {
     app.whenReady().then(() => handleBrxtFileOpen(brxtArg));
   }
@@ -825,7 +832,7 @@ app.on('will-finish-launching', () => {
 // Handle drag-and-drop onto dock icon
 app.on('open-file', async (event, filePath) => {
   event.preventDefault();
-  if (filePath.endsWith('.brxt')) {
+  if (isBrxtFile(filePath)) {
     if (app.isReady()) {
       handleBrxtFileOpen(filePath);
     } else {
@@ -2286,21 +2293,7 @@ ipcMain.handle('window:ensure-content-width', (event, minWidth: number) => {
 
 ipcMain.handle('open-external', async (_event, url: string) => {
   try {
-    if (typeof url !== 'string' || url.length > 8 * 1024) {
-      throw new Error('Blocked: invalid or oversized URL');
-    }
-    const parsed = new URL(url);
-    if (
-      (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
-      parsed.username !== '' ||
-      parsed.password !== ''
-    ) {
-      throw new Error(`Blocked: unsafe URL protocol '${parsed.protocol}'`);
-    }
-    // Pass the normalized URL — shell.openExternal and the WHATWG URL parser
-    // can disagree on edge-case inputs (embedded auth, backslashes, etc.),
-    // and using the parsed.href guarantees shell sees what we validated.
-    await shell.openExternal(parsed.href);
+    await shell.openExternal(normalizeExternalHttpUrl(url));
   } catch (err) {
     console.error('open-external blocked:', err);
   }
@@ -2445,7 +2438,7 @@ ipcMain.handle('open-notifications-settings', async () => {
       return true;
     } else if (process.platform === 'win32') {
       // Windows: Open notification settings in Settings app
-      spawn('ms-settings:notifications', { shell: true });
+      await shell.openExternal('ms-settings:notifications');
       return true;
     } else if (process.platform === 'linux') {
       // Linux: Try different desktop environments
@@ -5357,27 +5350,11 @@ async function appMain() {
     }
   });
 
-  ipcMain.on('open-in-chrome', (_event, url) => {
+  ipcMain.on('open-in-chrome', async (_event, url) => {
     try {
-      // Validate URL
-      const parsedUrl = new URL(url);
-
-      // Only allow http and https protocols
-      if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-        console.error('Invalid URL protocol. Only HTTP and HTTPS are allowed.');
-        return;
-      }
-
-      // On macOS, use the 'open' command with Chrome
-      if (process.platform === 'darwin') {
-        spawn('open', ['-a', 'Google Chrome', url]);
-      } else if (process.platform === 'win32') {
-        // On Windows, start is built-in command of cmd.exe
-        spawn('cmd.exe', ['/c', 'start', '', 'chrome', url]);
-      } else {
-        // On Linux, use xdg-open with chrome
-        spawn('xdg-open', [url]);
-      }
+      // Despite the legacy channel name, use Electron's non-shell URL opener.
+      // Passing a renderer URL through cmd.exe made &, | and ^ executable.
+      await shell.openExternal(normalizeExternalHttpUrl(url));
     } catch (error) {
       console.error('Error opening URL in browser:', error);
     }

--- a/ui/desktop/src/utils/dependencyChecker.ts
+++ b/ui/desktop/src/utils/dependencyChecker.ts
@@ -229,11 +229,23 @@ export async function runProbe(
     // `execFile` reports a timeout by killing the child, so the signal is the
     // only reliable marker — the exit code is null in that case.
     const timedOut = !!e?.killed && (e?.signal === 'SIGTERM' || e?.code === undefined);
+    let exitCode = typeof e?.code === 'number' ? e.code : null;
+    if (exitCode === 1 && needsShell(cmd)) {
+      try {
+        await execFileAsync('where.exe', [cmd], {
+          encoding: 'utf8',
+          env: SPAWN_ENV,
+          maxBuffer: 1024 * 1024,
+        });
+      } catch {
+        exitCode = null;
+      }
+    }
     return {
       stdout: e?.stdout ?? '',
       stderr: e?.stderr ?? '',
       ok: false,
-      code: typeof e?.code === 'number' ? e.code : null,
+      code: exitCode,
       timedOut,
       error: e?.message ?? null,
     };

--- a/ui/desktop/src/utils/downloadMinGit.test.ts
+++ b/ui/desktop/src/utils/downloadMinGit.test.ts
@@ -1,0 +1,52 @@
+/** @vitest-environment node */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import AdmZip from 'adm-zip';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { extract, handleMinGitFailure, missingMinGitAllowed } =
+  require('../../scripts/download-mingit.js') as {
+    extract: (zipPath: string, destDir: string) => void;
+    handleMinGitFailure: (error: Error, env?: Record<string, string | undefined>) => void;
+    missingMinGitAllowed: (env?: Record<string, string | undefined>) => boolean;
+  };
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('download-mingit', () => {
+  it('extracts without interpreting apostrophes in the destination path', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'biorouter-mingit-download-'));
+    roots.push(root);
+    const zipPath = path.join(root, 'mingit.zip');
+    const destination = path.join(root, "O'Neil", 'git');
+    const zip = new AdmZip();
+    zip.addFile('cmd/git.exe', Buffer.from('git'));
+    zip.writeZip(zipPath);
+
+    extract(zipPath, destination);
+
+    expect(fs.readFileSync(path.join(destination, 'cmd', 'git.exe'), 'utf8')).toBe('git');
+  });
+
+  it('requires an explicit truthy opt-out before allowing a missing fallback', () => {
+    const error = new Error('download failed');
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(missingMinGitAllowed({})).toBe(false);
+    expect(missingMinGitAllowed({ BIOROUTER_ALLOW_MISSING_MINGIT: 'false' })).toBe(false);
+    expect(missingMinGitAllowed({ BIOROUTER_ALLOW_MISSING_MINGIT: '1' })).toBe(true);
+    expect(missingMinGitAllowed({ BIOROUTER_ALLOW_MISSING_MINGIT: ' YES ' })).toBe(true);
+    expect(() => handleMinGitFailure(error, {})).toThrow(error);
+    expect(() =>
+      handleMinGitFailure(error, { BIOROUTER_ALLOW_MISSING_MINGIT: 'true' })
+    ).not.toThrow();
+  });
+});

--- a/ui/desktop/src/utils/externalUrl.test.ts
+++ b/ui/desktop/src/utils/externalUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeExternalHttpUrl } from './externalUrl';
+
+describe('normalizeExternalHttpUrl', () => {
+  it('preserves query delimiters and shell metacharacters as URL data', () => {
+    const input = 'https://example.test/search?a=1&b=two|three^four';
+    expect(normalizeExternalHttpUrl(input)).toBe(new URL(input).href);
+  });
+
+  it('accepts only credential-free HTTP(S) URLs', () => {
+    expect(normalizeExternalHttpUrl('https://example.test/path')).toBe('https://example.test/path');
+    expect(() => normalizeExternalHttpUrl('file:///C:/Windows/System32/calc.exe')).toThrow(
+      'unsafe URL protocol'
+    );
+    expect(() => normalizeExternalHttpUrl('https://user:secret@example.test/')).toThrow(
+      'unsafe URL protocol'
+    );
+  });
+
+  it('rejects non-strings and oversized URLs', () => {
+    expect(() => normalizeExternalHttpUrl(null)).toThrow('invalid or oversized URL');
+    expect(() => normalizeExternalHttpUrl(`https://example.test/${'x'.repeat(8192)}`)).toThrow(
+      'invalid or oversized URL'
+    );
+  });
+});

--- a/ui/desktop/src/utils/externalUrl.ts
+++ b/ui/desktop/src/utils/externalUrl.ts
@@ -1,0 +1,18 @@
+const MAX_EXTERNAL_URL_LENGTH = 8 * 1024;
+
+/** Validate and normalize an external web URL before handing it to Electron. */
+export function normalizeExternalHttpUrl(rawUrl: unknown): string {
+  if (typeof rawUrl !== 'string' || rawUrl.length > MAX_EXTERNAL_URL_LENGTH) {
+    throw new Error('Blocked: invalid or oversized URL');
+  }
+
+  const parsed = new URL(rawUrl);
+  if (
+    (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+    parsed.username !== '' ||
+    parsed.password !== ''
+  ) {
+    throw new Error(`Blocked: unsafe URL protocol '${parsed.protocol}'`);
+  }
+  return parsed.href;
+}

--- a/ui/desktop/src/utils/githubUpdaterDownload.test.ts
+++ b/ui/desktop/src/utils/githubUpdaterDownload.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * The update download streams to disk. The hand-rolled read/write loop it
  * replaced had two bugs that only surface on a failing disk, and both were bad

--- a/ui/desktop/src/utils/launchArguments.test.ts
+++ b/ui/desktop/src/utils/launchArguments.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { findBrxtArgument, isBrxtFile } from './launchArguments';
+
+describe('Biorouter extension launch arguments', () => {
+  it('finds case-insensitive .brxt paths with spaces', () => {
+    expect(findBrxtArgument(['Biorouter.exe', 'C:\\My Extensions\\Study.BRXT'])).toBe(
+      'C:\\My Extensions\\Study.BRXT'
+    );
+  });
+
+  it('removes quotes retained by a launcher', () => {
+    expect(findBrxtArgument(['Biorouter.exe', '"C:\\My Extensions\\Study.brxt"'])).toBe(
+      'C:\\My Extensions\\Study.brxt'
+    );
+  });
+
+  it('does not mistake a suffix after the extension for a bundle', () => {
+    expect(findBrxtArgument(['Biorouter.exe', 'study.brxt.exe'])).toBeUndefined();
+    expect(isBrxtFile('/tmp/study.brxt')).toBe(true);
+  });
+});

--- a/ui/desktop/src/utils/launchArguments.ts
+++ b/ui/desktop/src/utils/launchArguments.ts
@@ -1,0 +1,23 @@
+function withoutOuterQuotes(argument: string): string {
+  const trimmed = argument.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+export function isBrxtFile(argument: string): boolean {
+  return withoutOuterQuotes(argument).toLowerCase().endsWith('.brxt');
+}
+
+export function findBrxtArgument(arguments_: readonly string[]): string | undefined {
+  for (const argument of arguments_) {
+    const normalized = withoutOuterQuotes(argument);
+    if (normalized.toLowerCase().endsWith('.brxt')) return normalized;
+  }
+  return undefined;
+}

--- a/ui/desktop/src/utils/pathContainment.test.ts
+++ b/ui/desktop/src/utils/pathContainment.test.ts
@@ -9,6 +9,11 @@ import {
   isSensitivePreviewPath,
 } from './pathContainment';
 
+const protectedSystemPath =
+  process.platform === 'win32'
+    ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'drivers', 'etc', 'hosts')
+    : '/etc/hosts';
+
 /**
  * Gate for the live false-denial: a session tool call wrote /tmp/qa-r1b/hi.txt
  * and the preview panel refused it with "Access denied: path '/tmp/qa-r1b/hi.txt'
@@ -88,7 +93,15 @@ describe('isSensitivePreviewPath', () => {
   const home = os.homedir();
 
   it('denies protected system directories', () => {
-    for (const p of ['/etc/hosts', '/usr/bin/x', '/bin/ls', '/System/Library/x', '/Library/y']) {
+    const paths =
+      process.platform === 'win32'
+        ? [
+            protectedSystemPath,
+            path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Biorouter', 'x'),
+            path.join(process.env.ProgramData || 'C:\\ProgramData', 'Biorouter', 'x'),
+          ]
+        : ['/etc/hosts', '/usr/bin/x', '/bin/ls', '/System/Library/x', '/Library/y'];
+    for (const p of paths) {
       expect(isSensitivePreviewPath(p)).toBe(true);
     }
   });
@@ -121,11 +134,13 @@ describe('isFilePathAllowedForPreview', () => {
       isFilePathAllowedForPreview(path.join(home, 'a.txt'), [home], { fullyAutomatic: false })
     ).toBe(true);
     // Outside the allowed roots → denied when not fully automatic.
-    expect(
-      isFilePathAllowedForPreview('/data/out.csv', [home], { fullyAutomatic: false })
-    ).toBe(false);
+    expect(isFilePathAllowedForPreview('/data/out.csv', [home], { fullyAutomatic: false })).toBe(
+      false
+    );
     // Sensitive even though it would be "contained" → denied.
-    expect(isFilePathAllowedForPreview('/etc/hosts', [home], { fullyAutomatic: false })).toBe(false);
+    expect(
+      isFilePathAllowedForPreview(protectedSystemPath, [home], { fullyAutomatic: false })
+    ).toBe(false);
   });
 
   it('in Fully-Automatic mode, any non-sensitive path is allowed (parity with backend)', () => {
@@ -138,9 +153,13 @@ describe('isFilePathAllowedForPreview', () => {
   });
 
   it('keeps sensitive paths denied even in Fully-Automatic mode', () => {
-    expect(isFilePathAllowedForPreview('/etc/hosts', [home], { fullyAutomatic: true })).toBe(false);
+    expect(isFilePathAllowedForPreview(protectedSystemPath, [home], { fullyAutomatic: true })).toBe(
+      false
+    );
     expect(
-      isFilePathAllowedForPreview(path.join(home, '.ssh', 'id_rsa'), [home], { fullyAutomatic: true })
+      isFilePathAllowedForPreview(path.join(home, '.ssh', 'id_rsa'), [home], {
+        fullyAutomatic: true,
+      })
     ).toBe(false);
   });
 });

--- a/ui/desktop/src/utils/pathContainment.ts
+++ b/ui/desktop/src/utils/pathContainment.ts
@@ -63,6 +63,28 @@ const SENSITIVE_ABSOLUTE_PREFIXES = [
   '/lib64',
 ];
 
+function comparisonPath(p: string): string {
+  return canonicalizeForContainment(p).toLowerCase().split(path.sep).join('/');
+}
+
+function windowsSensitivePrefixes(): string[] {
+  if (process.platform !== 'win32') return [];
+
+  const systemDrive = process.env.SystemDrive || path.parse(process.cwd()).root.slice(0, 2) || 'C:';
+  const roots = [
+    process.env.SystemRoot,
+    process.env.windir,
+    process.env.ProgramFiles,
+    process.env['ProgramFiles(x86)'],
+    process.env.ProgramData,
+    `${systemDrive}\\Windows`,
+    `${systemDrive}\\Program Files`,
+    `${systemDrive}\\Program Files (x86)`,
+    `${systemDrive}\\ProgramData`,
+  ];
+  return [...new Set(roots.filter((root): root is string => !!root).map(comparisonPath))];
+}
+
 /** Credential / persistence directories under $HOME, `/`-separated + lowercased
  *  relative to the canonical home dir. Mirrors the backend list. */
 const SENSITIVE_HOME_SUBPATHS = [
@@ -88,10 +110,7 @@ const SENSITIVE_HOME_SUBPATHS = [
 /** True for an OS temp tree (`/tmp`, `$TMPDIR`, `/var/folders/**`), which is
  *  ordinary scratch space and must never be treated as sensitive. */
 function isTempPreviewPath(canonicalLower: string): boolean {
-  const tempRoots = [
-    canonicalizeForContainment('/tmp').toLowerCase(),
-    canonicalizeForContainment(os.tmpdir()).toLowerCase(),
-  ];
+  const tempRoots = [comparisonPath('/tmp'), comparisonPath(os.tmpdir())];
   if (tempRoots.some((r) => canonicalLower === r || canonicalLower.startsWith(r + '/'))) {
     return true;
   }
@@ -107,14 +126,14 @@ function isTempPreviewPath(canonicalLower: string): boolean {
  * canonicalized first so a symlink cannot dodge the check.
  */
 export function isSensitivePreviewPath(candidate: string): boolean {
-  const canonical = canonicalizeForContainment(candidate).toLowerCase();
+  const canonical = comparisonPath(candidate);
   if (isTempPreviewPath(canonical)) return false;
 
-  for (const prefix of SENSITIVE_ABSOLUTE_PREFIXES) {
+  for (const prefix of [...SENSITIVE_ABSOLUTE_PREFIXES, ...windowsSensitivePrefixes()]) {
     if (canonical === prefix || canonical.startsWith(prefix + '/')) return true;
   }
 
-  const home = canonicalizeForContainment(os.homedir()).toLowerCase();
+  const home = comparisonPath(os.homedir());
   if (home && (canonical === home || canonical.startsWith(home + '/'))) {
     const rel = canonical === home ? '' : canonical.slice(home.length + 1);
     for (const sub of SENSITIVE_HOME_SUBPATHS) {

--- a/ui/desktop/src/utils/permissionPolicy.test.ts
+++ b/ui/desktop/src/utils/permissionPolicy.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   isAllowedArtifactFrameNavigation,
   isAllowedRendererPermission,
@@ -15,16 +17,14 @@ describe('permissionPolicy', () => {
   });
 
   it('keeps packaged artifact files outside the renderer directory', () => {
-    const appUrl = new URL(
-      'file:///Applications/Biorouter.app/Contents/Resources/renderer/index.html'
-    );
+    const rendererDir = path.resolve('test-fixtures', 'packaged-app', 'renderer');
+    const appUrl = pathToFileURL(path.join(rendererDir, 'index.html'));
     expect(
-      isAppOrigin(
-        'file:///Applications/Biorouter.app/Contents/Resources/renderer/assets/app.js',
-        appUrl
-      )
+      isAppOrigin(pathToFileURL(path.join(rendererDir, 'assets', 'app.js')).href, appUrl)
     ).toBe(true);
-    expect(isAppOrigin('file:///tmp/biorouter-artifacts/artifact-1.html', appUrl)).toBe(false);
+    expect(
+      isAppOrigin(pathToFileURL(path.resolve('test-fixtures', 'artifact-1.html')).href, appUrl)
+    ).toBe(false);
   });
 
   it('never hands Biorouter itself to the external browser', () => {

--- a/ui/desktop/src/utils/winShims.test.ts
+++ b/ui/desktop/src/utils/winShims.test.ts
@@ -1,0 +1,66 @@
+/** @vitest-environment node */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ensureBundledGit } from './winShims';
+
+vi.mock('./logger', () => ({ default: { info: vi.fn(), error: vi.fn() } }));
+
+const originalPath = process.env.PATH;
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+});
+
+function fixture(version = '2.49.0') {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'biorouter-mingit-'));
+  const srcBin = path.join(root, 'resources', 'bin');
+  const srcGit = path.join(srcBin, 'git');
+  const localAppData = path.join(root, 'local');
+  fs.mkdirSync(path.join(srcGit, 'cmd'), { recursive: true });
+  fs.writeFileSync(path.join(srcGit, 'cmd', 'git.exe'), `git-${version}`);
+  fs.writeFileSync(path.join(srcGit, 'mingit-version.txt'), `${version}\n`);
+  return { root, srcBin, srcGit, localAppData };
+}
+
+describe('ensureBundledGit', () => {
+  it('replaces an older persistent MinGit tree', async () => {
+    const f = fixture('2.49.0');
+    const dstGit = path.join(f.localAppData, 'Biorouter', 'git');
+    fs.mkdirSync(path.join(dstGit, 'cmd'), { recursive: true });
+    fs.writeFileSync(path.join(dstGit, 'cmd', 'git.exe'), 'old-git');
+    fs.writeFileSync(path.join(dstGit, 'mingit-version.txt'), '2.48.0\n');
+
+    await ensureBundledGit(f.srcBin, f.localAppData);
+
+    expect(fs.readFileSync(path.join(dstGit, 'cmd', 'git.exe'), 'utf8')).toBe('git-2.49.0');
+    expect(fs.readFileSync(path.join(dstGit, 'mingit-version.txt'), 'utf8').trim()).toBe('2.49.0');
+    fs.rmSync(f.root, { recursive: true, force: true });
+  });
+
+  it('repairs a partial tree even when its version marker matches', async () => {
+    const f = fixture('2.49.0');
+    const dstGit = path.join(f.localAppData, 'Biorouter', 'git');
+    fs.mkdirSync(dstGit, { recursive: true });
+    fs.writeFileSync(path.join(dstGit, 'mingit-version.txt'), '2.49.0\n');
+
+    await ensureBundledGit(f.srcBin, f.localAppData);
+
+    expect(fs.existsSync(path.join(dstGit, 'cmd', 'git.exe'))).toBe(true);
+    fs.rmSync(f.root, { recursive: true, force: true });
+  });
+
+  it('keeps a complete current tree without replacing it', async () => {
+    const f = fixture('2.49.0');
+    const dstGit = path.join(f.localAppData, 'Biorouter', 'git');
+    fs.cpSync(f.srcGit, dstGit, { recursive: true });
+    fs.writeFileSync(path.join(dstGit, 'local-sentinel.txt'), 'keep');
+
+    await ensureBundledGit(f.srcBin, f.localAppData);
+
+    expect(fs.readFileSync(path.join(dstGit, 'local-sentinel.txt'), 'utf8')).toBe('keep');
+    fs.rmSync(f.root, { recursive: true, force: true });
+  });
+});

--- a/ui/desktop/src/utils/winShims.test.ts
+++ b/ui/desktop/src/utils/winShims.test.ts
@@ -12,6 +12,7 @@ const originalPath = process.env.PATH;
 
 afterEach(() => {
   process.env.PATH = originalPath;
+  vi.restoreAllMocks();
 });
 
 function fixture(version = '2.49.0') {
@@ -61,6 +62,29 @@ describe('ensureBundledGit', () => {
     await ensureBundledGit(f.srcBin, f.localAppData);
 
     expect(fs.readFileSync(path.join(dstGit, 'local-sentinel.txt'), 'utf8')).toBe('keep');
+    fs.rmSync(f.root, { recursive: true, force: true });
+  });
+
+  it('keeps the committed update on PATH when old-backup cleanup is locked', async () => {
+    const f = fixture('2.49.0');
+    const dstGit = path.join(f.localAppData, 'Biorouter', 'git');
+    fs.mkdirSync(path.join(dstGit, 'cmd'), { recursive: true });
+    fs.writeFileSync(path.join(dstGit, 'cmd', 'git.exe'), 'old-git');
+    fs.writeFileSync(path.join(dstGit, 'mingit-version.txt'), '2.48.0\n');
+
+    const realRm = fs.promises.rm.bind(fs.promises);
+    vi.spyOn(fs.promises, 'rm').mockImplementation(async (target, options) => {
+      if (String(target).includes('.backup-') && fs.existsSync(target)) {
+        throw new Error('simulated Windows file lock');
+      }
+      return realRm(target, options);
+    });
+
+    await expect(ensureBundledGit(f.srcBin, f.localAppData)).resolves.toBeUndefined();
+
+    expect(fs.readFileSync(path.join(dstGit, 'cmd', 'git.exe'), 'utf8')).toBe('git-2.49.0');
+    expect((process.env.PATH ?? '').split(path.delimiter)).toContain(path.join(dstGit, 'cmd'));
+    vi.restoreAllMocks();
     fs.rmSync(f.root, { recursive: true, force: true });
   });
 });

--- a/ui/desktop/src/utils/winShims.ts
+++ b/ui/desktop/src/utils/winShims.ts
@@ -59,20 +59,72 @@ export async function ensureWinShims(): Promise<void> {
   }
 }
 
-async function ensureBundledGit(srcBinDir: string, localAppData: string): Promise<void> {
-  const srcGitDir = path.join(srcBinDir, 'git');
-  const dstGitDir = path.join(localAppData, 'Biorouter', 'git');
-  const gitExe = path.join(dstGitDir, 'cmd', 'git.exe');
+const MINGIT_VERSION_FILE = 'mingit-version.txt';
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readMinGitVersion(gitDir: string): Promise<string | null> {
+  try {
+    return (await fs.promises.readFile(path.join(gitDir, MINGIT_VERSION_FILE), 'utf8')).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function replaceBundledGit(srcGitDir: string, dstGitDir: string): Promise<void> {
+  const suffix = `${process.pid}-${Date.now()}`;
+  const stagingDir = `${dstGitDir}.staging-${suffix}`;
+  const backupDir = `${dstGitDir}.backup-${suffix}`;
+  let movedOldInstall = false;
+
+  await fs.promises.rm(stagingDir, { recursive: true, force: true });
+  await fs.promises.rm(backupDir, { recursive: true, force: true });
+  await fs.promises.cp(srcGitDir, stagingDir, { recursive: true, force: true });
+  if (
+    !(await exists(path.join(stagingDir, 'cmd', 'git.exe'))) ||
+    !(await readMinGitVersion(stagingDir))
+  ) {
+    await fs.promises.rm(stagingDir, { recursive: true, force: true });
+    throw new Error('bundled MinGit staging copy is incomplete');
+  }
 
   try {
-    await fs.promises.access(srcGitDir);
-  } catch {
+    if (await exists(dstGitDir)) {
+      await fs.promises.rename(dstGitDir, backupDir);
+      movedOldInstall = true;
+    }
+    await fs.promises.rename(stagingDir, dstGitDir);
+    if (movedOldInstall) {
+      await fs.promises.rm(backupDir, { recursive: true, force: true });
+    }
+  } catch (error) {
+    await fs.promises.rm(stagingDir, { recursive: true, force: true });
+    if (movedOldInstall && !(await exists(dstGitDir)) && (await exists(backupDir))) {
+      await fs.promises.rename(backupDir, dstGitDir);
+    }
+    throw error;
+  }
+}
+
+export async function ensureBundledGit(srcBinDir: string, localAppData: string): Promise<void> {
+  const srcGitDir = path.join(srcBinDir, 'git');
+  const dstGitDir = path.join(localAppData, 'Biorouter', 'git');
+  const srcGitExe = path.join(srcGitDir, 'cmd', 'git.exe');
+  const gitExe = path.join(dstGitDir, 'cmd', 'git.exe');
+
+  const bundledVersion = await readMinGitVersion(srcGitDir);
+  if (!bundledVersion || !(await exists(srcGitExe))) {
     // Not bundled in this build (download-mingit.js may have been skipped)
     return;
   }
 
-  // Only copy once per install; Biorouter updates overwrite by deleting and re-copying.
-  //
   // ⚠ **Asynchronous, and that is issue #88 rather than a style preference.**
   // This ran as `fs.cpSync(...)`: a synchronous recursive copy of the bundled
   // MinGit tree, which is ~120 MB across thousands of files, with Defender
@@ -83,16 +135,11 @@ async function ensureBundledGit(srcBinDir: string, localAppData: string): Promis
   // watchdog nor `startupBlocking.test.ts` could see it. That test only banned
   // synchronous CHILD-PROCESS calls, because #88 was about probes; a bulk
   // filesystem copy blocks the loop just as hard.
-  let installed = true;
-  try {
-    await fs.promises.access(gitExe);
-  } catch {
-    installed = false;
-  }
-  if (!installed) {
-    log.info('Installing bundled git fallback...');
-    await fs.promises.cp(srcGitDir, dstGitDir, { recursive: true, force: true });
-    log.info(`Bundled git installed to ${dstGitDir}`);
+  const installedVersion = await readMinGitVersion(dstGitDir);
+  if (!(await exists(gitExe)) || installedVersion !== bundledVersion) {
+    log.info(`Installing bundled git fallback ${bundledVersion}...`);
+    await replaceBundledGit(srcGitDir, dstGitDir);
+    log.info(`Bundled git ${bundledVersion} installed to ${dstGitDir}`);
   }
 
   // Append to PATH as last-resort fallback — system git (Program Files\Git\bin) takes priority.

--- a/ui/desktop/src/utils/winShims.ts
+++ b/ui/desktop/src/utils/winShims.ts
@@ -101,15 +101,20 @@ async function replaceBundledGit(srcGitDir: string, dstGitDir: string): Promise<
       movedOldInstall = true;
     }
     await fs.promises.rename(stagingDir, dstGitDir);
-    if (movedOldInstall) {
-      await fs.promises.rm(backupDir, { recursive: true, force: true });
-    }
   } catch (error) {
     await fs.promises.rm(stagingDir, { recursive: true, force: true });
     if (movedOldInstall && !(await exists(dstGitDir)) && (await exists(backupDir))) {
       await fs.promises.rename(backupDir, dstGitDir);
     }
     throw error;
+  }
+
+  if (movedOldInstall) {
+    try {
+      await fs.promises.rm(backupDir, { recursive: true, force: true });
+    } catch (error) {
+      log.error(`Bundled Git was updated but its old backup remains at ${backupDir}`, error);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- make the Windows Electron release path portable on native Windows while preserving the supported macOS/Docker cross-build route
- build/extract release dependencies without POSIX-only shell assumptions and correct the Windows ZIP smoke-test root
- fix Windows-only hook-fixture quoting and replace a timing-sensitive knowledge-selection test sleep with deterministic lock-aware synchronization
- harden Windows redirect containment, external URL launching, notification settings, and warm-launch `.brxt` handling
- version, verify, repair, and staged-replace the persistent bundled MinGit fallback
- speed up native Windows Rust CI by disabling test PDB generation, removing duplicate unit-test reruns, retaining the sandbox integration target, and uploading Cargo timings
- document native Windows release prerequisites, macOS/Docker release steps, ZIP validation, MinGit maintenance, and CI lessons

## Validation

- `cargo build --release --bin biorouter --bin biorouterd --locked --jobs 16` — native MSVC release succeeded in 9m03s
- `npm run bundle:windows` — final Windows x64 ZIP built successfully (359,450,032 bytes; SHA-256 `F9B886F58FA18C1061D395AE23FF51AA296FF87DE6EB8939EB84CD71FCA144B1`)
- exact extracted ZIP smoke — CLI 1.89.2, daemon 1.89.2, `biorouter term --help`, bundled Git 2.49.0.windows.1, packaged/runtime MinGit markers 2.49.0, and desktop alive after 15 seconds
- `npm run test:run` — 310 files and 3,084 tests passed
- `npm run lint:check`, `npm run typecheck`, Prettier checks, and `cargo fmt --all -- --check` passed
- focused Windows Rust coverage passed: hook bridge (17), MCP developer (245), sandbox integration (17 + 1 Docker-only ignored), and knowledge-race stress (20 consecutive exact runs)
- final synchronized GitHub head is green across Rust, Frontend, Apps smoke, commit-message checks, Linux, macOS, Windows-GNU cross-check, and native Windows

## Windows CI result

Compared with the cached Windows baseline captured in #96:

| Sample | Cargo compile | Total Windows job |
|---|---:|---:|
| Baseline | 16m39s | ~23m |
| Warm 1 | 5m39s | 10m49s |
| Warm 2 (final head) | 5m15s | 13m00s |
| Warm 3 (final head) | 6m36s | 12m02s |
| **Warm average** | **5m50s** | **11m57s** |

The warm average is 65% faster for compilation and 48% faster for the full job. Cache payload fell from 2.45 GB to 1.07 GB (56% smaller); warm restore samples include 36s and 38s versus ~94s at baseline. The first no-PDB run was intentionally cold and green in 19m55s.

All three warm samples satisfy #96's <=10m compile and <=15m job acceptance targets. Cargo HTML timings are retained as a CI artifact for future regression analysis; #96 is closed as fixed.