### PR TITLE
Fix native Windows release artifact smoke root discovery

### DIFF
--- a/.github/workflows/release-artifact-smoke.yml
+++ b/.github/workflows/release-artifact-smoke.yml
@@ -52,7 +52,14 @@ jobs:
           VERSION: ${{ inputs.version }}
           BIOROUTER_DISABLE_KEYRING: "true"
         run: |
-          $app = Resolve-Path "artifact/unpacked"
+          $desktopMatches = @(
+            Get-ChildItem -LiteralPath "artifact/unpacked" -File -Recurse |
+              Where-Object { $_.Name -ceq "Biorouter.exe" }
+          )
+          if ($desktopMatches.Count -ne 1) {
+            throw "Expected one packaged Biorouter.exe, found $($desktopMatches.Count)"
+          }
+          $app = $desktopMatches[0].Directory.FullName
           $cli = Join-Path $app "resources/bin/biorouter.exe"
           $daemon = Join-Path $app "resources/bin/biorouterd.exe"
           $desktop = Join-Path $app "Biorouter.exe"


### PR DESCRIPTION
## Summary
- locate the single packaged Biorouter.exe after expanding the Electron ZIP
- derive the application root from that executable before checking embedded CLI, daemon, MinGit, and desktop startup
- fail clearly if the archive contains zero or multiple packaged application roots

## Why
The v1.89.2 draft smoke exposed that Electron Forge archives the app under Biorouter-win32-x64, while the workflow assumed executables were directly under the extraction directory.

## Validation
- workflow YAML parses successfully
- release ZIP inventory contains exactly one Biorouter.exe
- git diff --check passes