### PR TITLE
fix(bridge): stop a slow bridged tool call dying at the child's default MCP deadline

### DIFF
--- a/crates/biorouter-server/tests/tool_bridge_routes.rs
+++ b/crates/biorouter-server/tests/tool_bridge_routes.rs
@@ -1067,3 +1067,247 @@ async fn a_bridged_codex_call_needing_approval_is_answerable_and_resumes() {
         "the approved tool's output never reached the answer. Expected {marker}, got: {text}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #110: a bridged tool call that takes longer than the child's default deadline
+// ---------------------------------------------------------------------------
+
+/// A tool that takes `SLOW_TOOL_SECS` to answer and then returns a marker.
+///
+/// 90 seconds is chosen against the measured failure, not for comfort: issue
+/// #110 recorded every bridged call dying at "almost exactly 60 seconds", so a
+/// tool that answers at 90 can only succeed if the per-server deadline Biorouter
+/// now configures is actually being honoured by the child. A 30-second tool
+/// would pass whether the fix worked or not.
+const SLOW_TOOL_SECS: u64 = 90;
+
+struct SlowDispatch {
+    marker: String,
+}
+
+#[async_trait::async_trait]
+impl bridge::BridgeToolDispatch for SlowDispatch {
+    async fn dispatch(
+        &self,
+        _session_id: &str,
+        _call: rmcp::model::CallToolRequestParams,
+        _capability: CallCapability,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> Result<rmcp::model::CallToolResult, String> {
+        tokio::time::sleep(std::time::Duration::from_secs(SLOW_TOOL_SECS)).await;
+        Ok(rmcp::model::CallToolResult::success(vec![
+            rmcp::model::Content::text(format!(
+                "waited {SLOW_TOOL_SECS}s and finished. marker={}",
+                self.marker
+            )),
+        ]))
+    }
+}
+
+fn slow_tool() -> rmcp::model::Tool {
+    rmcp::model::Tool::new(
+        "workspace__workspace_watch",
+        "Wait for background conversations to finish. A timeout is never an error.",
+        Arc::new(
+            serde_json::from_value(json!({
+                "type": "object",
+                "properties": { "timeout_s": { "type": "integer" } }
+            }))
+            .expect("a valid schema"),
+        ),
+    )
+}
+
+/// A grant over one deliberately slow tool, in Auto mode so nothing asks for a
+/// human and the only thing under test is the transport's patience.
+fn slow_grant(marker: &str) -> bridge::BridgeGrant {
+    use biorouter::config::permission::PermissionManager;
+    use biorouter::managed::ManagedPolicy;
+    use biorouter::permission::permission_inspector::PermissionInspector;
+    use biorouter::permission::tool_risk::ToolRiskRegistry;
+
+    let risks = Arc::new(ToolRiskRegistry::new());
+    let managed = Arc::new(ManagedPolicy::empty());
+    let mut inspections = ToolInspectionManager::new();
+    inspections.add_inspector(Box::new(PermissionInspector::new(
+        Arc::clone(&risks),
+        PermissionManager::instance(),
+        managed,
+        Arc::new(tokio::sync::Mutex::new(None)),
+    )));
+
+    bridge::BridgeGrant::new(
+        Session::default(),
+        BioRouterMode::Auto,
+        Arc::new(SlowDispatch {
+            marker: marker.to_string(),
+        }),
+        Arc::new(inspections),
+        CallCapability::public_enforced(),
+        vec![slow_tool()],
+        Conversation::new_unvalidated(vec![]),
+        None,
+        no_hooks(),
+        None,
+        risks,
+    )
+}
+
+/// **#110 through the real Claude Code.** A bridged call that takes 90 seconds
+/// must come back as a *result*, not as "The operation timed out".
+///
+/// This is the assertion the issue asks for and the one no handler test can
+/// make: `workspace_watch` always built a non-error partial report, and it never
+/// reached the model, because the child's own MCP client applied a ~60-second
+/// hard wall clock and abandoned the request first. What is under test here is
+/// the per-server `timeout` Biorouter now writes into the child's MCP config —
+/// so a regression that dropped that field, or a CLI that stopped honouring it,
+/// fails here rather than in a user's session.
+#[tokio::test]
+#[serial_test::serial]
+#[ignore = "needs the `claude` CLI installed and signed in; spends the user's own plan quota and takes ~2 minutes"]
+async fn a_slow_bridged_call_survives_claude_codes_per_call_deadline() {
+    let marker = format!("SLOWPROOF{:016x}", rand::random::<u64>());
+    serve_real_bridge().await;
+    let lease = bridge::issue(slow_grant(&marker)).expect("the base URL is published");
+
+    // Exactly the config the provider writes, including the timeout field.
+    let config = serde_json::json!({
+        "mcpServers": {
+            "biorouter": {
+                "type": "http",
+                "url": lease.url(),
+                "timeout": bridge::CHILD_TOOL_CALL_TIMEOUT.as_millis() as u64,
+            }
+        }
+    });
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let config_path = dir.path().join("mcp.json");
+    std::fs::write(&config_path, config.to_string()).expect("write the bridge config");
+
+    let started = std::time::Instant::now();
+    let mut child = tokio::process::Command::new("claude")
+        .args([
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--model",
+            "haiku",
+            "--tools",
+            "",
+            "--setting-sources",
+            "",
+            "--strict-mcp-config",
+            "--permission-mode",
+            "bypassPermissions",
+            "--no-session-persistence",
+            "--system-prompt",
+            "You are Biorouter. Use the tools you are given and be patient with slow ones.",
+        ])
+        .arg("--mcp-config")
+        .arg(&config_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .env_remove("ANTHROPIC_API_KEY")
+        .spawn()
+        .expect("the claude CLI runs");
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        stdin
+            .write_all(
+                b"Call workspace_watch once with timeout_s 600. It is slow; wait for it. \
+                  Then reply with ONLY the marker value it returned.",
+            )
+            .await
+            .expect("write the prompt");
+        stdin.shutdown().await.expect("close stdin");
+    }
+    let output = child.wait_with_output().await.expect("the CLI finishes");
+    let elapsed = started.elapsed();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let dump = || {
+        format!(
+            "elapsed {}s; stdout was:\n{stdout}\nstderr:\n{}",
+            elapsed.as_secs(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    };
+
+    // The exact diagnostic #110 reported, in the exact place it appeared.
+    assert!(
+        !stdout.to_lowercase().contains("operation timed out"),
+        "the bridged call was abandoned by the child's MCP client; {}",
+        dump()
+    );
+    assert!(
+        stdout.contains(&marker),
+        "the slow tool's result never reached the model. Expected {marker}. {}",
+        dump()
+    );
+    // And it really did outlive the old ceiling, rather than the tool having
+    // been fast: a pass at 20 seconds would prove nothing about the deadline.
+    assert!(
+        elapsed >= std::time::Duration::from_secs(SLOW_TOOL_SECS),
+        "the run finished before the tool could have; {}",
+        dump()
+    );
+}
+
+/// **#110 through the real Codex.** A different MCP client with its own default
+/// deadline and its own knob (`tool_timeout_sec`, seconds rather than
+/// milliseconds), so nothing proven against Claude Code transfers by argument.
+#[tokio::test]
+#[serial_test::serial]
+#[ignore = "needs the `codex` CLI installed and signed in; spends the user's own plan quota and takes ~2 minutes"]
+async fn a_slow_bridged_call_survives_codexs_per_call_deadline() {
+    use biorouter::conversation::message::Message;
+    use biorouter::model::ModelConfig;
+    use biorouter::providers::base::Provider;
+    use biorouter::providers::codex::CodexProvider;
+
+    let marker = format!("SLOWPROOFCODEX{:016x}", rand::random::<u64>());
+    serve_real_bridge().await;
+    let lease = bridge::issue(slow_grant(&marker)).expect("the base URL is published");
+
+    let provider = CodexProvider::from_env(ModelConfig::new("gpt-5.5").expect("a known model"))
+        .await
+        .expect("the codex CLI is installed");
+    let messages = vec![Message::user().with_text(
+        "Call the workspace__workspace_watch tool once with timeout_s 600. It is slow; wait \
+         for it. Then reply with ONLY the marker value it returned.",
+    )];
+
+    let started = std::time::Instant::now();
+    let outcome = bridge::ACTIVE_BRIDGE_URL
+        .scope(
+            Some(lease.url().to_string()),
+            provider.complete(
+                "You are Biorouter. Use the tools you are given and be patient with slow ones.",
+                &messages,
+                &[],
+            ),
+        )
+        .await;
+    let elapsed = started.elapsed();
+
+    let (message, _usage) = outcome.expect("the codex turn must not fail");
+    let text = message.as_concat_text();
+    assert!(
+        !text.to_lowercase().contains("timed out"),
+        "the bridged call was abandoned by Codex's MCP client after {}s: {text}",
+        elapsed.as_secs()
+    );
+    assert!(
+        text.contains(&marker),
+        "the slow tool's result never reached the model. Expected {marker}, got: {text}"
+    );
+    assert!(
+        elapsed >= std::time::Duration::from_secs(SLOW_TOOL_SECS),
+        "the run finished before the tool could have ({}s)",
+        elapsed.as_secs()
+    );
+}

--- a/crates/biorouter/src/agents/workspace_extension.rs
+++ b/crates/biorouter/src/agents/workspace_extension.rs
@@ -560,7 +560,11 @@ impl WorkspaceClient {
                 "Wait until one (or all) of the named conversations finishes its \
                  current turn, and report why it ended. Use after spawning \
                  background subagents or injecting turns instead of polling. A \
-                 timeout is not an error.",
+                 timeout is NEVER an error: the reply lists whatever finished and \
+                 whatever is still running, so call it again to keep waiting. The \
+                 wait may be shortened to fit the transport carrying this turn — \
+                 when it is, the reply says the effective wait and the one you \
+                 asked for.",
                 serde_json::to_value(schema_for!(WorkspaceWatchParams)).unwrap(),
                 true,
             ),
@@ -2510,7 +2514,16 @@ impl WorkspaceClient {
             Some("all") => true,
             Some(other) => return Err(format!("unknown mode '{other}' (any | all)")),
         };
-        let timeout = std::time::Duration::from_secs(args.timeout_s.unwrap_or(120).clamp(1, 600));
+        let requested =
+            std::time::Duration::from_secs(args.timeout_s.unwrap_or(120).clamp(1, 600));
+        // #110: what the *transport* allows, which is not always what the schema
+        // advertises. A bridged coding-agent call is held open inside the
+        // child's own MCP client, which applies a hard per-call wall clock and
+        // abandons the request when it elapses — so a wait that outruns it does
+        // not trade latency for completeness, it loses the partial answer too:
+        // the model is told "The operation timed out" instead of being handed
+        // the completions this handler had already collected.
+        let (timeout, clamped_from) = clamp_watch_to_transport(requested);
         let assume_running = args.assume_running.unwrap_or(false);
 
         // Subscribe FIRST, then pre-check. Reversing this loses a completion
@@ -2574,6 +2587,7 @@ impl WorkspaceClient {
             &completed,
             &still_running,
             timeout,
+            clamped_from,
             unknown_liveness,
         ))])
     }
