### PR TITLE
build(codegraph): index this repo, and verify the graph is correct

### DIFF
--- a/codegraph.json
+++ b/codegraph.json
@@ -1,0 +1,6 @@
+{
+  "exclude": [
+    "**/*.min.js",
+    "crates/biorouter-bench/src/assets/"
+  ]
+}

--- a/scripts/codegraph/README.md
+++ b/scripts/codegraph/README.md
@@ -1,0 +1,53 @@
+# CodeGraph development index
+
+CodeGraph is optional local developer tooling. Its SQLite index lives in the
+gitignored `.codegraph/` directory; this repository commits only the exclusions
+and validation scripts.
+
+## Initialize and query
+
+From the repository root:
+
+```bash
+codegraph init
+codegraph sync
+codegraph status
+codegraph explore "dispatch_tool_call bridge path"
+python3 scripts/codegraph/test_verify_index.py
+python3 scripts/codegraph/verify_index.py
+python3 scripts/codegraph/query_smoke.py
+```
+
+Run `sync` after changing branches or if the watcher was not running. The
+validators are manual development checks rather than mandatory CI because the
+repository does not install or pin CodeGraph. `verify_index.py` requires exact
+agreement between tracked, non-ignored, non-excluded supported source paths and
+the index. It also fails when the measured resolver-error ratios exceed their
+checked-in ceilings. Those ceilings are regression baselines, not accuracy
+guarantees.
+`query_smoke.py` checks known BioRouter facts through the CLI and fails on any
+nonzero or malformed CLI response.
+
+## MCP and Codex
+
+Register the MCP server through CodeGraph's installer, or add the equivalent to
+the user's Codex configuration:
+
+```toml
+[mcp_servers.codegraph]
+command = "codegraph"
+args = ["serve", "--mcp"]
+```
+
+The MCP tool is `codegraph_explore`. When querying a worktree or a second
+repository, pass its absolute path as `projectPath`; CodeGraph selects the
+nearest `.codegraph/` index. MCP registration only exposes the tool. Codex also
+needs a user-global instruction telling it to use CodeGraph before grep or file
+reads when a repository has a `.codegraph/` directory. User-global Codex
+configuration and instructions deliberately do not live in this repository.
+
+CodeGraph 1.5.0 does not index shell scripts, and name-based cross-file
+resolution can produce false edges for common names. Treat `explore`, `impact`,
+and `affected` as navigation aids, then rely on source inspection, compilers,
+and tests for correctness. Keep `affected` depth low when selecting tests; the
+default depth can expand through false cross-language edges.

--- a/scripts/codegraph/query_smoke.py
+++ b/scripts/codegraph/query_smoke.py
@@ -18,11 +18,15 @@ ROOT = subprocess.run(["git", "rev-parse", "--show-toplevel"],
 
 def run(*args, as_json=False):
     p = subprocess.run([CG, *args], cwd=ROOT, capture_output=True, text=True, timeout=180)
+    if p.returncode != 0:
+        command = " ".join([CG, *args])
+        detail = p.stderr.strip() or p.stdout.strip() or "no diagnostic output"
+        raise RuntimeError(f"{command} failed with exit {p.returncode}: {detail}")
     if as_json:
         try:
             return json.loads(p.stdout)
-        except json.JSONDecodeError:
-            return {}
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"{CG} returned invalid JSON for {' '.join(args)}") from exc
     return p.stdout
 
 
@@ -67,9 +71,12 @@ out = run("node", "shouldAutoRepairArtifact")
 check("node resolves a TSX symbol (shouldAutoRepairArtifact)",
       "BaseChat" in out or "ARTIFACT_REPAIR_ACTIVE_GRACE_MS" in out)
 
