### PR TITLE
fix: dropped-file paths in browser mode, Windows binaries in the Linux packages, and the browser-access docs

### DIFF
--- a/landing/docs.html
+++ b/landing/docs.html
@@ -247,7 +247,7 @@
       <li><strong>macOS:</strong> open the <code>.dmg</code> and drag Biorouter to <code>/Applications</code>. A <code>.zip</code> is also published for the in-app auto-updater.</li>
       <li><strong>Windows:</strong> unzip <code>Biorouter-win32-x64-*.zip</code> and run <code>Biorouter.exe</code>.</li>
       <li><strong>Linux desktop:</strong> install <code>biorouter_*_amd64.deb</code> (Debian/Ubuntu) or <code>BioRouter-*-1.x86_64.rpm</code> (Fedora/RHEL).</li>
-      <li><strong>Linux headless</strong> (servers, HPC nodes, containers): install the CLI-only package <code>biorouter-cli_*_amd64.deb</code> or <code>biorouter-cli-*-1.x86_64.rpm</code>. It ships just the <code>biorouter</code> CLI and the <code>biorouterd</code> daemon, with no desktop app.</li>
+      <li><strong>Linux without a desktop</strong> (servers, HPC nodes, containers): install the CLI-only package <code>biorouter-cli_*_amd64.deb</code> or <code>biorouter-cli-*-1.x86_64.rpm</code>. It ships the <code>biorouter</code> CLI, the <code>biorouterd</code> daemon and the web interface, with no desktop app &mdash; so you can still work in a browser by running <a href="#doc-cli">biorouter serve</a>.</li>
     </ul>
     <div class="alert alert-info" style="margin-top:12px;">
       <strong>Node is not required to run the app.</strong> Biorouter's backend is a native Rust binary (Rust 1.92). You only need <strong>Node 24+</strong> if you install an extension whose MCP server launches through <code>npx</code>.
@@ -1199,31 +1199,99 @@ biorouter usage --json</code></pre>
 @g how do I fix these permission denied errors?</code></pre>
 <div class="alert alert-info">There is also a hidden <code>biorouter term log</code> subcommand. The shell hook calls it to record each command into the terminal session; you do not run it directly.</div>
 
-<h2>Server and headless</h2>
+<h2>Server and browser access</h2>
 
-<h3>web</h3>
-<p>Start BioRouter Web: a lightweight, browser-based chat interface launched from the CLI that mirrors the desktop chat experience. It is useful when you want a GUI without installing the desktop app, or need access from another device.</p>
-<pre><code>biorouter web [-p PORT] [--host HOST] [--open] [--auth-token TOKEN] [--no-auth]</code></pre>
+<h3>serve</h3>
+<p>Run Biorouter and reach it from a web browser. <code>biorouter serve</code> starts the <code>biorouterd</code> daemon, hands it the built interface, and prints a URL to open. It is the <strong>same interface the desktop app shows</strong>, served over HTTP instead of wrapped in Electron, so sessions, extensions, knowledge bases, workflows and Agent Drafter apps all behave the way they do on the desktop.</p>
+<pre><code>biorouter serve [--host ADDR] [-p PORT] [--token TOKEN] [--no-token] [--web-dir DIR] [--open]</code></pre>
+<div class="alert alert-info"><code>biorouter headless</code> is an accepted alias and behaves identically. It is the name the standalone <code>biorouter-headless</code> binary was known by; that binary and its <code>.tar.gz</code> release artifact were retired, and the capability now ships in every install.</div>
+
+<h4>Install it</h4>
+<p>There is nothing extra to install. Every Biorouter package carries the interface bundle and the daemon that serves it:</p>
+<ul>
+  <li><strong>macOS, Windows, Linux desktop</strong> — the app ships the CLI. Accept the &ldquo;Install Biorouter CLI&rdquo; prompt, or run <code>biorouter setup-path</code>, then <code>biorouter serve</code> from any terminal.</li>
+  <li><strong>Linux servers, HPC nodes, containers</strong> — install the CLI-only package, which has no desktop app and no GUI dependencies:
+<pre><code>sudo apt install ./biorouter-cli_*_amd64.deb     # Debian / Ubuntu
+sudo dnf install ./biorouter-cli-*-1.x86_64.rpm  # Fedora / RHEL / Rocky</code></pre>
+  These install <code>biorouter</code> and <code>biorouterd</code> to <code>/usr/bin</code> and the interface to <code>/usr/share/biorouter/web</code>.</li>
+</ul>
+
+<h4>Set it up</h4>
+<p><strong>Choose the provider and model before you start serving.</strong> A browser session cannot change them &mdash; see <a href="#serve-fixed-model">the model is fixed</a> below &mdash; so this step is not optional:</p>
+<pre><code>biorouter configure     # pick a provider and model, and store its credential
+biorouter serve --open</code></pre>
+<p><code>serve</code> stays in the foreground and prints the address to open:</p>
+<pre><code>  Biorouter is serving at
+
+      http://127.0.0.1:8765/?t=1f4c9e02&hellip;
+
+  The token above is shown once, and is new on every launch.
+
+  The model is whichever `biorouter configure` chose; a browser cannot change it.
+  Press Ctrl-C to stop.</code></pre>
+<p>Open that whole address, <code>?t=</code> included &mdash; the token is what authenticates you. Biorouter exchanges it once for a session cookie and removes it from the address bar, so it does not linger in your history. <code>Ctrl+C</code> stops the daemon and frees the port.</p>
+
 <div class="doc-table-scroll"><table class="doc-table">
   <thead><tr><th>Flag</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
   <tbody>