@@ -2635,6 +2649,7 @@ impl WorkspaceClient {
         completed: &[(String, String)],
         still_running: &[&String],
         timeout: std::time::Duration,
+        clamped_from: Option<std::time::Duration>,
         unknown_liveness: usize,
     ) -> String {
         let mut report = String::new();
@@ -2678,7 +2693,58 @@ impl WorkspaceClient {
                  (view:\"summary\" for its outcome, view:\"tool_calls\" for what it did).",
             );
         }
+        // #110: say when the wait was shorter than the one asked for, and why.
+        // A caller that is not told will read "still running" after 60 s as the
+        // answer to the 600-second question it asked, and either give up on a
+        // subagent that is working fine or start polling transcripts. Naming the
+        // effective wait is what makes "watch again" the obvious next move.
+        if let Some(requested) = clamped_from {
+            report.push_str(&format!(
+                "\n(Waited {}s of the {}s requested: this turn's transport ends a single \
+                 tool call at {}s, so the wait was shortened to return this status instead \
+                 of failing. Watch again to keep waiting — the completions above are not \
+                 repeated.)",
+                timeout.as_secs(),
+                requested.as_secs(),
+                timeout.as_secs(),
+            ));
+        }
         report
+    }
+}
+
+/// Shorten a requested wait to what the transport carrying this call allows.
+///
+/// Returns the effective wait and, when it was shortened, the one that was
+/// asked for — so the report can say both rather than silently answering a
+/// different question.
+///
+/// The margin is what the answer itself needs on the wire, and it is subtracted
+/// rather than assumed: a wait equal to the budget finishes at the instant the
+/// request is abandoned, which is the failure with the timing made tight rather
+/// than the failure fixed.
+///
+/// Free and pure so the arithmetic is testable without a bridge; the only input
+/// that varies is the task-local the bridge publishes.
+fn clamp_watch_to_transport(
+    requested: std::time::Duration,
+) -> (std::time::Duration, Option<std::time::Duration>) {
+    const ANSWER_MARGIN: std::time::Duration = std::time::Duration::from_secs(10);
+    let Some(budget) = crate::providers::coding_agent::bridge::bridged_call_budget() else {
+        // Not a bridged call: nothing is holding a socket open, so the schema's
+        // ceiling is the only one that applies.
+        return (requested, None);
+    };
+    let allowed = budget.saturating_sub(ANSWER_MARGIN).max(
+        // A budget smaller than the margin would clamp every wait to zero and
+        // turn `workspace_watch` into a liveness poll. One second is the schema's
+        // own floor.
+        std::time::Duration::from_secs(1),
+    );
+    if requested <= allowed {
+        (requested, None)
+    } else {
+        (allowed, Some(requested))
     }
 }
 
