### PR TITLE
fix(artifacts): the standalone artifact surfaces ran no JavaScript at all

### DIFF
--- a/docs/desktop-ui/artifact-cdn-assets.md
+++ b/docs/desktop-ui/artifact-cdn-assets.md
@@ -67,16 +67,32 @@ what lets both asset modes reach an identical runtime state.
 - **A report (`render_dashboard`) is a separate case.** It always inlines, ignoring the
   flag, because its library tags live inside base64 panel blobs the rewriter cannot
   reach. Guarded by `crates/biorouter-mcp/tests/autovis_dashboard_cdn.rs`.
-- **Not every display surface is the same.** The in-chat artifact panel hosts the
-  figure's `srcdoc` inside the renderer document, whose CSP allows inline scripts. The
-  standalone "open in window / in browser" path wraps it in a second document carrying
-  `ARTIFACT_WRAPPER_CSP` instead — and a `srcdoc` document inherits its parent's policy.
-  ⚠ **That wrapper policy has no `script-src`, so `default-src 'none'` applies to
-  scripts and *nothing* in the figure runs there** — measured 2026-08-22 with both a
-  Mermaid figure and a Chart.js figure: `window.mermaid` and `window.Chart` both
-  `undefined`, no error card, because the figure's own error handler is a script too.
-  This is unrelated to the CDN mechanism above and affects every figure type; it is
-  **not fixed** as of this writing.
+- **Not every display surface is the same, and the second one has its own policy.** The
+  in-chat artifact panel hosts the figure's `srcdoc` inside the renderer document. The
+  standalone surfaces — the artifact window, "open in browser", and the headless
+  renderer's `blob:` tab — wrap it in a second document carrying
+  `ARTIFACT_WRAPPER_CSP`, and **a `srcdoc` document inherits its parent's policy list
+  and enforces both**. So the guest's effective policy there is the *intersection*, and
+  a wrapper grant that is absent is a guest grant that is revoked. That is why
+  `ARTIFACT_WRAPPER_CSP` is derived from the figure policy rather than written beside
+  it, differing only in `frame-src`; see the comment on it in
+  [`artifactSecurity.ts`](../../ui/desktop/src/utils/artifactSecurity.ts) and the drift
+  guard in `artifactSecurity.test.ts`.
+
+  ⚠ **Tightening the wrapper does not constrain the figure, it breaks it.** Until
+  2026-08-22 the wrapper carried a hand-written
+  `default-src 'none'; style-src 'unsafe-inline'; frame-src 'self'`, and *nothing* in
+  any artifact ran on those three surfaces — not the chart runtime, and not the
+  figure's own error handler, so every figure was an empty card with no message.
+  Adding `script-src` alone is **not** the fix: measured in Chromium, that restores
+  scripts and leaves `data:` images blocked, so a figure that embeds its own assets
+  stays broken in a way that reads as a different bug. The containment that matters is
+  the guest's own identical policy plus the sandbox attribute (no `allow-same-origin`,
+  no `allow-top-navigation`).
+
+- **A map shows no tiles in either surface, by design.** `img-src data: blob:` names no
+  remote scheme, so Leaflet's tiles never load in an artifact; markers and vector
+  layers do. That is the offline guarantee working, not a rendering failure.
 
 ## Related documentation
 

