### PR TITLE
feat(skills): one inventory for every skill surface, and a package as one row (#113)

### DIFF
--- a/crates/biorouter-server/src/routes/skills.rs
+++ b/crates/biorouter-server/src/routes/skills.rs
@@ -293,6 +293,30 @@ mod tests {
         assert!(write < read, "the write must precede the read");
     }
 
+    /// A delete handler must not take its directory from the caller. The root
+    /// comes from the daemon's own enumeration, and a path outside it is
+    /// refused rather than resolved.
+    #[test]
+    fn the_remove_handler_chooses_its_root_from_the_catalogs_own_list() {
+        let src = include_str!("skills.rs");
+        let body = crate::routes::body_of(
+            src,
+            "pub async fn remove_skill_package(\n    Json(request): Json<RemovePackageRequest>,",
+        );
+        assert!(
+            body.contains("skill_catalog::roots()"),
+            "the root set comes from the catalog"
+        );
+        assert!(
+            body.contains("is not one of this machine's skill directories"),
+            "an unknown root is refused, not resolved"
+        );
+        assert!(
+            !body.contains("PathBuf::from(requested)"),
+            "a caller-supplied path must never become the delete target"
+        );
+    }
+
     /// `refresh` rescans; `catalog` may reuse the cached snapshot. Swapping
     /// them would make the post-install refresh a no-op that looks like one.
     #[test]
@@ -370,8 +394,18 @@ pub enum ImportResult {
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RemovePackageRequest {
-    /// The install directory name — `CatalogBundle.name`.
+    /// The install directory name — a `CatalogBundle.name`, or the last
+    /// component of a `CatalogSkill.slug`.
     pub id: String,
+    /// Which skills root it lives under. Omit for the Biorouter one.
+    ///
+    /// ⚠ **Validated against [`skill_catalog::roots`], not merely resolved.**
+    /// This handler deletes a directory tree, so the root is chosen from the
+    /// set the daemon itself enumerated rather than taken from the caller. A
+    /// path the caller invents matches nothing and is refused — which is why
+    /// this can safely cover `~/.claude/skills` and a project directory, the
+    /// two the Skills pane has always offered a Delete for.
+    pub source_root: Option<String>,
 }
 
 fn bad_request(message: impl std::fmt::Display) -> (StatusCode, String) {
@@ -521,7 +555,19 @@ pub async fn install_skill_package(
 pub async fn remove_skill_package(
     Json(request): Json<RemovePackageRequest>,
 ) -> Result<Json<PackageSummary>, (StatusCode, String)> {
-    let root = skill_package::install::install_root();
+    let root = match request.source_root.as_deref() {
+        None => skill_package::install::install_root(),
+        Some(requested) => skill_catalog::roots()
+            .into_iter()
+            .map(|root| root.path)
+            .find(|path| path.as_os_str() == requested)
+            .ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("`{requested}` is not one of this machine's skill directories"),
+                )
+            })?,
+    };
     skill_package::remove(&request.id, &root)
         .map(Json)
         .map_err(|e| (StatusCode::NOT_FOUND, format!("{e:#}")))

--- a/docs/extensions/skill-catalog.md
+++ b/docs/extensions/skill-catalog.md
@@ -41,6 +41,14 @@ fetches.
 | HTTP surface | `crates/biorouter-server/src/routes/skills.rs` |
 | Interface | `ui/desktop/src/components/skills/useSkillCatalog.ts` |
 
+Every interface surface that lists skills reads that one hook: Settings
+(`SkillsView`), the composer picker (`BottomMenuSkillSelection`), the
+`@`-mention list (`MentionPopover`) and the workflow resource picker. The
+renderer's own scanner — `loadSkillsFromDirs`, `ALL_SKILL_DIRS`,
+`OTHER_SKILL_DIRS` — is **deleted**, along with `skillUtils`'
+`BUILTIN_SKILL_NAMES`: "did Biorouter put this here?" is answered by
+`CatalogSkill.builtin`, in the process that owns the seeder.
+
 `SkillsClient::get_default_skill_directories()` still exists, and the CLI still
 calls it, but it is now the paths-only view of `roots()`. **Adding a root means
 editing `roots()` and nothing else.**
@@ -158,6 +166,28 @@ write. The refusal message travels back in the mutation's *result* rather than
 in hook state, because a caller reading it from hook state reads its own stale
 render closure — which is how every failure once reported "The change was not
 saved." with the reason dropped.
+
+## What Settings shows, and what it will not delete
+
+Rows are grouped by where the skill came from: **Biorouter Skills**, one group
+per installed extension (**From BiorOffice**), **Skills From Other Agents**, and
+**From This Project**.
+
+A package is one expandable row carrying its display name, version and entry
+point, opening to its components with their groups — not N unrelated rows.
+
+⚠ **Two kinds of skill have no Delete control.** One Biorouter ships and
+re-seeds on every start, and one an installed extension supplies. In both cases
+the delete would succeed, toast, and be silently undone. That is the lesson
+`BUILTIN_SKILL_NAMES` was originally written for, applied to a second case the
+list never covered.
+
+Deleting goes through the importer's remover
+(`POST /skills/packages/remove`), which renames the directory aside before
+deleting it. The root it deletes under is chosen from
+`skill_catalog::roots()` — a path a caller invents matches nothing and is
+refused, which is what makes it safe for this handler to cover
+`~/.claude/skills` and a project directory as well as Biorouter's own.
 
 ## Debugging a skill that is installed but not usable
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10443,7 +10443,12 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The install directory name — `CatalogBundle.name`."
+            "description": "The install directory name — a `CatalogBundle.name`, or the last\ncomponent of a `CatalogSkill.slug`."
+          },
+          "sourceRoot": {
+            "type": "string",
+            "description": "Which skills root it lives under. Omit for the Biorouter one.\n\n⚠ **Validated against [`skill_catalog::roots`], not merely resolved.**\nThis handler deletes a directory tree, so the root is chosen from the\nset the daemon itself enumerated rather than taken from the caller. A\npath the caller invents matches nothing and is refused — which is why\nthis can safely cover `~/.claude/skills` and a project directory, the\ntwo the Skills pane has always offered a Delete for.",
+            "nullable": true
           }
         }
       },

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -2630,9 +2630,21 @@ export type RemoveExtensionRequest = {
 
 export type RemovePackageRequest = {
     /**
-     * The install directory name — `CatalogBundle.name`.
+     * The install directory name — a `CatalogBundle.name`, or the last
+     * component of a `CatalogSkill.slug`.
      */
     id: string;
+    /**
+     * Which skills root it lives under. Omit for the Biorouter one.
+     *
+     * ⚠ **Validated against [`skill_catalog::roots`], not merely resolved.**
+     * This handler deletes a directory tree, so the root is chosen from the
+     * set the daemon itself enumerated rather than taken from the caller. A
+     * path the caller invents matches nothing and is refused — which is why
+     * this can safely cover `~/.claude/skills` and a project directory, the
+     * two the Skills pane has always offered a Delete for.
+     */
+    sourceRoot?: string | null;
 };
 
 export type Rename = {

--- a/ui/desktop/src/components/MentionPopover.tsx
+++ b/ui/desktop/src/components/MentionPopover.tsx
@@ -11,10 +11,11 @@ import { createPortal } from 'react-dom';
 import { ItemIcon } from './ItemIcon';
 import BuiltInBadge from './ui/BuiltInBadge';
 import { CommandType, getActive, getSessionExtensions, getSlashCommands, listBases } from '../api';
+import type { CatalogView } from '../api';
 import { getInitialWorkingDir } from '../utils/workingDir';
 import { labelledRefTag, refTag, type RefKind } from '../utils/resourceRefs';
 import { useConfig } from './ConfigContext';
-import { ALL_SKILL_DIRS, loadSkillsFromDirs } from './skills/skillUtils';
+import { fetchSkillCatalog, standaloneSkills } from './skills/useSkillCatalog';
 import bundledExtensionsData from './settings/extensions/bundled-extensions.json';
 
 type DisplayItemType = CommandType | 'Directory' | 'File' | 'KnowledgeBase' | 'Skill' | 'Extension';
@@ -559,7 +560,12 @@ const MentionPopover = forwardRef<
               query: sessionId ? { session_id: sessionId } : undefined,
               throwOnError: false,
             }),
-            loadSkillsFromDirs(ALL_SKILL_DIRS).catch(() => ({ singles: [], bundles: [] })),
+            // The daemon's catalog, not a renderer scan: a skill bundled inside
+            // an installed extension was loadable by the model and absent from
+            // this list, so `@skill:word` completed to nothing (#113).
+            fetchSkillCatalog(sessionId).catch(
+              () => ({ generation: 0, roots: [], skills: [], bundles: [] }) as CatalogView
+            ),
             sessionId
               ? getSessionExtensions({ path: { session_id: sessionId } }).catch(() => null)
               : Promise.resolve(null),
