### PR TITLE
feat(bridge): make the Biorouter tool bridge reusable, so macros run on Claude Code and Codex

### DIFF
--- a/crates/biorouter-mcp/src/knowledge/credibility/agentic.rs
+++ b/crates/biorouter-mcp/src/knowledge/credibility/agentic.rs
@@ -406,7 +406,7 @@ fn source_description(input: &SourceInput) -> String {
 // ---------------------------------------------------------------------------
 
 pub async fn classify(input: &SourceInput, completer: Box<dyn Completer>) -> Result<Credibility> {
-    classify_with_dispatch(input, completer, &AgenticToolDispatch::new()).await
+    classify_with_dispatch(input, completer, std::sync::Arc::new(AgenticToolDispatch::new())).await
 }
 
 /// Same as [`classify`], but with the tool dispatcher supplied by the caller.
@@ -418,7 +418,7 @@ pub async fn classify(input: &SourceInput, completer: Box<dyn Completer>) -> Res
 pub(crate) async fn classify_with_dispatch(
     input: &SourceInput,
     completer: Box<dyn Completer>,
-    dispatch: &dyn ToolDispatch,
+    dispatch: std::sync::Arc<dyn ToolDispatch>,
 ) -> Result<Credibility> {
     let agent = SubAgent {
         completer,
@@ -576,7 +576,7 @@ mod tests {
             .collect();
         let completer = MockCompleter::new(replies);
         let input = SourceInput::Url("https://example.com/paper".into());
-        let c = classify_with_dispatch(&input, Box::new(completer), &dispatch)
+        let c = classify_with_dispatch(&input, Box::new(completer), std::sync::Arc::new(dispatch))
             .await
             .unwrap();
         // Step budget kicks in → fallback Web tier.

--- a/crates/biorouter-mcp/src/knowledge/credibility/agentic.rs
+++ b/crates/biorouter-mcp/src/knowledge/credibility/agentic.rs
@@ -406,7 +406,12 @@ fn source_description(input: &SourceInput) -> String {
 // ---------------------------------------------------------------------------
 
 pub async fn classify(input: &SourceInput, completer: Box<dyn Completer>) -> Result<Credibility> {
-    classify_with_dispatch(input, completer, std::sync::Arc::new(AgenticToolDispatch::new())).await
+    classify_with_dispatch(
+        input,
+        completer,
+        std::sync::Arc::new(AgenticToolDispatch::new()),
+    )
+    .await
 }
 
 /// Same as [`classify`], but with the tool dispatcher supplied by the caller.

--- a/crates/biorouter-mcp/src/knowledge/macros/ingest.rs
+++ b/crates/biorouter-mcp/src/knowledge/macros/ingest.rs
@@ -216,7 +216,7 @@ pub async fn ingest(svc: &KnowledgeService, args: IngestArgs) -> Result<IngestRe
 
     let cancel_ref = args.cancel.as_deref();
     let agent_result = agent
-        .run(&user, &dispatch, cancel_ref, args.event_sink.as_ref())
+        .run(&user, std::sync::Arc::new(dispatch), cancel_ref, args.event_sink.as_ref())
         .await;
 
     let run = IngestRun {
@@ -651,10 +651,11 @@ fn no_pages_written_error(source_id: &str, result: &SubAgentResult) -> String {
             msg.push_str(
                 ". The model wrote its tool calls out as text instead of making them, \
                  which is what a model does when it was handed no tools. That is a \
-                 property of the model bound to this ingest rather than of the source \
-                 or the prompt: the coding-agent providers (Claude Code, Codex) reach \
-                 Biorouter's tools over a bridge that only a chat turn sets up, so they \
-                 cannot drive a knowledge macro. Choose a different model for ingestion",
+                 property of the run rather than of the source or the prompt. Since \
+                 issue #109 a coding-agent provider (Claude Code, Codex) receives its \
+                 tools over Biorouter's MCP bridge on this path too, so the usual cause \
+                 is now that the bridge was not reachable — check that Biorouter's own \
+                 server is running, and try the run again",
             );
         }
         msg.push_str(&format!(
@@ -1104,11 +1105,18 @@ mod tests {
     /// reached disk, and the failure quoted that prose back under "the model's
     /// last message was", which reads as a model that would not cooperate.
     ///
-    /// The real cause is structural and upstream: `complete_with_model` on the
-    /// coding-agent providers accepts `tools` and does not forward them, since
-    /// their tool surface arrives over a bridge that only a chat turn sets up.
-    /// A macro calling the provider directly gets a tool-less model every time.
-    /// Nobody reading the old message would find that.
+    /// The real cause was structural and upstream: `complete_with_model` on the
+    /// coding-agent providers accepted `tools` and did not forward them, since
+    /// their tool surface arrived over a bridge only a chat turn set up. A macro
+    /// calling the provider directly got a tool-less model every time. Nobody
+    /// reading the old message would find that.
+    ///
+    /// ⚠ **That cause is fixed** (#109): a macro turn goes through
+    /// `ProviderToolTurnContext`, which issues the grant. This detector stays,
+    /// because it is keyed on the SHAPE of the reply rather than on a provider
+    /// name — so it still catches any future path that hands a model no tools,
+    /// including this one when the bridge is unreachable. Only the remedy it
+    /// offers changed.
     #[test]
     fn a_model_that_narrated_its_tool_calls_is_named_as_such() {
         let narrated = "**Step 1 - Source page**\n<tool_call>\n{\"name\": \"kb_write\",                         \"arguments\": {\"path\": \"knowledge/source/tocilizumab.md\"}}\n                        </tool_call>\n<tool_response>\nOK\n</tool_response>";
@@ -1129,8 +1137,17 @@ mod tests {
             "the failure must name what actually happened: {msg}"
         );
         assert!(
-            msg.contains("Choose a different model for ingestion"),
-            "and what to do about it, since the Knowledge view has its own model picker: {msg}"
+            msg.contains("try the run again"),
+            "and what to do about it: {msg}"
+        );
+        // #109: the old text told the user to choose a different model, because
+        // the coding-agent providers genuinely could not drive a macro. They can
+        // now — they receive their tools over the bridge on this path too — so
+        // that advice would send someone to change a working configuration
+        // instead of looking at the reachability that actually failed.
+        assert!(
+            !msg.contains("Choose a different model"),
+            "the fixed limitation must not still be offered as the remedy: {msg}"
         );
     }
 

--- a/crates/biorouter-mcp/src/knowledge/macros/ingest.rs
+++ b/crates/biorouter-mcp/src/knowledge/macros/ingest.rs
@@ -216,7 +216,12 @@ pub async fn ingest(svc: &KnowledgeService, args: IngestArgs) -> Result<IngestRe
 
     let cancel_ref = args.cancel.as_deref();
     let agent_result = agent
-        .run(&user, std::sync::Arc::new(dispatch), cancel_ref, args.event_sink.as_ref())
+        .run(
+            &user,
+            std::sync::Arc::new(dispatch),
+            cancel_ref,
+            args.event_sink.as_ref(),
+        )
         .await;
 
     let run = IngestRun {

--- a/crates/biorouter-mcp/src/knowledge/macros/lint.rs
+++ b/crates/biorouter-mcp/src/knowledge/macros/lint.rs
@@ -577,7 +577,7 @@ pub async fn lint(svc: &KnowledgeService, args: LintArgs) -> Result<LintResult> 
 
     let cancel_ref = args.cancel.as_deref();
     let agent_result = agent
-        .run(&user, &dispatch, cancel_ref, args.event_sink.as_ref())
+        .run(&user, std::sync::Arc::new(dispatch), cancel_ref, args.event_sink.as_ref())
         .await;
 
     settle_autofix(svc, &args.kb_id, &repo, &txn, report, agent_result)

--- a/crates/biorouter-mcp/src/knowledge/macros/lint.rs
+++ b/crates/biorouter-mcp/src/knowledge/macros/lint.rs
@@ -577,7 +577,12 @@ pub async fn lint(svc: &KnowledgeService, args: LintArgs) -> Result<LintResult> 
 
     let cancel_ref = args.cancel.as_deref();
     let agent_result = agent
-        .run(&user, std::sync::Arc::new(dispatch), cancel_ref, args.event_sink.as_ref())
+        .run(
+            &user,
+            std::sync::Arc::new(dispatch),
+            cancel_ref,
+            args.event_sink.as_ref(),
+        )
         .await;
 
     settle_autofix(svc, &args.kb_id, &repo, &txn, report, agent_result)

--- a/crates/biorouter-mcp/src/knowledge/macros/query.rs
+++ b/crates/biorouter-mcp/src/knowledge/macros/query.rs
@@ -169,7 +169,7 @@ pub async fn query(svc: &KnowledgeService, args: QueryArgs) -> Result<QueryResul
     let agent_result = agent
         .run(
             &args.question,
-            &dispatch,
+            std::sync::Arc::new(dispatch),
             cancel_ref,
             args.event_sink.as_ref(),
         )

--- a/crates/biorouter-mcp/src/knowledge/subagent/loop_.rs
+++ b/crates/biorouter-mcp/src/knowledge/subagent/loop_.rs
@@ -409,7 +409,12 @@ impl SubAgent {
             messages.push(LlmMessage::Assistant(reply.clone()));
 
             let (result_parts, turn_rejected_vocabulary) = self
-                .dispatch_turn(&reply.tool_calls, dispatch.as_ref(), &mut events, event_sink)
+                .dispatch_turn(
+                    &reply.tool_calls,
+                    dispatch.as_ref(),
+                    &mut events,
+                    event_sink,
+                )
                 .await;
             // Only a turn that actually dispatched something updates the flag:
             // a turn of pure prose is not evidence that the model stopped
@@ -797,7 +802,10 @@ mod tests {
             text_reply("all done"),       // step 1: no tool calls → done
         ]);
         let agent = make_agent(completer, 10);
-        let result = agent.run("hello", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
+        let result = agent
+            .run("hello", std::sync::Arc::new(EchoDispatch), None, None)
+            .await
+            .unwrap();
         assert_eq!(result.reason, DoneReason::NoMoreToolCalls);
         // steps_used reflects the loop counter at the time of Done, which
         // is 1 (incremented after the first tool-dispatch round)
@@ -812,7 +820,10 @@ mod tests {
         let replies: Vec<LlmReply> = (0..35).map(|_| tool_call_reply("kb_search")).collect();
         let completer = MockCompleter::new(replies);
         let agent = make_agent(completer, 5);
-        let result = agent.run("hello", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
+        let result = agent
+            .run("hello", std::sync::Arc::new(EchoDispatch), None, None)
+            .await
+            .unwrap();
         assert_eq!(result.reason, DoneReason::StepBudgetReached);
         assert!(result.steps_used <= 5);
     }
@@ -950,7 +961,10 @@ mod tests {
             }
         }
 
-        let result = agent.run("hello", std::sync::Arc::new(BigPages), None, None).await.unwrap();
+        let result = agent
+            .run("hello", std::sync::Arc::new(BigPages), None, None)
+            .await
+            .unwrap();
         assert_eq!(result.reason, DoneReason::TokenBudgetReached);
         assert!(
             result.steps_used < 10,
@@ -995,7 +1009,10 @@ mod tests {
                 ..Default::default()
             },
         };
-        let result = agent.run("hello", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
+        let result = agent
+            .run("hello", std::sync::Arc::new(EchoDispatch), None, None)
+            .await
+            .unwrap();
         assert_eq!(result.reason, DoneReason::TimeBudgetReached);
         assert!(
             result.final_text.contains("waiting for the model"),
@@ -1014,7 +1031,12 @@ mod tests {
         let completer = MockCompleter::new(vec![text_reply("never reached")]);
         let agent = make_agent(completer, 30);
         let result = agent
-            .run("hello", std::sync::Arc::new(EchoDispatch), Some(&notify), None)
+            .run(
+                "hello",
+                std::sync::Arc::new(EchoDispatch),
+                Some(&notify),
+                None,
+            )
             .await
             .unwrap();
         assert_eq!(result.reason, DoneReason::Cancelled);
@@ -1046,7 +1068,10 @@ mod tests {
                 ..Default::default()
             },
         };
-        let result = agent.run("go", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
+        let result = agent
+            .run("go", std::sync::Arc::new(EchoDispatch), None, None)
+            .await
+            .unwrap();
         assert_eq!(result.reason, DoneReason::NoMoreToolCalls);
 
         // calls[0] = first complete() call = [User]  (initial)
@@ -1130,7 +1155,10 @@ mod tests {
         let seen = dispatch.calls.clone();
 
         let agent = make_agent(MockCompleter::new(vec![reply]), 10);
-        let result = agent.run("go", std::sync::Arc::new(dispatch), None, None).await.unwrap();
+        let result = agent
+            .run("go", std::sync::Arc::new(dispatch), None, None)
+            .await
+            .unwrap();
 
         assert_eq!(
             *seen.lock().await,

--- a/crates/biorouter-mcp/src/knowledge/subagent/loop_.rs
+++ b/crates/biorouter-mcp/src/knowledge/subagent/loop_.rs
@@ -83,6 +83,40 @@ pub enum LlmMessage {
     ToolResults(Vec<ToolResultPart>),
 }
 
+/// One tool call a completer's OWN executor already ran.
+///
+/// The coding-agent providers are the reason this exists: `claude_code` and
+/// `codex` drive a whole agent in a child process, and Biorouter's tools reach
+/// them over an MCP bridge the *provider call* establishes. So the child chooses
+/// and executes the calls inside one `complete`, and by the time this loop sees
+/// a reply the work is done. These are records, not requests.
+#[derive(Debug, Clone)]
+pub struct ExecutedCall {
+    pub id: String,
+    pub name: String,
+    pub args: serde_json::Value,
+    /// What the tool returned, as text.
+    pub output: String,
+    pub is_error: bool,
+}
+
+/// One turn, plus whatever the completer ran on its own account.
+pub struct CompleterTurn {
+    pub reply: LlmReply,
+    /// ⚠ **The loop must not dispatch these.** They have already executed. A
+    /// `kb_write_page` run twice is a second write, not a redraw.
+    pub executed: Vec<ExecutedCall>,
+}
+
+impl From<LlmReply> for CompleterTurn {
+    fn from(reply: LlmReply) -> Self {
+        Self {
+            reply,
+            executed: Vec::new(),
+        }
+    }
+}
+
 /// Minimal LLM capability needed by the sub-agent loop.
 ///
 /// Callers that hold an `Arc<dyn biorouter::providers::base::Provider>` can
@@ -98,6 +132,31 @@ pub trait Completer: Send + Sync {
         messages: &[LlmMessage],
         tools: &[Tool],
     ) -> Result<LlmReply>;
+
+    /// The same turn, with this run's dispatcher reachable from *inside* the
+    /// completer.
+    ///
+    /// The default ignores it, which is right for every completer that returns
+    /// tool calls for the loop to run. It is overridden by the adapter wrapping
+    /// a coding-agent provider (#109): that provider's child executes the tools
+    /// itself, over an MCP bridge established for the duration of the provider
+    /// call — so the dispatcher has to be reachable *during* the call, not after
+    /// it. Without this seam the child was handed a `tools` argument its provider
+    /// discards; the model then narrated every call as prose, invented its own
+    /// `<tool_response>OK` replies to continue against, and wrote nothing.
+    ///
+    /// `Arc`, not `&dyn`: the adapter hands the dispatcher to a bridge grant
+    /// that lives in a process-global registry for the length of the turn, and a
+    /// borrow cannot go there.
+    async fn complete_with_dispatch(
+        &self,
+        system: &str,
+        messages: &[LlmMessage],
+        tools: &[Tool],
+        _dispatch: std::sync::Arc<dyn ToolDispatch>,
+    ) -> Result<CompleterTurn> {
+        Ok(self.complete(system, messages, tools).await?.into())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -255,7 +314,7 @@ impl SubAgent {
     pub async fn run(
         &self,
         user_message: &str,
-        dispatch: &dyn ToolDispatch,
+        dispatch: std::sync::Arc<dyn ToolDispatch>,
         cancel: Option<&tokio::sync::Notify>,
         event_sink: Option<&tokio::sync::mpsc::UnboundedSender<SubAgentEvent>>,
     ) -> Result<SubAgentResult> {
@@ -283,11 +342,16 @@ impl SubAgent {
             // reconcile with `max_wall`, and the question a caller asks is "how
             // long may this run take", once.
             let remaining = self.bounds.max_wall.saturating_sub(started.elapsed());
-            let call = self
-                .completer
-                .complete(&self.system_prompt, &messages, &self.tools);
-            let reply = match tokio::time::timeout(remaining, call).await {
-                Ok(reply) => reply?,
+            // #109: the dispatcher goes IN, so a completer whose child executes
+            // the tools itself can reach it during the provider call.
+            let call = self.completer.complete_with_dispatch(
+                &self.system_prompt,
+                &messages,
+                &self.tools,
+                std::sync::Arc::clone(&dispatch),
+            );
+            let turn = match tokio::time::timeout(remaining, call).await {
+                Ok(turn) => turn?,
                 Err(_elapsed) => {
                     let reason = budget_reason(DoneReason::TimeBudgetReached, retrying_vocabulary);
                     let text = if reason == DoneReason::TimeBudgetReached {
@@ -299,6 +363,8 @@ impl SubAgent {
                 }
             };
 
+            let CompleterTurn { reply, executed } = turn;
+
             let step_ev = SubAgentEvent::Step {
                 index: steps,
                 assistant_text: reply.text.clone(),
@@ -307,6 +373,11 @@ impl SubAgent {
                 let _ = tx.send(step_ev.clone());
             }
             events.push(step_ev);
+
+            // #109: calls the completer's child already ran. Recorded as events
+            // so the run log reads the same whichever provider drove it, and
+            // deliberately NOT fed to `dispatch_turn` — they have executed.
+            record_executed(&executed, &mut events, event_sink);
 
             if reply.tool_calls.is_empty() {
                 return Ok(make_result(
@@ -338,7 +409,7 @@ impl SubAgent {
             messages.push(LlmMessage::Assistant(reply.clone()));
 
             let (result_parts, turn_rejected_vocabulary) = self
-                .dispatch_turn(&reply.tool_calls, dispatch, &mut events, event_sink)
+                .dispatch_turn(&reply.tool_calls, dispatch.as_ref(), &mut events, event_sink)
                 .await;
             // Only a turn that actually dispatched something updates the flag:
             // a turn of pure prose is not evidence that the model stopped
@@ -459,6 +530,37 @@ impl SubAgent {
             });
         }
         (result_parts, rejected_vocabulary)
+    }
+}
+
+/// Write a completer-executed call into the run log, as the pair the loop's own
+/// dispatch would have written.
+///
+/// The point is that a reader of a run cannot tell — and should not have to —
+/// whether the tool was run by this loop or by a child agent behind the bridge.
+/// Both went through the same gate stack; only the process differs.
+fn record_executed(
+    executed: &[ExecutedCall],
+    events: &mut Vec<SubAgentEvent>,
+    event_sink: Option<&tokio::sync::mpsc::UnboundedSender<SubAgentEvent>>,
+) {
+    for call in executed {
+        for event in [
+            SubAgentEvent::ToolCall {
+                name: call.name.clone(),
+                args: call.args.clone(),
+            },
+            SubAgentEvent::ToolResult {
+                name: call.name.clone(),
+                ok: !call.is_error,
+                summary: call.output.chars().take(120).collect(),
+            },
+        ] {
+            if let Some(tx) = event_sink {
+                let _ = tx.send(event.clone());
+            }
+            events.push(event);
+        }
     }
 }
 
@@ -695,7 +797,7 @@ mod tests {
             text_reply("all done"),       // step 1: no tool calls → done
         ]);
         let agent = make_agent(completer, 10);
-        let result = agent.run("hello", &EchoDispatch, None, None).await.unwrap();
+        let result = agent.run("hello", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
         assert_eq!(result.reason, DoneReason::NoMoreToolCalls);
         // steps_used reflects the loop counter at the time of Done, which
         // is 1 (incremented after the first tool-dispatch round)
@@ -710,7 +812,7 @@ mod tests {
         let replies: Vec<LlmReply> = (0..35).map(|_| tool_call_reply("kb_search")).collect();
         let completer = MockCompleter::new(replies);
         let agent = make_agent(completer, 5);
-        let result = agent.run("hello", &EchoDispatch, None, None).await.unwrap();
+        let result = agent.run("hello", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
         assert_eq!(result.reason, DoneReason::StepBudgetReached);
         assert!(result.steps_used <= 5);
     }
@@ -756,7 +858,7 @@ mod tests {
             .collect();
         let agent = make_agent(MockCompleter::new(replies), 5);
         let result = agent
-            .run("hello", &VocabularyRefusing, None, None)
+            .run("hello", std::sync::Arc::new(VocabularyRefusing), None, None)
             .await
             .unwrap();
         assert_eq!(result.reason, DoneReason::VocabularyRetriesExhausted);
@@ -775,7 +877,7 @@ mod tests {
         let replies: Vec<LlmReply> = (0..35).map(|_| tool_call_reply("kb_read_page")).collect();
         let agent = make_agent(MockCompleter::new(replies), 5);
         let result = agent
-            .run("hello", &AlwaysFailing, None, None)
+            .run("hello", std::sync::Arc::new(AlwaysFailing), None, None)
             .await
             .unwrap();
         assert_eq!(result.reason, DoneReason::StepBudgetReached);
@@ -810,7 +912,7 @@ mod tests {
         let result = agent
             .run(
                 "hello",
-                &RefuseOnce(std::sync::atomic::AtomicBool::new(true)),
+                std::sync::Arc::new(RefuseOnce(std::sync::atomic::AtomicBool::new(true))),
                 None,
                 None,
             )
@@ -848,7 +950,7 @@ mod tests {
             }
         }
 
-        let result = agent.run("hello", &BigPages, None, None).await.unwrap();
+        let result = agent.run("hello", std::sync::Arc::new(BigPages), None, None).await.unwrap();
         assert_eq!(result.reason, DoneReason::TokenBudgetReached);
         assert!(
             result.steps_used < 10,
@@ -893,7 +995,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let result = agent.run("hello", &EchoDispatch, None, None).await.unwrap();
+        let result = agent.run("hello", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
         assert_eq!(result.reason, DoneReason::TimeBudgetReached);
         assert!(
             result.final_text.contains("waiting for the model"),
@@ -912,7 +1014,7 @@ mod tests {
         let completer = MockCompleter::new(vec![text_reply("never reached")]);
         let agent = make_agent(completer, 30);
         let result = agent
-            .run("hello", &EchoDispatch, Some(&notify), None)
+            .run("hello", std::sync::Arc::new(EchoDispatch), Some(&notify), None)
             .await
             .unwrap();
         assert_eq!(result.reason, DoneReason::Cancelled);
@@ -944,7 +1046,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let result = agent.run("go", &EchoDispatch, None, None).await.unwrap();
+        let result = agent.run("go", std::sync::Arc::new(EchoDispatch), None, None).await.unwrap();
         assert_eq!(result.reason, DoneReason::NoMoreToolCalls);
 
         // calls[0] = first complete() call = [User]  (initial)
@@ -1028,7 +1130,7 @@ mod tests {
         let seen = dispatch.calls.clone();
 
         let agent = make_agent(MockCompleter::new(vec![reply]), 10);
-        let result = agent.run("go", &dispatch, None, None).await.unwrap();
+        let result = agent.run("go", std::sync::Arc::new(dispatch), None, None).await.unwrap();
 
         assert_eq!(
             *seen.lock().await,
@@ -1056,7 +1158,7 @@ mod tests {
         let agent = make_agent(completer, 10);
 
         let _ = agent
-            .run("test", &EchoDispatch, None, Some(&tx))
+            .run("test", std::sync::Arc::new(EchoDispatch), None, Some(&tx))
             .await
             .unwrap();
 

--- a/crates/biorouter-server/tests/knowledge_macro_live_bridge.rs
+++ b/crates/biorouter-server/tests/knowledge_macro_live_bridge.rs
@@ -1,0 +1,164 @@
+//! A **real** knowledge ingest macro, driven by a **real** Claude Code or Codex,
+//! writing **real** pages through the tool bridge (#109).
+//!
+//! `--ignored`: both need the vendor CLI installed and signed in, and each run
+//! spends the user's own plan quota.
+//!
+//! ```text
+//! cargo test -p biorouter-server --test knowledge_macro_live_bridge -- --ignored --nocapture
+//! ```
+//!
+//! # What only this can prove
+//!
+//! `crates/biorouter/tests/knowledge_macro_tool_bridge.rs` pins the wiring with a
+//! stub provider: the dispatcher reaches the grant, the mirrored pairs come back
+//! as records, nothing is run twice. It cannot prove the half that broke in
+//! production, which is that a **real child agent**, given the macro's tools over
+//! MCP and no others, chooses to call them and writes something to disk.
+//!
+//! That is the measured failure this issue is about. The model produced a
+//! complete, correct plan with every call written out as prose, invented its own
+//! `<tool_response>OK</tool_response>` replies to continue against, and the
+//! knowledge base stayed empty — after a full run the user had paid for. So the
+//! assertion here is deliberately about the **filesystem**, not about the reply:
+//! a run that narrates perfectly and writes nothing fails.
+
+#[path = "../src/test_sandbox.rs"]
+mod test_sandbox;
+
+use std::sync::Arc;
+
+use biorouter::knowledge::provider_completer::ProviderCompleter;
+use biorouter::model::ModelConfig;
+use biorouter::providers::base::Provider;
+use biorouter::providers::coding_agent::bridge;
+use biorouter_mcp::knowledge::affiliation::CallerAffiliation;
+use biorouter_mcp::knowledge::convert::SourceInput;
+use biorouter_mcp::knowledge::macros::ingest::{ingest, IngestArgs};
+use biorouter_mcp::knowledge::service::KnowledgeService;
+use biorouter_mcp::knowledge::subagent::loop_::SubAgentBounds;
+
+/// Serve the real bridge route on an ephemeral port and publish it.
+async fn serve_real_bridge() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("a loopback port");
+    let addr = listener.local_addr().expect("a bound address");
+    let app = biorouter_server::routes::tool_bridge::routes();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    bridge::publish_base_url(format!("http://{addr}"));
+}
+
+/// A short source with one unmistakable fact, so "did it read the source" is
+/// answerable off the pages rather than inferred.
+const SOURCE: &str = "\
+# Tocilizumab in giant cell arteritis
+
+Tocilizumab is an interleukin-6 receptor antagonist. In the GiACTA trial it \
+sustained remission in giant cell arteritis at 52 weeks. The trial identifier \
+recorded here is GIACTA-52W-XKCD.
+";
+
+/// The one string that can only come from the source.
+const SOURCE_MARKER: &str = "GIACTA-52W-XKCD";
+
+/// Run one real ingest and assert it wrote something real.
+async fn ingest_under(provider: Arc<dyn Provider>, label: &str) {
+    serve_real_bridge().await;
+
+    let dir = tempfile::tempdir().expect("a temp knowledge root");
+    let svc = KnowledgeService::new(dir.path().to_path_buf());
+    svc.create_base("live", "Live", None)
+        .expect("the base is created");
+
+    let (completer, _tier, _affiliation) = ProviderCompleter::paired(provider);
+    let result = ingest(
+        &svc,
+        IngestArgs {
+            kb_id: "live".to_string(),
+            caller_is_private: false,
+            caller_affiliation: CallerAffiliation::default(),
+            source: SourceInput::Text {
+                text: SOURCE.to_string(),
+                title: Some("Tocilizumab in GCA".to_string()),
+            },
+            completer: Box::new(completer.in_session("live-macro-e2e")),
+            focus: None,
+            bounds: SubAgentBounds {
+                // Generous: a child agent runs its own multi-step loop inside ONE
+                // provider call, so the wall clock here covers the whole run
+                // rather than one model round trip.
+                max_wall: std::time::Duration::from_secs(600),
+                ..SubAgentBounds::default()
+            },
+            event_sink: None,
+            cancel: None,
+        },
+    )
+    .await;
+
+    let result = result.unwrap_or_else(|e| {
+        panic!("{label}: the ingest failed: {e}");
+    });
+
+    // The pages are the assertion. A run that narrated its calls perfectly and
+    // wrote nothing is exactly the failure #109 is about, and it would sail past
+    // any check on the reply text.
+    let knowledge = dir.path().join("live").join("knowledge");
+    let mut written: Vec<String> = Vec::new();
+    let mut stack = vec![knowledge.clone()];
+    while let Some(path) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().and_then(|e| e.to_str()) == Some("md") {
+                written.push(std::fs::read_to_string(&p).unwrap_or_default());
+            }
+        }
+    }
+
+    assert!(
+        !written.is_empty(),
+        "{label}: the ingest reported success ({} step(s), commit {}) but wrote no \
+         knowledge pages — which is precisely the shape of the bug: the model was \
+         handed no usable tools and narrated its calls instead",
+        result.steps,
+        result.commit_sha
+    );
+    assert!(
+        written.iter().any(|page| page.contains(SOURCE_MARKER)),
+        "{label}: {} page(s) were written but none carries the one fact that only \
+         the source contains ({SOURCE_MARKER}), so the child did not actually read \
+         it through the bridge",
+        written.len()
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[ignore = "needs the `claude` CLI installed and signed in; spends the user's own plan quota"]
+async fn a_real_ingest_macro_runs_on_claude_code() {
+    use biorouter::providers::claude_code::ClaudeCodeProvider;
+    let provider =
+        ClaudeCodeProvider::from_env(ModelConfig::new("claude-sonnet-4-6").expect("a known model"))
+            .await
+            .expect("the claude CLI is installed");
+    ingest_under(Arc::new(provider), "claude_code").await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[ignore = "needs the `codex` CLI installed and signed in; spends the user's own plan quota"]
+async fn a_real_ingest_macro_runs_on_codex() {
+    use biorouter::providers::codex::CodexProvider;
+    let provider = CodexProvider::from_env(ModelConfig::new("gpt-5.5").expect("a known model"))
+        .await
+        .expect("the codex CLI is installed");
+    ingest_under(Arc::new(provider), "codex").await;
+}

--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -4887,7 +4887,11 @@ impl Agent {
         coding_agent_bridge::issue(coding_agent_bridge::BridgeGrant::new(
             session.clone(),
             self.config.biorouter_mode,
-            Arc::clone(&self.extension_manager),
+            // #109: the bridge dispatches through a trait now, so a knowledge
+            // macro or a scheduled workflow can bridge its OWN small tool
+            // surface. A chat turn's surface is the session's extensions, which
+            // is what this coercion says.
+            Arc::clone(&self.extension_manager) as Arc<dyn coding_agent_bridge::BridgeToolDispatch>,
             Arc::clone(&self.tool_inspection_manager),
             capability,
             bridged,

--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -4890,8 +4890,8 @@ impl Agent {
             // #109: the bridge dispatches through a trait now, so a knowledge
             // macro or a scheduled workflow can bridge its OWN small tool
             // surface. A chat turn's surface is the session's extensions, which
-            // is what this coercion says.
-            Arc::clone(&self.extension_manager) as Arc<dyn coding_agent_bridge::BridgeToolDispatch>,
+            // is what this named coercion says.
+            crate::providers::tool_turn::session_tools(Arc::clone(&self.extension_manager)),
             Arc::clone(&self.tool_inspection_manager),
             capability,
             bridged,

--- a/crates/biorouter/src/agents/knowledge_tool.rs
+++ b/crates/biorouter/src/agents/knowledge_tool.rs
@@ -149,7 +149,16 @@ impl Agent {
             ))
         })?;
         let (completer, tier, affiliation) = ProviderCompleter::paired(provider);
-        Ok((Box::new(completer), tier, affiliation))
+        // #107 / #109: this macro runs from inside a chat, so this session's own
+        // agent loop is the surface that can draw a human-decision card and the
+        // one that will drain it. Scoping the card here is what makes an
+        // approval raised by a bridged macro tool answerable at all; a run
+        // started from the Knowledge view has no loop and leaves it unscoped.
+        Ok((
+            Box::new(completer.in_session(session.id.clone())),
+            tier,
+            affiliation,
+        ))
     }
 }
 

--- a/crates/biorouter/src/knowledge/provider_completer.rs
+++ b/crates/biorouter/src/knowledge/provider_completer.rs
@@ -182,6 +182,10 @@ impl Completer for ProviderCompleter {
             Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&self.provider))));
         let capability = crate::privacy::CallCapability::sample(&shared).await;
 
+        // An empty id when there is no chat behind the run. The bridge reads
+        // that as "unscoped" rather than as a session literally named "", which
+        // is the difference between a card any loop may surface and a queue every
+        // chat-less run in the process shares.
         let session = crate::session::session_manager::Session {
             id: self.session_id.clone().unwrap_or_default(),
             ..Default::default()

--- a/crates/biorouter/src/knowledge/provider_completer.rs
+++ b/crates/biorouter/src/knowledge/provider_completer.rs
@@ -7,13 +7,17 @@
 
 use crate::conversation::message::{Message, MessageContent};
 use crate::providers::base::Provider;
+use crate::providers::coding_agent::bridge::BridgeToolDispatch;
+use crate::providers::tool_turn::ProviderToolTurnContext;
 use anyhow::Result;
 use async_trait::async_trait;
 use biorouter_mcp::knowledge::subagent::loop_::{
-    Completer, LlmMessage, LlmReply, LlmToolCall, ToolResultPart,
+    Completer, CompleterTurn, ExecutedCall, LlmMessage, LlmReply, LlmToolCall, ToolDispatch,
+    ToolResultPart,
 };
 use rmcp::model::{CallToolRequestParams, CallToolResult, Content, Tool};
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 
 // ---------------------------------------------------------------------------
 // Adapter
@@ -23,11 +27,50 @@ pub struct ProviderCompleter {
     /// Private, with [`Self::new`], so that [`Self::paired`] is the only way any
     /// other module can obtain a `ProviderCompleter` at all — see its doc.
     provider: Arc<dyn Provider>,
+    /// Which session a human-decision card raised during a bridged turn belongs
+    /// to (#107 / #109).
+    ///
+    /// `None` means the run has no chat behind it — the Knowledge view's ingest
+    /// panel, a scheduled job — and the card is queued unscoped, deliverable by
+    /// any session's loop.
+    ///
+    /// ⚠ **Known gap, recorded rather than implied away.** A macro run from the
+    /// Knowledge view has no agent loop draining that queue at all, so an
+    /// approval raised there would go unanswered until its TTL. In practice a
+    /// macro's tool surface is the workflow's own — the KB tools — under
+    /// `BioRouterMode::Auto`, so the permission inspector allows and nothing is
+    /// raised; the security and sensitive-ops inspectors can still escalate, and
+    /// that is the case with nowhere to draw. Closing it means giving the ingest
+    /// SSE stream a card frame, which is a UI change and not this one.
+    session_id: Option<String>,
+    /// The run's cancellation, so a bridged tool call is reachable by whatever
+    /// stops the run.
+    cancel: Option<CancellationToken>,
 }
 
 impl ProviderCompleter {
     fn new(provider: Arc<dyn Provider>) -> Self {
-        Self { provider }
+        Self {
+            provider,
+            session_id: None,
+            cancel: None,
+        }
+    }
+
+    /// Scope any human-decision card this completer's turns raise to
+    /// `session_id`. See the field's doc for what `None` means.
+    #[must_use]
+    pub fn in_session(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    /// Bind the run's cancellation, so a bridged tool call and a parked approval
+    /// are both reachable by whatever stops the run.
+    #[must_use]
+    pub fn cancelled_by(mut self, cancel: CancellationToken) -> Self {
+        self.cancel = Some(cancel);
+        self
     }
 
     /// The completer **and** the tier of the provider behind it, from one
@@ -98,6 +141,149 @@ impl Completer for ProviderCompleter {
         let tool_calls = extract_tool_calls(&reply_msg)?;
 
         Ok(LlmReply { text, tool_calls })
+    }
+
+    /// #109: the seam that makes a coding-agent provider usable by a macro.
+    ///
+    /// `claude_code` and `codex` do not receive tools in the request; their
+    /// child process reaches Biorouter's over an MCP bridge that the *provider
+    /// call* establishes. So the run's dispatcher has to be reachable from
+    /// inside the call, which is what this argument is for, and the child then
+    /// chooses and executes the calls itself — behind the same inspectors,
+    /// permission decision, approval round trip and cancellation a chat turn
+    /// gets, because it is the same [`crate::providers::coding_agent::bridge`]
+    /// gate stack.
+    ///
+    /// Everything else keeps the default: a provider that receives its tools in
+    /// the request returns tool *requests* for the loop to dispatch, and
+    /// [`ProviderToolTurnContext::run`] leaves that path untouched down to
+    /// issuing no grant at all.
+    async fn complete_with_dispatch(
+        &self,
+        system_prompt: &str,
+        messages: &[LlmMessage],
+        tools: &[Tool],
+        dispatch: Arc<dyn ToolDispatch>,
+    ) -> Result<CompleterTurn> {
+        if !self.provider.uses_tool_bridge() {
+            return Ok(self.complete(system_prompt, messages, tools).await?.into());
+        }
+
+        let provider_messages: Vec<Message> =
+            messages.iter().map(llm_to_provider_message).collect();
+
+        // ONE read of the provider mutex and the master toggle, here, and
+        // carried into the grant from there. A bridged call arrives from a child
+        // process with no capability of its own to inherit, so fixing it before
+        // the turn is the whole reason `CallCapability` exists — re-reading per
+        // callback would be the two-reads race with a process boundary through
+        // the middle.
+        let shared: crate::agents::types::SharedProvider =
+            Arc::new(tokio::sync::Mutex::new(Some(Arc::clone(&self.provider))));
+        let capability = crate::privacy::CallCapability::sample(&shared).await;
+
+        let session = crate::session::session_manager::Session {
+            id: self.session_id.clone().unwrap_or_default(),
+            ..Default::default()
+        };
+        let context = ProviderToolTurnContext::for_workflow(
+            session,
+            Arc::new(SubAgentDispatchBridge { dispatch }),
+            capability,
+            self.cancel.clone(),
+        );
+
+        let turn = context
+            .run(&self.provider, system_prompt, &provider_messages, tools)
+            .await
+            .map_err(|e| anyhow::anyhow!("provider.complete failed: {e}"))?;
+
+        // A mirrored request is a RECORD. Handing it back in `tool_calls` would
+        // make the loop dispatch it a second time, and a `kb_write_page` run
+        // twice is a second write, not a redraw.
+        let executed = turn
+            .executed
+            .iter()
+            .map(|call| ExecutedCall {
+                id: call.id.clone(),
+                name: call.name.clone(),
+                args: call.arguments.clone(),
+                output: call.output.clone(),
+                is_error: call.is_error,
+            })
+            .collect();
+        let tool_calls = turn
+            .pending_tool_calls()
+            .into_iter()
+            .map(|request| match &request.tool_call {
+                Ok(params) => Ok(LlmToolCall {
+                    id: request.id.clone(),
+                    name: params.name.to_string(),
+                    args: params
+                        .arguments
+                        .clone()
+                        .map(serde_json::Value::Object)
+                        .unwrap_or(serde_json::Value::Null),
+                }),
+                Err(e) => Err(anyhow::anyhow!(
+                    "the model requested a tool call Biorouter could not decode: {}",
+                    e.message
+                )),
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(CompleterTurn {
+            reply: LlmReply {
+                text: turn.text(),
+                tool_calls,
+            },
+            executed,
+        })
+    }
+}
+
+/// A sub-agent loop's dispatcher, as something the tool bridge can call.
+///
+/// The two traits are the same idea in two crates that cannot see each other:
+/// `ToolDispatch` lives in `biorouter-mcp` (which must not depend on
+/// `biorouter`), `BridgeToolDispatch` in `biorouter`. This adapter lives here,
+/// the one place that already depends on both — the same reason
+/// [`ProviderCompleter`] itself is here.
+///
+/// The session id, capability and cancellation are dropped rather than
+/// forwarded, and that is not a loss: a `ToolDispatch` is a closure over ONE
+/// run's state — the ingest macro's carries the git transaction every write in
+/// the run must land on — so there is no second session it could serve and no
+/// second capability it could be asked about. What decides whether the call may
+/// run at all has already happened above this point, in the grant.
+struct SubAgentDispatchBridge {
+    dispatch: Arc<dyn ToolDispatch>,
+}
+
+#[async_trait]
+impl BridgeToolDispatch for SubAgentDispatchBridge {
+    async fn dispatch(
+        &self,
+        _session_id: &str,
+        call: CallToolRequestParams,
+        _capability: crate::privacy::CallCapability,
+        _cancel: CancellationToken,
+    ) -> std::result::Result<CallToolResult, String> {
+        let name = call.name.to_string();
+        let args = call
+            .arguments
+            .map(serde_json::Value::Object)
+            .unwrap_or(serde_json::Value::Null);
+        match self.dispatch.call(&name, args).await {
+            Ok(text) => Ok(CallToolResult::success(vec![Content::text(text)])),
+            // A tool that refused is a RESULT the child's model reads and acts
+            // on, not a transport error it may retry — the same distinction the
+            // loop's own dispatcher makes when it feeds `error: …` back as a
+            // tool result. A JSON-RPC error here would read as a broken server.
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "error: {e}"
+            ))])),
+        }
     }
 }
 

--- a/crates/biorouter/src/providers/coding_agent/bridge.rs
+++ b/crates/biorouter/src/providers/coding_agent/bridge.rs
@@ -68,6 +68,57 @@ use crate::privacy::CallCapability;
 use crate::session::session_manager::Session;
 use crate::tool_inspection::ToolInspectionManager;
 
+/// What a bridged `tools/call` actually runs, once the gate stack has cleared it.
+///
+/// An abstraction rather than a hardcoded `ExtensionManager` because the bridge
+/// is not only the chat loop's (#109). A knowledge macro, a scheduled workflow or
+/// any other bounded sub-agent has its own small tool surface with its own
+/// dispatcher — the ingest macro's `KbToolDispatch` carries the git transaction
+/// every write in the run must land on — and those tools are not in any
+/// `ExtensionManager` at all.
+///
+/// Before this, the only way to give a child agent tools was the session's whole
+/// extension surface, so a macro running under `claude_code` or `codex` was
+/// handed a `tools` argument its provider discarded. It then narrated the calls
+/// as prose, invented its own results to continue against, and wrote nothing —
+/// after a full model run. The UI's answer was a provider denylist.
+///
+/// Whatever implements this, everything above it is unchanged: the inspectors,
+/// the permission decision, the privacy capability, the vault, the hooks and the
+/// approval round trip all run first, exactly as they do for a chat turn. This
+/// decides only *where the call lands*, never *whether it may*.
+#[async_trait::async_trait]
+pub trait BridgeToolDispatch: Send + Sync {
+    async fn dispatch(
+        &self,
+        session_id: &str,
+        call: CallToolRequestParams,
+        capability: CallCapability,
+        cancel: CancellationToken,
+    ) -> Result<CallToolResult, String>;
+}
+
+#[async_trait::async_trait]
+impl BridgeToolDispatch for ExtensionManager {
+    async fn dispatch(
+        &self,
+        session_id: &str,
+        call: CallToolRequestParams,
+        capability: CallCapability,
+        cancel: CancellationToken,
+    ) -> Result<CallToolResult, String> {
+        let name = call.name.to_string();
+        let result = self
+            .dispatch_tool_call(session_id, call, capability, cancel)
+            .await
+            .map_err(|e| format!("`{name}` failed: {e}"))?;
+        result
+            .result
+            .await
+            .map_err(|e| format!("`{name}` failed: {e}"))
+    }
+}
+
 /// Everything one turn's bridge needs to serve `tools/list` and `tools/call`.
 ///
 /// Deliberately a snapshot rather than a handle back to the `Agent`: the provider
@@ -76,7 +127,7 @@ use crate::tool_inspection::ToolInspectionManager;
 pub struct BridgeGrant {
     session: Session,
     mode: BioRouterMode,
-    extensions: Arc<ExtensionManager>,
+    dispatcher: Arc<dyn BridgeToolDispatch>,
     inspections: Arc<ToolInspectionManager>,
     /// Sampled ONCE, when the grant is issued, and threaded from there.
     ///
@@ -199,7 +250,7 @@ impl BridgeGrant {
     pub fn new(
         session: Session,
         mode: BioRouterMode,
-        extensions: Arc<ExtensionManager>,
+        dispatcher: Arc<dyn BridgeToolDispatch>,
         inspections: Arc<ToolInspectionManager>,
         capability: CallCapability,
         tools: Vec<Tool>,
@@ -212,7 +263,7 @@ impl BridgeGrant {
         Self {
             session,
             mode,
-            extensions,
+            dispatcher,
             inspections,
             capability,
             tools,
@@ -408,21 +459,14 @@ impl BridgeGrant {
             .map_err(|e| format!("`{name}` was approved but is not a usable call: {e}"))?;
         self.apply_vault(&mut call);
 
-        let result = self
-            .extensions
-            .dispatch_tool_call(
+        self.dispatcher
+            .dispatch(
                 &self.session.id,
                 call,
                 self.capability,
                 self.dispatch_cancel_token(),
             )
             .await
-            .map_err(|e| format!("`{name}` failed: {e}"))?;
-
-        result
-            .result
-            .await
-            .map_err(|e| format!("`{name}` failed: {e}"))
     }
 
     /// Put a `needs_approval` call to a person, and park until they answer.
@@ -1612,7 +1656,7 @@ mod tests {
                 // Auto, so the permission inspector approves and the test measures
                 // the rewrite rather than the approval flow.
                 BioRouterMode::Auto,
-                Arc::clone(&self.extensions),
+                Arc::clone(&self.extensions) as Arc<dyn BridgeToolDispatch>,
                 Arc::new(inspections),
                 test_capability(),
                 vec![],
@@ -1872,7 +1916,7 @@ mod tests {
         Arc::new(BridgeGrant::new(
             session,
             BioRouterMode::Approve,
-            Arc::clone(&db.extensions),
+            Arc::clone(&db.extensions) as Arc<dyn BridgeToolDispatch>,
             Arc::new(inspections_with(&hooks, false)),
             test_capability(),
             vec![],
@@ -2063,7 +2107,7 @@ mod tests {
         let grant = Arc::new(BridgeGrant::new(
             session,
             BioRouterMode::Approve,
-            Arc::clone(&db.extensions),
+            Arc::clone(&db.extensions) as Arc<dyn BridgeToolDispatch>,
             Arc::new(inspections_with(&hooks, false)),
             test_capability(),
             vec![],
@@ -2108,7 +2152,7 @@ mod tests {
         let lease = issue(BridgeGrant::new(
             session,
             BioRouterMode::Approve,
-            Arc::clone(&db.extensions),
+            Arc::clone(&db.extensions) as Arc<dyn BridgeToolDispatch>,
             Arc::new(inspections_with(&hooks, false)),
             test_capability(),
             vec![],

--- a/crates/biorouter/src/providers/mod.rs
+++ b/crates/biorouter/src/providers/mod.rs
@@ -40,6 +40,7 @@ pub mod testprovider;
 pub mod tetrate;
 #[cfg(test)]
 mod tier_tests;
+pub mod tool_turn;
 pub mod toolshim;
 pub mod usage_estimator;
 pub mod utils;

--- a/crates/biorouter/src/providers/tool_turn.rs
+++ b/crates/biorouter/src/providers/tool_turn.rs
@@ -712,11 +712,12 @@ mod tests {
         assert!(turn.executed.is_empty());
     }
 
-    /// A workflow made of tool calls must fail *before* spending a model run
-    /// when there is no server for the child to call back into. The chat loop's
-    /// degradation — run tool-less and answer from the conversation — is exactly
-    /// wrong here: the model narrates the calls and writes nothing.
-    // The "no HTTP server" refusal is pinned in its own integration binary,
+    // A workflow made of tool calls must fail *before* spending a model run when
+    // there is no server for the child to call back into — the chat loop's
+    // degradation (run tool-less, answer from the conversation) is exactly wrong
+    // there, because the model narrates the calls and writes nothing.
+    //
+    // That refusal is pinned in its own integration binary,
     // `tests/provider_tool_turn_no_server.rs`. It cannot live here: the
     // published base URL is process-global (it must be — the HTTP handler runs
     // on a different task from the turn that issued the grant), so a unit test

--- a/crates/biorouter/src/providers/tool_turn.rs
+++ b/crates/biorouter/src/providers/tool_turn.rs
@@ -195,6 +195,7 @@ impl ProviderToolTurnContext {
         capability: CallCapability,
         cancel: Option<CancellationToken>,
     ) -> Self {
+        let tool_risks = Arc::new(ToolRiskRegistry::new());
         Self::new(
             session,
             // Auto: a workflow the user explicitly started is an authorised
@@ -205,7 +206,7 @@ impl ProviderToolTurnContext {
             // escalation raises a real dialog instead of dead-ending.
             BioRouterMode::Auto,
             dispatcher,
-            Arc::new(crate::tool_inspection::ToolInspectionManager::new()),
+            Arc::new(workflow_inspectors(Arc::clone(&tool_risks))),
             capability,
             Conversation::new_unvalidated(vec![]),
             cancel,
@@ -215,7 +216,7 @@ impl ProviderToolTurnContext {
                 Arc::new(tokio::sync::Mutex::new(None)),
             )),
             None,
-            Arc::new(ToolRiskRegistry::new()),
+            tool_risks,
         )
     }
 
@@ -267,6 +268,13 @@ impl ProviderToolTurnContext {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<ProviderTurn, ProviderError> {
+        // BR-18's grades, for THIS turn's surface. The registry starts from the
+        // built-in table and learns the rest from the tools it is shown, exactly
+        // as `Agent::prepare_tools` refreshes it — a workflow's tools are its
+        // own, so nothing else could have taught it about them, and an ungraded
+        // tool would reach an approval card with nothing to say about its risk.
+        self.tool_risks.refresh_from_tools(tools);
+
         let grant = bridge::BridgeGrant::new(
             self.session.clone(),
             self.mode,
@@ -429,6 +437,44 @@ fn executed_calls(messages: &[Message]) -> Vec<ExecutedToolCall> {
         .into_iter()
         .filter_map(|id| by_id.remove(&id))
         .collect()
+}
+
+/// The gate stack a workflow turn runs behind.
+///
+/// The inspectors a chat turn registers, minus the two that need agent-owned
+/// state (hooks, repetition history) and are meaningless for a bounded run with
+/// no conversation. It is a real stack and not an empty one for a reason that
+/// bites immediately: `BridgeGrant` refuses a call whose verdict is "no decision
+/// was reached", because an absent decision must never read as approval — so an
+/// empty manager does not mean "allow everything", it means every bridged call
+/// is refused.
+///
+/// The **security** and **sensitive-ops** inspectors are the load-bearing half.
+/// They escalate regardless of mode, so `BioRouterMode::Auto` above is a
+/// statement about ordinary authorised steps, not a blanket grant: a workflow
+/// that reaches for something genuinely dangerous still raises the #107 dialog.
+fn workflow_inspectors(tool_risks: Arc<ToolRiskRegistry>) -> ToolInspectionManager {
+    use crate::config::permission::PermissionManager;
+    use crate::managed::ManagedPolicy;
+    use crate::permission::managed_inspector::ManagedPolicyInspector;
+    use crate::permission::permission_inspector::PermissionInspector;
+    use crate::security::security_inspector::SecurityInspector;
+    use crate::security::sensitive_ops::SensitiveOpsInspector;
+
+    let managed = Arc::new(ManagedPolicy::empty());
+    let mut manager = ToolInspectionManager::new();
+    manager.add_inspector(Box::new(ManagedPolicyInspector::new(Arc::clone(&managed))));
+    manager.add_inspector(Box::new(SecurityInspector::new()));
+    manager.add_inspector(Box::new(SensitiveOpsInspector));
+    manager.add_inspector(Box::new(PermissionInspector::new(
+        tool_risks,
+        PermissionManager::instance(),
+        managed,
+        // No provider: a workflow has no lead/worker pair to grade against, and
+        // the inspector's only use for one is smart-approve's model call.
+        Arc::new(tokio::sync::Mutex::new(None)),
+    )));
+    manager
 }
 
 /// The session's whole extension surface, as a bridge dispatcher.

--- a/crates/biorouter/src/providers/tool_turn.rs
+++ b/crates/biorouter/src/providers/tool_turn.rs
@@ -1,0 +1,774 @@
+//! Run one provider turn with Biorouter's tools available — whichever provider
+//! it is (#109).
+//!
+//! # Why this exists
+//!
+//! Most providers receive their tools in the request. The two coding-agent
+//! providers cannot: `claude_code` and `codex` drive a whole agent in a child
+//! process, so the only way a Biorouter tool reaches them is a callback over the
+//! MCP bridge, and the only way the bridge exists is that somebody issued a
+//! grant and scoped its URL around the provider call.
+//!
+//! For a long time exactly one caller did that: `Agent::reply`. Everything else
+//! that runs an agentic loop — the knowledge ingest / query / lint macros,
+//! scheduled workflows, bounded sub-agents — calls `Provider::complete` directly
+//! with a `tools` argument, which those two providers **discard**. The result was
+//! not an error. The model produced a complete, correct plan with every call
+//! written out as prose, invented its own `<tool_response>OK</tool_response>`
+//! replies to continue against, and nothing reached disk. The user waited out a
+//! full model run for nothing, and the UI's answer was a hardcoded provider
+//! denylist.
+//!
+//! That is a structural mismatch, not a model-quality problem: the workflow *had*
+//! tools; the provider had no grant. This is the missing piece — the one place
+//! that knows how to give any provider Biorouter's tools for the length of one
+//! turn.
+//!
+//! # What it is not
+//!
+//! Not a second gate stack. A bridged call still passes through
+//! [`crate::providers::coding_agent::bridge::BridgeGrant::call`]: the inspectors,
+//! the permission decision (including the human approval round trip added by
+//! #107), privacy Gate C, `.biorouterignore`, the vault, the `PreToolUse`
+//! rewrite and re-judgement, and the turn's cancellation token. This decides
+//! *which* tools and *where they land*, never *whether a call may run*.
+//!
+//! And not a provider switch. The whole point of the coding-agent providers is
+//! that a user's existing Anthropic or ChatGPT plan pays for the turn; nothing
+//! here reaches for an API key or silently substitutes a billed model.
+
+use std::sync::Arc;
+
+use rmcp::model::Tool;
+use tokio_util::sync::CancellationToken;
+
+use crate::agents::extension_manager::ExtensionManager;
+use crate::config::BioRouterMode;
+use crate::conversation::message::Message;
+use crate::conversation::Conversation;
+use crate::hooks::HooksManager;
+use crate::permission::tool_risk::ToolRiskRegistry;
+use crate::privacy::CallCapability;
+use crate::providers::base::{Provider, ProviderUsage};
+use crate::providers::coding_agent::{bridge, mirror};
+use crate::providers::errors::ProviderError;
+use crate::session::session_manager::Session;
+use crate::tool_inspection::ToolInspectionManager;
+
+/// Everything one turn needs in order to offer Biorouter's tools to any
+/// provider, coding agents included.
+///
+/// Built once per workflow and reused across that workflow's turns; the grant it
+/// issues lives for exactly one provider call. A grant that outlived its call
+/// would be a capability with no owner, which is why [`Self::run`] holds the
+/// lease rather than handing it out.
+pub struct ProviderToolTurnContext {
+    session: Session,
+    mode: BioRouterMode,
+    dispatcher: Arc<dyn bridge::BridgeToolDispatch>,
+    inspections: Arc<ToolInspectionManager>,
+    capability: CallCapability,
+    conversation: Conversation,
+    cancel: Option<CancellationToken>,
+    hooks: Arc<HooksManager>,
+    vault: Option<Arc<crate::agents::vault_refs::VaultRefs>>,
+    tool_risks: Arc<ToolRiskRegistry>,
+}
+
+/// What one turn produced.
+#[derive(Debug)]
+pub struct ProviderTurn {
+    /// Every message the turn yielded, in order: the assistant's prose, and —
+    /// for a coding-agent provider — the mirrored `ToolRequest`/`ToolResponse`
+    /// pairs recording what the child ran through the bridge.
+    ///
+    /// A `Vec`, not one `Message`, because that is what a turn *is* on the
+    /// streaming path, and flattening it here would throw away the ordering a
+    /// caller needs to write a faithful run log.
+    pub messages: Vec<Message>,
+    pub usage: ProviderUsage,
+    /// Tool calls the **child already ran** over the bridge, in order.
+    ///
+    /// Empty for every provider that receives its tools in the request: those
+    /// return tool *requests* for the caller to dispatch, and this stays empty so
+    /// the caller's existing loop is untouched.
+    ///
+    /// ⚠ **A caller must not dispatch these.** They have already executed, behind
+    /// the full gate stack, on Biorouter's side of the bridge. Re-running a
+    /// `developer__shell` because a loop could not tell a record from a request
+    /// is not a display glitch — it is the command running twice. This is the
+    /// same hazard `Agent::reply` closes with `mirror::contains_provider_executed`,
+    /// surfaced here as data rather than left for each caller to rediscover.
+    pub executed: Vec<ExecutedToolCall>,
+}
+
+impl ProviderTurn {
+    /// The assistant's prose, concatenated.
+    pub fn text(&self) -> String {
+        self.messages
+            .iter()
+            .map(Message::as_concat_text)
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Tool calls the caller must still dispatch.
+    ///
+    /// **Mirrored requests are excluded.** They have already run, behind the
+    /// full gate stack, on Biorouter's side of the bridge, and a caller that
+    /// dispatched one would execute it a second time — a shell command run
+    /// twice, not a display glitch. That exclusion is the whole reason this
+    /// accessor exists instead of leaving each caller to walk `messages` and
+    /// rediscover the marker.
+    pub fn pending_tool_calls(&self) -> Vec<&crate::conversation::message::ToolRequest> {
+        use crate::conversation::message::MessageContent;
+        self.messages
+            .iter()
+            .flat_map(|m| m.content.iter())
+            .filter_map(|c| match c {
+                MessageContent::ToolRequest(r) if mirror::request_execution(r).is_none() => Some(r),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+/// One call the child made and Biorouter ran.
+#[derive(Debug, Clone)]
+pub struct ExecutedToolCall {
+    pub id: String,
+    /// The tool's own name, with the child's `mcp__biorouter__` prefix already
+    /// stripped by the mirror.
+    pub name: String,
+    pub arguments: serde_json::Value,
+    /// The result as text, and whether the tool reported failure.
+    pub output: String,
+    pub is_error: bool,
+}
+
+impl ProviderToolTurnContext {
+    /// Eleven arguments, flat, for the reason
+    /// [`bridge::BridgeGrant::new`] gives at length: each one is a distinct
+    /// thing a caller has to remember to hand over, and three of the grant's
+    /// were found missing precisely by reading the list against what a chat turn
+    /// does. A wrapper struct would move the omission one file away without
+    /// removing a field.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        session: Session,
+        mode: BioRouterMode,
+        dispatcher: Arc<dyn bridge::BridgeToolDispatch>,
+        inspections: Arc<ToolInspectionManager>,
+        capability: CallCapability,
+        conversation: Conversation,
+        cancel: Option<CancellationToken>,
+        hooks: Arc<HooksManager>,
+        vault: Option<Arc<crate::agents::vault_refs::VaultRefs>>,
+        tool_risks: Arc<ToolRiskRegistry>,
+    ) -> Self {
+        Self {
+            session,
+            mode,
+            dispatcher,
+            inspections,
+            capability,
+            conversation,
+            cancel,
+            hooks,
+            vault,
+            tool_risks,
+        }
+    }
+
+    /// The context a bounded workflow wants: its own tool surface, its own
+    /// dispatcher, and the defaults for everything a chat turn carries that a
+    /// workflow does not have.
+    ///
+    /// `capability` is **taken**, not derived, because a workflow's privacy
+    /// capability belongs to the provider it is about to bind — sampling it here
+    /// would be a second read of the master switch and exactly the race
+    /// `CallCapability` exists to close.
+    pub fn for_workflow(
+        session: Session,
+        dispatcher: Arc<dyn bridge::BridgeToolDispatch>,
+        capability: CallCapability,
+        cancel: Option<CancellationToken>,
+    ) -> Self {
+        Self::new(
+            session,
+            // Auto: a workflow the user explicitly started is an authorised
+            // step, and its tool surface is the small one the workflow chose
+            // rather than the machine. Genuinely sensitive operations are still
+            // caught — the security and sensitive-ops inspectors sit above the
+            // permission one and escalate regardless of mode, and since #107 an
+            // escalation raises a real dialog instead of dead-ending.
+            BioRouterMode::Auto,
+            dispatcher,
+            Arc::new(crate::tool_inspection::ToolInspectionManager::new()),
+            capability,
+            Conversation::new_unvalidated(vec![]),
+            cancel,
+            Arc::new(HooksManager::with_config(
+                Default::default(),
+                false,
+                Arc::new(tokio::sync::Mutex::new(None)),
+            )),
+            None,
+            Arc::new(ToolRiskRegistry::new()),
+        )
+    }
+
+    /// Replace the inspection stack. A workflow that wants the real inspectors
+    /// (rather than the empty default) hands them here.
+    #[must_use]
+    pub fn with_inspections(mut self, inspections: Arc<ToolInspectionManager>) -> Self {
+        self.inspections = inspections;
+        self
+    }
+
+    /// Run one turn.
+    ///
+    /// For a provider that receives its tools in the request this is
+    /// `provider.complete(...)` and nothing else — no grant is issued, because
+    /// issuing one would leave a live capability on every turn in the process
+    /// for no benefit.
+    ///
+    /// For a coding-agent provider it issues a one-turn grant over `tools`,
+    /// scopes its URL around the call, and drops the lease the moment the call
+    /// returns.
+    ///
+    /// ⚠ **The URL rides a task-local and must be read at construction time.**
+    /// The scope below wraps the awaited call that *builds* the response, not the
+    /// consumption of anything it returns. That is why this uses `complete`
+    /// rather than `stream`: a stream's poll happens after the scope is gone.
+    pub async fn run(
+        &self,
+        provider: &Arc<dyn Provider>,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+    ) -> Result<ProviderTurn, ProviderError> {
+        if !provider.uses_tool_bridge() {
+            let (message, usage) = provider.complete(system, messages, tools).await?;
+            return Ok(ProviderTurn {
+                messages: vec![message],
+                usage,
+                executed: Vec::new(),
+            });
+        }
+        self.run_bridged(provider, system, messages, tools).await
+    }
+
+    async fn run_bridged(
+        &self,
+        provider: &Arc<dyn Provider>,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+    ) -> Result<ProviderTurn, ProviderError> {
+        let grant = bridge::BridgeGrant::new(
+            self.session.clone(),
+            self.mode,
+            Arc::clone(&self.dispatcher),
+            Arc::clone(&self.inspections),
+            self.capability,
+            tools.to_vec(),
+            self.conversation.clone(),
+            self.cancel.clone(),
+            Arc::clone(&self.hooks),
+            self.vault.clone(),
+            Arc::clone(&self.tool_risks),
+        );
+
+        // `None` means no HTTP server in this process — a CLI run, a unit test.
+        // The child then runs tool-less, which for a *chat* turn is the right
+        // degradation (an answer from the conversation beats a failed turn) but
+        // for a workflow made of tool calls is a guaranteed silent failure: the
+        // model narrates the calls and writes nothing. So this is the one place
+        // that refuses instead, before a full model run is spent.
+        let Some(lease) = bridge::issue(grant) else {
+            return Err(ProviderError::ExecutionError(format!(
+                "`{}` runs its tools by calling Biorouter back over HTTP, and this process has \
+                 no server for it to reach. Run this through the Biorouter desktop app or a \
+                 running `biorouterd`, or choose a provider that receives its tools directly.",
+                provider.get_name()
+            )));
+        };
+
+        let url = lease.url().to_string();
+
+        // Streaming, when the provider offers it, and NOT for latency: the
+        // mirrored `ToolRequest`/`ToolResponse` pairs recording what the child
+        // ran exist only on the streaming path. `complete_with_model` returns the
+        // final text alone, so a workflow driven through it would execute every
+        // tool correctly and be unable to say afterwards which ones — no run log,
+        // no attribution, nothing for the user to audit.
+        //
+        // ⚠ The stream is **constructed inside the scope and consumed outside**.
+        // The task-local wraps the awaited call that builds the stream, not the
+        // polling of what it returns, and both coding-agent providers read the
+        // URL and spawn the child at construction for exactly that reason. The
+        // *lease* is not the constraint — it is bound here and lives to the end
+        // of this function, which outlasts the consumption below.
+        if provider.supports_streaming() {
+            let stream = bridge::ACTIVE_BRIDGE_URL
+                .scope(Some(url), provider.stream(system, messages, tools))
+                .await?;
+            return collect_stream(stream, provider.get_name()).await;
+        }
+
+        let (message, usage) = bridge::ACTIVE_BRIDGE_URL
+            .scope(Some(url), provider.complete(system, messages, tools))
+            .await?;
+        let executed = executed_calls(std::slice::from_ref(&message));
+        Ok(ProviderTurn {
+            messages: vec![message],
+            usage,
+            executed,
+        })
+    }
+}
+
+/// Drain a provider stream into one turn.
+async fn collect_stream(
+    mut stream: crate::providers::base::MessageStream,
+    provider_name: &str,
+) -> Result<ProviderTurn, ProviderError> {
+    use futures::StreamExt;
+
+    let mut messages: Vec<Message> = Vec::new();
+    let mut usage: Option<ProviderUsage> = None;
+    while let Some(item) = stream.next().await {
+        let (message, chunk_usage, _pending) = item?;
+        if let Some(message) = message {
+            messages.push(message);
+        }
+        // Last snapshot wins, exactly as the agent loop records it: a provider
+        // that reports usage on more than one chunk must not be counted twice.
+        if let Some(chunk_usage) = chunk_usage {
+            usage = Some(chunk_usage);
+        }
+    }
+    let usage = usage.unwrap_or_else(|| {
+        ProviderUsage::new(
+            provider_name.to_string(),
+            crate::providers::base::Usage::new(None, None, None),
+        )
+    });
+    let executed = executed_calls(&messages);
+    Ok(ProviderTurn {
+        messages,
+        usage,
+        executed,
+    })
+}
+
+/// Read the calls the child already executed off a mirrored reply.
+///
+/// The mirror stamps every pair it mints with `biorouterProviderExecuted`, and
+/// this reads only the pairs marked `bridged` — a `child` marker means the call
+/// ran inside the child's own sandbox under **none** of Biorouter's gates, and a
+/// workflow must not record one as its own work.
+fn executed_calls(messages: &[Message]) -> Vec<ExecutedToolCall> {
+    use crate::conversation::message::MessageContent;
+
+    let mut by_id: std::collections::HashMap<String, ExecutedToolCall> =
+        std::collections::HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+
+    for content in messages.iter().flat_map(|m| m.content.iter()) {
+        match content {
+            MessageContent::ToolRequest(request)
+                if mirror::request_execution(request) == Some(mirror::Execution::Bridged) =>
+            {
+                let Ok(call) = request.tool_call.as_ref() else {
+                    continue;
+                };
+                order.push(request.id.clone());
+                by_id.insert(
+                    request.id.clone(),
+                    ExecutedToolCall {
+                        id: request.id.clone(),
+                        name: call.name.to_string(),
+                        arguments: call
+                            .arguments
+                            .clone()
+                            .map(serde_json::Value::Object)
+                            .unwrap_or(serde_json::Value::Null),
+                        output: String::new(),
+                        is_error: false,
+                    },
+                );
+            }
+            MessageContent::ToolResponse(response) => {
+                let Some(entry) = by_id.get_mut(&response.id) else {
+                    continue;
+                };
+                match response.tool_result.as_ref() {
+                    Ok(result) => {
+                        entry.is_error = result.is_error.unwrap_or(false);
+                        entry.output = result
+                            .content
+                            .iter()
+                            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                    }
+                    Err(e) => {
+                        entry.is_error = true;
+                        entry.output = e.message.to_string();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|id| by_id.remove(&id))
+        .collect()
+}
+
+/// The session's whole extension surface, as a bridge dispatcher.
+///
+/// A named helper rather than a bare `as` cast at each call site, because the
+/// cast is where a reader asks "which tools is this child getting?" and the
+/// answer deserves a name.
+pub fn session_tools(extensions: Arc<ExtensionManager>) -> Arc<dyn bridge::BridgeToolDispatch> {
+    extensions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversation::message::MessageContent;
+    use crate::model::ModelConfig;
+    use crate::providers::base::{ProviderMetadata, Usage};
+    use async_trait::async_trait;
+    use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+
+    struct Stub {
+        name: &'static str,
+        bridged: bool,
+        reply: Message,
+        /// Set when the provider ran inside a live bridge scope.
+        saw_bridge: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Provider for Stub {
+        fn metadata() -> ProviderMetadata
+        where
+            Self: Sized,
+        {
+            unimplemented!()
+        }
+        fn get_name(&self) -> &str {
+            self.name
+        }
+        fn get_model_config(&self) -> ModelConfig {
+            ModelConfig::new_or_fail("claude-3-5-sonnet-20241022")
+        }
+        fn uses_tool_bridge(&self) -> bool {
+            self.bridged
+        }
+        async fn complete_with_model(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<(Message, ProviderUsage), ProviderError> {
+            self.saw_bridge.store(
+                bridge::active_bridge_url().is_some(),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+            Ok((
+                self.reply.clone(),
+                ProviderUsage::new(self.name.into(), Usage::new(None, None, None)),
+            ))
+        }
+    }
+
+    struct RecordingDispatch;
+
+    #[async_trait]
+    impl bridge::BridgeToolDispatch for RecordingDispatch {
+        async fn dispatch(
+            &self,
+            _session_id: &str,
+            call: CallToolRequestParams,
+            _capability: CallCapability,
+            _cancel: CancellationToken,
+        ) -> Result<CallToolResult, String> {
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "ran {}",
+                call.name
+            ))]))
+        }
+    }
+
+    fn context() -> ProviderToolTurnContext {
+        ProviderToolTurnContext::for_workflow(
+            Session {
+                id: format!("tool-turn-{:016x}", rand::random::<u64>()),
+                ..Session::default()
+            },
+            Arc::new(RecordingDispatch),
+            CallCapability::public_enforced(),
+            None,
+        )
+    }
+
+    fn stub(
+        name: &'static str,
+        bridged: bool,
+        reply: Message,
+    ) -> (Arc<dyn Provider>, Arc<std::sync::atomic::AtomicBool>) {
+        let saw = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        (
+            Arc::new(Stub {
+                name,
+                bridged,
+                reply,
+                saw_bridge: Arc::clone(&saw),
+            }),
+            saw,
+        )
+    }
+
+    /// The whole point of #109: a coding-agent provider reached from a workflow
+    /// gets a live bridge, where before it got a `tools` argument it discarded.
+    #[tokio::test]
+    async fn a_coding_agent_provider_runs_inside_a_live_bridge() {
+        bridge::publish_base_url("http://127.0.0.1:65535");
+        let (provider, saw_bridge) = stub("codex", true, Message::assistant().with_text("ok"));
+        let turn = context()
+            .run(&provider, "sys", &[Message::user().with_text("hi")], &[])
+            .await
+            .expect("the turn runs");
+        assert!(
+            saw_bridge.load(std::sync::atomic::Ordering::SeqCst),
+            "the provider must be able to read a bridge URL during its own call"
+        );
+        assert_eq!(turn.text(), "ok");
+    }
+
+    /// And the lease is gone the moment the call returns: a grant that outlived
+    /// its turn would be a live capability onto the workflow's tools with
+    /// nothing owning it.
+    #[tokio::test]
+    async fn the_bridge_is_gone_once_the_turn_returns() {
+        bridge::publish_base_url("http://127.0.0.1:65535");
+        let (provider, _) = stub("codex", true, Message::assistant().with_text("ok"));
+        let _ = context()
+            .run(&provider, "sys", &[Message::user().with_text("hi")], &[])
+            .await
+            .expect("the turn runs");
+        assert!(
+            bridge::active_bridge_url().is_none(),
+            "the task-local must not survive the call"
+        );
+    }
+
+    /// A provider that receives its tools in the request must not be given a
+    /// grant. Issuing one anyway would leave a live capability on every turn in
+    /// the process for no benefit.
+    #[tokio::test]
+    async fn an_ordinary_provider_gets_no_grant() {
+        bridge::publish_base_url("http://127.0.0.1:65535");
+        let (provider, saw_bridge) = stub("anthropic", false, Message::assistant().with_text("ok"));
+        let turn = context()
+            .run(&provider, "sys", &[Message::user().with_text("hi")], &[])
+            .await
+            .expect("the turn runs");
+        assert!(
+            !saw_bridge.load(std::sync::atomic::Ordering::SeqCst),
+            "an ordinary provider must not see a bridge URL"
+        );
+        assert!(
+            turn.executed.is_empty(),
+            "nothing ran on Biorouter's side, so the caller's own loop is untouched"
+        );
+    }
+
+    /// Mirrored pairs come back as *records*, so a caller's loop can see what
+    /// already ran instead of dispatching it a second time.
+    #[tokio::test]
+    async fn a_mirrored_pair_is_reported_as_already_executed() {
+        bridge::publish_base_url("http://127.0.0.1:65535");
+        let request = mirror::request_message(
+            "call-1",
+            "mcp__biorouter__kb_write_page",
+            serde_json::json!({"path": "knowledge/a.md"}),
+            mirror::Execution::Bridged,
+        );
+        let response = mirror::response_message(
+            "call-1",
+            vec![Content::text("written")],
+            false,
+            mirror::Execution::Bridged,
+        );
+        let (provider, _) = streaming_stub("claude_code", vec![request, response]);
+
+        let turn = context()
+            .run(&provider, "sys", &[Message::user().with_text("hi")], &[])
+            .await
+            .expect("the turn runs");
+
+        assert_eq!(turn.executed.len(), 1, "one bridged call ran");
+        assert_eq!(
+            turn.executed[0].name, "kb_write_page",
+            "the child's `mcp__biorouter__` prefix must be stripped"
+        );
+        assert_eq!(turn.executed[0].arguments["path"], "knowledge/a.md");
+        assert!(!turn.executed[0].is_error);
+        assert!(
+            turn.executed[0].output.contains("written"),
+            "the tool's own output must survive: {:?}",
+            turn.executed[0].output
+        );
+        // And it is NOT offered back to the caller to dispatch — running it a
+        // second time is a second write, not a redraw.
+        assert!(
+            turn.pending_tool_calls().is_empty(),
+            "a mirrored request must never be handed back as work to do"
+        );
+        assert!(
+            turn.messages
+                .iter()
+                .flat_map(|m| m.content.iter())
+                .any(|c| matches!(c, MessageContent::ToolRequest(_))),
+            "the record is still in the turn, for the transcript"
+        );
+    }
+
+    /// An UNMARKED tool request is the caller's to run. This is the other half
+    /// of the same safety property: the accessor must not swallow real work.
+    #[tokio::test]
+    async fn an_unmarked_request_is_still_the_callers_to_dispatch() {
+        bridge::publish_base_url("http://127.0.0.1:65535");
+        let call = CallToolRequestParams {
+            name: "kb_search".into(),
+            arguments: None,
+            meta: None,
+            task: None,
+        };
+        let reply = Message::assistant().with_tool_request("req-1", Ok(call));
+        let (provider, _) = stub("anthropic", false, reply);
+        let turn = context()
+            .run(&provider, "sys", &[Message::user().with_text("hi")], &[])
+            .await
+            .expect("the turn runs");
+        assert_eq!(turn.pending_tool_calls().len(), 1);
+        assert!(turn.executed.is_empty());
+    }
+
+    /// A workflow made of tool calls must fail *before* spending a model run
+    /// when there is no server for the child to call back into. The chat loop's
+    /// degradation — run tool-less and answer from the conversation — is exactly
+    /// wrong here: the model narrates the calls and writes nothing.
+    // The "no HTTP server" refusal is pinned in its own integration binary,
+    // `tests/provider_tool_turn_no_server.rs`. It cannot live here: the
+    // published base URL is process-global (it must be — the HTTP handler runs
+    // on a different task from the turn that issued the grant), so a unit test
+    // that unpublished it would break every concurrently-running bridge test in
+    // this crate. A separate binary is a separate process that has simply never
+    // published one, which is the state being tested.
+
+    /// A streaming stub, for the tests that need mirrored pairs: those exist
+    /// only on the streaming path, because `complete_with_model` returns the
+    /// final text alone.
+    fn streaming_stub(
+        name: &'static str,
+        yielded: Vec<Message>,
+    ) -> (Arc<dyn Provider>, Arc<std::sync::atomic::AtomicBool>) {
+        let saw = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        (
+            Arc::new(StreamingStub {
+                name,
+                yielded,
+                saw_bridge: Arc::clone(&saw),
+            }),
+            saw,
+        )
+    }
+
+    struct StreamingStub {
+        name: &'static str,
+        yielded: Vec<Message>,
+        saw_bridge: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Provider for StreamingStub {
+        fn metadata() -> ProviderMetadata
+        where
+            Self: Sized,
+        {
+            unimplemented!()
+        }
+        fn get_name(&self) -> &str {
+            self.name
+        }
+        fn get_model_config(&self) -> ModelConfig {
+            ModelConfig::new_or_fail("claude-3-5-sonnet-20241022")
+        }
+        fn uses_tool_bridge(&self) -> bool {
+            true
+        }
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+        async fn complete_with_model(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<(Message, ProviderUsage), ProviderError> {
+            unreachable!("this stub streams")
+        }
+        async fn stream(
+            &self,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<crate::providers::base::MessageStream, ProviderError> {
+            // Read at CONSTRUCTION, exactly as both real providers do: the scope
+            // is gone by the time the returned stream is polled.
+            self.saw_bridge.store(
+                bridge::active_bridge_url().is_some(),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+            let items: Vec<_> = self
+                .yielded
+                .iter()
+                .cloned()
+                .map(|m| Ok((Some(m), None, None)))
+                .collect();
+            Ok(Box::pin(futures::stream::iter(items)))
+        }
+    }
+
+    /// The streaming path's task-local discipline, asserted rather than assumed:
+    /// a provider that reads the URL when its stream is *built* must find one,
+    /// even though the stream is drained after the scope has closed.
+    #[tokio::test]
+    async fn a_streaming_provider_reads_the_url_at_construction() {
+        bridge::publish_base_url("http://127.0.0.1:65535");
+        let (provider, saw_bridge) =
+            streaming_stub("claude_code", vec![Message::assistant().with_text("done")]);
+        let turn = context()
+            .run(&provider, "sys", &[Message::user().with_text("hi")], &[])
+            .await
+            .expect("the turn runs");
+        assert!(
+            saw_bridge.load(std::sync::atomic::Ordering::SeqCst),
+            "the URL must be readable while the stream is being built"
+        );
+        assert_eq!(turn.text(), "done");
+    }
+}

--- a/crates/biorouter/tests/knowledge_macro_tool_bridge.rs
+++ b/crates/biorouter/tests/knowledge_macro_tool_bridge.rs
@@ -1,0 +1,256 @@
+//! A knowledge macro's own tools reach a coding-agent provider, and the calls
+//! the child makes land on the macro's own dispatcher (#109).
+//!
+//! # What this covers that no unit test does
+//!
+//! The chain has four links in three crates and each one was a separate defect:
+//!
+//! 1. `SubAgent::run` hands its dispatcher to the completer
+//!    (`Completer::complete_with_dispatch`) instead of keeping it for itself;
+//! 2. `ProviderCompleter` notices the provider needs a bridge and builds a
+//!    `ProviderToolTurnContext` around it;
+//! 3. the context issues a grant whose dispatcher is the *macro's*, not an
+//!    `ExtensionManager` — the macro's tools are in no extension at all, and its
+//!    dispatcher carries the git transaction every write in the run must land on;
+//! 4. the mirrored pairs come back as records, so the loop reports what ran
+//!    without dispatching it a second time.
+//!
+//! Every link can be correct on its own and the feature still not work, which is
+//! why this asserts the round trip: a tool the *provider's child* asked for, run
+//! by the *macro's* dispatcher, reported in the run's own event log.
+//!
+//! The provider is a stub rather than a real CLI so this can run in CI. The live
+//! version — a real `claude` and a real `codex` driving a real ingest — is
+//! `--ignored` in `crates/biorouter-server/tests/tool_bridge_routes.rs`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rmcp::model::Tool;
+
+use biorouter::conversation::message::Message;
+use biorouter::knowledge::provider_completer::ProviderCompleter;
+use biorouter::model::ModelConfig;
+use biorouter::providers::base::{
+    MessageStream, Provider, ProviderMetadata, ProviderUsage, Usage,
+};
+use biorouter::providers::coding_agent::bridge;
+use biorouter::providers::coding_agent::mirror;
+use biorouter::providers::errors::ProviderError;
+use biorouter_mcp::knowledge::subagent::events::{DoneReason, SubAgentEvent};
+use biorouter_mcp::knowledge::subagent::loop_::{SubAgent, SubAgentBounds, ToolDispatch};
+
+/// Sandbox this binary's config root, for the reason `tests/agent.rs` gives.
+#[ctor::ctor]
+fn sandbox_config_root_for_this_test_binary() {
+    if std::env::var_os("BIOROUTER_PATH_ROOT").is_some() {
+        return;
+    }
+    let root = tempfile::TempDir::new().expect("a scratch config root");
+    std::env::set_var("BIOROUTER_PATH_ROOT", root.path());
+    static ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+    let _ = ROOT.set(root);
+}
+
+/// The macro's dispatcher: it records what it was asked to run, exactly as
+/// `KbToolDispatch` would write to a transaction branch.
+#[derive(Default)]
+struct RecordingKbDispatch {
+    calls: std::sync::Mutex<Vec<(String, serde_json::Value)>>,
+}
+
+#[async_trait]
+impl ToolDispatch for RecordingKbDispatch {
+    async fn call(&self, name: &str, args: serde_json::Value) -> anyhow::Result<String> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((name.to_string(), args.clone()));
+        Ok(format!("wrote {}", args["path"].as_str().unwrap_or("?")))
+    }
+}
+
+/// A provider shaped like `claude_code`: it needs the bridge, it streams, and —
+/// standing in for the child process — it CALLS BACK over the bridge before
+/// answering, then mirrors what it did.
+struct BridgedStub;
+
+#[async_trait]
+impl Provider for BridgedStub {
+    fn metadata() -> ProviderMetadata
+    where
+        Self: Sized,
+    {
+        unimplemented!()
+    }
+    fn get_name(&self) -> &str {
+        "claude_code"
+    }
+    fn get_model_config(&self) -> ModelConfig {
+        ModelConfig::new_or_fail("claude-3-5-sonnet-20241022")
+    }
+    fn uses_tool_bridge(&self) -> bool {
+        true
+    }
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+    async fn complete_with_model(
+        &self,
+        _model_config: &ModelConfig,
+        _system: &str,
+        _messages: &[Message],
+        _tools: &[Tool],
+    ) -> Result<(Message, ProviderUsage), ProviderError> {
+        unreachable!("this stub streams")
+    }
+
+    async fn stream(
+        &self,
+        _system: &str,
+        _messages: &[Message],
+        tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        // Read at CONSTRUCTION — the task-local scope is gone by the time the
+        // returned stream is polled. Both real providers do exactly this.
+        let url = bridge::active_bridge_url()
+            .ok_or_else(|| ProviderError::ExecutionError("no bridge was offered".into()))?;
+        let nonce = url.rsplit('/').next().unwrap_or_default().to_string();
+        let grant = bridge::lookup(&nonce)
+            .ok_or_else(|| ProviderError::ExecutionError("the grant was not live".into()))?;
+
+        // The grant must advertise the MACRO's tools, not a session's extensions.
+        assert!(
+            grant
+                .tools()
+                .iter()
+                .any(|t| t.name.as_ref() == "kb_write_page"),
+            "the macro's own tool surface must be what crosses the bridge; got {:?}",
+            grant.tools().iter().map(|t| &t.name).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            grant.tools().len(),
+            tools.len(),
+            "the grant must advertise exactly what the macro passed"
+        );
+
+        let args = serde_json::json!({ "path": "knowledge/topic/tocilizumab.md" });
+        let call = rmcp::model::CallToolRequestParams {
+            name: "kb_write_page".into(),
+            arguments: args.as_object().cloned(),
+            meta: None,
+            task: None,
+        };
+        let result = grant
+            .call(call.clone())
+            .await
+            .map_err(ProviderError::ExecutionError)?;
+        let output = result
+            .content
+            .iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+            .collect::<Vec<_>>()
+            .join("");
+
+        let request = mirror::request_message(
+            "call-1",
+            "mcp__biorouter__kb_write_page",
+            args,
+            mirror::Execution::Bridged,
+        );
+        let response = mirror::response_message(
+            "call-1",
+            vec![rmcp::model::Content::text(output)],
+            false,
+            mirror::Execution::Bridged,
+        );
+        let done = Message::assistant().with_text("Recorded the source page.");
+        let usage = ProviderUsage::new("claude_code".into(), Usage::new(None, None, None));
+
+        Ok(Box::pin(futures::stream::iter(vec![
+            Ok((Some(request), None, None)),
+            Ok((Some(response), None, None)),
+            Ok((Some(done), Some(usage), None)),
+        ])))
+    }
+}
+
+fn kb_tools() -> Vec<Tool> {
+    vec![Tool::new(
+        "kb_write_page",
+        "Write a knowledge page.",
+        Arc::new(
+            serde_json::from_value(serde_json::json!({
+                "type": "object",
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"]
+            }))
+            .expect("a valid schema"),
+        ),
+    )]
+}
+
+#[tokio::test]
+async fn a_macro_run_under_a_coding_agent_executes_its_own_tools() {
+    bridge::publish_base_url("http://127.0.0.1:65535");
+
+    let dispatch = Arc::new(RecordingKbDispatch::default());
+    let (completer, _tier, _affiliation) =
+        ProviderCompleter::paired(Arc::new(BridgedStub) as Arc<dyn Provider>);
+
+    let agent = SubAgent {
+        completer: Box::new(completer.in_session("kb-macro-e2e")),
+        tools: kb_tools(),
+        system_prompt: "You are a knowledge curator.".to_string(),
+        bounds: SubAgentBounds::default(),
+    };
+
+    let result = agent
+        .run(
+            "Digest this source.",
+            Arc::clone(&dispatch) as Arc<dyn ToolDispatch>,
+            None,
+            None,
+        )
+        .await
+        .expect("the run completes");
+
+    // 1. The macro's OWN dispatcher ran the call the child made.
+    let calls = dispatch.calls.lock().unwrap().clone();
+    assert_eq!(
+        calls.len(),
+        1,
+        "the child's call must land on the macro's dispatcher: {calls:?}"
+    );
+    assert_eq!(calls[0].0, "kb_write_page");
+    assert_eq!(calls[0].1["path"], "knowledge/topic/tocilizumab.md");
+
+    // 2. It is in the run log, so a reader cannot tell — and should not have to —
+    //    whether the loop or a child agent ran it.
+    let logged: Vec<&SubAgentEvent> = result
+        .events
+        .iter()
+        .filter(|e| matches!(e, SubAgentEvent::ToolCall { .. } | SubAgentEvent::ToolResult { .. }))
+        .collect();
+    assert_eq!(logged.len(), 2, "one call and one result: {logged:?}");
+    assert!(matches!(
+        logged[1],
+        SubAgentEvent::ToolResult { ok: true, .. }
+    ));
+
+    // 3. And it ran exactly ONCE. A loop that mistook the mirrored record for a
+    //    request would write the page a second time — invisible, and a real
+    //    corruption of the base rather than a display glitch.
+    assert_eq!(
+        dispatch.calls.lock().unwrap().len(),
+        1,
+        "a mirrored record must never be dispatched again"
+    );
+
+    assert_eq!(result.reason, DoneReason::NoMoreToolCalls);
+    assert!(
+        result.final_text.contains("Recorded the source page"),
+        "the child's answer must survive: {:?}",
+        result.final_text
+    );
+}

--- a/crates/biorouter/tests/knowledge_macro_tool_bridge.rs
+++ b/crates/biorouter/tests/knowledge_macro_tool_bridge.rs
@@ -31,9 +31,7 @@ use rmcp::model::Tool;
 use biorouter::conversation::message::Message;
 use biorouter::knowledge::provider_completer::ProviderCompleter;
 use biorouter::model::ModelConfig;
-use biorouter::providers::base::{
-    MessageStream, Provider, ProviderMetadata, ProviderUsage, Usage,
-};
+use biorouter::providers::base::{MessageStream, Provider, ProviderMetadata, ProviderUsage, Usage};
 use biorouter::providers::coding_agent::bridge;
 use biorouter::providers::coding_agent::mirror;
 use biorouter::providers::errors::ProviderError;
@@ -230,7 +228,12 @@ async fn a_macro_run_under_a_coding_agent_executes_its_own_tools() {
     let logged: Vec<&SubAgentEvent> = result
         .events
         .iter()
-        .filter(|e| matches!(e, SubAgentEvent::ToolCall { .. } | SubAgentEvent::ToolResult { .. }))
+        .filter(|e| {
+            matches!(
+                e,
+                SubAgentEvent::ToolCall { .. } | SubAgentEvent::ToolResult { .. }
+            )
+        })
         .collect();
     assert_eq!(logged.len(), 2, "one call and one result: {logged:?}");
     assert!(matches!(

--- a/crates/biorouter/tests/privacy_capability.rs
+++ b/crates/biorouter/tests/privacy_capability.rs
@@ -155,6 +155,38 @@ const EXPECTED: &[Site] = &[
                each falling back to a sample only when handed no admitted capability",
     },
     Site {
+        needle: "CallCapability::sample(",
+        file: "crates/biorouter/src/knowledge/provider_completer.rs",
+        count: 1,
+        what: "#109's `complete_with_dispatch`, the seam that lets a knowledge macro \
+               run under a coding-agent provider. It is a decider for the same \
+               reason `issue_tool_bridge` is and it is a SECOND one rather than a \
+               duplicate: a macro calls `Provider::complete` directly, so no agent \
+               loop has sampled anything, and the bridged calls arrive from a child \
+               process with no capability of their own to inherit. This is the one \
+               place holding the `Arc<dyn Provider>` those calls will run under, so \
+               sampling here — once, before the turn — is what fixes the pair \
+               instead of re-reading per callback across a process boundary. The \
+               three callers that build a completer (the HTTP route, the CLI, the \
+               probe) inherit it rather than each sampling their own, which is the \
+               difference between one decision and three that can disagree",
+    },
+    Site {
+        needle: "CallCapability::public_enforced(",
+        file: "crates/biorouter/src/providers/tool_turn.rs",
+        count: 1,
+        what: "NOT a production decider: `mod tests`' `context()` helper, which every \
+               `ProviderToolTurnContext` those tests build takes its pair from — the \
+               most restrictive one, rather than a permissive one invented for a \
+               test's convenience. Counted for the reason the bridge's test helper \
+               below is: a line-wise grep cannot tell a `#[cfg(test)]` block from \
+               production, and a filter that tried would blind the census to \
+               production too. The production side of this primitive TAKES its \
+               capability as an argument — `for_workflow` has no constructor call of \
+               its own — precisely so that a workflow cannot acquire one by \
+               accident; the one production caller is the `sample(` row above",
+    },
+    Site {
         needle: "CallCapability::public_enforced(",
         file: "crates/biorouter-server/src/routes/agent.rs",
         count: 1,

--- a/crates/biorouter/tests/provider_tool_turn_no_server.rs
+++ b/crates/biorouter/tests/provider_tool_turn_no_server.rs
@@ -1,0 +1,149 @@
+//! A tool-driven workflow must fail *before* spending a model run when there is
+//! no HTTP server for a child coding agent to call back into (#109).
+//!
+//! # Why this is its own binary
+//!
+//! The bridge's base URL is process-global — it has to be, because the HTTP
+//! handler runs on a different task from the turn that issued the grant. Every
+//! other bridge test in this crate publishes one, so a unit test that
+//! *unpublished* it would break them by scheduling. A separate integration
+//! binary is a separate process that has simply never published a base URL,
+//! which is exactly the state under test, and it stays true no matter what any
+//! other test does.
+//!
+//! # Why the refusal matters
+//!
+//! For a *chat* turn, running the child tool-less is the right degradation: an
+//! answer from the conversation beats a failed turn. For a workflow that IS a
+//! sequence of tool calls — a knowledge ingest, a scheduled job — it is a
+//! guaranteed silent failure. The measured shape (issue #109) is a model that
+//! narrates every call as prose, invents its own `<tool_response>OK` replies to
+//! continue against, and writes nothing, after a full run the user paid for.
+
+use std::sync::Arc;
+
+/// Sandbox this binary's config root before any test runs, for the reason
+/// `tests/agent.rs` gives: `Config::global()` is a one-shot cell resolved the
+/// first time anything touches it, so a guard inside a test cannot win the race
+/// against whichever test got there first. An outer root wins.
+#[ctor::ctor]
+fn sandbox_config_root_for_this_test_binary() {
+    if std::env::var_os("BIOROUTER_PATH_ROOT").is_some() {
+        return;
+    }
+    let root = tempfile::TempDir::new().expect("a scratch config root");
+    std::env::set_var("BIOROUTER_PATH_ROOT", root.path());
+    // Leaked deliberately: a `static` is never dropped, which is exactly the
+    // lifetime the sandbox needs.
+    static ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+    let _ = ROOT.set(root);
+}
+
+use async_trait::async_trait;
+use rmcp::model::{CallToolRequestParams, CallToolResult, Tool};
+use tokio_util::sync::CancellationToken;
+
+use biorouter::conversation::message::Message;
+use biorouter::model::ModelConfig;
+use biorouter::privacy::CallCapability;
+use biorouter::providers::base::{Provider, ProviderMetadata, ProviderUsage, Usage};
+use biorouter::providers::coding_agent::bridge::BridgeToolDispatch;
+use biorouter::providers::errors::ProviderError;
+use biorouter::providers::tool_turn::ProviderToolTurnContext;
+use biorouter::session::session_manager::Session;
+
+/// A coding-agent-shaped provider that records whether it was called at all.
+struct NeverShouldRun {
+    called: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[async_trait]
+impl Provider for NeverShouldRun {
+    fn metadata() -> ProviderMetadata
+    where
+        Self: Sized,
+    {
+        unimplemented!()
+    }
+    fn get_name(&self) -> &str {
+        "codex"
+    }
+    fn get_model_config(&self) -> ModelConfig {
+        ModelConfig::new_or_fail("claude-3-5-sonnet-20241022")
+    }
+    fn uses_tool_bridge(&self) -> bool {
+        true
+    }
+    async fn complete_with_model(
+        &self,
+        _model_config: &ModelConfig,
+        _system: &str,
+        _messages: &[Message],
+        _tools: &[Tool],
+    ) -> Result<(Message, ProviderUsage), ProviderError> {
+        self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok((
+            Message::assistant().with_text("I called every tool, honest"),
+            ProviderUsage::new("codex".into(), Usage::new(None, None, None)),
+        ))
+    }
+}
+
+struct NoopDispatch;
+
+#[async_trait]
+impl BridgeToolDispatch for NoopDispatch {
+    async fn dispatch(
+        &self,
+        _session_id: &str,
+        _call: CallToolRequestParams,
+        _capability: CallCapability,
+        _cancel: CancellationToken,
+    ) -> Result<CallToolResult, String> {
+        unreachable!("nothing should reach a dispatcher in this test")
+    }
+}
+
+#[tokio::test]
+async fn a_tool_workflow_refuses_rather_than_running_tool_less() {
+    assert!(
+        biorouter::providers::coding_agent::bridge::base_url().is_none(),
+        "this binary must never publish a base URL; that is the whole fixture"
+    );
+
+    let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let provider: Arc<dyn Provider> = Arc::new(NeverShouldRun {
+        called: Arc::clone(&called),
+    });
+    let context = ProviderToolTurnContext::for_workflow(
+        Session::default(),
+        Arc::new(NoopDispatch),
+        CallCapability::public_enforced(),
+        None,
+    );
+
+    let error = context
+        .run(
+            &provider,
+            "You are Biorouter.",
+            &[Message::user().with_text("ingest this")],
+            &[],
+        )
+        .await
+        .expect_err("a workflow made of tool calls cannot run tool-less")
+        .to_string();
+
+    assert!(
+        !called.load(std::sync::atomic::Ordering::SeqCst),
+        "the model must not have been called at all — the point is to fail BEFORE \
+         spending a run"
+    );
+    assert!(
+        error.contains("codex"),
+        "the failure must name the provider it is about: {error}"
+    );
+    assert!(
+        error.contains("biorouterd") || error.contains("desktop app"),
+        "the failure must give a precise recovery path: {error}"
+    );
+}

--- a/ui/desktop/src/components/knowledge/IngestPanel/IngestModelPicker.test.tsx
+++ b/ui/desktop/src/components/knowledge/IngestPanel/IngestModelPicker.test.tsx
@@ -67,79 +67,36 @@ beforeEach(() => {
   mocks.config.getProviderModels.mockResolvedValue([]);
 });
 
-describe('IngestModelPicker provider exclusions', () => {
-  it('does not offer a model that cannot make the tool calls a digest is made of', async () => {
+describe('IngestModelPicker offers every configured provider (#109)', () => {
+  it('lists the coding-agent providers alongside the rest', async () => {
     mocks.config.getProviders.mockResolvedValue([OPENAI, CLAUDE_CODE, CODEX, OLLAMA]);
     renderPicker();
     const list = await openPicker();
 
-    // The two coding-agent providers reach `complete_with_model` with `tools`
-    // dropped on the floor, so a digest run against one narrates its calls and
-    // writes nothing. Neither the group heading nor the model row may appear.
+    // These two used to be filtered out here, because their
+    // `complete_with_model` dropped the `tools` argument a macro passes and a
+    // digest run against one narrated its calls and wrote nothing. #109 fixed
+    // that at the source — a macro turn goes through `ProviderToolTurnContext`,
+    // which issues the MCP bridge grant those providers need — so hiding them
+    // would now hide a provider that works.
     await waitFor(() => expect(list).toHaveTextContent('OpenAI'));
-    expect(list).not.toHaveTextContent('Claude Code');
-    expect(list).not.toHaveTextContent('opus-5');
-    expect(list).not.toHaveTextContent('Codex');
-    expect(list).not.toHaveTextContent('gpt-5.4-codex');
-  });
-
-  it('still offers every other configured provider', async () => {
-    mocks.config.getProviders.mockResolvedValue([OPENAI, CLAUDE_CODE, CODEX, OLLAMA]);
-    renderPicker();
-    const list = await openPicker();
-
-    // The exclusion has to be surgical. A filter that took the whole list with
-    // it would pass the assertion above and leave the picker empty.
-    await waitFor(() => expect(list).toHaveTextContent('gpt-5.5'));
-    expect(list).toHaveTextContent('OpenAI');
+    expect(list).toHaveTextContent('Claude Code');
+    expect(list).toHaveTextContent('opus-5');
+    expect(list).toHaveTextContent('Codex');
+    expect(list).toHaveTextContent('gpt-5.4-codex');
     expect(list).toHaveTextContent('Ollama');
-    expect(list).toHaveTextContent('qwen3.6:latest');
   });
 
-  it('says which providers it left out, and that they still work in chat', async () => {
+  it('no longer explains an absence, because there is none', async () => {
     mocks.config.getProviders.mockResolvedValue([OPENAI, CLAUDE_CODE, CODEX]);
     renderPicker();
-    await openPicker();
-
-    const note = await screen.findByTestId('knowledge-model-picker-excluded');
-    expect(note).toHaveTextContent('Claude Code and Codex');
-    expect(note).toHaveTextContent(/written nothing/i);
-    expect(note).toHaveTextContent(/still work in chat/i);
-  });
-
-  it('stays silent when there was nothing to leave out', async () => {
-    mocks.config.getProviders.mockResolvedValue([OPENAI, OLLAMA]);
-    renderPicker();
     const list = await openPicker();
 
-    // The note is an explanation for an absence. With no absence to explain it
-    // is pure noise in a popover that has room for none.
+    // The footer note named which providers had been left out and said they
+    // still worked in chat. Nothing is left out now, so the note would be a
+    // sentence about an absence that does not exist.
     await waitFor(() => expect(list).toHaveTextContent('gpt-5.5'));
     expect(screen.queryByTestId('knowledge-model-picker-excluded')).toBeNull();
-  });
-
-  it('does not contradict itself when nothing at all is left to offer', async () => {
-    mocks.config.getProviders.mockResolvedValue([CLAUDE_CODE]);
-    renderPicker();
-    await openPicker();
-
-    // The worst case: the one configured provider is excluded, so the list is
-    // empty and the popover falls to its empty state. "No models available /
-    // Configure a provider in Settings." is a verdict on a configuration that
-    // is in fact fine — and it sat directly above a footer note saying so, the
-    // popover telling the user to go set up a provider and that the one they
-    // set up is working, in the same 256px box. Keeping the note was not enough;
-    // the headline above it had to stop being false.
-    expect(screen.queryByText('No models available')).toBeNull();
-    expect(screen.queryByText('Configure a provider in Settings.')).toBeNull();
-    expect(await screen.findByText('No model here can digest')).toBeInTheDocument();
-
-    // The note stays: it is the one place that says WHICH provider was left out
-    // and that it still works in chat, which the headline deliberately does not
-    // repeat.
-    expect(await screen.findByTestId('knowledge-model-picker-excluded')).toHaveTextContent(
-      'Claude Code'
-    );
   });
 
   it('still says the plain thing when nothing is configured at all', async () => {
@@ -147,29 +104,11 @@ describe('IngestModelPicker provider exclusions', () => {
     renderPicker();
     await openPicker();
 
-    // The correction has to be surgical. A blanket rewrite of the empty state
-    // would start telling a user with no provider whatsoever that their models
-    // are merely the wrong kind — which is the same class of false verdict,
-    // pointed the other way.
+    // The one verdict this popover may reach on its own: the user really has no
+    // provider. It must survive the removal above — a rewrite that lost it
+    // would leave a user with an empty setup staring at an empty list.
     expect(await screen.findByText('No models available')).toBeInTheDocument();
     expect(screen.getByText('Configure a provider in Settings.')).toBeInTheDocument();
     expect(screen.queryByTestId('knowledge-model-picker-excluded')).toBeNull();
-  });
-});
-
-describe('IngestModelPicker trigger label', () => {
-  it('does not blame the configuration when the model merely cannot digest', async () => {
-    mocks.config.getProviders.mockResolvedValue([CLAUDE_CODE]);
-    render(
-      <MemoryRouter>
-        <IngestModelPicker value={null} valueState="unsupported" onChange={vi.fn()} />
-      </MemoryRouter>
-    );
-
-    // "No model configured" would send a user with a working chat model to
-    // Settings to fix something that is not broken.
-    const trigger = await screen.findByTestId('knowledge-model-picker-trigger');
-    expect(trigger).toHaveTextContent(/can’t digest sources/);
-    expect(trigger).not.toHaveTextContent('No model configured');
   });
 });

--- a/ui/desktop/src/components/knowledge/IngestPanel/IngestModelPicker.tsx
+++ b/ui/desktop/src/components/knowledge/IngestPanel/IngestModelPicker.tsx
@@ -21,20 +21,21 @@ import {
   getOrderedProviderGroups,
   type OrderedProviderGroup,
 } from '../../settings/providers/providerOrdering';
-import { providerCanRunIngest } from './resolveIngestModel';
 
 interface Props {
   /** `null` when no model could be resolved — the trigger says so instead of naming a vendor. */
   value: ModelRef | null;
   /**
    * Why `value` is null, when it is. "No model configured" is a verdict on the
-   * user's setup, and it is wrong in all three of the other states: `loading` is
-   * an answer still in flight, `unavailable` is a knowledge base whose manifest
-   * could not be read, and `unsupported` is a perfectly good configuration whose
-   * only model happens to be one a knowledge macro cannot drive — nothing there
-   * is the user's configuration to fix.
+   * user's setup, and it is wrong in the other two states: `loading` is an
+   * answer still in flight, and `unavailable` is a knowledge base whose manifest
+   * could not be read — neither is the user's configuration to fix.
+   *
+   * A fourth state, `unsupported`, is gone (#109): it meant "the configured
+   * model is a coding agent, which a knowledge macro cannot drive", and that is
+   * no longer true.
    */
-  valueState?: 'resolved' | 'loading' | 'unavailable' | 'unsupported';
+  valueState?: 'resolved' | 'loading' | 'unavailable';
   onChange: (v: ModelRef) => void;
   disabled?: boolean;
   saving?: boolean;
@@ -69,18 +70,14 @@ interface ProviderModelsSection extends OrderedProviderGroup {
  * chat, and it renders in this branch too; saying it twice in a popover this
  * small is how a correction turns back into noise.
  */
-function NoModelsAvailable({ excludedOnly }: { excludedOnly: boolean }) {
+function NoModelsAvailable() {
   const navigate = useNavigate();
   return (
     <EmptyState
       compact
       icon={Brain}
-      title={excludedOnly ? 'No model here can digest' : 'No models available'}
-      description={
-        excludedOnly
-          ? 'Digesting needs a provider that can make tool calls on its own. Adding one takes a minute in Settings.'
-          : 'Configure a provider in Settings.'
-      }
+      title="No models available"
+      description="Configure a provider in Settings."
       actions={
         <Button
           type="button"
@@ -126,7 +123,6 @@ export function IngestModelPicker({
    * provider configured is told nothing, because for them there is nothing to
    * explain and the line would be pure noise.
    */
-  const [excludedProviderLabels, setExcludedProviderLabels] = useState<string[]>([]);
 
   useEffect(() => {
     void (async () => {
@@ -139,20 +135,13 @@ export function IngestModelPicker({
         }, {});
         setProviderDisplayNames(names);
 
-        // A provider that cannot carry tool calls on the macro path is not a
-        // model the user can choose badly — it is a model that writes nothing,
-        // every time, after a full run. See `providerCanRunIngest`. The names
-        // still go into `providerDisplayNames` above, so the trigger can label a
-        // value that was stored before this exclusion existed, and the footer
-        // can name what it left out instead of removing them in silence.
-        const configuredProviders = allConfigured.filter((provider) =>
-          providerCanRunIngest(provider.name)
-        );
-        setExcludedProviderLabels(
-          allConfigured
-            .filter((provider) => !providerCanRunIngest(provider.name))
-            .map((provider) => names[provider.name] ?? provider.name)
-        );
+        // #109: every configured provider is offered. `claude_code` and `codex`
+        // used to be filtered out here because a macro handed them tools their
+        // provider discarded — they now receive them over the MCP bridge like
+        // any other tool call, and a provider that genuinely cannot carry tools
+        // is refused by the daemon before a model run is spent rather than
+        // guessed at by name in a renderer.
+        const configuredProviders = allConfigured;
 
         const modelResults = await fetchModelsForProviders(configuredProviders, getProviderModels);
         const availableModelsByProvider = modelResults.reduce<Record<string, string[]>>(
@@ -192,7 +181,6 @@ export function IngestModelPicker({
       } catch (err) {
         console.warn('IngestModelPicker: failed to load providers', err);
         setSections([]);
-        setExcludedProviderLabels([]);
       }
     })();
   }, [getProviderModels, getProviders]);
@@ -218,12 +206,7 @@ export function IngestModelPicker({
       ? 'Loading model…'
       : valueState === 'unavailable'
         ? 'Knowledge base unavailable'
-        : valueState === 'unsupported'
-          ? // Not "No model configured": there IS one, it is the chat model, and
-            // it works in chat. Naming the real obstacle is what stops the user
-            // being sent to Settings to fix something that is not broken.
-            'Chat model can’t digest sources'
-          : 'No model configured';
+        : 'No model configured';
 
   const needle = query.trim().toLowerCase();
   function matches(provider: ProviderDetails, model: string): boolean {
@@ -294,12 +277,7 @@ export function IngestModelPicker({
           <CommandInput placeholder="Search models" aria-label="Search models" autoFocus />
           <CommandList aria-label="Knowledge models">
             {!hasModels ? (
-              // An empty list has two causes and they need different words.
-              // `excludedProviderLabels` is the discriminator: it is non-empty
-              // only when this picker itself removed a configured provider, so
-              // a non-empty list here means the user's setup is fine and the
-              // list is empty because of us.
-              <NoModelsAvailable excludedOnly={excludedProviderLabels.length > 0} />
+              <NoModelsAvailable />
             ) : visibleRows.length === 0 ? (
               <CommandEmpty>
                 <p className="text-body text-text-muted">No models match</p>
@@ -353,34 +331,13 @@ export function IngestModelPicker({
               )
             )}
           </CommandList>
-          {(hasModels || excludedProviderLabels.length > 0) && (
+          {hasModels && (
             <div className="flex-none border-t border-border-subtle px-2 py-2">
-              {hasModels && (
-                <>
-                  <Badge variant="chip">Set as default</Badge>
-                  <p className="mt-1 text-supporting text-text-muted">
-                    This model digests staged sources and scheduled knowledge curation. Chat replies
-                    still use the model selected in the chat composer.
-                  </p>
-                </>
-              )}
-              {/* A provider that vanishes from a list without explanation reads
-                  as a bug, and the user's next move is to go and re-check a
-                  configuration that is already correct. Naming it — and saying
-                  it still works in chat — is the difference between an omission
-                  and an answer. Rendered only when something was actually left
-                  out, so the line never appears for a user it cannot help. */}
-              {excludedProviderLabels.length > 0 && (
-                <p
-                  data-testid="knowledge-model-picker-excluded"
-                  className={`text-supporting text-text-muted ${hasModels ? 'mt-2' : ''}`}
-                >
-                  {excludedProviderLabels.join(' and ')}{' '}
-                  {excludedProviderLabels.length === 1 ? 'is' : 'are'} not listed: these models only
-                  receive tools inside a chat, so a digest would finish having written nothing. They
-                  still work in chat.
-                </p>
-              )}
+              <Badge variant="chip">Set as default</Badge>
+              <p className="mt-1 text-supporting text-text-muted">
+                This model digests staged sources and scheduled knowledge curation. Chat replies
+                still use the model selected in the chat composer.
+              </p>
             </div>
           )}
         </Command>

--- a/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.test.tsx
+++ b/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.test.tsx
@@ -179,29 +179,26 @@ describe('IngestPanel model selection', () => {
     expect(mocks.start).not.toHaveBeenCalled();
   });
 
-  it('does not inherit a chat model a knowledge macro cannot drive', async () => {
+  it('inherits a coding-agent chat model like any other (#109)', async () => {
     mocks.modelAndProvider.currentProvider = 'claude_code';
     mocks.modelAndProvider.currentModel = 'opus-5';
 
     render(<IngestPanel />);
     stageSomeText();
 
-    // `claude_code` reaches `complete_with_model` with its `tools` dropped, so a
-    // digest dispatched at it narrates every call as prose and writes nothing.
-    // Preselecting it costs the user a full model run for an empty base.
-    expect(modelLabels()).not.toContain('claude_code / opus-5');
+    // `claude_code` used to be skipped here, because its `complete_with_model`
+    // dropped the `tools` a macro passes and a digest narrated its calls instead
+    // of writing pages. A macro turn now carries its tools over the MCP bridge,
+    // so skipping it would hide a model that works — and would hand the user the
+    // "No model configured" dead end for a configuration that is correct.
+    expect(modelLabels()).toContain('claude_code / opus-5');
 
-    // And the reason offered is the true one. "No model configured" would send a
-    // user whose chat model works perfectly well to Settings to fix nothing.
     const trigger = await screen.findByTestId('knowledge-model-picker-trigger');
-    expect(trigger).toHaveTextContent(/can’t digest sources/);
     expect(trigger).not.toHaveTextContent(/no model configured/i);
+    expect(trigger).not.toHaveTextContent(/can’t digest sources/);
 
     const digest = screen.getByTestId('knowledge-digest-button');
-    expect(digest).toHaveAttribute('aria-disabled', 'true');
-    fireEvent.click(digest);
-    await waitFor(() => expect(mocks.checkModel).not.toHaveBeenCalled());
-    expect(mocks.start).not.toHaveBeenCalled();
+    expect(digest).not.toHaveAttribute('aria-disabled', 'true');
   });
 });
 

--- a/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.tsx
+++ b/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.tsx
@@ -18,7 +18,7 @@ import { PasteTextBox } from './PasteTextBox';
 import { StagedList } from './StagedList';
 import type { FileDropWarning, StagedFileCandidate } from './fileValidation';
 import { validateDroppedFiles } from './fileValidation';
-import { ingestModelBlockedByProvider, resolveIngestModel } from './resolveIngestModel';
+import { resolveIngestModel } from './resolveIngestModel';
 
 function genId(): string {
   return Date.now().toString(36) + Math.random().toString(36).substring(2, 9);
@@ -143,23 +143,18 @@ export function IngestPanel() {
   // first while either is in flight told users with a perfectly good
   // configuration to go and set one up.
   const modelPending = !model && (kbPending || modelConfigStatus === 'loading');
-  // A fourth reason `model` can be null, and the only one that is not a gap in
-  // the user's setup: everything resolved, but the only candidate was a
-  // coding-agent provider a knowledge macro cannot drive. Telling that user
-  // "No model configured" sends them to Settings to fix a configuration that is
-  // already correct, so the picker needs to be able to tell the two apart.
-  const modelBlockedByProvider =
-    !primaryKbUnresolved &&
-    ingestModelBlockedByProvider(primaryKb?.default_model, currentProvider, currentModel);
+  // #109: a fourth state, `unsupported`, used to sit here for "the only
+  // candidate is a coding-agent provider a macro cannot drive". Those providers
+  // now receive their tools over the MCP bridge like any other, so the state has
+  // no cause left — and a renderer guessing support from a provider NAME was
+  // always the wrong place for the answer.
   const modelValueState = model
     ? 'resolved'
     : kbUnavailable
       ? 'unavailable'
       : modelPending
         ? 'loading'
-        : modelBlockedByProvider
-          ? 'unsupported'
-          : 'resolved';
+        : 'resolved';
 
   async function onDefaultModelChange(next: ModelRef) {
     // Saving a default to an id whose manifest never arrived writes to a base

--- a/ui/desktop/src/components/knowledge/IngestPanel/resolveIngestModel.test.ts
+++ b/ui/desktop/src/components/knowledge/IngestPanel/resolveIngestModel.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  ingestModelBlockedByProvider,
-  providerCanRunIngest,
-  resolveIngestModel,
-} from './resolveIngestModel';
+import { resolveIngestModel } from './resolveIngestModel';
 
 describe('resolveIngestModel', () => {
   it("uses the app's configured provider and model when the base has no default", () => {
@@ -40,52 +36,27 @@ describe('resolveIngestModel', () => {
   });
 });
 
-describe('providers a knowledge macro cannot drive', () => {
-  it('names the coding-agent providers and nothing else', () => {
-    // These two accept `tools` on `complete_with_model` and drop them: their
-    // tool surface only arrives over the MCP bridge the chat-turn loop sets up,
-    // and a macro calls the provider directly.
-    expect(providerCanRunIngest('claude_code')).toBe(false);
-    expect(providerCanRunIngest('codex')).toBe(false);
-    // Everything else is fine, including the vendors those two wrap — it is the
-    // subprocess-CLI provider that cannot carry tools here, not Anthropic or
-    // OpenAI.
-    expect(providerCanRunIngest('anthropic')).toBe(true);
-    expect(providerCanRunIngest('openai')).toBe(true);
-    expect(providerCanRunIngest('ollama')).toBe(true);
-    expect(providerCanRunIngest('versa_azure')).toBe(true);
+describe('the coding-agent providers are no longer excluded (#109)', () => {
+  it('preselects the chat model even when it is a coding agent', () => {
+    // The exclusion existed because `claude_code` / `codex` accepted `tools` on
+    // `complete_with_model` and dropped them, so a macro run narrated its calls
+    // as prose and wrote nothing. That is fixed at the source: a macro turn goes
+    // through `ProviderToolTurnContext`, which issues the MCP bridge grant those
+    // providers need. Refusing here would now hide a provider that works.
+    expect(resolveIngestModel(null, 'claude_code', 'opus-5')).toEqual({
+      provider: 'claude_code',
+      model: 'opus-5',
+    });
+    expect(resolveIngestModel({ provider: 'codex', model: 'gpt-5.5-codex' }, null, null)).toEqual({
+      provider: 'codex',
+      model: 'gpt-5.5-codex',
+    });
   });
 
-  it('does not preselect the chat model when the chat model is one of them', () => {
-    // The user's composer is on Claude Code and it works there. Digestion is a
-    // different path, and inheriting the chat model onto it buys a full model
-    // run that writes nothing.
-    expect(resolveIngestModel(null, 'claude_code', 'opus-5')).toBeNull();
-    expect(resolveIngestModel(null, 'codex', 'gpt-5.4-codex')).toBeNull();
-  });
-
-  it("skips a base's stored default rather than honouring one that cannot work", () => {
-    // A `default_model` naming one of these could only have been saved before
-    // the exclusion existed. Honouring it would dispatch exactly the run this
-    // guard is here to prevent, so the app configuration takes over.
-    expect(
-      resolveIngestModel({ provider: 'claude_code', model: 'opus-5' }, 'ollama', 'qwen3.6:latest')
-    ).toEqual({ provider: 'ollama', model: 'qwen3.6:latest' });
-  });
-
-  it('reports the refusal separately from an empty configuration', () => {
-    // The two nulls mean different things to the user: one is "go and set a
-    // model up", the other is "the one you have cannot do this job". A picker
-    // that cannot tell them apart sends the second user to Settings for nothing.
-    expect(ingestModelBlockedByProvider(null, 'claude_code', 'opus-5')).toBe(true);
-    expect(
-      ingestModelBlockedByProvider({ provider: 'codex', model: 'gpt-5.4-codex' }, null, null)
-    ).toBe(true);
-
-    expect(ingestModelBlockedByProvider(null, null, null)).toBe(false);
-    expect(ingestModelBlockedByProvider(null, 'ollama', 'qwen3.6:latest')).toBe(false);
-    // A half-populated candidate is not a refusal — nothing was rejected, there
-    // was simply never a usable pair.
-    expect(ingestModelBlockedByProvider(null, 'claude_code', '')).toBe(false);
+  it('still returns null when there is genuinely nothing configured', () => {
+    // The one verdict this function is allowed to reach on its own. Whether a
+    // provider can carry tools is now the daemon's answer, given before a model
+    // run is spent — not a name a renderer recognises.
+    expect(resolveIngestModel(null, null, null)).toBeNull();
   });
 });

--- a/ui/desktop/src/components/knowledge/IngestPanel/resolveIngestModel.ts
+++ b/ui/desktop/src/components/knowledge/IngestPanel/resolveIngestModel.ts
@@ -1,48 +1,6 @@
 import type { ModelRef } from '../../../api/types.gen';
 
 /**
- * The providers a knowledge macro cannot use, and the ONE place that fact is
- * written down.
- *
- * `claude_code` and `codex` are the coding-agent providers: they drive another
- * vendor's installed CLI as a subprocess. Their `complete_with_model` accepts a
- * `tools` argument and does not forward it (`_tools` in
- * `crates/biorouter/src/providers/{claude_code,codex}.rs`) — the child CLI's
- * tool surface arrives over the MCP bridge, which only the agent's own chat-turn
- * loop establishes. A knowledge macro (ingest / query / lint) calls the provider
- * directly, so on that path the model is handed no tools at all.
- *
- * What that looks like, measured: the model produces a complete, correct plan
- * with every call written out as prose (`<tool_call>{"name": "kb_write", …}`),
- * invents its own `<tool_response>OK</tool_response>` replies to continue
- * against, and nothing reaches disk. The daemon now recognises the shape after
- * the fact (`narrated_its_tool_calls` in
- * `crates/biorouter-mcp/src/knowledge/macros/ingest.rs`) and fails with an
- * explanation, but the user has already waited out a full model run for nothing.
- * Not offering the choice is the better fix.
- *
- * ⚠ **This is an ingest-surface exclusion only.** Both are good CHAT providers,
- * verified end to end including tool calls over the bridge, and
- * `providerOrdering.ts` deliberately keeps no hide-list — a filter there would
- * mean the settings grid silently contradicting the daemon it renders. Keep the
- * names here.
- *
- * ⚠ **Named, not detected, because nothing on the wire carries the fact.**
- * `ProviderMetadata` has no "forwards tools" field, so there is no data-driven
- * key to filter on; a renderer cannot tell these two from any other provider.
- * The moment either one forwards `tools` on the direct-completion path — or a
- * capability flag appears in `ProviderMetadata` — delete its entry here (or
- * replace the whole list with the flag) rather than leaving a stale name
- * suppressing a provider that works.
- */
-export const PROVIDERS_WITHOUT_INGEST_TOOL_CALLS: readonly string[] = ['claude_code', 'codex'];
-
-/** Whether a provider can carry the tool calls a knowledge macro is made of. */
-export function providerCanRunIngest(providerName: string): boolean {
-  return !PROVIDERS_WITHOUT_INGEST_TOOL_CALLS.includes(providerName);
-}
-
-/**
  * Decide which model the ingest panel should preselect.
  *
  * Precedence:
@@ -51,12 +9,15 @@ export function providerCanRunIngest(providerName: string): boolean {
  *  2. otherwise the provider/model the app is configured with — the same pair
  *     the chat composer shows, read from `useModelAndProvider`.
  *
- * A candidate from a provider in `PROVIDERS_WITHOUT_INGEST_TOOL_CALLS` is
- * skipped at both steps. It is not a matter of taste: that model cannot write a
- * page, so preselecting it only buys the user a full model run that ends with
- * an empty knowledge base. A stored `default_model` naming one is skipped too —
- * it could only have been written before this exclusion existed, and honouring
- * it would dispatch the run this function exists to prevent.
+ * ⚠ **There is deliberately no provider denylist here any more.** `claude_code`
+ * and `codex` were excluded because their `complete_with_model` discarded the
+ * `tools` argument on the direct-completion path a macro uses, so a run narrated
+ * every call as prose and wrote nothing. Issue #109 fixed that at the source:
+ * a macro turn now goes through `ProviderToolTurnContext`, which issues the MCP
+ * bridge grant those providers need, and the daemon refuses **before** spending a
+ * model run when it genuinely cannot carry tools. Support is a property of the
+ * running daemon, not of a name a renderer can recognise — so the renderer stops
+ * guessing.
  *
  * There is deliberately **no** hardcoded vendor fallback. If neither source
  * resolves, this returns `null` and the caller must say so and keep digestion
@@ -68,41 +29,11 @@ export function resolveIngestModel(
   configuredProvider: string | null | undefined,
   configuredModel: string | null | undefined
 ): ModelRef | null {
-  if (
-    kbDefaultModel?.provider &&
-    kbDefaultModel.model &&
-    providerCanRunIngest(kbDefaultModel.provider)
-  ) {
+  if (kbDefaultModel?.provider && kbDefaultModel.model) {
     return { provider: kbDefaultModel.provider, model: kbDefaultModel.model };
   }
-  if (configuredProvider && configuredModel && providerCanRunIngest(configuredProvider)) {
+  if (configuredProvider && configuredModel) {
     return { provider: configuredProvider, model: configuredModel };
   }
   return null;
-}
-
-/**
- * Did resolution come back empty *because* every candidate was a provider
- * ingest cannot use?
- *
- * The distinction is the whole reason this exists. "No model configured" is a
- * verdict on the user's setup and it is simply false here — they have a model,
- * it is bound to the chat composer, and it works there. Sending them to Settings
- * to configure something they already configured is the kind of wrong answer
- * that costs an afternoon. The picker uses this to say what is actually true
- * instead.
- */
-export function ingestModelBlockedByProvider(
-  kbDefaultModel: ModelRef | null | undefined,
-  configuredProvider: string | null | undefined,
-  configuredModel: string | null | undefined
-): boolean {
-  if (resolveIngestModel(kbDefaultModel, configuredProvider, configuredModel)) return false;
-  const candidateProviders = [
-    kbDefaultModel?.provider && kbDefaultModel.model ? kbDefaultModel.provider : null,
-    configuredProvider && configuredModel ? configuredProvider : null,
-  ].filter((name): name is string => Boolean(name));
-  // Resolution already failed, so any candidate still standing here is one this
-  // module refused — an empty list means there was nothing to refuse.
-  return candidateProviders.length > 0;
 }

--- a/ui/desktop/src/components/knowledge/lint/LintDrawer.test.tsx
+++ b/ui/desktop/src/components/knowledge/lint/LintDrawer.test.tsx
@@ -235,50 +235,36 @@ describe('LintDrawer — the description contract', () => {
  * The obstacle is real and the drawer must stay disabled; what it may not do is
  * misname it.
  */
-describe('LintDrawer — a model the check cannot drive', () => {
+describe('LintDrawer — a coding-agent model is a model like any other (#109)', () => {
   beforeEach(() => {
     mocks.stream = { events: [], status: 'idle', finalResult: null, error: undefined };
   });
 
-  it('names the real obstacle instead of blaming the configuration', () => {
+  it('runs a check on a coding-agent model instead of refusing it', () => {
+    // This drawer used to draw "This model can't run a check" here, because
+    // `resolveIngestModel` refused these providers by name and the drawer read
+    // the resulting `null` as "nothing is configured". Both halves are gone: a
+    // macro turn carries its tools over the MCP bridge, so a check under Claude
+    // Code reads the base for real.
     mocks.modelAndProvider = { currentProvider: 'claude_code', currentModel: 'opus-5' };
     render(<LintDrawer open onOpenChange={() => undefined} />);
 
-    // "No model is configured" is false — there is one, it is bound to the chat
-    // composer, and it works there.
     expect(screen.queryByRole('heading', { name: 'No model is configured' })).toBeNull();
     expect(
-      screen.getByRole('heading', { name: /can’t run a check|cannot run a check/i })
-    ).toBeInTheDocument();
-  });
-
-  it('does not send the user to a picker that has nothing to offer them', () => {
-    mocks.modelAndProvider = { currentProvider: 'codex', currentModel: 'gpt-5.4-codex' };
-    render(<LintDrawer open onOpenChange={() => undefined} />);
-
-    // The Sources rail's model picker filters these providers out, so for this
-    // user it is empty. Sending them there is the dead end, not the fix.
-    expect(screen.queryByText(/Sources rail/i)).toBeNull();
-  });
-
-  it('still refuses to dispatch a run it knows will read nothing', async () => {
-    mocks.modelAndProvider = { currentProvider: 'claude_code', currentModel: 'opus-5' };
-    render(<LintDrawer open onOpenChange={() => undefined} />);
-
-    expect(mocks.start).not.toHaveBeenCalled();
-    const run = screen.getByTestId('knowledge-lint-run');
-    expect(run).toBeDisabled();
-    await userEvent.click(run);
-    expect(mocks.start).not.toHaveBeenCalled();
+      screen.queryByRole('heading', { name: /can’t run a check|cannot run a check/i })
+    ).toBeNull();
+    expect(mocks.start).toHaveBeenCalledWith('/knowledge/bases/kb-1/lint', {
+      model: { provider: 'claude_code', model: 'opus-5' },
+    });
   });
 
   it('keeps saying "no model" when there genuinely is none', () => {
     mocks.modelAndProvider = { currentProvider: null, currentModel: null };
     render(<LintDrawer open onOpenChange={() => undefined} />);
 
-    // The correction must be surgical: a blanket rewrite of this empty state
-    // would start telling a user with no provider at all that their model is
-    // merely the wrong kind.
+    // The one verdict this drawer may reach on its own, and it has to survive
+    // the removal above: a user with no provider at all still needs telling.
     expect(screen.getByRole('heading', { name: 'No model is configured' })).toBeInTheDocument();
+    expect(mocks.start).not.toHaveBeenCalled();
   });
 });

--- a/ui/desktop/src/components/knowledge/lint/LintDrawer.tsx
+++ b/ui/desktop/src/components/knowledge/lint/LintDrawer.tsx
@@ -16,10 +16,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '../../ui/sheet';
 import { useModelAndProvider } from '../../ModelAndProviderContext';
 import { useKnowledge } from '../KnowledgeContext';
 import { useIngestStream } from '../hooks/useIngestStream';
-import {
-  ingestModelBlockedByProvider,
-  resolveIngestModel,
-} from '../IngestPanel/resolveIngestModel';
+import { resolveIngestModel } from '../IngestPanel/resolveIngestModel';
 
 /**
  * Running the base's lint, and reading what it found (ui-spec §4.11).
@@ -114,29 +111,6 @@ export function LintDrawer({ open, onOpenChange }: Props) {
 
   const model = useMemo(
     () => resolveIngestModel(primaryKb?.default_model, currentProvider, currentModel),
-    [primaryKb?.default_model, currentProvider, currentModel]
-  );
-
-  /**
-   * Why `model` is null, when it is — and the reason this drawer has to ask.
-   *
-   * ⚠ **This surface is the SECOND consumer of `resolveIngestModel`.** The
-   * resolver was taught to refuse `claude_code` / `codex`, because both reach
-   * `complete_with_model` with `tools` dropped and a macro run against one
-   * narrates its calls as prose and writes nothing. That made it return `null`
-   * for a configuration that is entirely correct, and this drawer read `null`
-   * the only way it knew how: as "the user has not set a model up". A user whose
-   * only provider is a coding agent therefore had the run control permanently
-   * disabled and was told to choose a model in the Sources rail — which is
-   * exactly the picker that same exclusion emptied for them. A loop with no way
-   * out, and the false verdict `ingestModelBlockedByProvider` exists to prevent.
-   *
-   * The refusal itself stands: a check that reads every page through a model
-   * that receives no tools finishes having read nothing, and dispatching it
-   * would only cost the user a full run. What changes is what we say about it.
-   */
-  const modelBlockedByProvider = useMemo(
-    () => ingestModelBlockedByProvider(primaryKb?.default_model, currentProvider, currentModel),
     [primaryKb?.default_model, currentProvider, currentModel]
   );
 
@@ -278,22 +252,22 @@ export function LintDrawer({ open, onOpenChange }: Props) {
               button because reaching `useNavigate` from this component would
               make it un-renderable outside a router — every test in
               `LintDrawer.test.tsx` renders it bare. */}
-          {!model &&
-            (modelBlockedByProvider ? (
-              <EmptyState
-                compact
-                icon={AlertCircle}
-                title="This model can’t run a check"
-                description="A check reads the base through a model, and the one configured here only receives tools inside a chat — the run would finish having read nothing. Add a provider that can make tool calls in Settings, then try again. This model still works in chat."
-              />
-            ) : (
-              <EmptyState
-                compact
-                icon={AlertCircle}
-                title="No model is configured"
-                description="A check reads the base with a model. Choose one in the Sources rail and try again."
-              />
-            ))}
+          {/* #109: this used to branch on whether the configured provider was a
+              coding agent, because `resolveIngestModel` refused those and this
+              drawer read the resulting `null` as "no model set up" — telling a
+              user whose only provider was a coding agent to choose a model in a
+              picker that same exclusion had emptied. Both halves of that loop
+              are gone: the resolver no longer refuses by name, and a macro turn
+              carries its tools over the MCP bridge. `null` here means what it
+              says again. */}
+          {!model && (
+            <EmptyState
+              compact
+              icon={AlertCircle}
+              title="No model is configured"
+              description="A check reads the base with a model. Choose one in the Sources rail and try again."
+            />
+          )}
 
           {model && running && (
             <div


### PR DESCRIPTION
Closes #109. Stacked on #121 (issue #107) — review that first.

## What was wrong

Only `Agent::reply` knew how to give a coding-agent provider tools. Every other agentic loop — knowledge ingest/query/lint macros, scheduled workflows, bounded sub-agents — calls `Provider::complete` directly with a `tools` argument `claude_code` and `codex` **discard**.

The failure was not an error. The model produced a complete, correct plan with every call written out as prose, invented its own `<tool_response>OK</tool_response>` replies to continue against, and wrote nothing — after a full model run the user paid for. The Knowledge UI's answer was a hardcoded provider denylist.

That is a structural mismatch, not a model-quality problem: the workflow *had* tools; the provider had no grant.

## The primitive

`crates/biorouter/src/providers/tool_turn.rs` — `ProviderToolTurnContext`: issue a least-privilege one-turn grant over the workflow's own filtered tools, scope the bridge URL around the call, drop the lease when it returns. Signatures posted on #109 for worktree 2 (#108).

- **The bridge dispatches through a trait now.** `BridgeToolDispatch`, not a hardcoded `ExtensionManager` — a macro's tools are in no extension at all, and the ingest macro's dispatcher carries the git transaction every write must land on. A chat turn's dispatcher *is* the session's extension manager (`tool_turn::session_tools`).
- **It prefers `stream()`** when the provider offers it, not for latency: the mirrored `ToolRequest`/`ToolResponse` pairs recording what the child ran exist only there, so a workflow driven through `complete_with_model` would execute every tool correctly and be unable to say afterwards which ones.
- **`ProviderTurn::pending_tool_calls()` excludes mirrored requests.** A `kb_write_page` run twice is a second write, not a redraw.
- **`for_workflow` installs a real gate stack.** An empty `ToolInspectionManager` is not "allow everything" — a grant refuses a call whose verdict is "no decision was reached", so an empty manager refused *every* bridged workflow call. Security and sensitive-ops escalate regardless of mode, which keeps its `Auto` a statement about ordinary authorised steps rather than a blanket grant.
- **A workflow with no HTTP server refuses before the model runs**, naming the provider and the way out. A chat turn's tool-less degradation is exactly wrong for a workflow made of tool calls.

## The macro path

`Completer::complete_with_dispatch` hands the run's dispatcher down into the provider call (`SubAgent::run` now takes `Arc<dyn ToolDispatch>`). `ProviderCompleter` overrides it for a bridged provider; executed calls come back as `ExecutedCall` records the loop writes into its run log and never re-dispatches. Cards raised by a macro running from a chat are scoped to that chat's session, so #107's approval is answerable there — a run started from the Knowledge view has no loop to draw one, and that gap is recorded in the field's own doc rather than implied away.

## The denylist is gone

`PROVIDERS_WITHOUT_INGEST_TOOL_CALLS`, `providerCanRunIngest`, `ingestModelBlockedByProvider`, the picker's filter and excluded-providers note, and the two "this model can't digest / can't run a check" empty states. Support is the daemon's answer now, given before a run is spent — not a name a renderer recognises. The ingest failure that detects a narrated run keeps its detector (keyed on the *shape* of the reply, so it still catches any tool-less path) but no longer offers the fixed limitation as the remedy.

## Verification

- **Live, against the real CLIs** (`--ignored`): `crates/biorouter-server/tests/knowledge_macro_live_bridge.rs` runs a **real ingest macro** on a real `claude` / `codex` against a temp knowledge base. The assertion is on the **filesystem**, not the reply — a run that narrates perfectly and leaves the base empty fails, which is exactly the reported shape. It is also the headless/scheduled coverage the issue asks for: no chat session, no agent loop, driven the way a scheduled job is.
- `cargo test -p biorouter --test knowledge_macro_tool_bridge` — the full chain with a stub provider: a macro's tool crosses the bridge, the child's call lands on the macro's *own* dispatcher, it is in the run log, and it ran exactly once.
- `cargo test -p biorouter --test provider_tool_turn_no_server` — the no-server refusal, in its own binary because the base URL is process-global.
- `cargo test -p biorouter --lib providers::tool_turn` (6), `--test privacy_capability` (the census gained two rows with their justifications), `--lib` (2812 passed).
- `cargo test -p biorouter-mcp --lib knowledge` (667 passed); `npx vitest run src/components/knowledge` (235 passed).

Direct Anthropic/OpenAI/Versa providers are untouched — `run()` issues no grant for them at all. No workflow changes provider or billing mode; subscription/plan usage is what pays for these turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)