-    <tr><td><code>-p, --port &lt;PORT&gt;</code></td><td>integer</td><td><code>3000</code></td><td>Port to run the web server on.</td></tr>
-    <tr><td><code>--host &lt;HOST&gt;</code></td><td>string</td><td><code>127.0.0.1</code></td><td>Address to bind. Use a LAN address to reach it from other devices.</td></tr>
-    <tr><td><code>--open</code></td><td>flag</td><td>off</td><td>Open the browser automatically when the server starts.</td></tr>
-    <tr><td><code>--auth-token &lt;TOKEN&gt;</code></td><td>string</td><td>none</td><td>Require this token (as a password or bearer token) to access the interface.</td></tr>
-    <tr><td><code>--no-auth</code></td><td>flag</td><td>off</td><td>Allow running without auth even when bound to a network address. Unsafe; use only on trusted networks.</td></tr>
+    <tr><td><code>--host &lt;ADDR&gt;</code></td><td>string</td><td><code>127.0.0.1</code></td><td>Address to bind. Anything reachable from another machine requires a token.</td></tr>
+    <tr><td><code>-p, --port &lt;PORT&gt;</code></td><td>integer</td><td><code>8765</code></td><td>Port to listen on. Deliberately not <code>3000</code>, which is the daemon's own default.</td></tr>
+    <tr><td><code>--token &lt;TOKEN&gt;</code></td><td>string</td><td>new random token per launch</td><td>Use a fixed token instead of a generated one, for a service unit or a script.</td></tr>
+    <tr><td><code>--no-token</code></td><td>flag</td><td>off</td><td>Serve with no access token. Refused for any non-loopback bind, and cannot be combined with <code>--token</code>.</td></tr>
+    <tr><td><code>--web-dir &lt;DIR&gt;</code></td><td>path</td><td>found automatically</td><td>Directory holding the built interface. The error names every location it tried.</td></tr>
+    <tr><td><code>--open</code></td><td>flag</td><td>off</td><td>Open a browser once the server is ready.</td></tr>
   </tbody>
 </table></div>
-<pre><code># Local web UI, open the browser
-biorouter web --open
 
-# Reachable on the LAN, password-protected
-biorouter web --host 192.168.1.7 --port 8080 --auth-token "$TOKEN"</code></pre>
-<p>Stop the server with <code>Ctrl+C</code>. Extension management, some file operations, and configuration changes still go through the CLI or a restart.</p>
-<div class="alert alert-warning">Do not expose the web interface to the internet without a real authentication and transport layer in front of it.</div>
+<h4>Reach it from another machine</h4>
+<p>The default bind is loopback, so by default nothing outside the machine can connect. Reaching it from elsewhere is an explicit choice, and a token becomes mandatory rather than optional:</p>
+<pre><code># Reachable on the network. A token is generated and required; --no-token is refused here.
+biorouter serve --host 0.0.0.0 --port 8765</code></pre>
+<p>The console then prints a second URL built from an address other machines can actually use. If it cannot determine one, it says so rather than printing a loopback address that could not possibly work from somewhere else.</p>
+<div class="alert alert-warning"><strong>An exposed port is an exposed agent.</strong> Anyone who reaches it with the token can run tools, read files the daemon can read, and spend your model credits. The token is a launch credential, not a user account: there are no separate logins and no per-user permissions. On anything larger than a trusted lab network, put a reverse proxy with TLS and real authentication in front of it, and do not expose it to the internet directly.</div>
+
+<h4 id="serve-fixed-model">The model is fixed before you start</h4>
+<p><strong>A browser session cannot change its model or provider.</strong> The picker is inert, and this is deliberate &mdash; it is a privacy property, not a limitation.</p>
+<p>Biorouter classifies a conversation by the sensitivity of what it has touched, and a conversation that has reached a private, institution-hosted model may never later reach a public one. That guarantee depends on knowing which model a conversation ran against. The desktop app can change the provider mid-session because it holds proof that a human at the keyboard asked; a browser tab holds no such proof, and manufacturing one would put the key somewhere page JavaScript could reach &mdash; exactly what the mechanism exists to prevent.</p>
+<p>So the capability is withdrawn rather than approximated: the provider is chosen once, at the terminal, and the privacy tier that choice implies holds for <em>every</em> session in that daemon. A run started against an institutional model is private for its whole life; one started against a commercial model is public for its whole life. Neither can drift. To change it, stop <code>serve</code>, run <code>biorouter configure</code>, and start it again.</p>
+
+<h4>What works in a browser, and what does not</h4>
+<div class="doc-table-scroll"><table class="doc-table">
+  <thead><tr><th>Capability</th><th>In a browser</th></tr></thead>
+  <tbody>
+    <tr><td>Chat, streaming, sessions and history</td><td>Yes</td></tr>
+    <tr><td>Extensions, skills, workflows, scheduled jobs</td><td>Yes</td></tr>
+    <tr><td>Knowledge bases and ingest</td><td>Yes</td></tr>
+    <tr><td>Agent Drafter apps, including their live agent sockets</td><td>Yes</td></tr>
+    <tr><td>Changing the model or provider</td><td>No &mdash; by design, see above</td></tr>
+    <tr><td>Dragging a file in from your own computer</td><td>No &mdash; the agent runs on the server, which cannot see your local disk. Images are the exception: they are uploaded with the message. Reference other files by their path <em>on the server</em>.</td></tr>
+    <tr><td>Desktop-only shell features (tray, dock, native terminal dock)</td><td>No</td></tr>
+  </tbody>
+</table></div>
+
+<h4>Run it as a service</h4>
+<p>A systemd unit for a shared host. Give it a fixed token so the URL survives restarts, and keep the daemon under a dedicated account:</p>
+<pre><code>[Unit]
+Description=Biorouter
+After=network-online.target
+
+[Service]
+User=biorouter
+Environment=BIOROUTER_DISABLE_KEYRING=true
+# BIOROUTER_TOKEN=... , mode 0600, owned by the service account
+EnvironmentFile=/etc/biorouter/serve.env
+ExecStart=/usr/bin/biorouter serve --host 0.0.0.0 --port 8765 --token ${BIOROUTER_TOKEN}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target</code></pre>
+<p>On a host with no desktop keyring, Biorouter falls back to a plaintext <code>~/.config/biorouter/secrets.yaml</code>; <code>BIOROUTER_DISABLE_KEYRING=true</code> forces that behaviour explicitly. Restrict that file to the service account.</p>
+
+<h3>web (deprecated)</h3>
+<p><code>biorouter web</code> is superseded by <code>biorouter serve</code> and is hidden from <code>--help</code>. It served a small hand-written chat page rather than the Biorouter interface, defaulted to port <code>3000</code> (colliding with the daemon), and shared one agent across every chat. It still runs and prints a notice pointing at <code>serve</code>; it will be removed in a later release.</p>
 
 <h3>The biorouterd daemon</h3>
