### PR TITLE
fix(skills): defects the fixtures could not see (#113, #115)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -847,6 +847,77 @@ per-app agent over `GET /apps/<id>/agent`. Full design in
   arrive). Examples: `scripts/agent-drafter-apps/examples/ui/` +
   `install-examples.sh`.
 
+### Skills: one catalog, one importer (#113, #115)
+
+Two rules govern every skill surface, and both replaced a set of parallel
+implementations that had drifted. Reference:
+[`docs/extensions/skill-catalog.md`](docs/extensions/skill-catalog.md) and
+[`docs/extensions/skill-packages.md`](docs/extensions/skill-packages.md).
+
+**The daemon owns the catalog, and nothing else scans.**
+`crates/biorouter/src/agents/skill_catalog.rs` enumerates the roots *with
+provenance* (`roots()` — the ONE definition; `SkillsClient::get_default_skill_directories`
+is its paths-only view), discovers skills, derives bundles from the discovery
+result, and composes machine-wide with per-session state in `compose_state` —
+which `skills_extension`'s own filter also calls, so the model's view and the
+interface's switch cannot disagree. Served over `GET /skills/catalog`; the
+renderer's `loadSkillsFromDirs`/`ALL_SKILL_DIRS` scanner is **deleted**, and
+Settings, the composer picker, the `@`-mention list and the workflow picker all
+read `useSkillCatalog`.
+
+- **The catalog is a process-global snapshot every `SkillsClient` reads
+  through**, not a constructor-time map, so a skill installed mid-conversation
+  is loadable in that conversation. Staleness = the root set (an extension
+  install *adds a root*) + the mtime of every root and every **bundle**
+  directory (creating `<bundle>/<child>/` bumps the bundle's mtime, not the
+  root's). ⚠ mtime has a one-second window; in-process writers must call
+  `skill_catalog::invalidate()`/`refresh()` rather than rely on it.
+- **Per-chat state is `workspace_skills/v1` on the session row, never
+  `skills-config.json`** — that file is machine-wide and shared with
+  `biorouter skill enable/disable`. `POST /skills/session` persists first and
+  reads the catalog back *after* the write, so the interface renders confirmed
+  state; a refusal restores the previous catalog and raises an **error** toast.
+  Precedence: skill `add` > skill `remove` > **bundle** `add` > bundle `remove`
+  > machine-wide. The bundle arms are load-bearing — without them a per-chat
+  bundle toggle writes a name no skill matches.
+- ⚠ `CatalogSkill.builtin` answers "did Biorouter put this here?". The
+  hand-synced `skillUtils.BUILTIN_SKILL_NAMES` copy is gone; `contexts.test.ts`
+  now asserts it has not come back.
+
+**One import pipeline** — `crates/biorouter/src/agents/skill_package/`, reached
+from Add Skill (URL or `.zip`), the marketplace, the `importSkillPackage` MCP
+tool, `biorouter skill install <path-or-url>`, and `/skills/packages/*`. The two
+depth-counting archive parsers in `routes/shell.rs` and `commands/skill.rs` are
+deleted, not kept in step.
+
+- **Metadata beats shape**, and the ladder **merges** rather than picking one
+  rung: `biorouter-package.json` → `.codex-plugin/plugin.json` →
+  `.claude-plugin/plugin.json` → `skills-manifest.json` → structure. HyperFrames
+  ships all three plugin files and only the Codex one carries `skills`.
+- **A shared name prefix is never the detector** — `media-use`, `slideshow`,
+  `product-launch-video` and `faceless-explainer` carry none — and every
+  component keeps its declared name exactly.
+- **Ambiguity is a question**: components loose at an archive root with no
+  manifest could be one package or a zipped folder, so the plan says so and
+  install refuses until answered. A named parent directory is not ambiguous, and
+  neither is a manifest. Over HTTP the question is a **200** `needsChoice`, not
+  a 4xx — an agent seeing an error retries instead of asking.
+- **A partial write never lands**: staged in a sibling directory, verified by
+  reading the tree back, swapped in with two renames.
+- ⚠ **Run the live test after touching `manifest.rs` or `plan.rs`:**
+  `cargo test -p biorouter --test skill_package_live -- --ignored`. It downloads
+  the real HyperFrames repository. A complete synthetic fixture matrix passed
+  while **three** real defects survived — `skills-manifest.json`'s `skills` is a
+  *map* not an array (which failed the whole document and refused the import),
+  the display name lives in the plugin manifest's `interface` block, and package
+  identity was resolved before the single-skill collapse. A fixture is a
+  statement about what you *think* the world looks like.
+
+Tests: `cargo test -p biorouter --lib -- skill`,
+`cargo test -p biorouter-server --lib -- routes::skills`,
+`cargo test -p biorouter-cli --lib` (**needs an isolated `HOME`**), and
+`cd ui/desktop && npm run test:run`.
+
 ### Workspace control (several conversations at once)
 
 Workspace control (BR-71) is the agent's tool surface over *other* conversations:

--- a/crates/biorouter/src/agents/skill_package/manifest.rs
+++ b/crates/biorouter/src/agents/skill_package/manifest.rs
@@ -65,6 +65,11 @@ struct BiorouterComponent {
 ///
 /// `skills` is a path in both, and both spell it with a leading `./` and a
 /// trailing `/` in the wild — normalised in [`normalize_path`].
+///
+/// ⚠ **The two are not interchangeable, which is why the ladder merges.**
+/// HyperFrames ships both, and only the Codex one carries `skills` at all —
+/// its `.claude-plugin/plugin.json` is name, version and prose. Reading a
+/// single rung would have found a package with no components root.
 #[derive(Debug, Deserialize)]
 struct PluginManifest {
     name: Option<String>,
@@ -73,11 +78,30 @@ struct PluginManifest {
     version: Option<String>,
     #[serde(default)]
     skills: Option<serde_json::Value>,
+    /// The vendor's presentation block. Its `displayName` is where a
+    /// human-readable name actually lives in the wild — HyperFrames' is
+    /// "HyperFrames by HeyGen" — while the top-level `displayName` this
+    /// originally read is absent from every real manifest inspected.
+    #[serde(default)]
+    interface: Option<PluginInterface>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PluginInterface {
+    #[serde(rename = "displayName")]
+    display_name: Option<String>,
 }
 
 /// `skills-manifest.json`, as HyperFrames ships it: a source and a component
-/// list. Tolerant about the component shape, which is a bare string in some
-/// repositories and an object in others.
+/// list.
+///
+/// ⚠ **`skills` is a MAP in the real file**, keyed by component name with a
+/// content hash and file count as the value — not the array this originally
+/// assumed. A `Vec` here does not merely miss the names: serde fails the whole
+/// document, `detect` reports "skills-manifest.json is not valid JSON", and the
+/// import is refused outright. The fixture that said otherwise was invented,
+/// and only running the real archive through the real pipeline found it.
+/// [`SkillsList`] now accepts both, plus a bare string list.
 #[derive(Debug, Deserialize)]
 struct SkillsManifest {
     name: Option<String>,
@@ -86,10 +110,32 @@ struct SkillsManifest {
     #[serde(rename = "entryPoint", alias = "entry_point", alias = "router")]
     entry_point: Option<String>,
     #[serde(default)]
-    skills: Vec<serde_json::Value>,
+    skills: SkillsList,
     /// `{"core": ["a"], "on-demand": ["b"]}`, when present.
     #[serde(default)]
     groups: BTreeMap<String, Vec<String>>,
+}
+
+/// The component list, in every shape seen in the wild.
+#[derive(Debug, Default, Deserialize)]
+#[serde(untagged)]
+enum SkillsList {
+    /// `["a", "b"]`, or `[{"name": "a"}, …]`.
+    Array(Vec<serde_json::Value>),
+    /// `{"a": {"hash": …}, "b": {…}}` — HyperFrames' actual shape.
+    Map(BTreeMap<String, serde_json::Value>),
+    #[default]
+    Absent,
+}
+
+impl SkillsList {
+    fn names(&self) -> Vec<String> {
+        match self {
+            SkillsList::Array(items) => items.iter().filter_map(component_name).collect(),
+            SkillsList::Map(map) => map.keys().cloned().collect(),
+            SkillsList::Absent => Vec::new(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -252,10 +298,14 @@ fn plugin_manifest(
     let parsed: PluginManifest = serde_json::from_str(&entry.text())
         .map_err(|e| anyhow::anyhow!("{path} is not valid JSON: {e}"))?;
     let components_root = parsed.skills.as_ref().and_then(plugin_skills_path);
+    let display_name = parsed
+        .display_name
+        .or_else(|| parsed.interface.and_then(|i| i.display_name))
+        .or_else(|| parsed.name.clone());
     Ok(Some(ManifestFacts {
         evidence: Some(evidence),
-        name: parsed.name.clone(),
-        display_name: parsed.display_name.or(parsed.name),
+        name: parsed.name,
+        display_name,
         version: parsed.version,
         components_root,
         entry_point: None,
@@ -283,7 +333,7 @@ fn skills_manifest(entries: &[Entry]) -> anyhow::Result<Option<ManifestFacts>> {
             components_root: None,
             entry_point: parsed.entry_point,
             groups: parsed.groups,
-            declared: parsed.skills.iter().filter_map(component_name).collect(),
+            declared: parsed.skills.names(),
         }));
     }
     Ok(None)
@@ -311,6 +361,39 @@ mod tests {
         assert_eq!(facts.name.as_deref(), Some("hyperframes"));
         assert_eq!(facts.version.as_deref(), Some("0.8.12"));
         assert_eq!(facts.components_root.as_deref(), Some("skills"));
+    }
+
+    /// The real HyperFrames `skills-manifest.json`, in miniature: `skills` is a
+    /// map keyed by name, and there is no `entryPoint` or `groups` at all.
+    /// Reading it as an array failed the whole document and refused the import.
+    #[test]
+    fn a_skills_manifest_reads_the_map_shape_the_real_file_uses() {
+        let facts = detect(&[entry(
+            "skills-manifest.json",
+            r#"{"source":"heygen-com/hyperframes","skills":{
+                 "hyperframes":{"hash":"5be130da8d7ff59e","files":17},
+                 "media-use":{"hash":"1b0ce647f5c7df95","files":152}}}"#,
+        )])
+        .unwrap();
+        assert_eq!(facts.evidence, Some(Evidence::SkillsManifest));
+        assert_eq!(facts.declared, vec!["hyperframes", "media-use"]);
+        assert_eq!(facts.entry_point, None, "the real file declares none");
+        assert!(facts.groups.is_empty());
+    }
+
+    /// A human-readable name lives in the vendor's `interface` block in every
+    /// real manifest inspected; the top-level `displayName` this first read is
+    /// absent from all of them.
+    #[test]
+    fn a_plugin_manifests_interface_block_supplies_the_display_name() {
+        let facts = detect(&[entry(
+            ".codex-plugin/plugin.json",
+            r#"{"name":"hyperframes","version":"0.8.12","skills":"./skills/",
+                "interface":{"displayName":"HyperFrames by HeyGen"}}"#,
+        )])
+        .unwrap();
+        assert_eq!(facts.name.as_deref(), Some("hyperframes"));
+        assert_eq!(facts.display_name.as_deref(), Some("HyperFrames by HeyGen"));
     }
 
     #[test]

--- a/crates/biorouter/src/agents/skill_package/plan.rs
+++ b/crates/biorouter/src/agents/skill_package/plan.rs
@@ -84,16 +84,14 @@ pub fn plan_from_entries(
 
     let mut components = collect_components(&members)?;
 
-    let (id, display_name) = resolve_identity(&facts, id_hints, &components_root)?;
-
-    let (entry_point, groups) = apply_manifest_metadata(&facts, &mut components, &id);
-
+    // ⚠ **Before identity, not after.** A single skill in a named folder with
+    // no manifest needs no package name, and resolving one first refused the
+    // import with "this package has no name" — a message about a package the
+    // user never asked for. Found by running a real repository through the
+    // real pipeline; every synthetic fixture reached this shape via
+    // `strip_wrapper`, which unwraps it into the root-SKILL.md case and jumps
+    // over the branch entirely.
     let single_component = components.len() == 1;
-    let evidence = facts
-        .evidence
-        .clone()
-        .unwrap_or_else(|| root_evidence.clone());
-
     // A single component and no manifest is one skill in one folder, not a
     // package of one — installing it as a bundle would put it a level deeper
     // than every other single-skill install.
@@ -111,6 +109,15 @@ pub fn plan_from_entries(
             source,
         );
     }
+
+    let (id, display_name) = resolve_identity(&facts, id_hints, &components_root)?;
+
+    let (entry_point, groups) = apply_manifest_metadata(&facts, &mut components, &id);
+
+    let evidence = facts
+        .evidence
+        .clone()
+        .unwrap_or_else(|| root_evidence.clone());
 
     let ambiguity = ambiguity_for(&facts, &components, &components_root);
 

--- a/crates/biorouter/src/agents/skill_package/tests.rs
+++ b/crates/biorouter/src/agents/skill_package/tests.rs
@@ -177,6 +177,35 @@ fn one_folder_holding_one_skill_is_still_one_skill_not_a_package_of_one() {
     );
 }
 
+/// The same shape reached WITHOUT `strip_wrapper` unwrapping it first.
+///
+/// ⚠ This is the fixture that was missing, and its absence hid a real refusal.
+/// `plan()` above hands `<slug>/SKILL.md` to `strip_wrapper`, which unwraps it
+/// into the root-SKILL.md case — so every synthetic test jumped over the
+/// single-component-under-a-named-folder branch. A zip carrying a `README.md`
+/// beside the folder has no single common root, is not unwrapped, and lands
+/// squarely on it.
+#[test]
+fn one_folder_beside_a_readme_is_still_one_skill_and_needs_no_package_name() {
+    let plan = plan(
+        &[
+            ("my-skill/SKILL.md", skill_md("gwas-pipeline", "Run a GWAS")),
+            ("my-skill/references/notes.md", "notes".to_string()),
+            ("README.md", "# A repository".to_string()),
+        ],
+        WrapperHint::Infer,
+        &[],
+    )
+    .unwrap();
+    assert_eq!(plan.kind, ImportKind::Single);
+    assert_eq!(plan.id, "gwas-pipeline");
+    assert!(plan.files.iter().any(|(path, _)| path == "SKILL.md"));
+    assert!(plan
+        .files
+        .iter()
+        .any(|(path, _)| path == "references/notes.md"));
+}
+
 // ---------------------------------------------------------------------------
 // 3. the canonical BioRouter bundle
 // ---------------------------------------------------------------------------

--- a/crates/biorouter/tests/skill_package_live.rs
+++ b/crates/biorouter/tests/skill_package_live.rs
@@ -1,0 +1,194 @@
+//! The acceptance criterion of #115, against the real repository.
+//!
+//! ```bash
+//! cargo test -p biorouter --test skill_package_live -- --ignored --nocapture
+//! ```
+//!
+//! `#[ignore]` because it downloads ~120 MB from GitHub, so it is not part of
+//! any default run — but it is the only test that can fail for the reason the
+//! fixtures cannot. Two defects survived a complete synthetic fixture matrix
+//! and were found here in one run:
+//!
+//! * `skills-manifest.json`'s `skills` is a **map** keyed by component name,
+//!   not the array the fixtures invented. A `Vec` did not merely miss the
+//!   names — serde failed the whole document, and the import was refused with
+//!   "skills-manifest.json is not valid JSON".
+//! * the human-readable name lives in the plugin manifest's `interface` block,
+//!   not at the top level.
+//!
+//! A fixture is a statement about what you *think* the world looks like. Run
+//! this after touching `manifest.rs` or `plan.rs`.
+
+use biorouter::agents::skill_package::{self, Evidence, ImportKind, ImportSource};
+
+/// `https://github.com/heygen-com/hyperframes` — a declared plugin with a
+/// mandatory router and twenty component skills, several of which do **not**
+/// share the package's name prefix.
+const HYPERFRAMES: &str = "https://github.com/heygen-com/hyperframes";
+
+#[tokio::test]
+#[ignore = "downloads ~120 MB from github.com"]
+async fn hyperframes_main_imports_as_one_package_with_every_declared_skill() {
+    let fetched = skill_package::fetch(&ImportSource::Url {
+        url: HYPERFRAMES.to_string(),
+        reference: Some("main".to_string()),
+    })
+    .await
+    .expect("fetch");
+
+    // The archive's wrapper directory is stripped, so nothing downstream sees
+    // `hyperframes-main/`.
+    assert!(
+        fetched
+            .entries
+            .iter()
+            .any(|entry| entry.name == "skills/hyperframes/SKILL.md"),
+        "the repository wrapper directory was not stripped"
+    );
+
+    // What the repository itself says its components are — read here rather
+    // than hard-coded, so the assertion survives the package gaining a skill.
+    let manifest: serde_json::Value = serde_json::from_str(
+        &fetched
+            .entries
+            .iter()
+            .find(|entry| entry.name == "skills-manifest.json")
+            .expect("skills-manifest.json")
+            .text(),
+    )
+    .expect("skills-manifest.json parses");
+    let mut declared: Vec<String> = manifest["skills"]
+        .as_object()
+        .expect("`skills` is a map keyed by component name")
+        .keys()
+        .cloned()
+        .collect();
+    declared.sort();
+    assert!(
+        declared.len() >= 20,
+        "the manifest declared {} skills",
+        declared.len()
+    );
+
+    let plan = skill_package::plan_from_entries(fetched.entries, &fetched.id_hints, fetched.source)
+        .expect("plan");
+
+    // ONE package, not one top-level skill per SKILL.md.
+    assert_eq!(plan.kind, ImportKind::Bundle);
+    assert_eq!(plan.id, "hyperframes");
+    assert_eq!(plan.display_name, "HyperFrames by HeyGen");
+    assert_eq!(plan.evidence, Evidence::CodexPlugin);
+    assert!(
+        plan.ambiguity.is_none(),
+        "an explicitly declared package must not ask the user to choose"
+    );
+    assert_eq!(plan.version.as_deref(), Some("0.8.12"));
+
+    // Every skill the manifest declares, and only those.
+    let mut components: Vec<String> = plan.components.iter().map(|c| c.name.clone()).collect();
+    components.sort();
+    assert_eq!(components, declared);
+
+    // The router is the entry point, and it is the only one.
+    assert_eq!(plan.entry_point.as_deref(), Some("hyperframes"));
+    let routers: Vec<&str> = plan
+        .components
+        .iter()
+        .filter(|c| c.entry_point)
+        .map(|c| c.name.as_str())
+        .collect();
+    assert_eq!(routers, vec!["hyperframes"]);
+
+    // Names are preserved exactly, prefix or no prefix. These four are the
+    // reason `hyperframes-` cannot be the detector.
+    for name in [
+        "media-use",
+        "slideshow",
+        "product-launch-video",
+        "faceless-explainer",
+    ] {
+        assert!(
+            plan.components.iter().any(|c| c.name == name),
+            "`{name}` is missing — a member without the package's name prefix"
+        );
+    }
+    assert!(
+        plan.components
+            .iter()
+            .all(|c| !c.name.starts_with("hyperframes-") || declared.contains(&c.name)),
+        "the importer invented a prefix"
+    );
+
+    // A component's support files travel with it: `media-use` ships audio.
+    assert!(
+        plan.files
+            .iter()
+            .any(|(path, _)| path.starts_with("media-use/") && path.ends_with(".mp3")),
+        "binary support files were dropped"
+    );
+
+    // ...and install it, for real, into a temporary root.
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path().join("skills");
+    let installed = skill_package::install(&plan, &root).expect("install");
+    assert_eq!(installed.skills.len(), declared.len());
+    assert!(root.join("hyperframes/hyperframes/SKILL.md").is_file());
+    assert!(root.join("hyperframes/media-use/SKILL.md").is_file());
+    assert!(root
+        .join("hyperframes")
+        .join(biorouter::agents::skill_catalog::PACKAGE_RECORD_FILE)
+        .is_file());
+
+    // The catalog sees exactly one bundle here, not twenty top-level skills.
+    let roots = vec![biorouter::agents::skill_catalog::SkillRoot {
+        path: root.clone(),
+        source: biorouter::agents::skill_catalog::SkillSource::new(
+            biorouter::agents::skill_catalog::SkillSourceKind::Biorouter,
+            None,
+        ),
+    }];
+    let view = biorouter::agents::skill_catalog::SkillCatalog::scan(roots, 1)
+        .view(&biorouter::agents::session_skills::SessionSkillOverride::default());
+    assert_eq!(view.bundles.len(), 1);
+    assert_eq!(view.bundles[0].name, "hyperframes");
+    assert_eq!(view.bundles[0].display_name, "HyperFrames by HeyGen");
+    assert_eq!(view.bundles[0].skills.len(), declared.len());
+    assert_eq!(
+        view.bundles[0]
+            .package
+            .as_ref()
+            .and_then(|p| p.entry_point.as_deref()),
+        Some("hyperframes")
+    );
+}
+
+/// A repository that is one skill, not a package — the other half of the
+/// contract, and the case a bundle-happy importer would get wrong.
+#[tokio::test]
+#[ignore = "downloads from github.com"]
+async fn a_single_skill_repository_still_imports_as_one_skill() {
+    let fetched = skill_package::fetch(&ImportSource::Url {
+        url: "https://github.com/heygen-com/hyperframes".to_string(),
+        reference: Some("main".to_string()),
+    })
+    .await
+    .expect("fetch");
+
+    // Take just one component's subtree and re-plan it, which is what a user
+    // who zipped a single skill folder would hand us.
+    let one: Vec<_> = fetched
+        .entries
+        .into_iter()
+        .filter(|entry| entry.name.starts_with("skills/media-use/"))
+        .map(|entry| biorouter::agents::skill_package::archive::Entry {
+            name: entry.name.trim_start_matches("skills/").to_string(),
+            data: entry.data,
+        })
+        .collect();
+    assert!(!one.is_empty());
+
+    let plan = skill_package::plan_from_entries(one, &[], Default::default()).expect("plan");
+    assert_eq!(plan.kind, ImportKind::Single);
+    assert_eq!(plan.id, "media-use");
+    assert!(plan.ambiguity.is_none());
+}

--- a/docs/extensions/skill-packages.md
+++ b/docs/extensions/skill-packages.md
@@ -200,6 +200,30 @@ every defect this replaces lived in a seam between two steps — a test that han
 `plan_from_entries` a hand-built entry list jumps straight over the wrapper
 directory, which is the one that mattered most.
 
+⚠ **Run the live test after touching `manifest.rs` or `plan.rs`:**
+
+```bash
+cargo test -p biorouter --test skill_package_live -- --ignored
+```
+
+It downloads the real HyperFrames repository, so it is `#[ignore]`d — and it is
+the only test that can fail for the reason the fixtures cannot. A fixture is a
+statement about what you *think* the world looks like, and a complete synthetic
+matrix passed while **three** real defects survived, all three found in one live
+run:
+
+1. `skills-manifest.json`'s `skills` is a **map** keyed by component name, not
+   an array. A `Vec` did not merely miss the names — serde failed the whole
+   document, and importing HyperFrames was refused with "skills-manifest.json
+   is not valid JSON".
+2. The human-readable name lives in the plugin manifest's `interface` block,
+   not at the top level.
+3. Package identity was resolved *before* the single-skill collapse, so one
+   skill in a named folder with no manifest was refused with "this package has
+   no name" — about a package the user never asked for. Every fixture reached
+   that shape through `strip_wrapper`, which unwraps it into the root-`SKILL.md`
+   case and jumps over the branch.
+
 ## Related documentation
 
 - [The skill catalog](skill-catalog.md) — what happens after an install: discovery, enablement, and per-chat state

--- a/ui/desktop/src/components/bottom_menu/BottomMenuSkillSelection.test.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuSkillSelection.test.tsx
@@ -157,6 +157,50 @@ describe('BottomMenuSkillSelection', () => {
     await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
   });
 
+  /**
+   * The rollback must undo only the toggle that failed.
+   *
+   * ⚠ **Both clicks happen in ONE render**, with no `await` between them, and
+   * that is the whole test. With the previous catalog read from the render
+   * closure rather than from what the hook last committed, both callbacks
+   * capture the same starting catalog — so a refusal on the second restored the
+   * state from before the FIRST, silently undoing on screen a change the daemon
+   * had already accepted. Awaiting between the clicks lets React re-render and
+   * hands the second callback a fresh closure, which hides the defect
+   * completely: the first draft of this test passed against the broken code.
+   */
+  it('a refused second toggle does not undo a first one the daemon accepted', async () => {
+    serve(view({ skills: [skill('alpha'), skill('beta')] }));
+    const disabledAlpha = view({
+      skills: [
+        skill('alpha', {
+          state: {
+            machineEnabled: true,
+            session: 'removed',
+            sessionViaBundle: false,
+            hiddenContext: false,
+            effective: false,
+          },
+        }),
+        skill('beta'),
+      ],
+    });
+    mocks.setSessionSkills.mockImplementation(async (o: { body: { remove: string[] } }) => {
+      if (o.body.remove.includes('beta')) throw new Error('refused');
+      return { data: { catalog: disabledAlpha, sessionAdd: [], sessionRemove: ['alpha'] } };
+    });
+
+    render(<BottomMenuSkillSelection sessionId="20260824_1" />);
+    const [alpha, beta] = await openMenu();
+
+    fireEvent.click(alpha);
+    fireEvent.click(beta);
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(beta).toHaveAttribute('aria-checked', 'true'));
+    expect(alpha).toHaveAttribute('aria-checked', 'false');
+  });
+
   it('says "for this chat" only when there is a chat', async () => {
     mocks.setSessionSkills.mockResolvedValue({
       data: { catalog: view(), sessionAdd: [], sessionRemove: ['example-skill'] },

--- a/ui/desktop/src/components/skills/useSkillCatalog.ts
+++ b/ui/desktop/src/components/skills/useSkillCatalog.ts
@@ -120,6 +120,18 @@ function isPickerSkill(skill: CatalogSkill): boolean {
 
 export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
   const [view, setView] = useState<CatalogView>(EMPTY);
+  // ⚠ **The rollback target is a ref, not the render closure's `view`.**
+  // Two toggles can be made before React re-renders, and a callback created in
+  // the first render captures the catalog as it was *then*. So when the second
+  // toggle was refused, the rollback restored the state from before the FIRST —
+  // silently undoing a change the daemon had already accepted, on screen only.
+  // A ref written wherever the catalog is committed is always the last thing
+  // this hook actually published, whatever the render timing.
+  const committed = useRef<CatalogView>(EMPTY);
+  const commit = useCallback((next: CatalogView) => {
+    committed.current = next;
+    setView(next);
+  }, []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Serialises mutations so two fast clicks cannot land out of order and leave
@@ -134,7 +146,7 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
         const response = rescan
           ? await refreshSkillCatalog<true>({ query, throwOnError: true })
           : await skillCatalogHandler<true>({ query, throwOnError: true });
-        setView(response.data);
+        commit(response.data);
         setError(null);
       } catch (err) {
         setError(`Could not read the skill catalog: ${errorText(err)}`);
@@ -142,7 +154,7 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
         setLoading(false);
       }
     },
-    [sessionId]
+    [commit, sessionId]
   );
 
   useEffect(() => {
@@ -170,10 +182,10 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
       if (keys.length === 0) return Promise.resolve({ ok: true });
 
       const run = async (): Promise<SkillMutationResult> => {
-        const previous = view;
+        const previous = committed.current;
         // Optimistic, so the switch does not lag the click — and reverted below
         // if the write is refused.
-        setView(applyOptimistically(previous, keys, enabled, sessionId !== null));
+        commit(applyOptimistically(previous, keys, enabled, sessionId !== null));
 
         try {
           if (sessionId) {
@@ -185,7 +197,7 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
               },
               throwOnError: true,
             });
-            setView(response.data.catalog);
+            commit(response.data.catalog);
           } else {
             keys.forEach((key) => setSkillOverride(key, enabled));
             await saveSkillOverrides();
@@ -195,11 +207,11 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
               query: {},
               throwOnError: true,
             });
-            setView(response.data);
+            commit(response.data);
           }
           return { ok: true };
         } catch (err) {
-          setView(previous);
+          commit(previous);
           if (!sessionId) {
             // Put the in-memory store back in step with the file we failed to
             // write, or the next save would persist this failed edit.
@@ -213,7 +225,10 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
       queue.current = next;
       return next;
     },
-    [sessionId, view]
+    // ⚠ No `view` here — see `committed`. Depending on it would also give
+    // `setEnabled` a new identity on every catalog change, which every caller
+    // then has in ITS dependency array.
+    [commit, sessionId]
   );
 
   const entries = useMemo((): SkillCatalogEntry[] => {

--- a/ui/desktop/src/components/workflows/__tests__/CreateWorkflowFromSessionModal.test.tsx
+++ b/ui/desktop/src/components/workflows/__tests__/CreateWorkflowFromSessionModal.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CreateWorkflowFromSessionModal from '../CreateWorkflowFromSessionModal';
-import { createWorkflow } from '../../../api/sdk.gen';
+import { createWorkflow, skillCatalogHandler } from '../../../api/sdk.gen';
 import type { CreateWorkflowResponse } from '../../../api/types.gen';
 import { saveWorkflow } from '../../../workflow/workflow_management';
 
@@ -27,6 +27,38 @@ vi.mock('../../../api/sdk.gen', () => ({
     data: { active_kb: null, hidden_kbs: [] },
     error: undefined,
   }),
+  // ⚠ The skill picker reads the daemon's catalog now, not a renderer-side
+  // filesystem scan (#113). Omitting this did not fail anything — the modal
+  // catches the load and falls back to an empty list — so the test went on
+  // passing while silently exercising a workflow with NO skills to attach.
+  // A blank-but-correctly-shaped resolution is what the comment above promises.
+  skillCatalogHandler: vi.fn().mockResolvedValue({
+    data: {
+      generation: 1,
+      roots: [],
+      skills: [
+        {
+          name: 'literature-review',
+          description: 'Survey the literature',
+          slug: 'literature-review',
+          directory: '/skills/literature-review',
+          sourceRoot: '/skills',
+          source: { kind: 'biorouter', extension: null, label: 'Biorouter' },
+          bundle: null,
+          builtin: false,
+          state: {
+            machineEnabled: true,
+            session: 'default',
+            sessionViaBundle: false,
+            hiddenContext: false,
+            effective: true,
+          },
+        },
+      ],
+      bundles: [],
+    },
+    error: undefined,
+  }),
 }));
 
 vi.mock('../../../toasts', () => ({
@@ -38,6 +70,7 @@ vi.mock('../../../workflow/workflow_management', () => ({
 }));
 
 const mockCreateWorkflow = vi.mocked(createWorkflow);
+const mockSkillCatalog = vi.mocked(skillCatalogHandler);
 const mockSaveWorkflow = vi.mocked(saveWorkflow);
 
 describe('CreateWorkflowFromSessionModal', () => {
@@ -278,6 +311,20 @@ describe('CreateWorkflowFromSessionModal', () => {
         expect(defaultProps.onWorkflowCreated).toHaveBeenCalled();
         expect(defaultProps.onClose).toHaveBeenCalled();
       });
+    });
+
+    /**
+     * The picker's skills come from the daemon's catalog (#113), so a skill
+     * bundled inside an installed extension can be attached to a workflow —
+     * which the renderer-side scan this replaced never saw.
+     *
+     * ⚠ Asserted because the modal *catches* a failed load and falls back to an
+     * empty list. When the mock was incomplete this whole file still passed,
+     * while every test in it silently ran with no skills to attach at all.
+     */
+    it('asks the daemon for the skill catalog when it opens', async () => {
+      render(<CreateWorkflowFromSessionModal {...defaultProps} />);
+      await waitFor(() => expect(mockSkillCatalog).toHaveBeenCalled());
     });
 
     it('saves generated extensions, knowledge bases, and skills from the analysis response', async () => {


### PR DESCRIPTION
Follow-ups to #126 and #128, from two things the test suites could not see. Both were found *after* a complete, green fixture matrix.

---

## 1. Three importer defects, found on the real repository (#115)

Adds a live test that imports the real HyperFrames repository:

```bash
cargo test -p biorouter --test skill_package_live -- --ignored
```

`#[ignore]`d because it downloads ~120 MB from GitHub. It is the only test that can fail for the reason the fixtures cannot: a fixture is a statement about what you *think* the world looks like. It asserts #115's acceptance criterion directly, and reads the expected component set out of the repository's own manifest rather than hard-coding twenty names, so it survives the package gaining a skill.

**a. `skills-manifest.json`'s `skills` is a map, not an array.**

```json
{ "source": "heygen-com/hyperframes",
  "skills": { "hyperframes": { "hash": "5be1…", "files": 17 }, … } }
```

A `Vec<Value>` did not merely miss the names — serde failed the whole document, `detect` reported *"skills-manifest.json is not valid JSON"*, and importing HyperFrames was **refused outright**. `SkillsList` is now an untagged enum taking a map, an array of strings, or an array of objects.

**b. The display name lives in the plugin manifest's `interface` block.** HyperFrames' is `"HyperFrames by HeyGen"`; the top-level `displayName` the parser read is in no real manifest. (Its `.claude-plugin/plugin.json` also carries no `skills` key at all — which is exactly why the ladder merges rather than picking one rung.)

**c. Package identity was resolved before the single-skill collapse.** One skill in a named folder with no manifest was refused with *"this package has no name"* — about a package the user never asked for. This is the sharpest of the three: every fixture reached that shape through `strip_wrapper`, which unwraps it into the root-`SKILL.md` case and **jumps over the branch entirely**, so more fixtures of the same shape would never have found it. A zip carrying a `README.md` beside the folder has no single common root, is not unwrapped, and lands squarely on it. That fixture exists now too.

### What the live run confirms end to end

One `hyperframes` bundle, display name "HyperFrames by HeyGen", version 0.8.12, evidence `codexPlugin`, no ambiguity; **all 20 manifest-declared skills**, matched against the manifest itself; `hyperframes` as the entry point and the only one; `media-use`, `slideshow`, `product-launch-video`, `faceless-explainer` with names intact; binary support files carried (`media-use` ships `.mp3` assets — the old text-extension filter would have dropped them); installed for real, and the catalog sees **one bundle**, not 20 top-level skills.

Measured incidentally: 192 MB uncompressed / 8307 files, of which 1111 files / 15.8 MB are under `skills/` — inside the 256 MiB expansion cap.

---

## 2. A rollback that undid the wrong toggle (#113)

`useSkillCatalog` restored the catalog captured by the **render closure the callback was created in**. Two clicks made before React re-renders share that closure, so a refusal on the second restored the state from before the *first* — silently undoing on screen a change the daemon had already accepted and persisted.

The rollback target is now a ref written wherever the catalog is committed, so it is always the last thing the hook actually published. `setEnabled` also stops depending on `view`, which was giving it a new identity on every catalog change for every caller's dependency array to carry.

⚠ **The test for this passed against the broken code on its first draft**, because it awaited between the two clicks — which lets React re-render and hands the second callback a fresh closure, hiding the defect completely. It now clicks twice in one render, and was verified by reintroducing the bug: fails without the fix, passes with it.

---

## 3. `CLAUDE.md`

Neither the catalog nor the importer was in the steering file. Adds a section recording the invariants that are expensive to rediscover — `roots()` is the one root list, `compose_state` is the one precedence rule, per-chat state is the session row and never `skills-config.json`, the bundle arms of that precedence are load-bearing, and why the live importer test exists.

## Tests

```
cargo test -p biorouter --lib -- skill                       104 passed
cargo test -p biorouter --test skill_package_live -- --ignored  2 passed (network)
cd ui/desktop && npm run test:run                            339 files / 3284 passed
./scripts/clippy-lint.sh                                     clean
npm run lint:check                                           clean
```

Part of #113 and #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