--- a/ui/desktop/src/utils/artifactSecurity.browser.test.ts
+++ b/ui/desktop/src/utils/artifactSecurity.browser.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+/**
+ * Whether a figure actually runs inside the standalone wrapper page — the
+ * artifact window, "open in browser", and the headless renderer's blob: tab.
+ *
+ * jsdom cannot answer this: it neither evaluates CSP nor implements the
+ * inheritance rule that caused the bug (a `srcdoc` document enforces its
+ * parent's policy list as well as its own). The figure is a real CDN-mode
+ * `render_mermaid` document with the real library spliced in; only the network
+ * is stubbed, which is also what production does.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, type Browser } from 'playwright';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { inlineArtifactCdnAssets } from './artifactCdnAssets';
+import { ARTIFACT_WRAPPER_CSP, wrapArtifactForBrowser } from './artifactSecurity';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../../..');
+
+const MERMAID_CDN_URL = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
+const VENDORED_MERMAID = resolve(
+  repoRoot,
+  'crates/biorouter-mcp/src/autovisualiser/templates/assets/mermaid.min.js'
+);
+const CDN_FIXTURE = resolve(here, '__fixtures__/autovis-mermaid-cdn.html');
+
+/** The policy this page carried before the fix, kept as a negative control. */
+const PRE_FIX_WRAPPER_CSP = "default-src 'none'; style-src 'unsafe-inline'; frame-src 'self'";
+
+const fetchVendored = async (url: string): Promise<string> => {
+  if (url !== MERMAID_CDN_URL) throw new Error(`unexpected asset request: ${url}`);
+  return readFileSync(VENDORED_MERMAID, 'utf-8');
+};
+
+/** Launch whichever Chromium build this machine downloaded (full or headless shell). */
+const launchChromium = async (): Promise<Browser | null> => {
+  for (const options of [{}, { channel: 'chromium' }] as const) {
+    try {
+      return await chromium.launch(options);
+    } catch {
+      // try the next build
+    }
+  }
+  return null;
+};
+
+describe('a figure inside the standalone wrapper page', () => {
+  let browser: Browser | null = null;
+  let figure = '';
+
+  beforeAll(async () => {
+    browser = await launchChromium();
+    if (!browser) {
+      // Say so out loud: a silently skipped browser test reads as a passing one.
+      console.warn(
+        'No Playwright Chromium build found — skipping the wrapper CSP tests. ' +
+          'Run `npx playwright install chromium` to enable them.'
+      );
+    }
+    figure = await inlineArtifactCdnAssets(readFileSync(CDN_FIXTURE, 'utf-8'), fetchVendored);
+  }, 120_000);
+
+  // An explicit budget: tearing down a browser that parsed 3.3 MB of library
+  // three times has overrun the suite's default 30 s hook timeout on a loaded
+  // machine, which fails the file after every test in it has passed.
+  afterAll(async () => {
+    await browser?.close();
+  }, 120_000);
+
+  const openWrapped = async (wrapperCsp: string) => {
+    const page = await browser!.newPage();
+    await page.route('**/cdn.jsdelivr.net/**', (route) => route.abort());
+    await page.setContent(
+      wrapArtifactForBrowser(figure).replace(ARTIFACT_WRAPPER_CSP, wrapperCsp),
+      { waitUntil: 'load' }
+    );
+    return page;
+  };
+
+  /** The figure runs in a sandboxed, opaque-origin frame; reach it as a frame. */
+  const guestOf = (page: Awaited<ReturnType<typeof openWrapped>>) => {
+    const guest = page.frames().find((f) => f !== page.mainFrame());
+    if (!guest) throw new Error('the wrapper did not create its preview frame');
+    return guest;
+  };
+
+  it('runs its scripts and draws the diagram', async (ctx) => {
+    if (!browser) return ctx.skip();
+
+    const page = await openWrapped(ARTIFACT_WRAPPER_CSP);
+    try {
+      await expect
+        .poll(
+          () =>
+            guestOf(page).evaluate(
+              () => typeof (window as unknown as Record<string, unknown>).mermaid
+            ),
+          { timeout: 15_000 }
+        )
+        .toBe('object');
+      await guestOf(page).waitForSelector('#mermaidTarget svg', { timeout: 15_000 });
+      expect(await guestOf(page).locator('[role="alert"]').count()).toBe(0);
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+
+  it('renders a data: image, which script-src alone does not restore', async (ctx) => {
+    if (!browser) return ctx.skip();
+
+    // Measured while diagnosing this: adding only `script-src` to the wrapper
+    // left `default-src 'none'` governing images, so a figure that embeds its
+    // own assets stayed broken in a way that looks like a different bug.
+    const page = await openWrapped(ARTIFACT_WRAPPER_CSP);
+    try {
+      const decoded = await guestOf(page).evaluate(async () => {
+        const img = document.createElement('img');
+        img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        document.body.appendChild(img);
+        await new Promise((done) => {
+          img.onload = done;
+          img.onerror = done;
+        });
+        return img.naturalWidth;
+      });
+
+      expect(decoded).toBe(1);
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+
+  it('ran nothing at all under the policy this page used to carry', async (ctx) => {
+    if (!browser) return ctx.skip();
+
+    // The shipped defect, kept as a negative control: the guest inherits the
+    // wrapper's `default-src 'none'`, so not even the figure's own error card
+    // appears — which is why the surface failed silently.
+    const page = await openWrapped(PRE_FIX_WRAPPER_CSP);
+    try {
+      await page.waitForTimeout(2_000);
+      const guest = guestOf(page);
+      expect(
+        await guest.evaluate(() => typeof (window as unknown as Record<string, unknown>).mermaid)
+      ).toBe('undefined');
+      expect(await guest.locator('#mermaidTarget svg').count()).toBe(0);
+      expect(await guest.locator('[role="alert"]').count()).toBe(0);
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+});

--- a/ui/desktop/src/utils/artifactSecurity.test.ts
+++ b/ui/desktop/src/utils/artifactSecurity.test.ts
@@ -58,6 +58,44 @@ describe('wrapArtifactForBrowser', () => {
   });
 });
 
+describe('the wrapper policy against the policy it is inherited beside', () => {
+  const directives = (csp: string) => csp.split('; ').map((d) => d.trim());
+
+  // The failure this guards produced an empty card and no error message, because
+  // a `srcdoc` document enforces its parent's policy as well as its own: a
+  // wrapper grant that is *absent* is a guest grant that is *revoked*. Nothing
+  // about the wrapper's own markup needs these; they exist so the intersection
+  // leaves the figure exactly the policy it was written for.
+  it('grants everything the figure inside it is granted', () => {
+    const wrapper = new Set(directives(ARTIFACT_WRAPPER_CSP));
+    const missing = directives(ARTIFACT_BROWSER_CSP).filter(
+      (d) => !wrapper.has(d) && !d.startsWith('frame-src')
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it('differs from it only in frame-src, which the wrapper needs and the figure does not', () => {
+    const wrapperOnly = directives(ARTIFACT_WRAPPER_CSP).filter(
+      (d) => !directives(ARTIFACT_BROWSER_CSP).includes(d)
+    );
+
+    expect(wrapperOnly).toEqual(["frame-src 'self'"]);
+  });
+
+  it('still default-denies, and names no remote origin, on either surface', () => {
+    // Widening the wrapper to match the figure must not have widened it past
+    // the figure: the grants are all `data:`/`blob:`/inline, never a scheme
+    // that reaches a network.
+    for (const csp of [ARTIFACT_BROWSER_CSP, ARTIFACT_WRAPPER_CSP]) {
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("connect-src 'none'");
+      expect(csp).not.toMatch(/https?:/);
+      expect(csp).not.toContain('*');
+    }
+  });
+});
+
 describe('injectArtifactHostTheme', () => {
   it('handles generated documents whose head tag carries attributes', () => {
     expect(injectArtifactHostTheme('<html><head data-app="viz"></head></html>', 'dark')).toContain(

--- a/ui/desktop/src/utils/artifactSecurity.ts
+++ b/ui/desktop/src/utils/artifactSecurity.ts
@@ -1,4 +1,12 @@
-export const ARTIFACT_BROWSER_CSP = [
+/**
+ * The policy an Auto Visualiser figure (or any generated artifact) runs under.
+ *
+ * `default-src 'none'` with a handful of explicit grants: inline scripts and
+ * `blob:` workers so the chart runtime executes, `data:`/`blob:` images, fonts
+ * and media so a figure can embed its own assets — and nothing that reaches the
+ * network, navigates, submits, or nests a frame.
+ */
+const ARTIFACT_POLICY = [
   "default-src 'none'",
   "script-src 'unsafe-inline' 'unsafe-eval' blob:",
   "style-src 'unsafe-inline'",
@@ -12,13 +20,37 @@ export const ARTIFACT_BROWSER_CSP = [
   "form-action 'none'",
   "base-uri 'none'",
   "object-src 'none'",
-].join('; ');
+];
 
-export const ARTIFACT_WRAPPER_CSP = [
-  "default-src 'none'",
-  "style-src 'unsafe-inline'",
-  "frame-src 'self'",
-].join('; ');
+export const ARTIFACT_BROWSER_CSP = ARTIFACT_POLICY.join('; ');
+
+/**
+ * The policy for the standalone wrapper page — the artifact window, the
+ * open-in-browser file, and the headless renderer's blob: tab — which holds the
+ * figure in a `srcdoc` iframe.
+ *
+ * ⚠ **It must grant everything `ARTIFACT_BROWSER_CSP` grants, and it is derived
+ * rather than written for exactly that reason.** A `srcdoc` document inherits
+ * its parent's policy list and enforces *both*, so the guest's effective policy
+ * is the intersection. A hand-written wrapper policy of
+ * `default-src 'none'; style-src 'unsafe-inline'; frame-src 'self'` — which is
+ * what this used to be — therefore did not "tighten the wrapper": it silently
+ * governed the figure, and **no script in any artifact ran** on those three
+ * surfaces. Not the chart runtime, and not the figure's own error handler, so
+ * the failure was an empty card with no message.
+ *
+ * Tightening this does not constrain the guest, it breaks it. The guest is
+ * contained by its own identical policy plus the sandbox attribute in
+ * {@link wrapArtifactForBrowser} (no `allow-same-origin`, so it cannot script
+ * this page; no `allow-top-navigation`), and this page contributes no script of
+ * its own — its only variable content is the escaped `srcdoc`.
+ *
+ * The single deliberate difference is `frame-src`: the wrapper exists to embed
+ * one frame, while a figure may embed none.
+ */
+export const ARTIFACT_WRAPPER_CSP = ARTIFACT_POLICY.map((directive) =>
+  directive === "frame-src 'none'" ? "frame-src 'self'" : directive
+).join('; ');
 
 export function injectArtifactBrowserCsp(html: string): string {
   const meta = `<meta http-equiv="Content-Security-Policy" content="${ARTIFACT_BROWSER_CSP}">`;


### PR DESCRIPTION
Every Auto Visualiser figure opened through **"open in window"**, **"open in browser"**,
or the headless renderer's `blob:` tab was an empty card — not a blank chart, an empty
card with *no error message*, because the figure's own error handler is a script too.

Found while verifying #99; deliberately left out of that PR because it is a
security-policy change on a different surface, and it affects every figure type rather
than Mermaid.

## Root cause

A `srcdoc` document **inherits its parent's CSP list and enforces both**, so the guest's
effective policy is the intersection. `ARTIFACT_WRAPPER_CSP`
([`artifactSecurity.ts:17`](https://github.com/BaranziniLab/biorouter/blob/main/ui/desktop/src/utils/artifactSecurity.ts#L17)) was hand-written as

```
default-src 'none'; style-src 'unsafe-inline'; frame-src 'self'
```

which reads as a tight wrapper and is really a policy *on the figure*: `default-src
'none'` governed its scripts, images, fonts, workers and media. `wrapArtifactForBrowser`
is the only thing on those three surfaces, and it is used by `openArtifactInWindow` and
`openArtifactInBrowser` in `main.ts` and by the headless fallback in `renderer.tsx`. The
same constant is also served as a response header for `file://` artifact URLs
(`main.ts:4819`), so both deliveries carried it.

Measured in the running dev app before the change, inside the opened window's guest
frame: `window.mermaid` and `window.Chart` both `undefined`, zero `<svg>`, an empty
`<canvas>`, zero `[role=alert]`.

The in-chat artifact panel was unaffected because it hosts the figure's `srcdoc` inside
the renderer document, whose policy allows inline scripts — which is why this never
showed up there, and why `mcp_ui_proxy.html` (whose wrapper policy *does* carry
`script-src 'unsafe-inline'`) works.

## The fix

Derive the wrapper policy from the figure policy rather than writing it beside it,
overriding exactly one directive — `frame-src`, which the wrapper needs and a figure
does not.

- `ARTIFACT_BROWSER_CSP` is **unchanged, directive for directive** (asserted against
  `main` while writing this), so the in-chat panel is untouched.
- The wrapper gains 10 directives, and **five of them are further denials** it never
  stated: `connect-src 'none'`, `navigate-to 'none'`, `form-action 'none'`,
  `base-uri 'none'`, `object-src 'none'`. The five actual grants — `script-src`,
  `img-src data: blob:`, `font-src data:`, `worker-src blob:`, `media-src data: blob:` —
  are exactly what the figure was already granted by its own policy.
- Nothing about containment moves. The guest still carries the identical policy itself,
  and the sandbox attribute still withholds `allow-same-origin` and
  `allow-top-navigation`, so it cannot script the wrapper it sits in. The wrapper page
  contributes no script of its own; its only variable content is the escaped `srcdoc`.

**Adding `script-src` alone is not the fix**, and that is worth stating because it is the
obvious one-line patch: measured in Chromium, it restores scripts and leaves `data:`
images blocked, so a figure that embeds its own assets stays broken as what looks like an
unrelated bug. The browser test pins that case on its own.

## Verified in the real app

Dev GUI on this branch, sandboxed with `BIOROUTER_PATH_ROOT`, driven over CDP; each
figure produced by the app's own daemon and opened with the real
`window.electron.openArtifactWindow`. Read from inside the opened window's guest frame:

| Figure | Before | After |
|---|---|---|
| `render_mermaid` | `mermaid` undefined, 0 svg, 0 alerts | `mermaid` object, 1 svg, 0 alerts |
| `show_chart` | `Chart` undefined, empty canvas | `Chart` function, 1 canvas drawn |
| `render_map` | (not run before) | `L` object, 1 svg |
| `render_mermaid` in **CDN mode**, through `prepareArtifactHtml` | — | `mermaid` object, 1 svg |

Screenshots of the window surface show the diagram and the bar chart where there was
previously a bare title card.

## Tests

- `artifactSecurity.test.ts` — the drift guard that would have caught this: the wrapper
  must grant everything the figure is granted, and may differ only in `frame-src`. It
  fails on the pre-fix policy with 10 missing directives.
- `artifactSecurity.browser.test.ts` — real Chromium, real `wrapArtifactForBrowser`, real
  figure: scripts run and the diagram is drawn; a `data:` image decodes; and a negative
  control replays the pre-fix wrapper policy and asserts that *nothing* ran, not even the
  error card. On the pre-fix policy the first two fail with `expected 'undefined' to be
  'object'` and `expected +0 to be 1`.
- `npm run test:run` — 3124 passed, 0 failed. `npm run lint:check` clean.

Rust is untouched, so `cargo` was not exercised beyond what #99 already covers.

## Two things noted, not changed

- **`mcp_ui_proxy.html` has the same trap latent in it.** Its wrapper policy carries
  `script-src 'unsafe-inline'` but also `img-src 'none'`, `font-src 'none'`,
  `media-src 'none'` and no `worker-src` — so a figure rendered through it would lose
  images and blob workers by inheritance. It is not reachable for figures in the desktop
  app today (`onOpenArtifact` is always supplied by `BaseChat`, so `MCPUIResourceRenderer`
  renders the open button and never mounts `UIResourceRenderer`), so there is no
  reproducible symptom to fix against and I have not guessed at one.
- **A map shows no tiles in any artifact surface, by design.** `img-src data: blob:`
  names no remote scheme; markers and vector layers draw, tiles do not. Unchanged by this
  PR, and called out in the docs so it is not re-reported as a rendering bug.