-<p><code>biorouterd</code> is the REST plus WebSocket agent server. The desktop GUI spawns it on an ephemeral local port and talks to it over HTTP and WebSocket using a type-safe client generated from the OpenAPI spec. You rarely start it yourself, but you can run it headlessly to back a self-hosted GUI, an exported app, or automation.</p>
+<p><code>biorouterd</code> is the REST plus WebSocket agent server. The desktop GUI spawns it on an ephemeral local port and talks to it over HTTP and WebSocket using a type-safe client generated from the OpenAPI spec. You rarely start it yourself: <code>biorouter serve</code> starts and supervises it for browser access, and exported apps launch it on demand. Run it directly for automation, or when you want the API without an interface.</p>
 <pre><code># Run the agent server (foreground, graceful shutdown on SIGINT/SIGTERM)
 biorouterd agent</code></pre>
 <div class="doc-table-scroll"><table class="doc-table">
@@ -1232,6 +1300,8 @@ biorouterd agent</code></pre>
     <tr><td><code>BIOROUTER_PORT</code></td><td><code>3000</code></td><td>Port the daemon binds. This is the flat form (the <code>Settings</code> struct is flat); it is not <code>BIOROUTER_SERVER__PORT</code>.</td></tr>
     <tr><td><code>BIOROUTER_HOST</code></td><td><code>127.0.0.1</code></td><td>Address the daemon binds.</td></tr>
     <tr><td><code>BIOROUTER_SERVER__SECRET_KEY</code></td><td>random per run</td><td>Auth key required on requests. If unset, the daemon generates a random key for the process and logs a warning. The nested key uses the <code>__</code> separator. In debug-server mode this is <code>test</code>.</td></tr>
+    <tr><td><code>BIOROUTER_SERVE_UI</code></td><td>unset</td><td>Directory holding the built interface. When set, the daemon serves it at <code>/</code> in addition to its API, which is how <code>biorouter serve</code> reaches a browser. Unset, the daemon serves only its API &mdash; what the desktop app wants, since Electron loads the interface itself.</td></tr>
+    <tr><td><code>BIOROUTER_BROWSER_TOKEN</code></td><td>unset</td><td>The token a browser must present once to receive a session cookie. <code>biorouter serve</code> generates and passes this; set it directly only if you are running the daemon yourself.</td></tr>
   </tbody>
 </table></div>
 <p>On start the daemon publishes its base URL as <code>BIOROUTER_APP_BASE_URL</code> so in-process tools can emit absolute <code>http://host:port/apps/&lt;id&gt;/</code> links. CORS is restricted to local origins. The daemon also exposes the same bundled MCP servers via <code>biorouterd mcp &lt;server&gt;</code>.</p>

--- a/ui/desktop/scripts/build-linux-deb.sh
+++ b/ui/desktop/scripts/build-linux-deb.sh
@@ -22,13 +22,16 @@ for f in biorouterd biorouter jbang npx uvx node; do
         echo "  Removed macOS binary: $f"
     fi
 done