-# 6. Vendored bundles stay OUT of the graph (codegraph.json exclude works).
-out = run("query", "gsap", "--limit", "5")
-check("minified vendor bundles are excluded", ".min.js" not in out)
+# 6. Vendored bundles stay OUT of a complete, successful file listing. The
+# positive checks keep an empty-but-successful response from satisfying the
+# negative exclusion assertion.
+files = run("files")
+check("minified vendor bundles are excluded",
+      "Project Structure (" in files and "crates" in files and ".min.js" not in files)
 
 # 7. affected narrows, rather than returning the whole suite, at low depth.
 n1 = len([l for l in run("affected", "ui/desktop/src/components/artifacts/ArtifactViewer.tsx",

--- a/scripts/codegraph/query_smoke.py
+++ b/scripts/codegraph/query_smoke.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Regression smoke test for CodeGraph queries against known BioRouter facts.
+
+Every assertion below is ground truth independently verifiable with grep, so a
+wrong index fails the suite rather than quietly returning plausible output.
+
+Usage: python3 scripts/codegraph/query_smoke.py
+"""
+import json
+import os
+import subprocess
+import sys
+
+CG = os.environ.get("CODEGRAPH_BIN", "codegraph")
+ROOT = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                      capture_output=True, text=True).stdout.strip()
+
+
+def run(*args, as_json=False):
+    p = subprocess.run([CG, *args], cwd=ROOT, capture_output=True, text=True, timeout=180)
+    if as_json:
+        try:
+            return json.loads(p.stdout)
+        except json.JSONDecodeError:
+            return {}
+    return p.stdout
+
+
+results = []
+
+
+def check(name, ok, detail=""):
+    results.append((name, ok, detail))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f"  — {detail}" if detail else ""))
+
+
+print("== CodeGraph query smoke tests ==")
+
+# 1. Both dispatch_tool_call definitions are found, in the right files.
+out = run("query", "dispatch_tool_call", "--limit", "10")
+check("query finds ExtensionManager::dispatch_tool_call",
+      "extension_manager.rs" in out)
+check("query finds Agent::dispatch_tool_call",
+      "crates/biorouter/src/agents/agent.rs" in out)
+
+# 2. node returns the real source of the five-condition delegation gate.
+out = run("node", "subagents_enabled")
+check("node returns subagents_enabled source",
+      "has_non_injected_extensions" in out and "BioRouterMode::Auto" in out,
+      "the 5-condition gate body")
+
+# 3. callers attributes a call to its ENCLOSING function, not the raw line.
+callers = run("callers", "dispatch_tool_call", "--limit", "200", "--json", as_json=True)
+names = {c["name"] for c in callers.get("callers", [])}
+check("callers finds the HTTP route handler call_tool", "call_tool" in names)
+check("callers finds the coding-agent bridge dispatch_one", "dispatch_one" in names)
+check("callers finds Agent::handle_approved_and_denied_tools",
+      "handle_approved_and_denied_tools" in names)
+
+# 4. impact reaches the route node, i.e. routes are first-class graph nodes.
+out = run("impact", "dispatch_tool_call", "--depth", "2")
+check("impact reaches the POST /agent/call_tool route node",
+      "POST /agent/call_tool" in out)
+
+# 5. A distinctively-named frontend symbol resolves in the TS half.
+out = run("node", "shouldAutoRepairArtifact")
+check("node resolves a TSX symbol (shouldAutoRepairArtifact)",
+      "BaseChat" in out or "ARTIFACT_REPAIR_ACTIVE_GRACE_MS" in out)
+
+# 6. Vendored bundles stay OUT of the graph (codegraph.json exclude works).
+out = run("query", "gsap", "--limit", "5")
+check("minified vendor bundles are excluded", ".min.js" not in out)
+
+# 7. affected narrows, rather than returning the whole suite, at low depth.
+n1 = len([l for l in run("affected", "ui/desktop/src/components/artifacts/ArtifactViewer.tsx",
+                         "--quiet", "--depth", "1").splitlines() if l.strip()])
+check("affected --depth 1 is selective", 0 < n1 < 20, f"{n1} test files")
+
+print()
+bad = [n for n, ok, _ in results if not ok]
+print(f"query_smoke: {len(results)-len(bad)}/{len(results)} passed")
+sys.exit(1 if bad else 0)

--- a/scripts/codegraph/test_verify_index.py
+++ b/scripts/codegraph/test_verify_index.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from verify_index import (
+    check_ratio,
+    is_excluded,
+    pattern_matches,
+    tracked_source_paths,
+)
+
+
+class ExclusionTests(unittest.TestCase):
+    def test_glob_matches_root_and_nested_minified_files(self):
+        self.assertTrue(pattern_matches("bundle.min.js", "**/*.min.js"))
+        self.assertTrue(pattern_matches("assets/bundle.min.js", "**/*.min.js"))
+        self.assertFalse(pattern_matches("assets/bundle.js", "**/*.min.js"))
+
+    def test_directory_and_negation_follow_order(self):
+        patterns = ["vendor/", "!vendor/keep.js"]
+        self.assertTrue(is_excluded("vendor/drop.js", patterns))
+        self.assertFalse(is_excluded("vendor/keep.js", patterns))
+
+    def test_tracked_paths_honor_gitignore_config_and_typescript_variants(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            files = {
+                ".gitignore": ".claude\n",
+                ".claude/release.js": "ignored()\n",
+                "src/main.ts": "export const ts = true\n",
+                "src/config.mts": "export const mts = true\n",
+                "vendor/bundle.min.js": "minified()\n",
+            }
+            for relative, content in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "-f", *files], cwd=root, check=True)
+
+            expected = tracked_source_paths(str(root), ["**/*.min.js"])
+
+            self.assertEqual(expected["typescript"], {"src/main.ts", "src/config.mts"})
+            self.assertEqual(expected["javascript"], set())
+
+
+class CeilingTests(unittest.TestCase):
+    def test_ratio_at_ceiling_passes_and_regression_fails(self):
+        note = lambda *_: None
+        self.assertTrue(check_ratio(note, "risk", 112, 1000, 0.100, 0.112))
+        self.assertFalse(check_ratio(note, "risk", 113, 1000, 0.100, 0.112))
+        self.assertFalse(check_ratio(note, "risk", 0, 0, 0.100, 0.112))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/codegraph/verify_index.py
+++ b/scripts/codegraph/verify_index.py
@@ -13,9 +13,12 @@ Four independent checks, each able to fail a plausible-but-wrong index:
                   where a single unlucky in-repo definition absorbs them.
 
 Usage: python3 scripts/codegraph/verify_index.py [repo-root]
-Exit status is non-zero if a hard check (parse errors, coverage gap) fails.
+Exit status is non-zero for parse errors, exact-path coverage drift, or a
+resolver-risk metric above its checked-in regression ceiling.
 """
 import collections
+import fnmatch
+import json
 import os
 import re
 import sqlite3
@@ -26,7 +29,97 @@ STDLIB_NAMES = """map filter len push get set insert remove next into from clone
 to_string iter collect contains join split trim parse unwrap expect is_empty
 keys values entries find reduce sort slice replace then catch""".split()
 
-LANG_BY_EXT = {"rs": "rust", "ts": "typescript", "tsx": "tsx", "py": "python"}
+LANG_EXTENSIONS = {
+    "rust": (".rs",),
+    "typescript": (".ts", ".mts", ".cts"),
+    "tsx": (".tsx",),
+    "javascript": (".js", ".mjs", ".cjs"),
+    "python": (".py",),
+    "yaml": (".yaml", ".yml"),
+    "swift": (".swift",),
+    "xml": (".xml",),
+}
+
+# These baselines record CodeGraph 1.5.0 on this commit. The ceilings allow
+# ordinary source growth while still turning material resolver drift into a
+# failing check. Lower both when CodeGraph improves; raise a ceiling only after
+# reviewing the newly introduced false-positive or unresolved edges.
+BASELINE_IMPOSSIBLE_RUST_CALL_RATIO = 0.1115
+BASELINE_RESOLVABLE_MISS_RATIO = 0.0267
+BASELINE_STDLIB_TARGET_RATIO = 0.1620
+MAX_IMPOSSIBLE_RUST_CALL_RATIO = 0.120
+MAX_RESOLVABLE_MISS_RATIO = 0.030
+MAX_STDLIB_TARGET_RATIO = 0.170
+
+
+def pattern_matches(path: str, pattern: str) -> bool:
+    """Match the gitignore-style forms used by codegraph.json."""
+    pattern = pattern.lstrip("/")
+    if pattern.endswith("/"):
+        directory = pattern.rstrip("/")
+        return path == directory or path.startswith(directory + "/")
+    if pattern.startswith("**/"):
+        return fnmatch.fnmatchcase(path, pattern) or fnmatch.fnmatchcase(path, pattern[3:])
+    if "/" not in pattern:
+        return any(fnmatch.fnmatchcase(part, pattern) for part in path.split("/"))
+    return fnmatch.fnmatchcase(path, pattern)
+
+
+def load_excludes(root: str) -> list[str]:
+    config_path = os.path.join(root, "codegraph.json")
+    with open(config_path, encoding="utf-8") as fh:
+        config = json.load(fh)
+    excludes = config.get("exclude", [])
+    if not isinstance(excludes, list) or not all(isinstance(item, str) for item in excludes):
+        raise ValueError("codegraph.json 'exclude' must be a list of strings")
+    return excludes
+
+
+def is_excluded(path: str, patterns: list[str]) -> bool:
+    excluded = False
+    for raw_pattern in patterns:
+        negated = raw_pattern.startswith("!")
+        pattern = raw_pattern[1:] if negated else raw_pattern
+        if pattern_matches(path, pattern):
+            excluded = not negated
+    return excluded
+
+
+def tracked_source_paths(root: str, excludes: list[str]) -> dict[str, set[str]]:
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z"], cwd=root, capture_output=True, check=True
+    ).stdout.decode("utf-8").split("\0")
+    ignored = set(
+        subprocess.run(
+            ["git", "ls-files", "-ci", "--exclude-standard", "-z"],
+            cwd=root,
+            capture_output=True,
+            check=True,
+        ).stdout.decode("utf-8").split("\0")
+    )
+    expected = {language: set() for language in LANG_EXTENSIONS}
+    for path in tracked:
+        if not path or path in ignored or is_excluded(path, excludes):
+            continue
+        lowered = path.lower()
+        for language, extensions in LANG_EXTENSIONS.items():
+            if lowered.endswith(extensions):
+                expected[language].add(path)
+                break
+    return expected
+
+
+def check_ratio(note, label: str, numerator: int, denominator: int,
+                baseline: float, ceiling: float) -> bool:
+    if denominator <= 0:
+        note(label, "FAIL: denominator is zero")
+        return False
+    ratio = numerator / denominator
+    status = "ok" if ratio <= ceiling else "REGRESSION"
+    note(label, f"{numerator} of {denominator} ({100.0 * ratio:.2f}%; "
+         f"baseline {100.0 * baseline:.2f}%; "
+         f"ceiling {100.0 * ceiling:.2f}%) {status}")
+    return ratio <= ceiling
 
 
 def main() -> int:
@@ -44,14 +137,24 @@ def main() -> int:
     hard_fail = False
 
     print("== 1. COVERAGE ==")
-    for ext, lang in LANG_BY_EXT.items():
-        tracked = len(subprocess.run(
-            ["git", "ls-files", f"*.{ext}"], cwd=root, capture_output=True, text=True
-        ).stdout.split())
-        indexed = one("SELECT COUNT(*) FROM files WHERE language=?", lang)
-        gap = tracked - indexed
-        note(f".{ext}  tracked={tracked} indexed={indexed}", "ok" if gap <= 0 else f"GAP {gap}")
-        if gap > 0:
+    expected = tracked_source_paths(root, load_excludes(root))
+    indexed_languages = {row[0] for row in q("SELECT DISTINCT language FROM files")}
+    unknown_languages = sorted(indexed_languages - LANG_EXTENSIONS.keys())
+    if unknown_languages:
+        note("indexed languages without a path rule", ", ".join(unknown_languages))
+        hard_fail = True
+    for lang in LANG_EXTENSIONS:
+        indexed = {row[0] for row in q("SELECT path FROM files WHERE language=?", lang)}
+        missing = sorted(expected[lang] - indexed)
+        unexpected = sorted(indexed - expected[lang])
+        note(f"{lang} expected={len(expected[lang])} indexed={len(indexed)}",
+             "ok" if not missing and not unexpected else
+             f"MISSING {len(missing)} UNEXPECTED {len(unexpected)}")
+        for path in missing[:10]:
+            print(f"    MISSING     {path}")
+        for path in unexpected[:10]:
+            print(f"    UNEXPECTED  {path}")
+        if missing or unexpected:
             hard_fail = True
     errs = one("SELECT COUNT(*) FROM files WHERE errors IS NOT NULL AND errors NOT IN ('','[]')")
     note("files with parse errors", errs)
@@ -85,8 +188,10 @@ def main() -> int:
     for (sc, tc), n in pairs.most_common(10):
         print(f"  IMPOSSIBLE  {sc} -> {tc}   {n} edges")
     bad = sum(pairs.values())
-    note("impossible cross-crate call edges", f"{bad} of {total_rust} rust calls "
-         f"({100.0*bad/total_rust:.1f}%)")
+    if not check_ratio(note, "impossible cross-crate call edges", bad, total_rust,
+                       BASELINE_IMPOSSIBLE_RUST_CALL_RATIO,
+                       MAX_IMPOSSIBLE_RUST_CALL_RATIO):
+        hard_fail = True
 
     print("\n== 3. COMPLETENESS: calls naming an in-repo fn that failed to resolve ==")
     misses = one("""SELECT COUNT(*) FROM unresolved_refs u WHERE u.reference_kind='calls'
@@ -95,15 +200,19 @@ def main() -> int:
     allun = one("SELECT COUNT(*) FROM unresolved_refs WHERE reference_kind='calls'")
     resolved = one("SELECT COUNT(*) FROM edges WHERE kind='calls'")
     note("unresolved calls naming an in-repo fn", f"{misses} of {allun} unresolved")
-    note("resolution rate over the resolvable universe",
-         f"{100.0*resolved/(resolved+misses):.1f}%")
+    if not check_ratio(note, "resolvable calls left unresolved", misses, resolved + misses,
+                       BASELINE_RESOLVABLE_MISS_RATIO,
+                       MAX_RESOLVABLE_MISS_RATIO):
+        hard_fail = True
 
     print("\n== 4. FP EXPOSURE: resolved calls onto stdlib-shaped names ==")
     marks = ",".join("?" * len(STDLIB_NAMES))
     risk = one(f"""SELECT COUNT(*) FROM edges e JOIN nodes t ON t.id=e.target
                    WHERE e.kind='calls' AND t.name IN ({marks})""", *STDLIB_NAMES)
-    note("calls resolved onto a stdlib-shaped name", f"{risk} of {resolved} "
-         f"({100.0*risk/resolved:.1f}%)")
+    if not check_ratio(note, "calls resolved onto a stdlib-shaped name", risk, resolved,
+                       BASELINE_STDLIB_TARGET_RATIO,
+                       MAX_STDLIB_TARGET_RATIO):
+        hard_fail = True
     print("  worst absorbers (one in-repo def soaking up many calls):")
     for name, n, defs in q(f"""
         SELECT * FROM (

--- a/scripts/codegraph/verify_index.py
+++ b/scripts/codegraph/verify_index.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Verify a CodeGraph index of this repo against ground truth.
+
+Four independent checks, each able to fail a plausible-but-wrong index:
+
+  1. COVERAGE     every tracked source file of a supported language is indexed,
+                  and nothing failed to parse.
+  2. SOUNDNESS    no `calls` edge crosses a Rust crate boundary that has no
+                  Cargo dependency. Such an edge cannot exist in a compiling
+                  workspace, so every hit is a resolver false positive.
+  3. COMPLETENESS calls that name an in-repo function but failed to resolve.
+  4. FP EXPOSURE  resolved calls whose target name is a stdlib/builtin method,
+                  where a single unlucky in-repo definition absorbs them.
+
+Usage: python3 scripts/codegraph/verify_index.py [repo-root]
+Exit status is non-zero if a hard check (parse errors, coverage gap) fails.
+"""
+import collections
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+
+STDLIB_NAMES = """map filter len push get set insert remove next into from clone
+to_string iter collect contains join split trim parse unwrap expect is_empty
+keys values entries find reduce sort slice replace then catch""".split()
+
+LANG_BY_EXT = {"rs": "rust", "ts": "typescript", "tsx": "tsx", "py": "python"}
+
+
+def main() -> int:
+    root = sys.argv[1] if len(sys.argv) > 1 else subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    ).stdout.strip()
+    db_path = os.path.join(root, ".codegraph", "codegraph.db")
+    if not os.path.exists(db_path):
+        print(f"no index at {db_path} — run 'codegraph init' first", file=sys.stderr)
+        return 1
+    db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    q = lambda s, *a: db.execute(s, a).fetchall()
+    one = lambda s, *a: db.execute(s, a).fetchone()[0]
+    note = lambda k, v: print(f"  {k:<48} {v}")
+    hard_fail = False
+
+    print("== 1. COVERAGE ==")
+    for ext, lang in LANG_BY_EXT.items():
+        tracked = len(subprocess.run(
+            ["git", "ls-files", f"*.{ext}"], cwd=root, capture_output=True, text=True
+        ).stdout.split())
+        indexed = one("SELECT COUNT(*) FROM files WHERE language=?", lang)
+        gap = tracked - indexed
+        note(f".{ext}  tracked={tracked} indexed={indexed}", "ok" if gap <= 0 else f"GAP {gap}")
+        if gap > 0:
+            hard_fail = True
+    errs = one("SELECT COUNT(*) FROM files WHERE errors IS NOT NULL AND errors NOT IN ('','[]')")
+    note("files with parse errors", errs)
+    if errs:
+        hard_fail = True
+
+    print("\n== 2. SOUNDNESS: impossible cross-crate call edges ==")
+    deps = {}
+    crates_dir = os.path.join(root, "crates")
+    for crate in sorted(os.listdir(crates_dir)):
+        toml = os.path.join(crates_dir, crate, "Cargo.toml")
+        if not os.path.isfile(toml):
+            continue
+        with open(toml) as fh:
+            body = fh.read()
+        deps[crate] = set(re.findall(r"^(biorouter[a-z-]*)\s*(?:=|\.)", body, re.M))
+
+    pairs = collections.Counter()
+    for sfile, tfile, n in q("""
+        SELECT src.file_path, tgt.file_path, COUNT(*)
+        FROM edges e JOIN nodes src ON src.id=e.source JOIN nodes tgt ON tgt.id=e.target
+        WHERE e.kind='calls' AND src.language='rust' AND tgt.language='rust'
+          AND src.file_path LIKE 'crates/%' AND tgt.file_path LIKE 'crates/%'
+        GROUP BY 1,2"""):
+        sc, tc = sfile.split("/")[1], tfile.split("/")[1]
+        if sc != tc and tc not in deps.get(sc, set()):
+            pairs[(sc, tc)] += n
+
+    total_rust = one("""SELECT COUNT(*) FROM edges e JOIN nodes s ON s.id=e.source
+                        WHERE e.kind='calls' AND s.language='rust'""")
+    for (sc, tc), n in pairs.most_common(10):
+        print(f"  IMPOSSIBLE  {sc} -> {tc}   {n} edges")
+    bad = sum(pairs.values())
+    note("impossible cross-crate call edges", f"{bad} of {total_rust} rust calls "
+         f"({100.0*bad/total_rust:.1f}%)")
+
+    print("\n== 3. COMPLETENESS: calls naming an in-repo fn that failed to resolve ==")
+    misses = one("""SELECT COUNT(*) FROM unresolved_refs u WHERE u.reference_kind='calls'
+        AND EXISTS (SELECT 1 FROM nodes n WHERE n.name=u.reference_name
+                    AND n.kind IN ('function','method'))""")
+    allun = one("SELECT COUNT(*) FROM unresolved_refs WHERE reference_kind='calls'")
+    resolved = one("SELECT COUNT(*) FROM edges WHERE kind='calls'")
+    note("unresolved calls naming an in-repo fn", f"{misses} of {allun} unresolved")
+    note("resolution rate over the resolvable universe",
+         f"{100.0*resolved/(resolved+misses):.1f}%")
+
+    print("\n== 4. FP EXPOSURE: resolved calls onto stdlib-shaped names ==")
+    marks = ",".join("?" * len(STDLIB_NAMES))
+    risk = one(f"""SELECT COUNT(*) FROM edges e JOIN nodes t ON t.id=e.target
+                   WHERE e.kind='calls' AND t.name IN ({marks})""", *STDLIB_NAMES)
+    note("calls resolved onto a stdlib-shaped name", f"{risk} of {resolved} "
+         f"({100.0*risk/resolved:.1f}%)")
+    print("  worst absorbers (one in-repo def soaking up many calls):")
+    for name, n, defs in q(f"""
+        SELECT * FROM (
+          SELECT t.name AS nm, COUNT(*) AS c,
+                 (SELECT COUNT(*) FROM nodes n2 WHERE n2.name=t.name
+                  AND n2.kind IN ('function','method')) AS defs
+          FROM edges e JOIN nodes t ON t.id=e.target
+          WHERE e.kind='calls' AND t.name IN ({marks})
+          GROUP BY t.name
+        ) WHERE defs = 1 ORDER BY c DESC LIMIT 8""", *STDLIB_NAMES):
+        print(f"    {name:<12} {n:>5} calls -> {defs} in-repo def")
+
+    print()
+    print("verify_index: " + ("FAIL" if hard_fail else "PASS"))
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Sets up [CodeGraph](https://github.com/colbymchenry/codegraph) against this repo, keeps vendored bundles out of the graph, and adds two scripts that check the index is actually *correct* rather than merely present.

Nothing here changes product code. `.codegraph/` (the 160 MB SQLite graph) is already gitignored and is not in this PR.

## Why the config

CodeGraph skips files over 1 MB to keep generated blobs out of the index. Six of our vendored bundles sit under it — `d3.min.js` (280 KB), `chart.min.js` (208 KB), `leaflet.min.js` (148 KB), `gsap.min.js` (73 KB) and two smaller ones — so they were parsed as ordinary source, contributing **1,853 nodes and 14,583 edges**. `.gitignore` can't drop them because they're committed; `codegraph.json`'s `exclude` is the documented mechanism.

It was reaching users: `codegraph explore` on a privacy-tier question returned a `gsap.min.js` symbol as a "dynamic boundary" hop.

## Why the scripts

A code index fails quietly — every command returns confident, well-formatted output whether or not the graph is right. Both scripts are built so a plausible-but-wrong index fails them.

The load-bearing check is **soundness**: it reads each crate's `Cargo.toml` and flags any `calls` edge crossing a crate boundary with no declared dependency. Such an edge cannot exist in a workspace that compiles, so every hit is a resolver false positive — no threshold, no judgement call.

## What it currently reports

| Check | Result |
|---|---|
| Coverage | 691/691 Rust, 523/523 TSX indexed; **0 parse errors** |
| Resolution rate (resolvable universe) | **97.4%** overall, **99.7%** Rust |
| Soundness | **11.1%** of Rust call edges are structurally impossible |
| FP exposure | **16.2%** of resolved calls land on stdlib-shaped names |

The graph is accurate on distinctively-named symbols — verified against grep for `dispatch_tool_call`, `subagents_enabled`, `shouldAutoRepairArtifact`, and callers are attributed to their *enclosing function* rather than the raw line. The false positives cluster on names that collide with stdlib: `to_string` has 2,961 inbound edges and one in-repo definition, a `biorouter-bench` config method — and `biorouter-acp` doesn't depend on `biorouter-bench`, so all of them are wrong. Likewise 2,038 edges from `biorouter-mcp` into `biorouter`, which by design has no such dependency.

**Caveat worth knowing before trusting `codegraph affected`:** at its default `--depth 5` it returns 416 of our 434 test files for a single Rust change, and leaks Rust tests into a TSX change via cross-language name collisions. At `--depth 1`/`2` it's selective (1 and 10 files).

## Test plan

```bash
python3 scripts/codegraph/verify_index.py && python3 scripts/codegraph/query_smoke.py
```

`query_smoke.py` is 10/10 green; `verify_index.py` passes its hard checks (coverage, parse errors) and reports the soundness/FP figures above. Both open the DB read-only and write nothing. They need an index — `codegraph init` — and no-op with a clear message without one.

Not included, happy to add if wanted: a `docs/` page. It'd need a subsystem folder with a `README.md` index plus rows in `docs/README.md` and `docs/organization.md` §2 per our own rules, which felt like more scope than two scripts warrant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