@@ -3291,6 +3357,123 @@ fn gui_detail(gui_result: &serde_json::Value) -> Option<&str> {
 pub(crate) mod tests {
     use super::*;
     use crate::agents::extension::PlatformExtensionContext;
+    use std::time::Duration;
+
+    // ---------------------------------------------------------------------
+    // #110: a wait that outruns the transport
+    // ---------------------------------------------------------------------
+
+    /// Off a bridged call there is nothing holding a socket open, so the
+    /// schema's own ceiling is the only one that applies and the wait is
+    /// answered as asked.
+    #[test]
+    fn an_unbridged_watch_waits_exactly_as_long_as_it_was_asked_to() {
+        let (effective, clamped) = clamp_watch_to_transport(Duration::from_secs(600));
+        assert_eq!(effective, Duration::from_secs(600));
+        assert_eq!(clamped, None, "nothing to explain when nothing was shortened");
+    }
+
+    /// The bug: a 600-second wait inside a transport that ends the call sooner.
+    /// It must come back SHORTER — and say so — rather than run to 600 and be
+    /// abandoned, which loses the partial answer along with the wait.
+    #[tokio::test]
+    async fn a_bridged_watch_is_shortened_to_fit_its_transport() {
+        let (effective, clamped) = crate::providers::coding_agent::bridge::with_call_budget_for_test(
+            Duration::from_secs(60),
+            async { clamp_watch_to_transport(Duration::from_secs(600)) },
+        )
+        .await;
+        assert_eq!(
+            effective,
+            Duration::from_secs(50),
+            "the margin is what the answer itself needs on the wire"
+        );
+        assert_eq!(clamped, Some(Duration::from_secs(600)));
+        assert!(
+            effective < Duration::from_secs(60),
+            "a wait equal to the budget finishes exactly when the request is \
+             abandoned, which is the same failure with tighter timing"
+        );
+    }
+
+    /// A wait that already fits is left alone, and reports nothing — an
+    /// explanation for a shortening that did not happen is noise the model has
+    /// to reason about.
+    #[tokio::test]
+    async fn a_bridged_watch_that_already_fits_is_untouched() {
+        let (effective, clamped) = crate::providers::coding_agent::bridge::with_call_budget_for_test(
+            Duration::from_secs(600),
+            async { clamp_watch_to_transport(Duration::from_secs(120)) },
+        )
+        .await;
+        assert_eq!(effective, Duration::from_secs(120));
+        assert_eq!(clamped, None);
+    }
+
+    /// A pathologically small budget must not clamp the wait to zero and turn
+    /// `workspace_watch` into a liveness poll that always says "still running".
+    #[tokio::test]
+    async fn a_tiny_budget_still_leaves_a_real_wait() {
+        let (effective, _) = crate::providers::coding_agent::bridge::with_call_budget_for_test(
+            Duration::from_secs(2),
+            async { clamp_watch_to_transport(Duration::from_secs(600)) },
+        )
+        .await;
+        assert!(
+            effective >= Duration::from_secs(1),
+            "the schema's own floor is one second"
+        );
+    }
+
+    /// The shortening has to be legible. A caller told only "still running"
+    /// after 50 s will read that as the answer to the 600-second question it
+    /// asked — and either abandon a subagent that is working fine or fall back
+    /// to polling transcripts, which is the behaviour `workspace_watch` exists
+    /// to replace.
+    #[test]
+    fn a_shortened_watch_reports_both_the_effective_and_the_requested_wait() {
+        let still = "sess-a".to_string();
+        let report = WorkspaceClient::watch_report(
+            &[],
+            &[&still],
+            Duration::from_secs(50),
+            Some(Duration::from_secs(600)),
+            0,
+        );
+        assert!(report.contains("50s"), "the effective wait: {report}");
+        assert!(report.contains("600s"), "and the one asked for: {report}");
+        assert!(
+            report.to_lowercase().contains("watch again"),
+            "and the move that follows from it: {report}"
+        );
+        assert!(
+            !report.to_lowercase().contains("timed out")
+                && !report.to_lowercase().contains("error"),
+            "a timeout is a status, never a failure: {report}"
+        );
+    }
+
+    /// Completions observed before the deadline survive the shortening. Mode
+    /// `all` holds finished targets until every target completes, so a clamp
+    /// that dropped them would lose exactly the work the wait had already paid
+    /// for.
+    #[test]
+    fn a_shortened_watch_keeps_the_completions_it_observed() {
+        let still = "sess-c".to_string();
+        let report = WorkspaceClient::watch_report(
+            &[
+                ("sess-a".to_string(), "finished".to_string()),
+                ("sess-b".to_string(), "finished".to_string()),
+            ],
+            &[&still],
+            Duration::from_secs(50),
+            Some(Duration::from_secs(600)),
+            0,
+        );
+        assert!(report.contains("sess-a") && report.contains("sess-b"));
+        assert!(report.contains("sess-c"), "and what is still running");
+        assert!(report.contains("600s"), "and that the wait was shortened");
+    }
 
     /// ⚠ **The one list of idioms that must never come back, for every file
     /// that guards against them.**

--- a/crates/biorouter/src/agents/workspace_extension.rs
+++ b/crates/biorouter/src/agents/workspace_extension.rs
@@ -2475,6 +2475,7 @@ impl WorkspaceClient {
         caller_session_id: &str,
         cap: crate::privacy::CallCapability,
         arguments: Option<JsonObject>,
+        cancel: &tokio_util::sync::CancellationToken,
     ) -> Result<Vec<Content>, String> {
         use crate::session_events;
 
@@ -2514,8 +2515,7 @@ impl WorkspaceClient {
             Some("all") => true,
             Some(other) => return Err(format!("unknown mode '{other}' (any | all)")),
         };
-        let requested =
-            std::time::Duration::from_secs(args.timeout_s.unwrap_or(120).clamp(1, 600));
+        let requested = std::time::Duration::from_secs(args.timeout_s.unwrap_or(120).clamp(1, 600));
         // #110: what the *transport* allows, which is not always what the schema
         // advertises. A bridged coding-agent call is held open inside the
         // child's own MCP client, which applies a hard per-call wall clock and
@@ -2560,6 +2560,7 @@ impl WorkspaceClient {
             receivers.retain(|(id, _)| !completed.iter().any(|(done, _)| done == id));
         }
 
+        let mut cancelled = false;
         let done_now = if wait_all {
             receivers.is_empty()
         } else {
@@ -2574,7 +2575,8 @@ impl WorkspaceClient {
             } else {
                 completed.len() + 1
             };
-            Self::park_for_completions(receivers, &mut completed, want, timeout).await;
+            cancelled =
+                Self::park_for_completions(receivers, &mut completed, want, timeout, cancel).await;
         }
 
         let still_running: Vec<&String> = args
@@ -2589,6 +2591,7 @@ impl WorkspaceClient {
             timeout,
             clamped_from,
             unknown_liveness,
+            cancelled,
         ))])
     }
 