-# Remove Windows executables and DLLs — they do not belong in Linux packages
-for f in "$BIN_DIR"/*.exe "$BIN_DIR"/*.dll "$BIN_DIR"/*.cmd; do
-    if [ -f "$f" ]; then
-        rm -f "$f"
-        echo "  Removed Windows file: $(basename "$f")"
-    fi
-done
+# Remove Windows executables and DLLs — they do not belong in Linux packages.
+#
+# ⚠ RECURSIVE, deliberately. This was a top-level glob (`$BIN_DIR/*.exe`), which
+# cannot match `$BIN_DIR/llamacpp/llama-server.exe` — and that is exactly where
+# they were. The shipped .deb carried 31 Windows files under
+# resources/bin/llamacpp/ as a result. `prepare-platform-binaries.js` below
+# replaces that whole directory with the Linux sidecar and then asserts no
+# foreign executable survives anywhere, so this sweep is defence in depth rather
+# than the only guard.
+find "$BIN_DIR" \( -name '*.exe' -o -name '*.dll' -o -name '*.cmd' \) -type f -print -delete 2>/dev/null || true
 # Remove bundled MinGit (Windows-only Git distribution dropped by download-mingit.js)
 if [ -d "$BIN_DIR/git" ]; then
     rm -rf "$BIN_DIR/git"
@@ -51,21 +54,23 @@ echo "  Installed Linux x64: biorouterd"
 cd "$DESKTOP_DIR"
 npm ci --cache /root/.npm
 
-# The browser interface bundle biorouterd serves (BIOROUTER_SERVE_UI), shipped
-# as the extraResource 'src/web'. Built explicitly HERE because this script
-# calls `npm run make` directly and so never runs prepare-platform-binaries.js,
-# which is where every other platform's packaging path builds it.
+# Run the SAME preparation every other platform runs. This script used to call
+# `npm run make` directly and skip it entirely, which is why the Linux packages
+# were the only ones with no binary validation — and why they shipped a Windows
+# llama-server: nothing here fetched the Linux one, so whatever the macOS build
+# had left in src/bin/llamacpp/ was packaged as-is.
+#
+# It fetches the Linux sidecar (replacing that directory wholesale), builds the
+# browser interface bundle biorouterd serves (BIOROUTER_SERVE_UI, shipped as the
+# extraResource 'src/web'), asserts the required binaries are present, and
+# asserts no foreign executable survived.
 #
 # The deb and rpm install under /opt, so `<exe dir>/../web` resolves inside the
 # app tree exactly as it does on macOS and Windows. It is the CLI-only packages
 # (packaging/cli/nfpm.yaml, /usr/bin) that cannot use that rule and place the
 # bundle at /usr/share/biorouter/web instead.
-echo "Building browser interface bundle (npm run build:web)..."
-npm run build:web
-[ -s "$DESKTOP_DIR/src/web/index.html" ] || {
-    echo "ERROR: npm run build:web produced no src/web/index.html"
-    exit 1
-}
+echo "Preparing Linux platform binaries (llama-server, web bundle, validation)..."
+ELECTRON_PLATFORM=linux ELECTRON_ARCH=x64 node scripts/prepare-platform-binaries.js
 
 echo "Running electron-forge make for Linux x64 (deb, rpm, zip)..."
 ELECTRON_PLATFORM=linux ELECTRON_ARCH=x64 npm run make -- --platform=linux --arch=x64 \

--- a/ui/desktop/scripts/prepare-platform-binaries.js
+++ b/ui/desktop/scripts/prepare-platform-binaries.js
@@ -163,6 +163,50 @@ function buildWebBundle() {
 }
 
 // Validate that required platform binaries are present before packaging
+function listFilesRecursive(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listFilesRecursive(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+/// Fail if a package carries another platform's executables.
+///
+/// `validateRequiredBinaries` asserts the RIGHT files are present. Nothing
+/// asserted the WRONG ones are absent, and the two are not the same check: the
+/// Linux .deb shipped 31 Windows files under `bin/llamacpp/` — `llama-server.exe`
+/// among them — while every "is it there" assertion passed.
+///
+/// It has to recurse. The Linux packaging script removed `*.exe` with a
+/// top-level glob, which cannot match `bin/llamacpp/llama-server.exe`, and
+/// `cleanBinDirectory` walks one level for the same reason.
+function assertNoForeignBinaries(targetPlatform) {
+  const foreign = {
+    darwin: [/\.exe$/i, /\.dll$/i, /\.cmd$/i],
+    linux: [/\.exe$/i, /\.dll$/i, /\.cmd$/i],
+    win32: [],
+  }[targetPlatform];
+  if (!foreign || foreign.length === 0) return;
+
+  const offenders = listFilesRecursive(srcBinDir)
+    .filter((f) => foreign.some((re) => re.test(f)))
+    .map((f) => path.relative(srcBinDir, f));
+
+  if (offenders.length > 0) {
+    const label = targetPlatform === 'darwin' ? 'macOS' : 'Linux';
+    console.error(`\n❌ PACKAGING ERROR: ${offenders.length} foreign executable(s) in the ${label} bundle:`);
+    for (const o of offenders.slice(0, 40)) console.error(`   - ${o}`);
+    if (offenders.length > 40) console.error(`   ... and ${offenders.length - 40} more`);
+    console.error('\nThese belong to another platform and must not ship. If they are');
+    console.error('under llamacpp/, the wrong platform\'s sidecar was fetched.');
+    process.exit(1);
+  }
+}
+
 function validateRequiredBinaries(targetPlatform) {
   // Both the server (biorouterd) AND the CLI (biorouter) must ship, so the app
   // can offer "install the Biorouter CLI" from its bundled binary.
@@ -245,6 +289,9 @@ function preparePlatformBinaries() {
   // Fail fast if the backend binary or the web bundle is absent — prevents
   // silent broken packages
   validateRequiredBinaries(targetPlatform);
+
+  // ...and that no other platform's executables came along for the ride.
+  assertNoForeignBinaries(targetPlatform);
 
   console.log('Platform binary preparation complete');
 }

--- a/ui/desktop/src/components/BrxtInstallModal.tsx
+++ b/ui/desktop/src/components/BrxtInstallModal.tsx
@@ -42,6 +42,9 @@ interface Props {
   registrySource?: { registryId: string; sourceUrl?: string };
 }
 
+const NO_LOCAL_PATH_MESSAGE =
+  'Biorouter is running on another machine, so it cannot read a file you drop here. Copy the file onto that machine and install it with `biorouter extension install <path>`.';
+
 export function BrxtInstallModal({
   onClose,
   onInstalled,
@@ -64,6 +67,15 @@ export function BrxtInstallModal({
   const { addExtension } = useConfig();
 
   const processFile = useCallback(async (fp: string) => {
+    // An empty path means the surface could not supply one -- a browser tab
+    // cannot know where a dropped file lives, and the daemon that would open it
+    // is on another machine. Refusing here is the point: passing the bare file
+    // name on would make the daemon resolve it against ITS working directory
+    // and possibly validate some unrelated bundle.
+    if (!fp) {
+      setError(NO_LOCAL_PATH_MESSAGE);
+      return;
+    }
     setError(null);
     setManifest(null);
     setSkillsPreview([]);

--- a/ui/desktop/src/components/ChatInput.droppedFileError.test.tsx
+++ b/ui/desktop/src/components/ChatInput.droppedFileError.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// A dropped file that could not be located must SAY SO in the composer.
+//
+// Only the image branch of the attachment chip rendered `error`; a document
+// with one rendered as an ordinary chip showing its MIME type, so the user
+// attached a file that would never be read and had no way to tell. That is the
+// display half of the browser-mode path defect -- the data half lives in
+// `useFileDrop`.
+
+vi.mock('./ConfigContext', () => ({
+  useConfig: () => ({
+    getProviders: vi.fn(async () => []),
+    read: vi.fn(async () => null),
+  }),
+}));
+vi.mock('./ModelAndProviderContext', () => ({
+  useModelAndProvider: () => ({
+    getCurrentModelAndProvider: vi.fn(async () => ({ model: null, provider: null })),
+    currentModel: null,
+    currentProvider: null,
+    currentModelSupportsVision: false,
+    currentModelSupportedInputMimeTypes: null,
+  }),
+}));
+vi.mock('../hooks/useDiverge', () => ({
+  useDiverge: () => ({ diverge: vi.fn() }),
+}));
+vi.mock('./settings/models/bottom_bar/ModelsBottomBar', () => ({ default: () => null }));
+vi.mock('./bottom_menu/BottomMenuExtensionSelection', () => ({
+  BottomMenuExtensionSelection: () => null,
+}));
+vi.mock('./bottom_menu/BottomMenuSkillSelection', () => ({
+  BottomMenuSkillSelection: () => null,
+}));
+vi.mock('./bottom_menu/BottomMenuKnowledgeSelection', () => ({
+  BottomMenuKnowledgeSelection: () => null,
+}));
+vi.mock('./bottom_menu/BottomMenuReasoningEffort', () => ({
+  BottomMenuReasoningEffort: () => null,
+}));
+vi.mock('./bottom_menu/CostTracker', () => ({ CostTracker: () => null }));
+vi.mock('./MessageQueue', () => ({ default: () => null }));
+vi.mock('./MentionPopover', () => {
+  const MentionPopoverMock = React.forwardRef(() => null);
+  MentionPopoverMock.displayName = 'MentionPopoverMock';
+  return { default: MentionPopoverMock };
+});
+vi.mock('../api', () => ({
+  getSession: vi.fn(async () => ({ data: null })),
+  llamacppStatus: vi.fn(async () => ({ data: {} })),
+  updateWorkingDir: vi.fn(async () => ({ data: {} })),
+}));
+
+import ChatInput from './ChatInput';
+import type { DroppedFile } from '../hooks/useFileDrop';
+import { ChatState } from '../types/chatState';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(window, {
+    appConfig: { get: () => '/w' },
+    electron: {
+      directoryChooser: vi.fn(),
+      addRecentDir: vi.fn(),
+      logInfo: vi.fn(),
+      getPathForFile: vi.fn(() => ''),
+      on: vi.fn(),
+      off: vi.fn(),
+    },
+  });
+});
+
+
+const erroredFile: DroppedFile = {
+  id: 'dropped-nopath-1',
+  path: '',
+  name: 'results.csv',
+  type: 'text/csv',
+  isImage: false,
+  canUploadAsImage: false,
+  isLoading: false,
+  error: 'This file cannot be read from a browser tab. Biorouter runs on another machine here.',
+};
+
+const okFile: DroppedFile = {
+  id: 'dropped-ok-1',
+  path: '/data/results.csv',
+  sourcePath: '/data/results.csv',
+  name: 'results.csv',
+  type: 'text/csv',
+  isImage: false,
+  canUploadAsImage: false,
+  isLoading: false,
+};
+
+const renderWithFiles = (droppedFiles: DroppedFile[]) => {
+  render(
+    <ChatInput
+      sessionId="session-1"
+      handleSubmit={vi.fn()}
+      chatState={ChatState.Idle}
+      onStop={vi.fn()}
+      initialValue=""
+      setView={vi.fn()}
+      totalTokens={0}
+      accumulatedInputTokens={0}
+      accumulatedOutputTokens={0}
+      droppedFiles={droppedFiles}
+      onFilesProcessed={vi.fn()}
+      messagesLength={0}
+      disableAnimation={false}
+      toolCount={0}
+      onWorkingDirChange={vi.fn()}
+    />
+  );
+};
+
+describe('an attachment that could not be located', () => {
+  /// Fails against the previous component, which rendered the file's MIME type
+  /// here and showed `error` only for images. Measured, not assumed: reverting
+  /// the chip fails this and the next, and leaves the control below passing.
+  it('shows the reason on the chip instead of looking ordinary', async () => {
+    renderWithFiles([erroredFile]);
+    await waitFor(() => {
+      expect(screen.getByText(/cannot be read from a browser tab/i)).toBeTruthy();
+    });
+  });
+
+  it('does not show the harmless-looking type line in its place', async () => {
+    renderWithFiles([erroredFile]);
+    await waitFor(() => {
+      expect(screen.getByText(/cannot be read from a browser tab/i)).toBeTruthy();
+    });
+    expect(screen.queryByText('text/csv')).toBeNull();
+  });
+
+  /// The control: a fix that marked every attachment broken would satisfy both
+  /// assertions above and fail this one.
+  it('leaves a file that does have a path alone', async () => {
+    renderWithFiles([okFile]);
+    await waitFor(() => {
+      expect(screen.getByText('text/csv')).toBeTruthy();
+    });
+    expect(screen.queryByText(/cannot be read/i)).toBeNull();
+  });
+});

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -2670,8 +2670,22 @@ export default function ChatInput({
                     )}
                   </div>
                 ) : (
-                  // File box preview
-                  <div className="flex items-center gap-2 px-3 py-2 bg-background-medium border border-border-subtle rounded-element min-w-[120px] max-w-[200px]">
+                  // File box preview.
+                  //
+                  // The error branch is not decoration. A file that could not be
+                  // located is still attached and still looks ordinary, so
+                  // without it the user sends a message believing a file went
+                  // with it. Only the image branch rendered `error` before, so a
+                  // dropped document failed completely silently.
+                  <div
+                    className={`flex items-center gap-2 px-3 py-2 bg-background-medium border rounded-element min-w-[120px] ${
+                      // An error needs room to be read. Clamping it to the
+                      // normal chip width hid all but two lines behind a
+                      // `title` tooltip, which is not a place a person looks
+                      // when they think their file attached fine.
+                      file.error ? 'border-border-danger max-w-[420px]' : 'border-border-subtle max-w-[200px]'
+                    }`}
+                  >
                     <div className="flex-shrink-0 w-8 h-8 bg-background-default border border-border-subtle rounded-inner flex items-center justify-center text-supporting font-mono text-text-muted">
                       {file.name.split('.').pop()?.toUpperCase() || 'FILE'}
                     </div>
@@ -2679,9 +2693,13 @@ export default function ChatInput({
                       <p className="text-secondary text-text-default truncate" title={file.name}>
                         {file.name}
                       </p>
-                      <p className="text-supporting text-text-muted">
-                        {file.type || 'Unknown type'}
-                      </p>
+                      {file.error ? (
+                        <p className="text-supporting text-text-danger">{file.error}</p>
+                      ) : (
+                        <p className="text-supporting text-text-muted">
+                          {file.type || 'Unknown type'}
+                        </p>
+                      )}
                     </div>
                   </div>
                 )}

--- a/ui/desktop/src/components/skills/AddSkillModal.tsx
+++ b/ui/desktop/src/components/skills/AddSkillModal.tsx
@@ -94,6 +94,18 @@ export default function AddSkillModal({ onClose, onSaved }: Props) {
 
   const processZipFile = async (file: File) => {
     const filePath = window.electron.getPathForFile(file);
+    // See `BrxtInstallModal`: an empty path means this surface cannot supply
+    // one. Sending the bare name would have the daemon extract whatever
+    // matching archive sat in its own working directory.
+    if (!filePath) {
+      setError(
+        'Biorouter is running on another machine, so it cannot read a file you ' +
+          'drop here. Copy the skill onto that machine and add it with ' +
+          '`biorouter skill install <path>`.'
+      );
+      setPreview(null);
+      return;
+    }
     const result = await window.electron.extractSkillZip(filePath);
     if ('error' in result) {
       setError(result.error);

--- a/ui/desktop/src/hooks/useFileDrop.test.tsx
+++ b/ui/desktop/src/hooks/useFileDrop.test.tsx
@@ -103,7 +103,17 @@ describe('useFileDrop', () => {
     expect(window.electron.saveDataUrlToTemp).not.toHaveBeenCalled();
   });
 
-  it('falls back to the file name when Electron cannot expose a path', async () => {
+  /// Previously named "falls back to the file name when Electron cannot expose
+  /// a path", and it asserted exactly that fallback. The fallback was the bug.
+  ///
+  /// A bare name is not a safe default, it is a *plausible* one: whatever
+  /// eventually opens it resolves it against its own working directory, so the
+  /// agent can be handed a different file of the same name and no error is
+  /// raised anywhere. Electron returns an empty path for a File that is not
+  /// backed by a real file on disk, and guessing a path for those is the same
+  /// wrong answer -- merely likelier to be right by accident, since at least
+  /// the machine matches.
+  it('refuses to invent a path when none can be exposed', async () => {
     vi.mocked(window.electron.getPathForFile).mockReturnValueOnce('');
     const { result } = renderHook(() => useFileDrop());
     const file = new File(['note'], 'note.txt', { type: 'text/plain' });
@@ -113,12 +123,13 @@ describe('useFileDrop', () => {
     });
 
     expect(result.current.droppedFiles[0]).toMatchObject({
-      path: 'note.txt',
+      path: '',
       sourcePath: undefined,
       name: 'note.txt',
       isImage: false,
       canUploadAsImage: false,
     });
+    expect(result.current.droppedFiles[0].error).toBeTruthy();
   });
 
   it('adds file URI-list paths when drops do not expose File objects', async () => {
@@ -136,6 +147,84 @@ describe('useFileDrop', () => {
       name: 'Folder A',
       isImage: false,
       canUploadAsImage: false,
+    });
+  });
+});
+
+/// Browser mode: the surface cannot supply a filesystem path, and the failure
+/// this guards against is silent rather than loud.
+///
+/// Every assertion here fails against the previous implementation, which read
+/// `sourcePath || file.name`. That fallback produced a *plausible* path — the
+/// bare file name — which the daemon then resolved against its OWN working
+/// directory on a different machine. Dropping `results.csv` could hand the
+/// agent an unrelated `results.csv`, and nothing reported anything.
+describe('useFileDrop when the surface has no filesystem paths', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      value: {
+        // What the browser shim returns: the "no path" sentinel.
+        getPathForFile: vi.fn(() => ''),
+        saveDataUrlToTemp: vi.fn(async (dataUrl: string, id: string) => ({
+          id,
+          filePath: dataUrl,
+        })),
+      },
+    });
+    Object.defineProperty(globalThis, 'FileReader', {
+      configurable: true,
+      value: MockFileReader,
+    });
+  });
+
+  it('never invents a path from the file name', async () => {
+    const { result } = renderHook(() => useFileDrop());
+    const file = new File(['a,b\n1,2'], 'results.csv', { type: 'text/csv' });
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([file]));
+    });
+
+    const dropped = result.current.droppedFiles[0];
+    expect(dropped).toBeDefined();
+    // The old code set this to 'results.csv'. That is the bug: it names a real
+    // file on the server often enough to be dangerous.
+    expect(dropped.path).toBe('');
+    expect(dropped.sourcePath).toBeUndefined();
+  });
+
+  it('says so, rather than failing silently', async () => {
+    const { result } = renderHook(() => useFileDrop());
+    const file = new File(['x'], 'notes.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([file]));
+    });
+
+    const dropped = result.current.droppedFiles[0];
+    expect(dropped.error).toBeTruthy();
+    expect(dropped.error).toMatch(/another machine/i);
+    expect(dropped.isLoading).toBe(false);
+  });
+
+  /// Images must keep working: they are read as data URLs and never need a
+  /// path, so a fix that refused everything without a path would break the one
+  /// drop that browser mode can actually honour.
+  it('still accepts an image, which needs no path at all', async () => {
+    const { result } = renderHook(() => useFileDrop());
+    const image = new File(['png'], 'figure.png', { type: 'image/png' });
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent([image]));
+    });
+
+    const dropped = result.current.droppedFiles[0];
+    expect(dropped.error).toBeUndefined();
+    expect(dropped.canUploadAsImage).toBe(true);
+    await waitFor(() => {
+      expect(result.current.droppedFiles[0].stagedPath).toBeTruthy();
     });
   });
 });

--- a/ui/desktop/src/hooks/useFileDrop.ts
+++ b/ui/desktop/src/hooks/useFileDrop.ts
@@ -110,14 +110,47 @@ export const useFileDrop = () => {
 
         try {
           const sourcePath = window.electron.getPathForFile(file);
-          const path = sourcePath || file.name;
           const canUploadAsImage =
             UPLOADABLE_IMAGE_TYPES.has(file.type.toLowerCase()) &&
             file.size <= MAX_STAGED_IMAGE_BYTES;
 
+          // ⚠ NEVER fall back to `file.name` when there is no source path.
+          //
+          // This used to read `sourcePath || file.name`, which looks like a
+          // harmless default and is not. A bare name is resolved against the
+          // working directory of whatever reads it -- and in browser mode that
+          // is the SERVER, a different machine from the one the file was
+          // dragged off. Dropping `results.csv` could therefore hand the agent
+          // a completely different `results.csv` that happened to exist there,
+          // with nothing anywhere reporting a problem.
+          //
+          // Images are exempt because they never need a path: they are read
+          // here as data URLs and staged by `saveDataUrlToTemp`, which is why
+          // dropping an image still works with no filesystem access at all.
+          if (!sourcePath && !canUploadAsImage) {
+            droppedFileObjects.push({
+              id: `dropped-nopath-${Date.now()}-${i}`,
+              path: '',
+              // Explicitly absent, matching the shape of the normal branch, so
+              // nothing downstream can read a stale or invented source.
+              sourcePath: undefined,
+              name: file.name,
+              type: file.type,
+              isImage: file.type.startsWith('image/'),
+              canUploadAsImage: false,
+              isLoading: false,
+              error:
+                'This file cannot be read from a browser tab. Biorouter runs on ' +
+                'another machine here, so it has no way to reach the file you ' +
+                'dropped. Copy it onto that machine and reference it by path, ' +
+                'or paste its contents into the message.',
+            });
+            continue;
+          }
+
           droppedFile = {
             id: `dropped-${Date.now()}-${i}`,
-            path,
+            path: sourcePath,
             sourcePath: sourcePath || undefined,
             name: file.name,
             type: file.type,

--- a/ui/desktop/src/renderer.tsx
+++ b/ui/desktop/src/renderer.tsx
@@ -405,7 +405,20 @@ if (needsHeadlessElectron || typeof window.appConfig === 'undefined') {
       installUpdate: () => {},
       restartApp: () => {},
       onUpdaterEvent: () => () => {},
-      getPathForFile: (file: File) => file.name,
+      // A browser cannot know where a dropped file lives on disk -- and the
+      // agent runs on the SERVER, so even if it could, that path would name a
+      // different machine. Returning `file.name` was actively dangerous: the
+      // bare name resolves against the server's working directory, so dropping
+      // `results.csv` could hand the agent some *other* `results.csv` that
+      // happens to exist there. A wrong answer with no error, which in a
+      // biomedical tool is the worst failure mode available.
+      //
+      // The empty string is the established "no path" sentinel here (see
+      // `useFileDrop`, whose tests already exercise it). Callers must treat it
+      // as "this surface cannot supply a path" and say so, never fall back to
+      // the name. Images are unaffected: they are staged as data URLs and never
+      // need a filesystem path at all.
+      getPathForFile: (_file: File) => '',
       ensureWindowContentWidth: async (width: number) => ({
         expanded: false,
         width,


### PR DESCRIPTION
Three follow-ups from the `biorouter serve` work (#104), plus the documentation website.

## 1. A dropped file could resolve to a different file

**The worst failure mode available in a tool people use for biomedical data: a wrong answer with no error.**

In browser mode `getPathForFile` returned `file.name`, and `useFileDrop` read `sourcePath || file.name`. A bare name is not a safe default, it is a *plausible* one — whatever opens it resolves it against its **own** working directory, and in browser mode that is the daemon on another machine. Dropping `results.csv` could hand the agent an unrelated `results.csv` that happened to exist there, and nothing reported anything.

The shim now returns the established empty-string sentinel, and nothing invents a path from it. The three callers that passed the value straight to the daemon refuse an empty path and say why.

**Images are deliberately unaffected.** They are read as data URLs and staged by `saveDataUrlToTemp`, so they never needed a path — which is why the shim returns a sentinel rather than throwing: it is called for *every* file before the image branch is reached, so throwing would have broken the one drop browser mode can honour.

The existing test named *"falls back to the file name"* asserted the vulnerability. It now asserts the refusal.

## 2. Half of that fix was invisible

Found by running it in a real browser, not by reading the diff: `useFileDrop` set the error correctly, but only the **image** branch of the attachment chip rendered `error`. A document showed its MIME type like any healthy attachment — so the user saw a normal chip and sent the message believing a file went with it.

The chip now carries the reason in the danger colour and is widened for it. It was first clamped to two lines behind a `title` tooltip; measured in the running app that was **32px of 176px** shown, and a tooltip is not where someone looks when they think their file attached fine.

## 3. The Linux GUI packages shipped Windows binaries

The `.deb` carried 31 Windows files under `resources/bin/llamacpp/`, `llama-server.exe` among them. Two independent causes:

- The Linux script stripped Windows files with a **top-level** glob (`$BIN_DIR/*.exe`), which cannot match `$BIN_DIR/llamacpp/llama-server.exe`. The sweep is recursive now.
- More importantly, the Linux path called `npm run make` directly and was **the only platform that never ran `prepare-platform-binaries.js`** — where the Linux `llama-server` is fetched (so nothing replaced the sidecar a previous macOS build left behind) and where binaries are validated (so nothing noticed). It now runs the same preparation as macOS and Windows.

Validation gains the check that was missing rather than merely absent: `validateRequiredBinaries` asserts the RIGHT files are present, which is not the same as asserting the WRONG ones are gone — every presence check passed while the Windows payload shipped. `assertNoForeignBinaries` recurses and fails the build.

## 4. The documentation website

`docs.html` led with `biorouter web` — a deprecated hand-written chat page — and never mentioned that Biorouter can be reached from a browser at all. The section is now **Server and browser access**, covering install, setup and use: that nothing extra is installed because every package carries the interface; that the provider must be chosen with `biorouter configure` first, and why a browser session cannot change it; the flag table with real defaults; remote access and what exposing that port means; a works / does-not-work table including the file-drop limit above; and a systemd unit.

## Testing

- `npm run test:run` — **3230 passed** (331 files), up 6 from the new tests.
- `npm run lint:check` — exit 0.
- **Discrimination measured, not assumed.** Reverting the chip fails both error assertions and leaves the healthy-file control passing. The foreign-binary guard was probed against three bundles: it catches a nested `llama-server.exe`, accepts a correct Linux bundle, and leaves Windows builds their own executables.
- **Verified in a running browser** against `biorouter serve`: the shim returns `""` rather than `results.csv`, and a dropped `.csv` renders the reason in full (64px of 64px, danger border) instead of an ordinary chip.
- **The website was rendered and inspected**, light and dark, desktop and narrow: the section and its two tables render correctly, neither overflows at desktop width, dark mode measures 16.65:1 body contrast, and the page parses with no unbalanced tags.

No Rust changed on this branch.