@@ -603,13 +609,13 @@ const MentionPopover = forwardRef<
         }
         for (const bundle of skillsResult.bundles) {
           commandItems.push({
-            name: `skill:${bundle.bundleName}`,
+            name: `skill:${bundle.name}`,
             extra: `${bundle.skills.length} skill${bundle.skills.length === 1 ? '' : 's'} in bundle`,
             itemType: 'Skill',
-            relativePath: bundle.bundleName,
+            relativePath: bundle.name,
           });
         }
-        for (const skill of skillsResult.singles) {
+        for (const skill of standaloneSkills(skillsResult)) {
           commandItems.push({
             name: `skill:${skill.name}`,
             extra: skill.description,

--- a/ui/desktop/src/components/bottom_menu/BottomMenuSkillSelection.test.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuSkillSelection.test.tsx
@@ -157,6 +157,57 @@ describe('BottomMenuSkillSelection', () => {
     await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
   });
 
+  /**
+   * Two fast clicks must land in the order they were made. Without the queue
+   * in `useSkillCatalog`, the second request can resolve first and the switch
+   * settles on the OLDER of the two answers — a toggle that looks like it
+   * ignored the last click.
+   */
+  it('serialises concurrent toggles so the last click wins', async () => {
+    const order: string[] = [];
+    let releaseFirst: (() => void) | null = null;
+    mocks.setSessionSkills.mockImplementation(async (options: { body: { remove: string[] } }) => {
+      const disabling = options.body.remove.length > 0;
+      order.push(disabling ? 'disable' : 'enable');
+      if (disabling) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return {
+        data: {
+          catalog: view({
+            skills: [
+              skill('example-skill', {
+                state: {
+                  machineEnabled: true,
+                  session: disabling ? 'removed' : 'added',
+                  sessionViaBundle: false,
+                  hiddenContext: false,
+                  effective: !disabling,
+                },
+              }),
+            ],
+          }),
+          sessionAdd: disabling ? [] : ['example-skill'],
+          sessionRemove: disabling ? ['example-skill'] : [],
+        },
+      };
+    });
+
+    render(<BottomMenuSkillSelection sessionId="20260824_1" />);
+    const [toggle] = await openMenu();
+
+    fireEvent.click(toggle); // disable — parked
+    await waitFor(() => expect(order).toEqual(['disable']));
+    fireEvent.click(toggle); // enable — must wait its turn
+    expect(order).toEqual(['disable']);
+
+    releaseFirst!();
+    await waitFor(() => expect(order).toEqual(['disable', 'enable']));
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
+  });
+
   it('says "for this chat" only when there is a chat', async () => {
     mocks.setSessionSkills.mockResolvedValue({
       data: { catalog: view(), sessionAdd: [], sessionRemove: ['example-skill'] },

--- a/ui/desktop/src/components/settings/contexts/contexts.test.ts
+++ b/ui/desktop/src/components/settings/contexts/contexts.test.ts
@@ -100,6 +100,12 @@ describe('Settings -> Chat section order', () => {
  * user's skill list and counted; a name missing from Rust means the seeder
  * stops writing a file the UI still advertises.
  *
+ * ⚠ **There are TWO copies now, not three.** `skillUtils.BUILTIN_SKILL_NAMES`
+ * is gone: it answered "did Biorouter put this here?", which the daemon answers
+ * directly as `CatalogSkill.builtin`. A pinning test over a list nothing reads
+ * guards nothing, so what is asserted below is that the copy has not come
+ * back.
+ *
  * Reading the Rust source is the only way to check this from here, and it is
  * the same approach `measures.test.ts` takes for a value only the source can
  * settle.
@@ -160,8 +166,20 @@ describe('the built-in skill list, across all three copies', () => {
     expect([...CONTEXT_IDS].sort()).toEqual(rustNames());
   });
 
-  it('skillUtils names every skill Rust SEEDS, not only the Contexts', async () => {
-    const { BUILTIN_SKILL_NAMES } = await import('../../skills/skillUtils');
-    expect([...BUILTIN_SKILL_NAMES].sort()).toEqual(shippedNames());
+  it('the renderer keeps no second list of the skills Rust seeds', () => {
+    const source = readFileSync(
+      join(__dirname, '..', '..', 'skills', 'skillUtils.ts'),
+      'utf8'
+    );
+    // `shippedNames()` is still called, so the extractor it exercises stays
+    // honest: a name Rust seeds must be findable from here even though nothing
+    // in the renderer mirrors the list any more.
+    expect(shippedNames().length).toBeGreaterThan(CONTEXT_IDS.size);
+    for (const name of shippedNames()) {
+      expect(
+        source.includes(`'${name}'`),
+        `skillUtils.ts names '${name}' again — read CatalogSkill.builtin instead`
+      ).toBe(false);
+    }
   });
 });

--- a/ui/desktop/src/components/skills/SkillItem.tsx
+++ b/ui/desktop/src/components/skills/SkillItem.tsx
@@ -1,14 +1,20 @@
-import { Skill, BIOROUTER_SKILLS_DIR, isBuiltinSkill } from './skillUtils';
 import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
 import BuiltInBadge from '../ui/BuiltInBadge';
 import { Copy, Trash2, FolderDot } from '../icons/app-icons';
+import type { CatalogSkill } from '../../api';
 
 interface SkillItemProps {
-  skill: Skill;
+  skill: CatalogSkill;
   enabled: boolean;
   onClick: () => void;
-  onDelete: () => void;
+  /**
+   * Omitted where the skill is not the user's to delete: one Biorouter ships
+   * and re-seeds on every start, or one an installed extension supplies. A
+   * delete that succeeds and silently reverts is worse than no button — the
+   * lesson `BUILTIN_SKILL_NAMES` was written for, applied to a second case.
+   */
+  onDelete?: () => void;
   onShare: () => void;
   onToggle: (enabled: boolean) => void;
 }
@@ -21,7 +27,9 @@ export default function SkillItem({
   onShare,
   onToggle,
 }: SkillItemProps) {
-  const builtin = isBuiltinSkill(skill.name);
+  // ⚠ From the daemon, not from the hand-synced `BUILTIN_SKILL_NAMES` copy.
+  // Rust owns the seeder, so Rust owns the answer.
+  const builtin = skill.builtin;
   return (
     <div className="biorouter-list-row flex items-start gap-3 px-3 py-3 group">
       <button
@@ -30,13 +38,15 @@ export default function SkillItem({
         onClick={onClick}
         aria-label={`Open skill ${skill.name}`}
       >
-        <div className="flex items-center gap-1.5">
-          <p className="text-label text-text-default">{skill.name}</p>
+        <div className="flex items-center gap-1.5 min-w-0">
+          <p className="text-label text-text-default truncate">{skill.name}</p>
           {builtin && <BuiltInBadge />}
         </div>
         <p className="text-supporting text-text-muted mt-0.5 line-clamp-1">{skill.description}</p>
-        {skill.sourceDir !== BIOROUTER_SKILLS_DIR && (
-          <p className="text-supporting text-text-subtle mt-0.5 font-mono">{skill.sourceDir}</p>
+        {skill.source.kind !== 'biorouter' && (
+          <p className="text-supporting text-text-subtle mt-0.5 font-mono truncate">
+            {skill.sourceRoot}
+          </p>
         )}
       </button>
       <div className="flex items-center gap-2 flex-shrink-0 mt-0.5">
@@ -62,7 +72,7 @@ export default function SkillItem({
           >
             <Copy className="h-4 w-4" />
           </Button>
-          {!builtin && (
+          {onDelete && !builtin && (
             <Button
               variant="ghost"
               size="sm"

--- a/ui/desktop/src/components/skills/SkillsView.test.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SkillsView from './SkillsView';
+import type { CatalogBundle, CatalogSkill, CatalogView } from '../../api';
+
+const mocks = vi.hoisted(() => ({
+  skillCatalogHandler: vi.fn(),
+  refreshSkillCatalog: vi.fn(),
+  setSessionSkills: vi.fn(),
+  removeSkillPackage: vi.fn(),
+  saveSkillOverrides: vi.fn(async () => undefined),
+  loadSkillOverrides: vi.fn(async () => true),
+  overrides: new Map<string, boolean>(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('../../api', () => ({
+  skillCatalogHandler: (...a: unknown[]) => mocks.skillCatalogHandler(...a),
+  refreshSkillCatalog: (...a: unknown[]) => mocks.refreshSkillCatalog(...a),
+  setSessionSkills: (...a: unknown[]) => mocks.setSessionSkills(...a),
+  removeSkillPackage: (...a: unknown[]) => mocks.removeSkillPackage(...a),
+}));
+
+vi.mock('../../store/skillOverrides', () => ({
+  loadSkillOverrides: mocks.loadSkillOverrides,
+  saveSkillOverrides: mocks.saveSkillOverrides,
+  setSkillOverride: (name: string, enabled: boolean) => mocks.overrides.set(name, enabled),
+  isSkillEnabled: (name: string) => mocks.overrides.get(name) ?? true,
+  getSkillOverrides: () => mocks.overrides,
+}));
+
+vi.mock('../../toasts', () => ({
+  toastSuccess: mocks.toastSuccess,
+  toastError: mocks.toastError,
+}));
+
+vi.mock('../Layout/MainPanelLayout', () => ({
+  MainPanelLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../Layout/ReadableContent', () => ({
+  ReadableContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../conversation/SearchView', () => ({
+  SearchView: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../baam/BrowseSkillsModal', () => ({ default: () => null }));
+vi.mock('./AddSkillModal', () => ({ default: () => null }));
+vi.mock('./CustomSkillModal', () => ({ default: () => null }));
+
+const state = {
+  machineEnabled: true,
+  session: 'default' as const,
+  sessionViaBundle: false,
+  hiddenContext: false,
+  effective: true,
+};
+
+function skill(name: string, overrides: Partial<CatalogSkill> = {}): CatalogSkill {
+  return {
+    name,
+    description: `${name} does things`,
+    slug: name,
+    directory: `/skills/${name}`,
+    sourceRoot: '/skills',
+    source: { kind: 'biorouter', extension: null, label: 'Biorouter' },
+    bundle: null,
+    builtin: false,
+    state,
+    ...overrides,
+  };
+}
+
+function bundle(name: string, members: string[], overrides: Partial<CatalogBundle> = {}): CatalogBundle {
+  return {
+    name,
+    displayName: name,
+    directory: `/skills/${name}`,
+    sourceRoot: '/skills',
+    source: { kind: 'biorouter', extension: null, label: 'Biorouter' },
+    skills: members,
+    package: null,
+    state,
+    ...overrides,
+  };
+}
+
+function serve(view: Partial<CatalogView>) {
+  const full: CatalogView = { generation: 1, roots: [], skills: [], bundles: [], ...view };
+  mocks.skillCatalogHandler.mockResolvedValue({ data: full });
+  mocks.refreshSkillCatalog.mockResolvedValue({ data: full });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.overrides.clear();
+  // @ts-expect-error test shim
+  window.electron = { openDirectoryInExplorer: vi.fn(), readFile: vi.fn() };
+  serve({ skills: [skill('my-skill')] });
+});
+
+describe('SkillsView', () => {
+  /**
+   * The visible half of #113 root cause 2: BiorOffice's bundled skills were
+   * loaded by the model and had no row here, because this view scanned three
+   * roots against the backend's seven.
+   */
+  it('lists extension-bundled skills in their own group', async () => {
+    serve({
+      skills: [
+        skill('my-skill'),
+        skill('word', {
+          sourceRoot: '/extensions/BiorOffice/skills',
+          source: { kind: 'extension', extension: 'BiorOffice', label: 'BiorOffice' },
+        }),
+      ],
+    });
+    render(<SkillsView />);
+    expect(await screen.findByText('From BiorOffice (1)')).toBeInTheDocument();
+    expect(screen.getByText('Biorouter Skills (1)')).toBeInTheDocument();
+  });
+
+  /**
+   * A skill an extension supplies is not the user's to delete — the extension
+   * would put it back. Same lesson as the built-in badge, second case.
+   */
+  it('offers no Delete for a skill an installed extension supplies', async () => {
+    serve({
+      skills: [
+        skill('word', {
+          sourceRoot: '/extensions/BiorOffice/skills',
+          source: { kind: 'extension', extension: 'BiorOffice', label: 'BiorOffice' },
+        }),
+      ],
+    });
+    render(<SkillsView />);
+    await screen.findByText('word');
+    expect(screen.queryByLabelText('Delete word')).not.toBeInTheDocument();
+  });
+
+  it('shows a package as one expandable row, and opens to its components', async () => {
+    serve({
+      skills: [
+        skill('hyperframes', { bundle: 'hyperframes', slug: 'hyperframes/hyperframes' }),
+        skill('media-use', { bundle: 'hyperframes', slug: 'hyperframes/media-use' }),
+      ],
+      bundles: [
+        bundle('hyperframes', ['hyperframes', 'media-use'], {
+          displayName: 'HyperFrames',
+          package: {
+            id: 'hyperframes',
+            displayName: 'HyperFrames',
+            version: '0.8.12',
+            entryPoint: 'hyperframes',
+            sourceUrl: null,
+            sourceRef: null,
+            resolvedCommit: null,
+            installer: null,
+            installedAt: null,
+            groups: { core: ['hyperframes'], 'on-demand': ['media-use'] },
+          },
+        }),
+      ],
+    });
+    render(<SkillsView />);
+
+    expect(await screen.findByText('HyperFrames')).toBeInTheDocument();
+    expect(screen.getByText('Biorouter Skills (1)')).toBeInTheDocument();
+    expect(screen.getByText('entry point: hyperframes')).toBeInTheDocument();
+
+    // Collapsed, the row summarises; expanded, it details.
+    fireEvent.click(screen.getByLabelText('Expand HyperFrames'));
+    const list = await screen.findByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[1]).toHaveTextContent('media-use');
+    expect(items[1]).toHaveTextContent('[on-demand]');
+    expect(items[0]).toHaveTextContent('→');
+  });
+
+  it('removes a package through the importer rather than deleting a directory', async () => {
+    serve({
+      skills: [skill('alpha', { bundle: 'pack', slug: 'pack/alpha' })],
+      bundles: [bundle('pack', ['alpha'])],
+    });
+    mocks.removeSkillPackage.mockResolvedValue({ data: { id: 'pack' } });
+    render(<SkillsView />);
+
+    fireEvent.click(await screen.findByLabelText('Delete skill package pack'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete Package' }));
+
+    await waitFor(() => expect(mocks.removeSkillPackage).toHaveBeenCalledTimes(1));
+    expect(mocks.removeSkillPackage.mock.calls[0][0].body).toEqual({
+      id: 'pack',
+      sourceRoot: '/skills',
+    });
+  });
+
+  /**
+   * A skill's directory name and its declared name are allowed to differ, and
+   * the frontmatter is what wins for identity — so removal must use the
+   * INSTALLED directory or it would miss the folder entirely.
+   */
+  it('removes a single skill by its installed directory, not its declared name', async () => {
+    serve({ skills: [skill('gwas-pipeline', { slug: 'run-gwas', directory: '/skills/run-gwas' })] });
+    mocks.removeSkillPackage.mockResolvedValue({ data: { id: 'run-gwas' } });
+    render(<SkillsView />);
+
+    fireEvent.click(await screen.findByLabelText('Delete gwas-pipeline'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mocks.removeSkillPackage).toHaveBeenCalledTimes(1));
+    expect(mocks.removeSkillPackage.mock.calls[0][0].body.id).toBe('run-gwas');
+  });
+
+  it('reports a catalog it could not read instead of claiming there are no skills', async () => {
+    mocks.skillCatalogHandler.mockRejectedValue(new Error('daemon is down'));
+    mocks.refreshSkillCatalog.mockRejectedValue(new Error('daemon is down'));
+    render(<SkillsView />);
+    expect(await screen.findByText(/Could not read the skill catalog/)).toBeInTheDocument();
+  });
+});

--- a/ui/desktop/src/components/skills/SkillsView.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.tsx
@@ -1,18 +1,9 @@
-import { isContextSkill } from '../settings/contexts/contexts';
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { MainPanelLayout } from '../Layout/MainPanelLayout';
 import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
 import { ConfirmationModal } from '../ui/ConfirmationModal';
-import { Plus, Upload, Globe, Trash2 } from '../icons/app-icons';
-import {
-  Skill,
-  SkillBundle,
-  BIOROUTER_SKILLS_DIR,
-  OTHER_SKILL_DIRS,
-  loadSkillsFromDirs,
-  isBuiltinSkill,
-} from './skillUtils';
+import { Plus, Upload, Globe, Trash2, ChevronRight } from '../icons/app-icons';
 import SkillItem from './SkillItem';
 import AddSkillModal from './AddSkillModal';
 import CustomSkillModal from './CustomSkillModal';
@@ -21,166 +12,153 @@ import { toastSuccess, toastError } from '../../toasts';
 import { SearchView } from '../conversation/SearchView';
 import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
 import { ReadableContent } from '../Layout/ReadableContent';
-import {
-  loadSkillOverrides,
-  saveSkillOverrides,
-  setSkillOverride,
-  isSkillEnabled,
-} from '../../store/skillOverrides';
+import { removeSkillPackage } from '../../api';
+import type { CatalogBundle, CatalogSkill } from '../../api';
+import { useSkillCatalog, type SkillCatalogEntry } from './useSkillCatalog';
+
+/**
+ * Settings → Skills.
+ *
+ * ⚠ **The inventory is the daemon's** (#113). This view used to scan
+ * `BIOROUTER_SKILLS_DIR` and `OTHER_SKILL_DIRS` itself — three roots against the
+ * backend's seven — so BiorOffice's Word/Excel/PowerPoint skills and
+ * MarkItDown's converter were loaded by the model and had no row here at all.
+ * There is no scanner left; `useSkillCatalog` fetches, and everything below
+ * groups what it returns.
+ *
+ * Deletion goes to the importer's remover, which renames the directory aside
+ * before deleting it — so a package leaves in one step rather than emptying out
+ * under a catalog scan in flight.
+ */
+type Group = {
+  key: string;
+  title: string;
+  entries: SkillCatalogEntry[];
+  /** Skills an installed extension supplies. Not the user's to delete. */
+  fromExtension: boolean;
+};
 
 export default function SkillsView() {
-  const [bioRouterSkills, setBioRouterSkills] = useState<Skill[]>([]);
-  const [otherSkills, setOtherSkills] = useState<Skill[]>([]);
-  const [bioBundles, setBioBundles] = useState<SkillBundle[]>([]);
-  const [otherBundles, setOtherBundles] = useState<SkillBundle[]>([]);
+  const catalog = useSkillCatalog(null);
+  const { entries, reload, setEnabled } = catalog;
+
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isCustomModalOpen, setIsCustomModalOpen] = useState(false);
   const [isBrowseModalOpen, setIsBrowseModalOpen] = useState(false);
-  const [skillToDelete, setSkillToDelete] = useState<Skill | null>(null);
-  const [bundleToDelete, setBundleToDelete] = useState<SkillBundle | null>(null);
-  const [isDeletingSkill, setIsDeletingSkill] = useState(false);
-  const [isDeletingBundle, setIsDeletingBundle] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<SkillCatalogEntry | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
-  const [overrideTrigger, setOverrideTrigger] = useState(0);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  const loadSkills = useCallback(async () => {
-    try {
-      const [brResult, otherResult] = await Promise.all([
-        loadSkillsFromDirs([BIOROUTER_SKILLS_DIR]),
-        loadSkillsFromDirs(OTHER_SKILL_DIRS),
-      ]);
-      // ⚠ Filtered HERE, not inside `loadSkillsFromDirs`. That helper is shared
-      // with the composer popup and the workflow pickers, so a filter inside it
-      // would need a per-caller opt-out and would quietly change three surfaces
-      // at once. Contexts are shipped, not installed: they belong in
-      // Settings -> Chat -> Contexts, not in a list of the user's own skills.
-      setBioRouterSkills(brResult.singles.filter((s) => !isContextSkill(s.name)));
-      setBioBundles(brResult.bundles);
-      setOtherSkills(otherResult.singles.filter((s) => !isContextSkill(s.name)));
-      setOtherBundles(otherResult.bundles);
-    } catch {
-      setBioRouterSkills([]);
-      setBioBundles([]);
-      setOtherSkills([]);
-      setOtherBundles([]);
-    }
-  }, []);
+  const toggle = useCallback(
+    async (entry: SkillCatalogEntry, enabled: boolean) => {
+      const result = await setEnabled([entry.key], enabled);
+      if (!result.ok) {
+        toastError({
+          title: displayNameOf(entry),
+          msg: `The change was not saved: ${result.error}`,
+        });
+      }
+    },
+    [setEnabled]
+  );
 
-  useEffect(() => {
-    loadSkills();
-    loadSkillOverrides();
-  }, [loadSkills]);
+  const groups = useMemo((): Group[] => {
+    const match = (entry: SkillCatalogEntry) => {
+      if (!searchTerm) return true;
+      const q = searchTerm.toLowerCase();
+      if (entry.kind === 'single') {
+        return (
+          entry.skill.name.toLowerCase().includes(q) ||
+          entry.skill.description.toLowerCase().includes(q)
+        );
+      }
+      return (
+        entry.bundle.displayName.toLowerCase().includes(q) ||
+        entry.bundle.name.toLowerCase().includes(q) ||
+        entry.bundle.skills.some((name) => name.toLowerCase().includes(q))
+      );
+    };
 
-  const handleToggle = async (skill: Skill, enabled: boolean) => {
-    const previous = isSkillEnabled(skill.name);
-    setSkillOverride(skill.name, enabled);
-    setOverrideTrigger((prev) => prev + 1);
-    try {
-      await saveSkillOverrides();
-    } catch (error) {
-      setSkillOverride(skill.name, previous);
-      setOverrideTrigger((prev) => prev + 1);
-      toastError({
-        title: skill.name,
-        msg: error instanceof Error ? error.message : 'Could not save the skill preference',
-      });
-    }
-  };
-
-  const handleBundleToggle = async (bundle: SkillBundle, enabled: boolean) => {
-    const previous = isSkillEnabled(bundle.bundleName);
-    setSkillOverride(bundle.bundleName, enabled);
-    setOverrideTrigger((prev) => prev + 1);
-    try {
-      await saveSkillOverrides();
-    } catch (error) {
-      setSkillOverride(bundle.bundleName, previous);
-      setOverrideTrigger((prev) => prev + 1);
-      toastError({
-        title: bundle.bundleName,
-        msg: error instanceof Error ? error.message : 'Could not save the bundle preference',
-      });
-    }
-  };
-
-  const filterSkill = (skill: Skill) => {
-    if (!searchTerm) return true;
-    const q = searchTerm.toLowerCase();
-    return skill.name.toLowerCase().includes(q) || skill.description.toLowerCase().includes(q);
-  };
-
-  const filterBundle = (bundle: SkillBundle) => {
-    if (!searchTerm) return true;
-    const q = searchTerm.toLowerCase();
-    return (
-      bundle.bundleName.toLowerCase().includes(q) ||
-      bundle.skills.some(
-        (s) => s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
-      )
+    const visible = entries.filter(match);
+    const biorouter = visible.filter((e) => sourceOf(e).kind === 'biorouter');
+    const project = visible.filter((e) => sourceOf(e).kind === 'project');
+    const other = visible.filter((e) =>
+      ['claudeHome', 'agentsHome'].includes(sourceOf(e).kind)
     );
-  };
 
-  const handleOpen = async (skill: Skill) => {
-    await window.electron.openDirectoryInExplorer(skill.folderPath);
-  };
-
-  const handleOpenBundle = async (bundle: SkillBundle) => {
-    await window.electron.openDirectoryInExplorer(bundle.folderPath);
-  };
-
-  const confirmDeleteSkill = async () => {
-    if (!skillToDelete) return;
-    if (isBuiltinSkill(skillToDelete.name)) {
-      toastError({ title: skillToDelete.name, msg: 'Built-in skills cannot be deleted' });
-      setSkillToDelete(null);
-      return;
+    // One group per extension, so a bundled skill says which extension it came
+    // from rather than appearing among the user's own installs.
+    const byExtension = new Map<string, SkillCatalogEntry[]>();
+    for (const entry of visible) {
+      const source = sourceOf(entry);
+      if (source.kind !== 'extension') continue;
+      const label = source.extension ?? source.label;
+      byExtension.set(label, [...(byExtension.get(label) ?? []), entry]);
     }
-    setIsDeletingSkill(true);
-    const skill = skillToDelete;
-    const ok = await window.electron.deleteDirectory(skill.folderPath);
-    setIsDeletingSkill(false);
-    setSkillToDelete(null);
-    if (ok) {
-      setBioRouterSkills((prev) => prev.filter((s) => s.folderPath !== skill.folderPath));
-      setOtherSkills((prev) => prev.filter((s) => s.folderPath !== skill.folderPath));
-      toastSuccess({ title: skill.name, msg: 'Skill deleted' });
-    } else {
-      toastError({ title: 'Delete failed', msg: `Could not delete ${skill.folderPath}` });
-    }
-  };
 
-  const confirmDeleteBundle = async () => {
-    if (!bundleToDelete) return;
-    setIsDeletingBundle(true);
-    const bundle = bundleToDelete;
-    const ok = await window.electron.deleteDirectory(bundle.folderPath);
-    setIsDeletingBundle(false);
-    setBundleToDelete(null);
-    if (ok) {
-      setBioBundles((prev) => prev.filter((b) => b.folderPath !== bundle.folderPath));
-      setOtherBundles((prev) => prev.filter((b) => b.folderPath !== bundle.folderPath));
-      toastSuccess({ title: bundle.bundleName, msg: 'Bundle deleted' });
-    } else {
-      toastError({ title: 'Delete failed', msg: `Could not delete ${bundle.folderPath}` });
+    const out: Group[] = [];
+    if (biorouter.length)
+      out.push({ key: 'biorouter', title: 'Biorouter Skills', entries: biorouter, fromExtension: false });
+    for (const [extension, extensionEntries] of [...byExtension].sort()) {
+      out.push({
+        key: `extension:${extension}`,
+        title: `From ${extension}`,
+        entries: extensionEntries,
+        fromExtension: true,
+      });
     }
-  };
+    if (other.length)
+      out.push({ key: 'other', title: 'Skills From Other Agents', entries: other, fromExtension: false });
+    if (project.length)
+      out.push({ key: 'project', title: 'From This Project', entries: project, fromExtension: false });
+    return out;
+  }, [entries, searchTerm]);
 
-  const handleShare = async (skill: Skill) => {
+  const total = groups.reduce((sum, group) => sum + group.entries.length, 0);
+
+  const confirmDelete = async () => {
+    if (!pendingDelete) return;
+    setIsDeleting(true);
+    const entry = pendingDelete;
     try {
-      await navigator.clipboard.writeText(skill.content);
-      toastSuccess({ title: skill.name, msg: 'SKILL.md copied to clipboard' });
-    } catch {
-      toastError({ title: 'Copy failed', msg: 'Could not copy to clipboard' });
+      await removeSkillPackage<true>({
+        body: {
+          id: installedIdOf(entry),
+          sourceRoot: sourceRootOf(entry),
+        },
+        throwOnError: true,
+      });
+      toastSuccess({
+        title: displayNameOf(entry),
+        msg: entry.kind === 'bundle' ? 'Package removed' : 'Skill deleted',
+      });
+      await reload(true);
+    } catch (err) {
+      toastError({
+        title: 'Delete failed',
+        msg: err instanceof Error ? err.message : 'Could not remove it',
+      });
+    } finally {
+      setIsDeleting(false);
+      setPendingDelete(null);
     }
   };
 
-  const filteredBR = bioRouterSkills.filter(filterSkill);
-  const filteredOther = otherSkills.filter(filterSkill);
-  const filteredBRBundles = bioBundles.filter(filterBundle);
-  const filteredOtherBundles = otherBundles.filter(filterBundle);
-
-  const totalBR = filteredBR.length + filteredBRBundles.length;
-  const totalOther = filteredOther.length + filteredOtherBundles.length;
+  const installedIds = useMemo(
+    () =>
+      new Set(
+        entries
+          .flatMap((entry) =>
+            entry.kind === 'single'
+              ? [entry.skill.name, lastPathComponent(entry.skill.slug)]
+              : [entry.bundle.name, entry.bundle.displayName]
+          )
+          .map((value) => value.toLowerCase())
+          .filter(Boolean)
+      ),
+    [entries]
+  );
 
   return (
     <MainPanelLayout>
@@ -188,7 +166,6 @@ export default function SkillsView() {
         className="flex flex-col min-w-0 flex-1 overflow-y-auto relative"
         data-search-scroll-area
       >
-        {/* Header */}
         <ReadableContent className="px-8 pt-12 pb-6 border-b border-border-subtle flex-shrink-0">
           <div className="flex flex-col page-transition">
             <h1 className="text-title mb-1">Skills</h1>
@@ -225,89 +202,70 @@ export default function SkillsView() {
           </div>
         </ReadableContent>
 
-        {/* List */}
         <SearchView
           onSearch={(term, _caseSensitive) => setSearchTerm(term)}
           placeholder="Search skills..."
         >
-          <ReadableContent key={overrideTrigger} className="px-8 py-4">
-            {totalBR > 0 && (
-              <>
-                <h2 className="text-caps text-text-muted uppercase mb-3 flex items-center gap-2">
-                  {/* The same decorative marker as the sibling group below.
-                      This one was `bg-background-info` — rgb(30, 95, 191), the
-                      only saturated blue on the page — beside a neutral
-                      `bg-background-strong` dot in exactly the same role, so two
-                      group markers carried different semantics and wildly
-                      different weight for no reason a reader could recover. The
-                      heading text is what distinguishes the groups; the dot is
-                      punctuation, and punctuation does not need a hue. */}
+          <ReadableContent className="px-8 py-4">
+            {groups.map((group) => (
+              <div key={group.key}>
+                <h2 className="text-caps text-text-muted uppercase mt-6 mb-3 flex items-center gap-2 first:mt-0">
+                  {/* Punctuation, not semantics — see the note this replaced:
+                      two group markers once carried different hues in the same
+                      role, which a reader could not recover a meaning for. */}
                   <span className="inline-block w-1.5 h-1.5 rounded-full bg-background-strong flex-shrink-0" />
-                  Biorouter Skills ({totalBR})
+                  {group.title} ({group.entries.length})
                 </h2>
                 <div className="biorouter-list-shell">
-                  {filteredBRBundles.map((bundle) => (
-                    <BundleItem
-                      key={bundle.folderPath}
-                      bundle={bundle}
-                      enabled={isSkillEnabled(bundle.bundleName)}
-                      onClick={() => handleOpenBundle(bundle)}
-                      onDelete={() => setBundleToDelete(bundle)}
-                      onToggle={(e) => handleBundleToggle(bundle, e)}
-                    />
-                  ))}
-                  {filteredBR.map((skill) => (
-                    <SkillItem
-                      key={skill.folderPath}
-                      skill={skill}
-                      enabled={isSkillEnabled(skill.name)}
-                      onClick={() => handleOpen(skill)}
-                      onDelete={() => setSkillToDelete(skill)}
-                      onShare={() => handleShare(skill)}
-                      onToggle={(e) => handleToggle(skill, e)}
-                    />
-                  ))}
+                  {group.entries.map((entry) =>
+                    entry.kind === 'bundle' ? (
+                      <BundleRow
+                        key={entry.key}
+                        bundle={entry.bundle}
+                        skills={catalog.skills}
+                        enabled={entry.enabled}
+                        expanded={expanded.has(entry.key)}
+                        onExpandToggle={() =>
+                          setExpanded((current) => {
+                            const next = new Set(current);
+                            if (next.has(entry.key)) next.delete(entry.key);
+                            else next.add(entry.key);
+                            return next;
+                          })
+                        }
+                        onOpen={() =>
+                          void window.electron.openDirectoryInExplorer(entry.bundle.directory)
+                        }
+                        onDelete={group.fromExtension ? undefined : () => setPendingDelete(entry)}
+                        onToggle={(enabled) => void toggle(entry, enabled)}
+                      />
+                    ) : (
+                      <SkillItem
+                        key={entry.key}
+                        skill={entry.skill}
+                        enabled={entry.enabled}
+                        onClick={() =>
+                          void window.electron.openDirectoryInExplorer(entry.skill.directory)
+                        }
+                        onDelete={group.fromExtension ? undefined : () => setPendingDelete(entry)}
+                        onShare={() => void copySkill(entry.skill)}
+                        onToggle={(enabled) => void toggle(entry, enabled)}
+                      />
+                    )
+                  )}
                 </div>
-              </>
-            )}
+              </div>
+            ))}
 
-            {totalOther > 0 && (
-              <>
-                <h2 className="text-caps text-text-muted uppercase mt-6 mb-3 flex items-center gap-2">
-                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-background-strong flex-shrink-0" />
-                  Skills From Other Agents ({totalOther})
-                </h2>
-                <div className="biorouter-list-shell">
-                  {filteredOtherBundles.map((bundle) => (
-                    <BundleItem
-                      key={bundle.folderPath}
-                      bundle={bundle}
-                      enabled={isSkillEnabled(bundle.bundleName)}
-                      onClick={() => handleOpenBundle(bundle)}
-                      onDelete={() => setBundleToDelete(bundle)}
-                      onToggle={(e) => handleBundleToggle(bundle, e)}
-                    />
-                  ))}
-                  {filteredOther.map((skill) => (
-                    <SkillItem
-                      key={skill.folderPath}
-                      skill={skill}
-                      enabled={isSkillEnabled(skill.name)}
-                      onClick={() => handleOpen(skill)}
-                      onDelete={() => setSkillToDelete(skill)}
-                      onShare={() => handleShare(skill)}
-                      onToggle={(e) => handleToggle(skill, e)}
-                    />
-                  ))}
-                </div>
-              </>
-            )}
-
-            {totalBR === 0 && totalOther === 0 && (
+            {total === 0 && (
               <p className="text-body text-text-muted mt-10 text-center">
-                {searchTerm
-                  ? 'No skills match your search.'
-                  : 'No skills found. Add one to get started.'}
+                {catalog.error
+                  ? catalog.error
+                  : catalog.loading
+                    ? 'Loading skills…'
+                    : searchTerm
+                      ? 'No skills match your search.'
+                      : 'No skills found. Add one to get started.'}
               </p>
             )}
           </ReadableContent>
@@ -315,114 +273,211 @@ export default function SkillsView() {
       </div>
 
       {isAddModalOpen && (
-        <AddSkillModal onClose={() => setIsAddModalOpen(false)} onSaved={loadSkills} />
+        <AddSkillModal onClose={() => setIsAddModalOpen(false)} onSaved={() => void reload(true)} />
       )}
       {isCustomModalOpen && (
-        <CustomSkillModal onClose={() => setIsCustomModalOpen(false)} onSaved={loadSkills} />
+        <CustomSkillModal
+          onClose={() => setIsCustomModalOpen(false)}
+          onSaved={() => void reload(true)}
+        />
       )}
       {isBrowseModalOpen && (
         <BrowseSkillsModal
           onClose={() => setIsBrowseModalOpen(false)}
-          onInstalled={loadSkills}
-          installedIds={
-            new Set(
-              [...bioRouterSkills, ...otherSkills]
-                .flatMap((s) => [
-                  s.name.toLowerCase(),
-                  s.folderPath.split('/').pop()?.toLowerCase() ?? '',
-                ])
-                .concat(
-                  [...bioBundles, ...otherBundles].flatMap((b) => [
-                    b.bundleName.toLowerCase(),
-                    b.folderPath.split('/').pop()?.toLowerCase() ?? '',
-                  ])
-                )
-                .filter(Boolean)
-            )
-          }
+          onInstalled={() => void reload(true)}
+          installedIds={installedIds}
         />
       )}
 
       <ConfirmationModal
-        isOpen={skillToDelete !== null}
-        title={`Delete "${skillToDelete?.name}"?`}
-        message="This will permanently remove the skill folder from disk. This action cannot be undone."
-        confirmLabel="Delete"
+        isOpen={pendingDelete !== null}
+        title={
+          pendingDelete?.kind === 'bundle'
+            ? `Delete package "${pendingDelete.bundle.displayName}"?`
+            : `Delete "${pendingDelete ? displayNameOf(pendingDelete) : ''}"?`
+        }
+        message={
+          pendingDelete?.kind === 'bundle'
+            ? `This will permanently remove all ${pendingDelete.bundle.skills.length} skills in this package. This action cannot be undone.`
+            : 'This will permanently remove the skill folder from disk. This action cannot be undone.'
+        }
+        confirmLabel={pendingDelete?.kind === 'bundle' ? 'Delete Package' : 'Delete'}
         cancelLabel="Cancel"
         confirmVariant="destructive"
-        isSubmitting={isDeletingSkill}
-        onConfirm={confirmDeleteSkill}
-        onCancel={() => setSkillToDelete(null)}
-      />
-
-      <ConfirmationModal
-        isOpen={bundleToDelete !== null}
-        title={`Delete bundle "${bundleToDelete?.bundleName}"?`}
-        message={`This will permanently remove all ${bundleToDelete?.skills.length ?? 0} skills in this bundle. This action cannot be undone.`}
-        confirmLabel="Delete Bundle"
-        cancelLabel="Cancel"
-        confirmVariant="destructive"
-        isSubmitting={isDeletingBundle}
-        onConfirm={confirmDeleteBundle}
-        onCancel={() => setBundleToDelete(null)}
+        isSubmitting={isDeleting}
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
       />
     </MainPanelLayout>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Inline bundle row component
-// ---------------------------------------------------------------------------
-interface BundleItemProps {
-  bundle: SkillBundle;
+
+function sourceOf(entry: SkillCatalogEntry) {
+  return entry.kind === 'single' ? entry.skill.source : entry.bundle.source;
+}
+
+function sourceRootOf(entry: SkillCatalogEntry): string {
+  return entry.kind === 'single' ? entry.skill.sourceRoot : entry.bundle.sourceRoot;
+}
+
+function displayNameOf(entry: SkillCatalogEntry): string {
+  return entry.kind === 'single' ? entry.skill.name : entry.bundle.displayName;
+}
+
+/**
+ * The directory name to remove.
+ *
+ * ⚠ The **installed directory**, not the frontmatter name. A skill stored in
+ * `run-gwas/` may declare `name: gwas-pipeline`, and the two are allowed to
+ * differ — removing by the declared name would miss it.
+ */
+function installedIdOf(entry: SkillCatalogEntry): string {
+  return entry.kind === 'single' ? lastPathComponent(entry.skill.slug) : entry.bundle.name;
+}
+
+function lastPathComponent(slug: string): string {
+  return slug.split('/').pop() ?? slug;
+}
+
+async function copySkill(skill: CatalogSkill) {
+  try {
+    const result = await window.electron.readFile(`${skill.directory}/SKILL.md`);
+    if (!result.found || !result.file) throw new Error('SKILL.md could not be read');
+    await navigator.clipboard.writeText(result.file);
+    toastSuccess({ title: skill.name, msg: 'SKILL.md copied to clipboard' });
+  } catch {
+    toastError({ title: 'Copy failed', msg: 'Could not copy to clipboard' });
+  }
+}
+
+interface BundleRowProps {
+  bundle: CatalogBundle;
+  skills: CatalogSkill[];
   enabled: boolean;
-  onClick: () => void;
-  onDelete: () => void;
+  expanded: boolean;
+  onExpandToggle: () => void;
+  onOpen: () => void;
+  onDelete?: () => void;
   onToggle: (enabled: boolean) => void;
 }
 
-function BundleItem({ bundle, enabled, onClick, onDelete, onToggle }: BundleItemProps) {
+/**
+ * One package, expandable.
+ *
+ * #115 asks for "one expandable bundle in the UI with component details"
+ * rather than N unrelated rows — so the row carries the package's own name, its
+ * version and entry point when a manifest declared them, and opens to show each
+ * component with its group.
+ */
+function BundleRow({
+  bundle,
+  skills,
+  enabled,
+  expanded,
+  onExpandToggle,
+  onOpen,
+  onDelete,
+  onToggle,
+}: BundleRowProps) {
+  const members = skills.filter((skill) => skill.bundle === bundle.name);
+  const entryPoint = bundle.package?.entryPoint ?? null;
   return (
-    <div className="biorouter-list-row flex items-start gap-3 px-3 py-3 group">
-      <button
-        type="button"
-        className="flex-1 min-w-0 cursor-pointer rounded-inner text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
-        onClick={onClick}
-        aria-label={`Open skill bundle ${bundle.bundleName}`}
-      >
-        <div className="flex items-center gap-1.5">
-          <p className="text-label text-text-default">{bundle.bundleName}</p>
-          <span className="text-supporting text-text-subtle">· {bundle.skills.length} skills</span>
-        </div>
-        <p className="text-supporting text-text-subtle mt-1 font-mono">
-          {bundle.skills.map((s) => s.name).join(' · ')}
-        </p>
-      </button>
-      <div className="flex items-center gap-2 flex-shrink-0 mt-0.5">
-        <div
-          className="flex gap-1 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
-          onClick={(e) => e.stopPropagation()}
+    <div className="biorouter-list-row px-3 py-3 group">
+      <div className="flex items-start gap-2">
+        <button
+          type="button"
+          onClick={onExpandToggle}
+          className="mt-0.5 flex-shrink-0 cursor-pointer rounded-inner p-0.5 text-text-muted hover:text-text-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+          aria-expanded={expanded}
+          aria-label={`${expanded ? 'Collapse' : 'Expand'} ${bundle.displayName}`}
         >
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-text-danger"
-            onClick={onDelete}
-            title="Delete bundle"
-            aria-label={`Delete skill bundle ${bundle.bundleName}`}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
-        <div onClick={(e) => e.stopPropagation()}>
-          <Switch
-            checked={enabled}
-            onCheckedChange={onToggle}
-            variant="mono"
-            aria-label={`${enabled ? 'Disable' : 'Enable'} ${bundle.bundleName}`}
+          <ChevronRight
+            className={`h-4 w-4 transition-transform duration-[var(--motion-fast)] ${
+              expanded ? 'rotate-90' : ''
+            }`}
           />
+        </button>
+        <button
+          type="button"
+          className="flex-1 min-w-0 cursor-pointer rounded-inner text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+          onClick={onOpen}
+          aria-label={`Open skill package ${bundle.displayName}`}
+        >
+          <div className="flex items-center gap-1.5 min-w-0">
+            <p className="text-label text-text-default truncate">{bundle.displayName}</p>
+            {bundle.package?.version && (
+              <span className="text-supporting text-text-subtle">{bundle.package.version}</span>
+            )}
+            <span className="text-supporting text-text-subtle">
+              · {bundle.skills.length} skill{bundle.skills.length === 1 ? '' : 's'}
+            </span>
+          </div>
+          {entryPoint && (
+            <p className="text-supporting text-text-subtle mt-0.5">entry point: {entryPoint}</p>
+          )}
+          {!expanded && (
+            <p className="text-supporting text-text-subtle mt-1 font-mono truncate">
+              {bundle.skills.join(' · ')}
+            </p>
+          )}
+        </button>
+        <div className="flex items-center gap-2 flex-shrink-0 mt-0.5">
+          {onDelete && (
+            <div
+              className="flex gap-1 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-text-danger"
+                onClick={onDelete}
+                title="Delete package"
+                aria-label={`Delete skill package ${bundle.displayName}`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+          <div onClick={(e) => e.stopPropagation()}>
+            <Switch
+              checked={enabled}
+              onCheckedChange={onToggle}
+              variant="mono"
+              aria-label={`${enabled ? 'Disable' : 'Enable'} ${bundle.displayName}`}
+            />
+          </div>
         </div>
       </div>
+
+      {expanded && (
+        <ul className="mt-2 ml-7 flex flex-col gap-1">
+          {members.map((member) => (
+            <li key={member.name} className="min-w-0">
+              <p className="text-supporting text-text-default truncate">
+                {member.name === entryPoint && <span className="text-text-subtle">→ </span>}
+                {member.name}
+                {groupOf(bundle, member.name) && (
+                  <span className="text-text-subtle"> [{groupOf(bundle, member.name)}]</span>
+                )}
+              </p>
+              {member.description && (
+                <p className="text-supporting text-text-subtle truncate">{member.description}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
+}
+
+function groupOf(bundle: CatalogBundle, name: string): string | null {
+  const groups = (bundle.package?.groups ?? {}) as Record<string, unknown>;
+  for (const [group, names] of Object.entries(groups)) {
+    if (Array.isArray(names) && names.includes(name)) return group;
+  }
+  return null;
 }

--- a/ui/desktop/src/components/skills/skillUtils.test.ts
+++ b/ui/desktop/src/components/skills/skillUtils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { loadSkillsFromDirs, parseSkillFrontmatter, toSlug } from './skillUtils';
+import { describe, it, expect } from 'vitest';
+import { parseSkillFrontmatter, toSlug } from './skillUtils';
 
 describe('parseSkillFrontmatter', () => {
   it('returns name and description from valid frontmatter', () => {
@@ -76,50 +76,5 @@ describe('toSlug', () => {
 
   it('collapses multiple hyphens', () => {
     expect(toSlug('a  b')).toBe('a-b');
-  });
-});
-
-describe('loadSkillsFromDirs', () => {
-  it('loads a bundle when the top-level folder has only subskill SKILL.md files', async () => {
-    const files = new Map([
-      [
-        '~/.config/biorouter/skills/tcr-bcr-analysis/mixcr-analysis/SKILL.md',
-        '---\nname: mixcr-analysis\ndescription: Analyze AIRR data with MiXCR\n---\nBody',
-      ],
-      [
-        '~/.config/biorouter/skills/tcr-bcr-analysis/scirpy-analysis/SKILL.md',
-        '---\nname: scirpy-analysis\ndescription: Analyze single-cell immune receptors\n---\nBody',
-      ],
-    ]);
-
-    Object.assign(window, {
-      electron: {
-        listSkillDirs: vi.fn(async (dir: string) => {
-          if (dir === '~/.config/biorouter/skills') return ['tcr-bcr-analysis'];
-          if (dir === '~/.config/biorouter/skills/tcr-bcr-analysis') {
-            return ['mixcr-analysis', 'scirpy-analysis'];
-          }
-          return [];
-        }),
-        readFile: vi.fn(async (filePath: string) => ({
-          file: files.get(filePath) ?? '',
-          filePath,
-          error: files.has(filePath) ? null : 'ENOENT',
-          found: files.has(filePath),
-        })),
-      },
-    });
-
-    const result = await loadSkillsFromDirs(['~/.config/biorouter/skills']);
-
-    expect(result.singles).toEqual([]);
-    expect(result.bundles).toHaveLength(1);
-    expect(result.bundles[0]).toMatchObject({
-      bundleName: 'tcr-bcr-analysis',
-      skills: [
-        { name: 'mixcr-analysis', bundleName: 'tcr-bcr-analysis' },
-        { name: 'scirpy-analysis', bundleName: 'tcr-bcr-analysis' },
-      ],
-    });
   });
 });

--- a/ui/desktop/src/components/skills/skillUtils.ts
+++ b/ui/desktop/src/components/skills/skillUtils.ts
@@ -1,56 +1,27 @@
-export interface Skill {
-  folderPath: string; // absolute path to the skill folder  e.g. ~/.config/biorouter/skills/my-skill
-  sourceDir: string; // parent directory (one of the watched dirs)
-  name: string; // from SKILL.md frontmatter
-  description: string; // from SKILL.md frontmatter
-  content: string; // raw SKILL.md content
-  bundleName?: string; // optional: parent bundle name if part of a bundle
-}
-
-export interface SkillBundle {
-  bundleName: string; // folder name of the bundle
-  folderPath: string; // absolute path to the bundle folder
-  sourceDir: string; // parent directory (one of the watched dirs)
-  skills: Skill[]; // array of skills in this bundle
-}
-
+/**
+ * What is left of the renderer's own view of skills.
+ *
+ * ⚠ **The filesystem scanner is gone** (#113). `loadSkillsFromDirs`,
+ * `ALL_SKILL_DIRS` and `OTHER_SKILL_DIRS` walked three roots against the
+ * backend's seven, so a skill bundled inside an installed extension was
+ * loadable by the model and invisible in every interface surface that used
+ * them — Settings, the composer picker, the `@`-mention list and the workflow
+ * resource picker alike. They all read `useSkillCatalog` now, and the
+ * `Skill`/`SkillBundle` shapes it produced are the generated `CatalogSkill` and
+ * `CatalogBundle`.
+ *
+ * What remains is the two things a renderer legitimately does without asking
+ * the daemon: parse the frontmatter of a file the user is *authoring*
+ * (`CustomSkillModal`), and derive a folder name from it.
+ *
+ * ⚠ **The `BUILTIN_SKILL_NAMES` copy is gone too**, and deliberately. Its job
+ * was to hide Delete and show the "Built-in" badge, and a hand-synced list is a
+ * bad way to answer "did Biorouter put this here?" — it had already drifted
+ * once, and the Skills pane offered a Delete that succeeded, toasted, and was
+ * silently rewritten by the next startup. `CatalogSkill.builtin` answers it
+ * from `is_builtin_skill_name`, in the process that owns the seeder.
+ */
 export const BIOROUTER_SKILLS_DIR = '~/.config/biorouter/skills';
-
-// Skills that ship with Biorouter. The backend re-seeds them on every session
-// start ('about-biorouter', 'develop-biorouter', 'develop-biorouter-extension'
-// and 'develop-biorouter-skill' via skills_extension.rs's BUILTIN_SKILLS;
-// 'update-soul' via knowledge/soul.rs), so deleting their folder has no lasting
-// effect — the UI therefore offers only the enable/disable toggle for them, not
-// deletion.
-export const BUILTIN_SKILL_NAMES = [
-  'about-biorouter',
-  'develop-biorouter',
-  'develop-biorouter-extension',
-  'develop-biorouter-skill',
-  'update-soul',
-  // ⚠ Shipped, but NOT Contexts — so they belong here and not in `CONTEXTS`.
-  //
-  // Rust draws the same line with two functions: `context_skill_names()`
-  // (BUILTIN_SKILLS + soul) is what the Settings toggles mirror, while
-  // `is_builtin_skill_name()` is over `shipped_skills()`, which also includes
-  // KNOWLEDGE_SKILLS. This list mirrors the SECOND one, because its job is to
-  // hide Delete and show the Built-in badge.
-  //
-  // Without them the Skills pane offered a Delete control on a seeded skill:
-  // the delete succeeded, the toast said so, and the next startup rewrote the
-  // folder. A button that reports success and silently reverts is worse than
-  // no button.
-  'knowledge-choose-a-format',
-  'knowledge-ingest-okf',
-  'knowledge-ingest-biookf',
-  'knowledge-lint',
-];
-
-export function isBuiltinSkill(name: string): boolean {
-  return BUILTIN_SKILL_NAMES.includes(name);
-}
-export const OTHER_SKILL_DIRS = ['~/.claude/skills', '~/.config/agents/skills'];
-export const ALL_SKILL_DIRS = [BIOROUTER_SKILLS_DIR, ...OTHER_SKILL_DIRS];
 
 /**
  * Read a single top-level frontmatter field, supporting both inline values
@@ -113,73 +84,6 @@ export function parseSkillFrontmatter(
   const description = readFrontmatterField(fm, 'description');
   if (!name || !description) return null;
   return { name, description };
-}
-
-/**
- * Load all skills from a list of directories using Electron IPC.
- *
- * Detection rule per directory entry `<slug>`:
- *   - `<dir>/<slug>/SKILL.md` exists → single skill
- *   - No root SKILL.md, but sub-dirs of `<dir>/<slug>/` contain SKILL.md → bundle
- *   - Otherwise → ignored
- */
-export async function loadSkillsFromDirs(
-  dirs: string[]
-): Promise<{ singles: Skill[]; bundles: SkillBundle[] }> {
-  const singles: Skill[] = [];
-  const bundles: SkillBundle[] = [];
-
-  for (const dir of dirs) {
-    const folders: string[] = await window.electron.listSkillDirs(dir);
-
-    for (const folder of folders) {
-      const skillMdPath = `${dir}/${folder}/SKILL.md`;
-      const result = await window.electron.readFile(skillMdPath);
-
-      if (result.found && result.file) {
-        const parsed = parseSkillFrontmatter(result.file);
-        if (!parsed) continue;
-        singles.push({
-          folderPath: `${dir}/${folder}`,
-          sourceDir: dir,
-          name: parsed.name,
-          description: parsed.description,
-          content: result.file,
-        });
-      } else {
-        // No SKILL.md at root — check if sub-dirs have SKILL.md (bundle)
-        const subFolders: string[] = await window.electron.listSkillDirs(`${dir}/${folder}`);
-        const bundleSkills: Skill[] = [];
-
-        for (const sub of subFolders) {
-          const subPath = `${dir}/${folder}/${sub}/SKILL.md`;
-          const subResult = await window.electron.readFile(subPath);
-          if (!subResult.found || !subResult.file) continue;
-          const parsed = parseSkillFrontmatter(subResult.file);
-          if (!parsed) continue;
-          bundleSkills.push({
-            folderPath: `${dir}/${folder}/${sub}`,
-            sourceDir: dir,
-            name: parsed.name,
-            description: parsed.description,
-            content: subResult.file,
-            bundleName: folder,
-          });
-        }
-
-        if (bundleSkills.length > 0) {
-          bundles.push({
-            bundleName: folder,
-            folderPath: `${dir}/${folder}`,
-            sourceDir: dir,
-            skills: bundleSkills,
-          });
-        }
-      }
-    }
-  }
-
-  return { singles, bundles };
 }
 
 /**

--- a/ui/desktop/src/components/skills/useSkillCatalog.ts
+++ b/ui/desktop/src/components/skills/useSkillCatalog.ts
@@ -118,6 +118,27 @@ function isPickerSkill(skill: CatalogSkill): boolean {
   return !isContextSkill(skill.name);
 }
 
+/**
+ * The catalog once, for a caller that is not a React component.
+ *
+ * Same endpoint, same answer as the hook. It exists so a one-shot loader — the
+ * `@`-mention list, the workflow resource picker — does not have to keep its
+ * own filesystem scan around, which is what left both of them blind to
+ * extension-bundled skills.
+ */
+export async function fetchSkillCatalog(sessionId?: string | null): Promise<CatalogView> {
+  const response = await skillCatalogHandler<true>({
+    query: sessionId ? { session_id: sessionId } : {},
+    throwOnError: true,
+  });
+  return response.data;
+}
+
+/** Standalone skills — bundle members are reached through their bundle. */
+export function standaloneSkills(view: CatalogView): CatalogSkill[] {
+  return view.skills.filter((skill) => !skill.bundle && !isContextSkill(skill.name));
+}
+
 export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
   const [view, setView] = useState<CatalogView>(EMPTY);
   const [loading, setLoading] = useState(true);

--- a/ui/desktop/src/components/workflows/CreateWorkflowFromSessionModal.tsx
+++ b/ui/desktop/src/components/workflows/CreateWorkflowFromSessionModal.tsx
@@ -10,7 +10,7 @@ import { WorkflowParameter } from './shared/workflowFormSchema';
 import { toastError } from '../../toasts';
 import { saveWorkflow } from '../../workflow/workflow_management';
 import type { ExtensionConfig, Manifest } from '../../api';
-import { ALL_SKILL_DIRS, loadSkillsFromDirs } from '../skills/skillUtils';
+import { fetchSkillCatalog, standaloneSkills } from '../skills/useSkillCatalog';
 import type { WorkflowResourceItem } from './shared/WorkflowResourcePicker';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../ui/dialog';
 import { storeSubscriptionCleanup } from '../../utils/storeSubscription';
@@ -127,16 +127,18 @@ export default function CreateWorkflowFromSessionModal({
         setDefaultKnowledgeBaseId(defaultId);
       });
 
-      loadSkillsFromDirs(ALL_SKILL_DIRS)
-        .then(({ singles, bundles }) => {
+      // The daemon's catalog, so a skill bundled inside an installed extension
+      // can be attached to a workflow like any other (#113).
+      fetchSkillCatalog()
+        .then((view) => {
           if (cancelled) return;
-          const bundleItems: WorkflowResourceItem[] = bundles.map((bundle) => ({
-            id: bundle.bundleName,
-            label: bundle.bundleName,
-            description: bundle.skills.map((skill) => skill.name).join(', '),
+          const bundleItems: WorkflowResourceItem[] = view.bundles.map((bundle) => ({
+            id: bundle.name,
+            label: bundle.displayName,
+            description: bundle.skills.join(', '),
             badge: 'bundle',
           }));
-          const singleItems: WorkflowResourceItem[] = singles.map((skill) => ({
+          const singleItems: WorkflowResourceItem[] = standaloneSkills(view).map((skill) => ({
             id: skill.name,
             label: skill.name,
             description: skill.description,


### PR DESCRIPTION
The finish half of #113, stacked on #128. #126 made the daemon the source of truth and rewired the composer; this removes the last three renderer-side scanners and gives a package one expandable row in Settings.

## What was still wrong after #126

Three surfaces still walked the filesystem over their own list of three roots, against the backend's seven:

- **Settings** (`SkillsView`) — so BiorOffice's Word/Excel/PowerPoint skills and MarkItDown's converter were loaded by the model and had no row at all;
- **the `@`-mention list** — so `@skill:word` completed to nothing;
- **the workflow resource picker** — so a bundled skill could not be attached to a workflow.

`loadSkillsFromDirs`, `ALL_SKILL_DIRS` and `OTHER_SKILL_DIRS` are **deleted**, not kept in step. All four skill surfaces now read `useSkillCatalog`, which is one fetch.

## Settings

Rows are grouped by provenance: **Biorouter Skills**, one group per installed extension (**From BiorOffice**), **Skills From Other Agents**, **From This Project**.

A package is one **expandable** row carrying its display name, version and entry point, opening to its components with their `core`/`on-demand` groups — the shape #115 asks for, rather than twenty unrelated rows.

Deleting goes through the importer's remover, which renames the directory aside before deleting so a package leaves the catalog's view in one step rather than emptying out under a scan in flight. The root it deletes under is chosen from `skill_catalog::roots()` — a path a caller invents matches nothing and is refused, which is what makes it safe for that handler to cover `~/.claude/skills` and a project directory as well as Biorouter's own.

⚠ **Two kinds of skill lose their Delete control**: one Biorouter re-seeds on every start, and one an installed extension supplies. In both cases the delete would succeed, toast, and be silently undone by the next startup or reinstall. That is the lesson `BUILTIN_SKILL_NAMES` was originally written for, applied to the second case it never covered.

## One list fewer

`skillUtils.BUILTIN_SKILL_NAMES` is gone. Its job was to hide Delete and show the "Built-in" badge, and `CatalogSkill.builtin` answers that from `is_builtin_skill_name` — in the process that owns the seeder. A pinning test over a list nothing reads guards nothing, so `contexts.test.ts` now asserts the copy has **not come back**, still exercising the same Rust-source extractor.

`skillUtils.ts` keeps only what a renderer legitimately does without asking the daemon: parse the frontmatter of a file the user is authoring, and derive a folder name from it.

## Tests

New: `SkillsView.test.tsx` (extension grouping, no Delete for extension-supplied skills, the expandable package row, removal by installed directory rather than declared name — those can differ, and the frontmatter wins for identity), and a concurrent-toggle test proving `useSkillCatalog`'s queue makes the last click win rather than the last response.

```
cargo test -p biorouter --lib -- skill                     101 passed
cargo test -p biorouter-server --lib -- routes::shell routes::skills   22 passed
cargo test -p biorouter-cli --lib   (isolated HOME)        363 passed
cd ui/desktop && npm run test:run                          340 files / 3289 passed
just check-everything                                       clean
```

One note on the suite: `artifactCdnAssets.browser.test.ts` failed once in a full-suite run with an `afterAll` hook timeout while both its assertions passed, and passes on its own. It launches a real browser and this machine had six worktrees building; unrelated to these changes.

## Acceptance criteria (#113), now complete

| Criterion | State |
|---|---|
| Toggling in an active chat persists `workspace_skills/v1` and changes `listSkills`/`loadSkill` next turn | #126 |
| Refresh/restart preserves the per-chat choice | #126 |
| Extension-bundled skills appear in Settings **and** composer | **this PR** completes Settings |
| A newly installed skill becomes selectable without a new chat | #126 |
| Removing a skill makes it unavailable in that chat only | #126 |
| Failed mutations roll back and show an error; no false success toast | #126 |
| Tests cover singles, bundles, extension-bundled skills, concurrent toggles, live install refresh | complete |

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