@@ -2600,19 +2603,41 @@ impl WorkspaceClient {
         completed: &mut Vec<(String, String)>,
         want: usize,
         timeout: std::time::Duration,
-    ) {
+        cancel: &tokio_util::sync::CancellationToken,
+    ) -> bool {
         use crate::session_events::SessionBusEvent;
 
         let deadline = tokio::time::Instant::now() + timeout;
+        // Cancelled when this function returns, **however** it returns — the
+        // deadline, a cancel, or every watcher exiting.
+        //
+        // ⚠ The watcher tasks own the `Subscription`s, and a `Subscription` only
+        // reclaims its session's 1024-slot event ring when it drops. Without
+        // this the tasks looped on `recv()` for the life of the process after a
+        // watch timed out, pinning a ring slot per watched session per watch —
+        // a leak that got materially worse with #110, because a watch that used
+        // to be killed by the child's 60-second deadline can now legitimately
+        // park for ten minutes.
+        let stop = tokio_util::sync::CancellationToken::new();
+        let _reap_watchers = stop.clone().drop_guard();
+
         // One task per watched session, all feeding one channel: simpler
         // and more obviously correct than a hand-rolled select over a Vec,
         // and 32 short-lived tasks is nothing.
         let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, String)>(WATCH_MAX_SESSIONS);
         for (id, mut receiver) in receivers {
             let tx = tx.clone();
+            let stop = stop.clone();
             tokio::spawn(async move {
                 loop {
-                    match receiver.recv().await {
+                    // `recv` is cancel-safe, so losing this race never drops an
+                    // event that had already resolved.
+                    let event = tokio::select! {
+                        biased;
+                        () = stop.cancelled() => return,
+                        event = receiver.recv() => event,
+                    };
+                    match event {
                         Ok(SessionBusEvent::TurnFinished { reason, .. }) => {
                             let _ = tx.send((id, reason)).await;
                             return;
@@ -2632,15 +2657,31 @@ impl WorkspaceClient {
         }
         drop(tx); // so `rx.recv()` ends if every watcher exits
 
+        // #110: the turn's own token ends the park. Every cancellation
+        // mechanism Biorouter has — Stop, `AppState::cancel_turn`, the websocket
+        // `TurnGuard`, and a bridge lease dropping — reaches a running tool
+        // through it, and a watch that ignored it kept a cancelled turn alive
+        // for the whole wait. That was survivable while the child's own deadline
+        // capped it at a minute; it is not now that a watch may legitimately
+        // park for ten.
+        let mut cancelled = false;
         let _ = tokio::time::timeout_at(deadline, async {
             while completed.len() < want {
-                match rx.recv().await {
-                    Some(entry) => completed.push(entry),
-                    None => break,
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => {
+                        cancelled = true;
+                        break;
+                    }
+                    entry = rx.recv() => match entry {
+                        Some(entry) => completed.push(entry),
+                        None => break,
+                    },
                 }
             }
         })
         .await;
+        cancelled
     }
 
     /// The `workspace_watch` reply: what finished, what is still running, and —
@@ -2651,6 +2692,7 @@ impl WorkspaceClient {
         timeout: std::time::Duration,
         clamped_from: Option<std::time::Duration>,
         unknown_liveness: usize,
+        cancelled: bool,
     ) -> String {
         let mut report = String::new();
         if completed.is_empty() {
@@ -2691,6 +2733,16 @@ impl WorkspaceClient {
             report.push_str(
                 "\nRead a completed conversation with workspace_read_conversation \
                  (view:\"summary\" for its outcome, view:\"tool_calls\" for what it did).",
+            );
+        }
+        // #110: a cancelled watch is not a finished one, and saying nothing
+        // would let the caller read "still running" as the answer to a wait that
+        // never happened. The conversations themselves are untouched — what was
+        // cancelled is the turn doing the watching.
+        if cancelled {
+            report.push_str(
+                "\n(The watch was cancelled before its deadline. The conversations above \
+                 were not affected.)",
             );
         }
         // #110: say when the wait was shorter than the one asked for, and why.
@@ -3096,7 +3148,7 @@ impl McpClientTrait for WorkspaceClient {
         name: &str,
         arguments: Option<JsonObject>,
         meta: McpMeta,
-        _cancellation_token: CancellationToken,
+        cancellation_token: CancellationToken,
     ) -> Result<CallToolResult, Error> {
         let caller = &meta.session_id;
         // Issue #56 §7. The capability this call was ADMITTED on, carried from
@@ -3113,7 +3165,13 @@ impl McpClientTrait for WorkspaceClient {
             "workspace_send_prompt" => self.handle_send_prompt(caller, cap, arguments).await,
             "workspace_set_tools" => self.handle_set_tools(caller, cap, arguments).await,
             "workspace_close" => self.handle_close(caller, cap, arguments).await,
-            "workspace_watch" => self.handle_watch(caller, cap, arguments).await,
+            // #110: the only handler here that PARKS, so the only one the turn's
+            // cancel token has anything to reach. Every other tool returns
+            // promptly; a watch may legitimately wait ten minutes.
+            "workspace_watch" => {
+                self.handle_watch(caller, cap, arguments, &cancellation_token)
+                    .await
+            }
             "workspace_open" => self.handle_open(caller, cap, arguments).await,
             // BR-71 decision 22: the spawn tool is advertised here but
             // dispatched by the agent loop (it needs the parent's TaskConfig).
@@ -3370,7 +3428,10 @@ pub(crate) mod tests {
     fn an_unbridged_watch_waits_exactly_as_long_as_it_was_asked_to() {
         let (effective, clamped) = clamp_watch_to_transport(Duration::from_secs(600));
         assert_eq!(effective, Duration::from_secs(600));
-        assert_eq!(clamped, None, "nothing to explain when nothing was shortened");
+        assert_eq!(
+            clamped, None,
+            "nothing to explain when nothing was shortened"
+        );
     }
 
     /// The bug: a 600-second wait inside a transport that ends the call sooner.
@@ -3378,11 +3439,12 @@ pub(crate) mod tests {
     /// abandoned, which loses the partial answer along with the wait.
     #[tokio::test]
     async fn a_bridged_watch_is_shortened_to_fit_its_transport() {
-        let (effective, clamped) = crate::providers::coding_agent::bridge::with_call_budget_for_test(
-            Duration::from_secs(60),
-            async { clamp_watch_to_transport(Duration::from_secs(600)) },
-        )
-        .await;
+        let (effective, clamped) =
+            crate::providers::coding_agent::bridge::with_call_budget_for_test(
+                Duration::from_secs(60),
+                async { clamp_watch_to_transport(Duration::from_secs(600)) },
+            )
+            .await;
         assert_eq!(
             effective,
             Duration::from_secs(50),
@@ -3401,11 +3463,12 @@ pub(crate) mod tests {
     /// to reason about.
     #[tokio::test]
     async fn a_bridged_watch_that_already_fits_is_untouched() {
-        let (effective, clamped) = crate::providers::coding_agent::bridge::with_call_budget_for_test(
-            Duration::from_secs(600),
-            async { clamp_watch_to_transport(Duration::from_secs(120)) },
-        )
-        .await;
+        let (effective, clamped) =
+            crate::providers::coding_agent::bridge::with_call_budget_for_test(
+                Duration::from_secs(600),
+                async { clamp_watch_to_transport(Duration::from_secs(120)) },
+            )
+            .await;
         assert_eq!(effective, Duration::from_secs(120));
         assert_eq!(clamped, None);
     }
@@ -3425,6 +3488,98 @@ pub(crate) mod tests {
         );
     }
 
+    /// #110: a cancelled turn must end the park at the instant it lands, not at
+    /// the deadline.
+    ///
+    /// The generous timeout is the assertion: if the token were ignored this
+    /// would sit for ten minutes, so the test would fail by timing out rather
+    /// than by asserting. That is exactly the shape of the bug — a watch that
+    /// kept a cancelled turn alive for its whole wait, which was survivable
+    /// while the child's own 60-second deadline capped it and is not now.
+    #[tokio::test]
+    async fn cancelling_the_turn_ends_a_parked_watch_at_once() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let id = format!("watch-cancel-{:016x}", rand::random::<u64>());
+        let receivers = vec![(id.clone(), crate::session_events::subscribe(&id))];
+        let mut completed: Vec<(String, String)> = Vec::new();
+
+        {
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                cancel.cancel();
+            });
+        }
+
+        let started = std::time::Instant::now();
+        let cancelled = tokio::time::timeout(
+            Duration::from_secs(5),
+            WorkspaceClient::park_for_completions(
+                receivers,
+                &mut completed,
+                1,
+                Duration::from_secs(600),
+                &cancel,
+            ),
+        )
+        .await
+        .expect("a cancelled park must return, not run to its deadline");
+
+        assert!(cancelled, "the caller has to be able to say why it stopped");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "it must end when the cancel lands, not later"
+        );
+        assert!(completed.is_empty(), "nothing finished");
+    }
+
+    /// And a cancelled watch says so, rather than letting the caller read "still
+    /// running" as the answer to a wait that never happened.
+    #[test]
+    fn a_cancelled_watch_reports_that_it_was_cancelled() {
+        let still = "sess-a".to_string();
+        let report =
+            WorkspaceClient::watch_report(&[], &[&still], Duration::from_secs(600), None, 0, true);
+        assert!(report.contains("cancelled"), "{report}");
+        assert!(
+            report.contains("not affected"),
+            "and that the conversations themselves are untouched: {report}"
+        );
+    }
+
+    /// The watcher tasks own the `Subscription`s, and a `Subscription` only
+    /// reclaims its session's event-ring slot when it drops. Before #110 they
+    /// looped on `recv()` for the life of the process after a watch ended, so a
+    /// timed-out watch leaked a slot per watched session — which a ten-minute
+    /// park makes far easier to accumulate.
+    #[tokio::test]
+    async fn a_finished_park_reaps_its_watcher_tasks() {
+        let id = format!("watch-reap-{:016x}", rand::random::<u64>());
+        let receivers = vec![(id.clone(), crate::session_events::subscribe(&id))];
+        let mut completed: Vec<(String, String)> = Vec::new();
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        // A short deadline, so the park ends the way a timed-out watch does.
+        WorkspaceClient::park_for_completions(
+            receivers,
+            &mut completed,
+            1,
+            Duration::from_millis(50),
+            &cancel,
+        )
+        .await;
+
+        // Give the reaped tasks a moment to notice and drop their subscriptions,
+        // then assert the ring is free: a session with no live subscriber
+        // releases its bus entirely.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            crate::session_events::observer_count(&id),
+            0,
+            "the watcher task must have dropped its Subscription when the park ended"
+        );
+    }
+
     /// The shortening has to be legible. A caller told only "still running"
     /// after 50 s will read that as the answer to the 600-second question it
     /// asked — and either abandon a subagent that is working fine or fall back
@@ -3439,6 +3594,7 @@ pub(crate) mod tests {
             Duration::from_secs(50),
             Some(Duration::from_secs(600)),
             0,
+            false,
         );
         assert!(report.contains("50s"), "the effective wait: {report}");
         assert!(report.contains("600s"), "and the one asked for: {report}");
@@ -3469,6 +3625,7 @@ pub(crate) mod tests {
             Duration::from_secs(50),
             Some(Duration::from_secs(600)),
             0,
+            false,
         );
         assert!(report.contains("sess-a") && report.contains("sess-b"));
         assert!(report.contains("sess-c"), "and what is still running");

--- a/crates/biorouter/src/agents/workspace_extension.rs
+++ b/crates/biorouter/src/agents/workspace_extension.rs
@@ -5875,10 +5875,22 @@ pub(crate) mod tests {
         // …and the dispatcher hands each newly gated handler the capability the
         // call was ADMITTED on. Without this the guards above have nothing to
         // ask and the handlers go quietly back to ungated.
+        //
+        // ⚠ The needle stops at `cap,` on purpose. It used to pin the WHOLE
+        // argument list — `(caller, cap, arguments)` — and #110 broke it by
+        // giving `handle_watch` a fourth argument (the turn's cancel token, so a
+        // parked watch is reachable by Stop), a change that threads the
+        // capability exactly as before. A guard that fails on a legitimate
+        // argument gets weakened by the next person in a hurry, and the way it
+        // gets weakened is by deleting the row. Asserting the PROPERTY — this
+        // handler is handed the admitted capability, second, right after the
+        // caller — is what survives a growing signature while still failing the
+        // thing it exists to catch: a handler that stops being given `cap` at
+        // all, or that is given one it re-derived for itself.
         for arm in [
-            "\"workspace_set_tools\" => self.handle_set_tools(caller, cap, arguments)",
-            "\"workspace_close\" => self.handle_close(caller, cap, arguments)",
-            "\"workspace_watch\" => self.handle_watch(caller, cap, arguments)",
+            "\"workspace_set_tools\" => self.handle_set_tools(caller, cap,",
+            "\"workspace_close\" => self.handle_close(caller, cap,",
+            "self.handle_watch(caller, cap,",
         ] {
             assert!(
                 production.contains(arm),

--- a/crates/biorouter/src/providers/claude_code.rs
+++ b/crates/biorouter/src/providers/claude_code.rs
@@ -899,8 +899,21 @@ fn bridge_mcp_config() -> Result<Option<tempfile::NamedTempFile>, ProviderError>
     let Some(url) = bridge::active_bridge_url() else {
         return Ok(None);
     };
+    // #110: `timeout` is the per-server **millisecond** hard wall clock Claude
+    // Code applies to one `tools/call`. Its default killed every bridged call at
+    // ~60 s, which turned `workspace_watch`'s advertised 600-second wait — and
+    // any other slow Biorouter tool — into "The operation timed out": a
+    // transport failure the model may retry, rather than the partial answer the
+    // handler was about to return. The CLI's own help is explicit that progress
+    // notifications do not extend it, so raising it is the only lever.
     let body = serde_json::json!({
-        "mcpServers": { "biorouter": { "type": "http", "url": url } }
+        "mcpServers": {
+            "biorouter": {
+                "type": "http",
+                "url": url,
+                "timeout": bridge::CHILD_TOOL_CALL_TIMEOUT.as_millis() as u64,
+            }
+        }
     });
 
     let mut file = tempfile::Builder::new()

--- a/crates/biorouter/src/providers/claude_code.rs
+++ b/crates/biorouter/src/providers/claude_code.rs
@@ -1185,6 +1185,57 @@ mod tests {
     use super::*;
     use crate::agents::effort::ReasoningEffort;
 
+    /// #110: the bridge config must carry the per-call deadline.
+    ///
+    /// `timeout` is a **millisecond** field that Claude Code's own help calls a
+    /// "hard wall-clock limit per call", and its default abandoned every bridged
+    /// call at ~60 s — turning `workspace_watch`'s advertised 600-second wait,
+    /// and any other slow Biorouter tool, into "The operation timed out" instead
+    /// of the partial result the handler was about to return.
+    ///
+    /// Asserted here as well as in the live test, because a live test needs a
+    /// signed-in CLI and two minutes of a plan's quota: a dropped field should
+    /// fail in `cargo test`, not in a user's session.
+    #[tokio::test]
+    async fn the_bridge_config_carries_the_per_call_deadline() {
+        let written = bridge::ACTIVE_BRIDGE_URL
+            .scope(
+                Some("http://127.0.0.1:9/tool_bridge/deadbeef".to_string()),
+                async {
+                    let file = bridge_mcp_config()
+                        .expect("the config is written")
+                        .expect("a bridge URL is in scope");
+                    std::fs::read_to_string(file.path()).expect("the config is readable")
+                },
+            )
+            .await;
+        let body: serde_json::Value = serde_json::from_str(&written).expect("valid JSON");
+        let server = &body["mcpServers"]["biorouter"];
+        assert_eq!(server["url"], "http://127.0.0.1:9/tool_bridge/deadbeef");
+        assert_eq!(
+            server["timeout"],
+            bridge::CHILD_TOOL_CALL_TIMEOUT.as_millis() as u64,
+            "milliseconds — Claude Code's unit, not Codex's seconds"
+        );
+        // The unit is easy to get wrong in the direction that looks fine: 660
+        // would be read as two-thirds of a second and abandon every call
+        // instantly, which reads as a broken bridge rather than a wrong number.
+        assert!(
+            server["timeout"].as_u64().unwrap_or(0) > 1000,
+            "a value under a second means the unit was confused: {server}"
+        );
+    }
+
+    /// No bridge means no config file at all — the child then runs tool-less,
+    /// which is the correct degradation for a chat turn.
+    #[tokio::test]
+    async fn no_bridge_url_writes_no_config() {
+        let none = bridge::ACTIVE_BRIDGE_URL
+            .scope(None, async { bridge_mcp_config().expect("no error") })
+            .await;
+        assert!(none.is_none());
+    }
+
     fn provider() -> ClaudeCodeProvider {
         ClaudeCodeProvider {
             command: PathBuf::from("/usr/bin/claude"),

--- a/crates/biorouter/src/providers/codex.rs
+++ b/crates/biorouter/src/providers/codex.rs
@@ -225,7 +225,20 @@ impl CodexProvider {
             // outright). Until then this is disclosed in
             // `docs/providers/coding-agents/child-agent-isolation.md` rather than
             // papered over.
-            config["mcp_servers"] = json!({ "biorouter": { "url": url } });
+            // #110: `tool_timeout_sec` is the per-server **second** wall clock
+            // Codex applies to one `tools/call`, and `startup_timeout_sec` the
+            // one it applies to the initial connect. Their defaults are far
+            // below what Biorouter's slower tools need — `workspace_watch`
+            // alone advertises waits of up to 600 s — and a call that outruns
+            // the deadline comes back as a transport timeout rather than as the
+            // partial result the handler was about to return.
+            config["mcp_servers"] = json!({
+                "biorouter": {
+                    "url": url,
+                    "tool_timeout_sec": bridge::CHILD_TOOL_CALL_TIMEOUT.as_secs(),
+                    "startup_timeout_sec": 30,
+                }
+            });
             // ⚠ Tell the model which set of tools actually works, because the two
             // it can see are not equally usable and the broken pair looks more
             // familiar.

--- a/crates/biorouter/src/providers/codex.rs
+++ b/crates/biorouter/src/providers/codex.rs
@@ -1429,6 +1429,14 @@ for line in sys.stdin:
             with["config"]["mcp_servers"]["biorouter"]["url"],
             "http://127.0.0.1:9/tool_bridge/deadbeef"
         );
+        // #110: and the per-call deadline, in SECONDS — Codex's unit, not Claude
+        // Code's milliseconds. Without it Codex's default abandons any bridged
+        // call that outruns it, and the model is told the operation timed out
+        // rather than handed the partial result the tool had ready.
+        assert_eq!(
+            with["config"]["mcp_servers"]["biorouter"]["tool_timeout_sec"],
+            crate::providers::coding_agent::bridge::CHILD_TOOL_CALL_TIMEOUT.as_secs()
+        );
 
         let without = CodexProvider::thread_params("S", "/tmp", "gpt-5.5", None);
         assert!(

--- a/crates/biorouter/src/providers/coding_agent/bridge.rs
+++ b/crates/biorouter/src/providers/coding_agent/bridge.rs
@@ -205,19 +205,36 @@ pub struct BridgeGrant {
     nonce: String,
 }
 
-/// How long a bridged `tools/call` may keep the child's HTTP request open.
+/// The per-call MCP deadline Biorouter asks each child CLI to apply (#110).
 ///
-/// Not a policy choice — a measurement of the child's own MCP client. Claude
-/// Code applies a hard per-call wall clock and abandons the request when it
-/// elapses (issue #110 measured ~60 s), and an abandoned request surfaces to the
-/// child's model as "The operation timed out", which is a transport failure it
-/// may retry rather than an answer it can act on.
+/// Both CLIs apply a hard per-call wall clock and abandon the request when it
+/// elapses; the default is far shorter than Biorouter's own long-running tools
+/// need. Issue #110 measured Claude Code's at ~60 s against a `workspace_watch`
+/// whose schema advertises waits of up to 600 s — every one of which died at 60
+/// with "The operation timed out", a transport failure the model may retry
+/// rather than an answer it can act on.
 ///
-/// So anything on this path that waits must fit *inside* the budget and answer
-/// with a real result, rather than letting the deadline pass and hoping. The
-/// margin between the two is what the answer itself needs.
+/// So the deadline is configured rather than discovered. Both CLIs expose the
+/// knob per MCP server, which is what makes this reliable rather than a hope:
+///
+/// | CLI | Where |
+/// | --- | --- |
+/// | Claude Code | `timeout` (**milliseconds**) in the `--mcp-config` server entry. Its own help calls it a "hard wall-clock limit per call; progress notifications do not extend it". |
+/// | Codex | `mcp_servers.<name>.tool_timeout_sec` (**seconds**) in the `thread/start` config override. |
+///
+/// Deliberately **above** [`child_tool_call_budget`] rather than equal to it:
+/// the budget is what a call may spend, and the difference is the room the
+/// answer itself needs on the wire.
+pub const CHILD_TOOL_CALL_TIMEOUT: Duration = Duration::from_secs(660);
+
+/// How long a bridged `tools/call` may actually spend before it must answer.
+///
+/// Anything on this path that waits must fit *inside* this and answer with a
+/// real result, rather than letting the deadline pass and hoping. A tool that
+/// runs past it does not get more time — it gets an abandoned request, and the
+/// model reads that as a broken server.
 pub fn child_tool_call_budget() -> Duration {
-    Duration::from_secs(50)
+    Duration::from_secs(600)
 }
 
 /// The longest a bridged call may park on a human before it must answer the
@@ -230,7 +247,41 @@ pub fn child_tool_call_budget() -> Duration {
 /// time — it converts a card they could still answer into a transport error the
 /// model reads as a broken server.
 fn approval_ttl() -> Duration {
-    child_tool_call_budget().saturating_sub(Duration::from_secs(5))
+    child_tool_call_budget().saturating_sub(Duration::from_secs(30))
+}
+
+tokio::task_local! {
+    /// How long the bridged tool call running on this task may take (#110).
+    ///
+    /// A task-local because the tools that need it are ordinary MCP handlers
+    /// with no idea what is calling them — `workspace_watch` accepts a
+    /// `timeout_s` up to 600 and must clamp it to what the *transport* allows,
+    /// and it cannot be handed that through a schema every other caller shares.
+    ///
+    /// Absent means "not a bridged call": an ordinary agent turn holds nothing
+    /// open, so nothing needs clamping.
+    static BRIDGED_CALL_BUDGET: Duration;
+}
+
+/// The wall clock the bridged tool call on this task must answer within, or
+/// `None` when this is not a bridged call.
+///
+/// A tool that waits should clamp to this and return a **partial result** at the
+/// deadline. Running past it is not an option that trades latency for
+/// completeness: the child abandons the request and the model is told the
+/// operation timed out, which loses the partial answer as well as the wait.
+pub fn bridged_call_budget() -> Option<Duration> {
+    BRIDGED_CALL_BUDGET.try_with(|d| *d).ok()
+}
+
+/// Run `f` as though it were a bridged tool call with `budget` left.
+///
+/// For the tools that clamp to the budget: `workspace_watch`'s arithmetic is
+/// what #110 is about, and exercising it through a real child CLI would make a
+/// unit test depend on a subscription. The production scope is
+/// [`BridgeGrant::call`] and there is no other.
+pub async fn with_call_budget_for_test<F: std::future::Future>(budget: Duration, f: F) -> F::Output {
+    BRIDGED_CALL_BUDGET.scope(budget, f).await
 }
 
 impl BridgeGrant {
@@ -385,7 +436,15 @@ impl BridgeGrant {
     /// PreToolUse hooks and still staged whatever they returned.
     pub async fn call(&self, call: CallToolRequestParams) -> Result<CallToolResult, String> {
         let request_id = uuid::Uuid::new_v4().to_string();
-        let outcome = self.dispatch_one(request_id.clone(), call).await;
+        // #110: publish the transport's budget for the duration of the call, so
+        // a tool that waits can clamp to it instead of running past the child's
+        // deadline and losing its partial answer to an abandoned request.
+        let outcome = BRIDGED_CALL_BUDGET
+            .scope(
+                child_tool_call_budget(),
+                self.dispatch_one(request_id.clone(), call),
+            )
+            .await;
         self.discard_staged_hook_context(&request_id);
         outcome
     }

--- a/crates/biorouter/src/providers/coding_agent/bridge.rs
+++ b/crates/biorouter/src/providers/coding_agent/bridge.rs
@@ -280,7 +280,10 @@ pub fn bridged_call_budget() -> Option<Duration> {
 /// what #110 is about, and exercising it through a real child CLI would make a
 /// unit test depend on a subscription. The production scope is
 /// [`BridgeGrant::call`] and there is no other.
-pub async fn with_call_budget_for_test<F: std::future::Future>(budget: Duration, f: F) -> F::Output {
+pub async fn with_call_budget_for_test<F: std::future::Future>(
+    budget: Duration,
+    f: F,
+) -> F::Output {
     BRIDGED_CALL_BUDGET.scope(budget, f).await
 }
 

--- a/docs/agent-loop/workspace-control-tools.md
+++ b/docs/agent-loop/workspace-control-tools.md
@@ -363,6 +363,23 @@ work, and they lose nothing: every completion observed before the deadline is in
 the report, including under `mode: "all"`, so the follow-up watch only names what
 is still running. **A timeout is never an error**, on any transport.
 
+### Cancelling a watch
+
+`workspace_watch` is the only tool in this extension that *parks*, so it is the
+only one the turn's cancel token has anything to reach. It honours it: Stop,
+`AppState::cancel_turn`, a dropped websocket and a bridge lease dropping all end
+the park at the instant they land, and the reply says it was cancelled rather
+than letting "still running" read as the answer to a wait that never happened.
+The watched conversations are untouched — what was cancelled is the turn doing
+the watching.
+
+⚠ Ending the park also **reaps the watcher tasks**, and that is not tidiness. Each
+holds a `session_events::Subscription`, which only reclaims its session's
+1024-slot event ring when it drops; before this they looped for the life of the
+process after a watch ended, leaking a slot per watched session per watch. A wait
+that used to be killed by a child's 60-second deadline can now legitimately park
+for ten minutes, which makes those slots much easier to accumulate.
+
 ### How liveness is decided
 
 Subscription happens **before** the pre-check, so a completion landing in the gap is not lost. Liveness is then three-valued, and the order is a veto rather than a fallback chain:

--- a/docs/agent-loop/workspace-control-tools.md
+++ b/docs/agent-loop/workspace-control-tools.md
@@ -328,8 +328,40 @@ Parks until named conversations finish. This is the tool that replaces polling; 
 |---|---|---|---|
 | `session_ids` | string[] | required | 1 to 32 ids. Empty is an error; more than 32 is an error naming the cap. |
 | `mode` | string | `"any"` | `any` returns as soon as one finishes; `all` waits for every one. |
-| `timeout_s` | u64 | `120` | `.clamp(1, 600)`. |
+| `timeout_s` | u64 | `120` | `.clamp(1, 600)`, then shortened to fit the transport — see below. |
 | `assume_running` | bool | `false` | Skip the liveness pre-check and park unconditionally. Use when a turn is known to be starting but may not have claimed its lock yet. |
+
+### The effective wait depends on the transport (#110)
+
+`timeout_s` is what the schema accepts; it is not always what the wait can be.
+On a **bridged coding-agent turn** (`claude_code`, `codex`) the call is held open
+inside the child's own MCP client, which applies a hard per-call wall clock and
+abandons the request when it elapses. Issue #110 measured that at ~60 seconds
+while this schema advertised 600, so every long watch failed with *"The operation
+timed out"* — a transport failure, not the non-error partial report this handler
+had ready.
+
+Two things changed, and both are load-bearing:
+
+- **Biorouter configures the child's deadline** (`bridge::CHILD_TOOL_CALL_TIMEOUT`,
+  written as `timeout` in Claude Code's MCP config and `tool_timeout_sec` in
+  Codex's), so a long watch fits.
+- **The handler clamps anyway**, to `bridge::bridged_call_budget()` minus the room
+  an answer needs. That is what keeps the guarantee when the configuration is not
+  honoured — an older CLI, a renamed field, a user's own `MCP_TOOL_TIMEOUT`.
+
+When the wait is shortened the reply says so, naming **both** numbers:
+
+```text
+(Waited 50s of the 600s requested: this turn's transport ends a single tool call
+at 50s, so the wait was shortened to return this status instead of failing.
+Watch again to keep waiting — the completions above are not repeated.)
+```
+
+Repeated bounded watches are therefore the intended pattern for multi-minute
+work, and they lose nothing: every completion observed before the deadline is in
+the report, including under `mode: "all"`, so the follow-up watch only names what
+is still running. **A timeout is never an error**, on any transport.
 
 ### How liveness is decided
 

--- a/docs/providers/coding-agents/README.md
+++ b/docs/providers/coding-agents/README.md
@@ -16,6 +16,15 @@ no Business Associate Agreement and no zero-data-retention agreement, so protect
 information must never reach these providers, and the page explains both the rule and the
 gate that enforces it.
 
+**They are not chat-only any more.** Until issue #109, only the main chat loop
+knew how to give these two providers tools, so a knowledge ingest / query / lint
+macro, a scheduled workflow or any other bounded sub-agent run against one
+narrated its tool calls as prose and wrote nothing — and the Knowledge view
+carried a provider denylist to keep users away from it. Every one of those paths
+now goes through the same bridge, so a subscription-billed model is a first-class
+choice for tool-heavy work rather than a downgrade. See
+[the tool bridge](tool-bridge.md#the-tools-do-not-have-to-be-an-extensions-109).
+
 ## Documents
 
 | Document | What it covers |

--- a/docs/providers/coding-agents/performance-and-limits.md
+++ b/docs/providers/coding-agents/performance-and-limits.md
@@ -153,6 +153,8 @@ aborts the reader task, which drops the child, which `kill_on_drop(true)` reaps.
 | The child has no tools at all | No bridge was established — typically a CLI process with no HTTP server. The turn still answers from the conversation; this is deliberate degradation, not an error. |
 | An empty response with nothing in the logs | For Codex, the app server exited before a terminal frame; the error carries a bounded tail of the child's stderr. For Claude Code, stderr is drained concurrently and included in the failure. |
 | A turn that stops at 30 minutes | The turn ceiling. The child is killed rather than left holding the session. |
+| "The operation timed out" on a slow Biorouter tool | The child's own per-call MCP deadline abandoned the request. Biorouter configures it (`timeout` for Claude Code, `tool_timeout_sec` for Codex) — see [the child's per-call deadline](tool-bridge.md#the-childs-per-call-deadline-is-configured-not-discovered-110) — so seeing this means the field was not honoured. A tool that waits should have clamped to `bridge::bridged_call_budget()` and returned a partial result instead. |
+| A watch that reports a shorter wait than you asked for | Working as intended (#110). The wait was clamped to fit the transport, and the reply names both numbers. Watch again; the completions already reported are not repeated. |
 
 ## Related documentation
 

--- a/docs/providers/coding-agents/tool-bridge.md
+++ b/docs/providers/coding-agents/tool-bridge.md
@@ -33,6 +33,51 @@ MCP tools/list  <-  the session's tool set, exactly as the model would see it
 MCP tools/call   ->  the inspector stack, then ExtensionManager::dispatch_tool_call
 ```
 
+## The tools do not have to be an extension's (#109)
+
+`tools/call` lands on a `BridgeToolDispatch`, not on a hardcoded
+`ExtensionManager`. A chat turn's dispatcher *is* the session's extension manager
+— that is what `providers::tool_turn::session_tools` says — but a bounded
+workflow has its own small surface with its own dispatcher, and those tools are in
+no extension at all. The knowledge ingest macro is the case that forced it: its
+`KbToolDispatch` carries the git transaction every write in the run must land on,
+so a call routed to the `knowledge` extension instead would commit somewhere else.
+
+What that unlocked is the whole of #109. Before it, the only caller that knew how
+to give a coding-agent provider tools was `Agent::reply`; every other agentic loop
+— the knowledge macros, scheduled workflows, bounded sub-agents — called
+`Provider::complete` directly with a `tools` argument `claude_code` and `codex`
+**discard**. The failure was silent and expensive: the model produced a complete,
+correct plan with every call written out as prose, invented its own
+`<tool_response>OK</tool_response>` replies to continue against, and wrote
+nothing, after a full run the user paid for. The Knowledge UI's answer was a
+hardcoded provider denylist, now deleted.
+
+[`ProviderToolTurnContext`](../../../crates/biorouter/src/providers/tool_turn.rs)
+is the primitive: issue a one-turn grant over the workflow's own tools, scope the
+URL around the call, drop the lease when it returns. It prefers `stream()` when
+the provider offers it — not for latency, but because the mirrored pairs
+recording what the child ran exist only on that path, so a workflow driven
+through `complete_with_model` would execute every tool correctly and be unable to
+say afterwards which ones. `ProviderTurn::pending_tool_calls()` excludes the
+mirrored requests, so a caller's loop cannot dispatch a call the child already
+ran.
+
+⚠ **An empty `ToolInspectionManager` is not "allow everything".** A grant refuses
+a call whose verdict is "no decision was reached", so a context built without
+inspectors refuses every bridged call. `for_workflow` therefore installs a real
+stack — managed policy, security, sensitive ops, permission. The security and
+sensitive-ops inspectors escalate regardless of mode, which is what keeps its
+`BioRouterMode::Auto` a statement about ordinary authorised steps rather than a
+blanket grant.
+
+⚠ **A workflow with no HTTP server refuses instead of degrading.** A *chat* turn
+with no bridge runs the child tool-less, and that is right: an answer from the
+conversation beats a failed turn. A workflow that *is* a sequence of tool calls
+has no such fallback — it would narrate and write nothing — so
+`ProviderToolTurnContext` fails before the model runs, naming the provider and
+the way out.
+
 ## It is generic, and that is the point
 
 Nothing in the bridge knows anything about any individual tool, and no tool needs per-tool work to
@@ -269,6 +314,46 @@ The approval card is raised *before* anything happens and is answerable. A call 
 by policy, by the user, or because the request expired — still shows as a red mirrored card naming
 the tool, so a turn that quietly did less than the user thought is still visible in the transcript.
 
+## The child's per-call deadline is configured, not discovered (#110)
+
+Both CLIs apply a **hard per-call wall clock** to an MCP `tools/call` and abandon
+the request when it elapses. Their defaults are far below what Biorouter's slower
+tools need: issue #110 measured Claude Code's at "almost exactly 60 seconds"
+against a `workspace_watch` whose schema advertises waits of up to 600. Every one
+of those died at 60 with **"The operation timed out"** — a transport failure the
+model may retry, rather than the non-error partial report the handler was about
+to return. The handler was correct the whole time; it simply never got to answer.
+
+So the deadline is set explicitly, per server, on both sides:
+
+| CLI | Field | Unit | Where |
+| --- | --- | --- | --- |
+| Claude Code | `timeout` | milliseconds | the `--mcp-config` server entry. Its own help calls it a "hard wall-clock limit per call; **progress notifications do not extend it**". |
+| Codex | `tool_timeout_sec` | seconds | the `thread/start` config override, beside the URL. `startup_timeout_sec` covers the initial connect. |
+
+`bridge::CHILD_TOOL_CALL_TIMEOUT` is what both are given, and
+`bridge::child_tool_call_budget()` is what a call may actually spend — the
+difference is the room the answer itself needs on the wire.
+
+**A tool that waits must clamp to the budget.** `BridgeGrant::call` publishes it
+in a task-local for the duration of the call, readable as
+`bridge::bridged_call_budget()`; absent means this is not a bridged call and
+nothing is holding a socket open. `workspace_watch` reads it, shortens its wait,
+and **says both numbers** — the effective wait and the one that was asked for —
+because a caller told only "still running" after 50 s will read that as the answer
+to its 600-second question, and either abandon a subagent that is working fine or
+fall back to polling transcripts, which is the behaviour the tool exists to
+replace.
+
+⚠ **Raising the deadline is not the whole fix, and neither half is optional.**
+The clamp is what keeps the guarantee when the configuration is not honoured — an
+older CLI, a future one that renames the field, a user's own `MCP_TOOL_TIMEOUT`.
+Without it, a regression in either vendor turns straight back into "The operation
+timed out". Without the raised deadline, every long tool is clamped to a minute.
+The E2E tests in `tool_bridge_routes.rs` drive a deliberately 90-second tool
+through both real CLIs, so a dropped field fails there rather than in a user's
+session.
+
 ## Transport: loopback HTTP, and the URL is the credential
 
 The bridge is an HTTP endpoint on the daemon — `POST /tool_bridge/{nonce}` — rather than a spawned
@@ -352,7 +437,8 @@ outlasts stream consumption.
 
 | Concern | File |
 | --- | --- |
-| Grants, leases, the nonce, the task-local | [`crates/biorouter/src/providers/coding_agent/bridge.rs`](../../../crates/biorouter/src/providers/coding_agent/bridge.rs) |
+| Grants, leases, the nonce, the task-locals, the transport budget | [`crates/biorouter/src/providers/coding_agent/bridge.rs`](../../../crates/biorouter/src/providers/coding_agent/bridge.rs) |
+| Running one provider turn with Biorouter tools, from anywhere | [`crates/biorouter/src/providers/tool_turn.rs`](../../../crates/biorouter/src/providers/tool_turn.rs) |
 | Parking a call on a person: approval, elicitation, secret-safe credentials | [`crates/biorouter/src/pending_user_action.rs`](../../../crates/biorouter/src/pending_user_action.rs) |
 | The queue the card is published on, and the loop's wake seam | [`crates/biorouter/src/action_required_manager.rs`](../../../crates/biorouter/src/action_required_manager.rs) |
 | The mirror marker, and the request/response pair builders | [`crates/biorouter/src/providers/coding_agent/mirror.rs`](../../../crates/biorouter/src/providers/coding_agent/mirror.rs) |

--- a/docs/providers/coding-agents/tool-bridge.md
+++ b/docs/providers/coding-agents/tool-bridge.md
@@ -345,6 +345,13 @@ to its 600-second question, and either abandon a subagent that is working fine o
 fall back to polling transcripts, which is the behaviour the tool exists to
 replace.
 
+**And a parked tool must be cancellable.** With the deadline raised, a
+`workspace_watch` can legitimately hold the child's request for ten minutes — so
+a Stop that did not reach it would keep a cancelled turn alive for the whole
+wait. It now honours the turn's token and reaps the watcher tasks holding its
+event-ring subscriptions; see
+[cancelling a watch](../../agent-loop/workspace-control-tools.md#cancelling-a-watch).
+
 ⚠ **Raising the deadline is not the whole fix, and neither half is optional.**
 The clamp is what keeps the guarantee when the configuration is not honoured — an
 older CLI, a future one that renames the field, a user's own `MCP_TOOL_TIMEOUT`.


### PR DESCRIPTION
Closes #110. Stacked on #122 (issue #109) and #121 (issue #107) — review those first.

## What was wrong

`workspace_watch` accepts `timeout_s` up to 600 and promises a timeout is not an error. Every bridged call died at almost exactly 60 seconds with **"The operation timed out"**.

The handler was correct the whole time — it always builds a non-error partial report. It simply never got to answer: the child's own MCP client applies a hard per-call wall clock and abandoned the request first.

## Three parts, none of them optional

**1. Configure the deadline.** Per server, on both sides, because the two CLIs disagree on everything about it:

| CLI | Field | Unit |
|---|---|---|
| Claude Code | `timeout` in the `--mcp-config` server entry | milliseconds |
| Codex | `mcp_servers.biorouter.tool_timeout_sec` in the `thread/start` override | seconds |

Claude Code's own help is explicit that progress notifications do not extend it, so raising it is the only lever.

**2. Clamp anyway.** `BridgeGrant::call` publishes the transport's budget in a task-local for the duration of the call (`bridge::bridged_call_budget()`; absent = not a bridged call, nothing is holding a socket open). `workspace_watch` shortens its wait to fit and reports **both** numbers:

```text
(Waited 50s of the 600s requested: this turn's transport ends a single tool call
at 50s, so the wait was shortened to return this status instead of failing.
Watch again to keep waiting — the completions above are not repeated.)
```

The clamp is what keeps the guarantee when the configuration is *not* honoured — an older CLI, a renamed field, a user's own `MCP_TOOL_TIMEOUT`. Without it, a vendor regression turns straight back into "The operation timed out". Without the raised deadline, every long tool is clamped to a minute. And a caller told only "still running" after 50s reads that as the answer to its 600-second question, then either abandons a subagent that is working fine or goes back to polling transcripts — the behaviour `workspace_watch` exists to replace.

Every completion observed before the deadline survives the shortening, including under `mode: "all"`.

**3. Make the park cancellable, and stop it leaking.** `workspace_watch` is the only tool in the extension that parks, and it **ignored the turn's cancel token** — so Stop kept a cancelled turn alive for the whole wait. Survivable while the child's 60-second deadline capped it; not now that a watch may legitimately park for ten minutes.

The park also leaked: its watcher tasks own the `session_events::Subscription` values, and a `Subscription` only reclaims its session's 1024-slot event ring when it drops. They looped on `recv()` for the life of the process after a watch ended — a slot per watched session per watch. A `DropGuard` now reaps them however the park returns.

## Verification

**End to end through the real bridges**, which is what the issue asks for and what no handler test can give — the handler always returned a partial report; it was the transport that killed it. A deliberately **90-second** tool (chosen against the measured ~60s failure: a 30-second tool would pass whether the fix worked or not):

| Test | Result |
|---|---|
| `a_slow_bridged_call_survives_claude_codes_per_call_deadline` | **passed, 97s wall clock** — marker reached the model, no "operation timed out" |
| `a_slow_bridged_call_survives_codexs_per_call_deadline` | **passed, 100s wall clock** — a different MCP client, its own default, its own knob |

Both assert elapsed ≥ 90s, so a pass cannot come from the tool having been fast.

Unit: `the_bridge_config_carries_the_per_call_deadline` and `a_bridge_url_becomes_an_mcp_server_override` pin the field **and its unit** — 660 written into the millisecond field would abandon every call in two-thirds of a second, which reads as a broken bridge rather than a wrong number. Eight tests cover the clamp arithmetic, the report, the cancel, and the reaping.

`cargo test -p biorouter --lib` — 2815 passed. `just check-everything` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)