### PR TITLE
fix(desktop): stop the catalogue subscription starving the renderer's sockets

### DIFF
--- a/ui/desktop/src/components/ConfigContext.test.tsx
+++ b/ui/desktop/src/components/ConfigContext.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   providers: vi.fn(),
   getProviderModels: vi.fn(),
   syncBundledExtensions: vi.fn(),
+  catalogChanges: vi.fn(),
 }));
 
 vi.mock('../api', () => ({
@@ -32,6 +33,7 @@ vi.mock('../api', () => ({
   removeExtension: mocks.removeExtension,
   providers: mocks.providers,
   getProviderModels: mocks.getProviderModels,
+  catalogChanges: mocks.catalogChanges,
 }));
 
 vi.mock('./settings/extensions', () => ({
@@ -87,6 +89,9 @@ beforeEach(() => {
   mocks.providers.mockResolvedValue({ data: [] });
   mocks.syncBundledExtensions.mockResolvedValue(undefined);
   mocks.upsertConfig.mockResolvedValue({ data: {} });
+  // The quiet daemon: park and never answer. Any test that wants the catalogue
+  // to move says so itself.
+  mocks.catalogChanges.mockImplementation(() => new Promise(() => {}));
 });
 
 function renderProbe() {
@@ -254,5 +259,156 @@ describe('ConfigContext cache integrity', () => {
     await waitFor(() => expect(screen.getByTestId('upsert-result')).toHaveTextContent('ok'));
     expect(mocks.upsertConfig).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('provider')).toHaveTextContent('ollama');
+  });
+});
+
+/**
+ * Issue #112's catalogue subscription, against a daemon that has something to
+ * report — which is every daemon whose revision is not zero.
+ *
+ * `GET /catalog/changes?since=0` does NOT park: a caller at revision 0 is
+ * already behind, so the daemon answers immediately with the current revision
+ * and the buffered changes. That is correct, and it is the whole hazard: a
+ * subscription that is torn down and restarted resets its cursor to 0, so the
+ * restart is answered instantly and the handler fires again. If the handler's
+ * own work changes the identity of anything the subscribing effect depends on,
+ * the effect re-subscribes and the two feed each other with a loopback round
+ * trip (~1 ms) as the only brake.
+ *
+ * That is not a slow leak. Chromium allows six sockets per host, `stop()` does
+ * not abort the request already on the wire, and each turn of the loop opens
+ * another — so within a few hundred milliseconds every socket to the daemon is
+ * spoken for and *every other request the renderer makes queues behind them and
+ * never runs*: the model picker's bind, the provider model lists, the
+ * diagnostics bundle, the chat reply. The window looks alive and answers
+ * nothing, which is exactly how it was reported ("the Select Model button froze
+ * without telling me why").
+ *
+ * ⚠ The unit tests next door cannot see this. `catalogSubscription.test.ts`
+ * scripts its poll to park after the last scripted delta *specifically so the
+ * loop cannot spin* — a reasonable thing to do to keep a test fast, and it
+ * makes the runaway structurally unreachable there. The loop only exists once
+ * the module is wired to a React effect, so this is where it has to be pinned.
+ */
+describe('ConfigContext catalogue subscription (#112)', () => {
+  /** A faithful daemon: immediate when the caller is behind, parked when level. */
+  function daemonAtRevision(revision: number) {
+    return ({ query }: { query: { since: number } }) => {
+      if (query.since >= revision) return new Promise(() => {});
+      return Promise.resolve({
+        data: {
+          revision,
+          changes: [
+            {
+              revision,
+              reason: 'install' as const,
+              extensions: [
+                {
+                  key: 'spokeagent',
+                  name: 'SPOKEAgent',
+                  change: 'added' as const,
+                  enabled: true,
+                  bundledSkillIds: [],
+                },
+              ],
+              skills: [],
+            },
+          ],
+          truncated: false,
+        },
+      });
+    };
+  }
+
+  /**
+   * ⚠ `mockResolvedValue` is the wrong tool for this file and it hid the bug.
+   *
+   * It hands every caller back the SAME object, so `setExtensionsList` receives
+   * an array it is already holding, `Object.is` says equal, React bails out of
+   * the update, and nothing downstream re-renders — which is precisely the
+   * re-render the runaway is made of. A real response is parsed from a fresh
+   * body on every call and is never reference-equal to the last one. Modelling
+   * that is what makes this test able to fail.
+   */
+  function freshExtensionsResponse() {
+    mocks.getExtensions.mockImplementation(() =>
+      Promise.resolve({ data: { extensions: [], warnings: [] }, response: { status: 200 } })
+    );
+  }
+
+  it('polls a moved catalogue a bounded number of times, not in a loop', async () => {
+    freshExtensionsResponse();
+    mocks.catalogChanges.mockImplementation(daemonAtRevision(4));
+
+    renderProbe();
+
+    // Let every microtask and timer settle. A correct subscription advances its
+    // cursor to 4 and parks; a subscription that restarts re-asks from 0 and is
+    // answered instantly, forever.
+    for (let i = 0; i < 40; i += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    // Two is the honest ceiling for correct behaviour: the opening poll at
+    // since=0, and the parked poll at since=4 that follows it. The assertion is
+    // loose enough to survive an extra render, and orders of magnitude below
+    // what the runaway produces.
+    expect(mocks.catalogChanges.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it('advances its cursor, so the poll after a change asks from the new revision', async () => {
+    freshExtensionsResponse();
+    mocks.catalogChanges.mockImplementation(daemonAtRevision(4));
+
+    renderProbe();
+
+    await waitFor(() => expect(mocks.catalogChanges.mock.calls.length).toBeGreaterThan(1));
+
+    // The second poll must carry the revision the first one reported. Asking
+    // from 0 again is the restart this whole describe exists to rule out.
+    const second = mocks.catalogChanges.mock.calls[1][0] as { query: { since: number } };
+    expect(second.query.since).toBe(4);
+  });
+
+  /**
+   * The crash that told us where to look. Under a network failure the generated
+   * client resolves with `{ error, response: undefined }` (see
+   * `api/client/client.gen.ts` — it returns `response: undefined as any` from
+   * the fetch catch), so reading `.status` off it throws a TypeError. Because
+   * the subscription calls `refreshExtensions` with a bare `void`, that
+   * TypeError became an unhandled rejection rather than a handled failure:
+   *
+   *   [UNHANDLED REJECTION] TypeError: Cannot read properties of undefined (reading 'status')
+   *
+   * A backend that cannot be reached must leave the cached list alone and say
+   * so, never throw a type error out of a promise nobody is holding.
+   */
+  it('survives an extension refresh whose fetch never reached the daemon', async () => {
+    mocks.getExtensions.mockResolvedValue({
+      error: new TypeError('Failed to fetch'),
+      response: undefined,
+    });
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (event: PromiseRejectionEvent) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', onUnhandled);
+
+    try {
+      renderProbe();
+      for (let i = 0; i < 20; i += 1) {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
+    } finally {
+      window.removeEventListener('unhandledrejection', onUnhandled);
+    }
+
+    expect(unhandled).toEqual([]);
   });
 });

--- a/ui/desktop/src/components/ConfigContext.tsx
+++ b/ui/desktop/src/components/ConfigContext.tsx
@@ -21,6 +21,7 @@ import {
 import { syncBundledExtensions } from './settings/extensions';
 import { userActionHeaders } from '../utils/userAction';
 import { newlyInstalledExtensions, subscribeToCatalog } from '../utils/catalogSubscription';
+import type { CatalogDelta } from '../api';
 import { toastService } from '../toasts';
 import {
   isCapabilityDefaultEnabled,
@@ -229,23 +230,63 @@ export const ConfigProvider: React.FC<ConfigProviderProps> = ({ children }) => {
     [reloadConfigAfterWrite]
   );
 
+  /**
+   * The last extension list we successfully read, as a ref.
+   *
+   * ⚠ **`refreshExtensions` must not close over `extensionsList` as a
+   * dependency**, and the reason is not tidiness — it is the runaway loop that
+   * took the whole renderer down in 1.89.5.
+   *
+   * This function ends by calling `setExtensionsList` with an array parsed
+   * fresh from the response body, so it is never reference-equal to the one in
+   * state and React always commits the update. With `extensionsList` in the
+   * dependency array, *every successful refresh minted a new
+   * `refreshExtensions`* — and the catalogue subscription below listed that
+   * function among its effect dependencies, so every refresh tore the
+   * subscription down and started a new one from `since = 0`. A restart at zero
+   * is answered by the daemon **immediately** rather than parked (the caller is
+   * behind), which re-fired the handler, which refreshed again. Two correct
+   * pieces, feeding each other, with a loopback round trip as the only brake.
+   *
+   * The fallback below is the only thing the old dependency bought, and a ref
+   * serves it exactly as well while keeping this function's identity stable for
+   * the life of the provider.
+   */
+  const extensionsListRef = useRef<FixedExtensionEntry[]>([]);
+  useEffect(() => {
+    extensionsListRef.current = extensionsList;
+  }, [extensionsList]);
+
   const refreshExtensions = useCallback(async () => {
     const result = await apiGetExtensions();
 
-    if (result.response.status === 422) {
+    // ⚠ `result.response` is OPTIONAL in practice, whatever the generated types
+    // say. On a network-level failure the client returns `response: undefined`
+    // (`api/client/client.gen.ts` returns `response: undefined as any` from its
+    // fetch catch), so an unguarded `.status` throws
+    // `TypeError: Cannot read properties of undefined (reading 'status')` —
+    // which is how a backend that merely could not be reached surfaced as an
+    // unhandled rejection rather than as a handled, reported failure.
+    if (result.response?.status === 422) {
       throw new MalformedConfigError();
     }
 
     if (result.error && !result.data) {
       console.log(result.error);
-      return extensionsList;
+      return extensionsListRef.current;
     }
 
-    const extensionResponse: ExtensionResponse = result.data!;
+    if (!result.data) {
+      // No body and no error: nothing was learned, so nothing is published. The
+      // cache keeps what it had rather than being emptied by a failed read.
+      return extensionsListRef.current;
+    }
+
+    const extensionResponse: ExtensionResponse = result.data;
     setExtensionsList(extensionResponse.extensions);
     setExtensionWarnings(extensionResponse.warnings || []);
     return extensionResponse.extensions;
-  }, [extensionsList]);
+  }, []);
 
   const addExtension = useCallback(
     async (name: string, config: ExtensionConfig, enabled: boolean) => {
@@ -339,27 +380,54 @@ export const ConfigProvider: React.FC<ConfigProviderProps> = ({ children }) => {
    * this refetches. Applying a partial history and believing yourself current is
    * the same stale-inventory bug one layer down.
    */
-  useEffect(() => {
-    return subscribeToCatalog({
-      onChange: (delta) => {
-        void refreshExtensions();
-        void reloadConfigAfterWrite();
+  /**
+   * The subscription's handler, held in a ref so the effect below can mount
+   * ONCE and never re-subscribe.
+   *
+   * ⚠ This is belt-and-braces on top of the stable `refreshExtensions` above,
+   * and it is worth having both. Listing callbacks as effect dependencies is
+   * the idiomatic thing to do and reads as obviously correct; what makes it
+   * unsafe *here* is that a re-subscribe is not a cheap no-op but a cursor
+   * reset to zero, which the daemon answers instantly. Anything that costs a
+   * restart must not be re-run because a function identity moved — so the
+   * effect depends on nothing, and the handler is read fresh at call time.
+   */
+  const onCatalogChangeRef = useRef<(delta: CatalogDelta) => void>(() => {});
 
-        // ⚠ OFFER, never attach. A running chat snapshots the extensions it
-        // started with, and an install made somewhere else — another terminal,
-        // another window — is not that chat's decision to have made. An agent
-        // asked to install one *in* a chat attaches it itself, because there
-        // the user did ask; here they did not, so this says the row is now
-        // there and leaves the click to them.
-        for (const extension of newlyInstalledExtensions(delta)) {
-          toastService.success({
-            title: extension.name,
-            msg: 'Extension installed. Turn it on for this chat from the extensions menu below the composer.',
-          });
-        }
-      },
-    });
+  useEffect(() => {
+    onCatalogChangeRef.current = (delta: CatalogDelta) => {
+      // ⚠ `.catch`, not `void`. These are fire-and-forget by intent, but
+      // "nobody is waiting for the result" is not the same as "nobody handles a
+      // failure": a bare `void` on a rejecting promise is an unhandled
+      // rejection, and that is how a merely-unreachable daemon reached the log
+      // as an uncaught TypeError instead of a console warning.
+      refreshExtensions().catch((error: unknown) =>
+        console.warn('Catalogue changed, but the extension list could not be refreshed:', error)
+      );
+      reloadConfigAfterWrite().catch((error: unknown) =>
+        console.warn('Catalogue changed, but the config could not be re-read:', error)
+      );
+
+      // ⚠ OFFER, never attach. A running chat snapshots the extensions it
+      // started with, and an install made somewhere else — another terminal,
+      // another window — is not that chat's decision to have made. An agent
+      // asked to install one *in* a chat attaches it itself, because there
+      // the user did ask; here they did not, so this says the row is now
+      // there and leaves the click to them.
+      for (const extension of newlyInstalledExtensions(delta)) {
+        toastService.success({
+          title: extension.name,
+          msg: 'Extension installed. Turn it on for this chat from the extensions menu below the composer.',
+        });
+      }
+    };
   }, [refreshExtensions, reloadConfigAfterWrite]);
+
+  useEffect(() => {
+    return subscribeToCatalog({ onChange: (delta) => onCatalogChangeRef.current(delta) });
+    // Mount-once, deliberately. See `onCatalogChangeRef` above: a re-subscribe
+    // resets the cursor to zero, and a zero cursor is answered without parking.
+  }, []);
 
   useEffect(() => {
     // Load all configuration data and providers on mount

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.test.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SwitchModelModal } from './SwitchModelModal';
 
@@ -78,5 +78,146 @@ describe('SwitchModelModal onboarding initialization', () => {
       expect(document.querySelector('[data-testid="provider-select"]')).toHaveTextContent('openai');
       expect(document.querySelector('[data-testid="model-select"]')).toHaveTextContent('gpt-4o');
     });
+  });
+});
+
+/**
+ * What the dialog does while a bind is in flight, and what it says when one
+ * fails.
+ *
+ * Reported as *"the Select Model button actually froze without telling me
+ * why"* against Versa API Azure. The button had not frozen: `changeModel` was
+ * awaiting the daemon, the button carried no pending state to show it, and on
+ * failure `handleSubmit` returned leaving the dialog byte-for-byte as it was.
+ * Every report the user got lived in a toast in the opposite corner of the
+ * screen — including `TypeError: Failed to fetch`, which is what the underlying
+ * fault (a runaway catalogue poll exhausting the renderer's socket pool)
+ * produced. A dialog that cannot say "working" or "that failed" is
+ * indistinguishable from a dead one.
+ */
+describe('SwitchModelModal switch feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviders.mockResolvedValue([
+      {
+        name: 'versa_azure',
+        is_configured: true,
+        provider_type: 'Institutional',
+        metadata: {
+          name: 'versa_azure',
+          display_name: 'Versa API Azure',
+          default_model: 'gpt-5.5-2026-04-24',
+          known_models: [{ name: 'gpt-5.5-2026-04-24' }],
+          allows_unlisted_models: false,
+          config_keys: [],
+        },
+      },
+    ]);
+    mocks.getProviderModels.mockResolvedValue(['gpt-5.5-2026-04-24']);
+    mocks.read.mockResolvedValue('');
+  });
+
+  const renderModal = (onClose = vi.fn()) =>
+    render(
+      <SwitchModelModal
+        sessionId="s-1"
+        onClose={onClose}
+        setView={vi.fn()}
+        initialProvider="versa_azure"
+        initialModel="gpt-5.5-2026-04-24"
+      />
+    );
+
+  const clickSelect = async () => {
+    const button = await waitFor(() => {
+      const found = screen.getAllByRole('button').find((el) => el.textContent === 'Select model');
+      if (!found) throw new Error('Select model button not rendered');
+      return found;
+    });
+    fireEvent.click(button);
+    return button;
+  };
+
+  it('shows the switch is running, and refuses a second one while it is', async () => {
+    let release: (ok: boolean) => void = () => {};
+    mocks.changeModel.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          release = resolve;
+        })
+    );
+
+    renderModal();
+    const button = await clickSelect();
+
+    // The label is the whole point: a bind crosses the network twice and the
+    // user must be able to tell "working" from "ignored me".
+    await waitFor(() => expect(button).toHaveTextContent('Switching'));
+    expect(button).toBeDisabled();
+
+    // A second click must not start a second bind — two racing binds write two
+    // providers through `/config/set_provider` and the loser wins.
+    fireEvent.click(button);
+    expect(mocks.changeModel).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      release(true);
+    });
+  });
+
+  it('says so in the dialog when the switch did not happen', async () => {
+    mocks.changeModel.mockResolvedValue(false);
+    const onClose = vi.fn();
+
+    renderModal(onClose);
+    await clickSelect();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('switch-model-submit-error')).toHaveTextContent(
+        'The model was not switched'
+      )
+    );
+    // A refused switch leaves the dialog open — closing it would hide the one
+    // control that can retry.
+    expect(onClose).not.toHaveBeenCalled();
+    // And the button must come back, or the dialog is a dead end.
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole('button').find((el) => el.textContent === 'Select model')
+      ).toBeEnabled()
+    );
+  });
+
+  /**
+   * ⚠ `handleSubmit` is wired straight to `onClick`, so nothing holds the
+   * promise it returns. Before this, a throw anywhere inside it became an
+   * unhandled rejection and the dialog did not move — the exact silent freeze
+   * that was reported.
+   */
+  it('reports a thrown failure instead of leaving an unhandled rejection', async () => {
+    mocks.changeModel.mockRejectedValue(new Error('Failed to fetch'));
+
+    const unhandled: unknown[] = [];
+    const onUnhandled = (event: PromiseRejectionEvent) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', onUnhandled);
+
+    try {
+      renderModal();
+      await clickSelect();
+
+      await waitFor(() =>
+        expect(screen.getByTestId('switch-model-submit-error')).toHaveTextContent('Failed to fetch')
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+    } finally {
+      window.removeEventListener('unhandledrejection', onUnhandled);
+    }
+
+    expect(unhandled).toEqual([]);
   });
 });

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -103,11 +103,7 @@ const llamaModelOption = (
   // download is, whether they already have it, and whether it suits this machine.
   // The fallback state and the raw `owner/repo:QUANT` spec are diagnostics, not
   // selection criteria — LocalModelInventory in Settings is where those belong.
-  const detail = [
-    entry.download_size,
-    llamaDownloadLabel(entry),
-    llamaFitLabel(entry),
-  ]
+  const detail = [entry.download_size, llamaDownloadLabel(entry), llamaFitLabel(entry)]
     .filter(Boolean)
     .join(' · ');
 
@@ -368,15 +364,39 @@ export const SwitchModelModal = ({
     onClose();
   };
 
+  /**
+   * The switch, as a state the dialog can render.
+   *
+   * ⚠ **A bind is not instant and can fail, and until this existed the dialog
+   * admitted neither.** `changeModel` awaits two round trips to the daemon
+   * (`/agent/update_provider`, then `/config/set_provider`); the button stayed
+   * fully live throughout, and on failure `handleSubmit` returned without
+   * closing the dialog and without writing anything into it — the sole report
+   * was a toast in the far corner of the screen, which is off-screen for anyone
+   * looking at the dialog they just clicked in. The bug this was reported as is
+   * quotable: *"the Select Model button actually froze without telling me
+   * why"*. It had not frozen. It had no way to speak.
+   */
+  const [switching, setSwitching] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const handleSubmit = async () => {
     // The button below is already disabled on a browser surface; this is the
     // second half of the same guard, for a keyboard submit or a call site that
     // renders its own confirm.
     if (hostManaged) return;
+    // Re-entrancy: the button is disabled while a switch is in flight, but a
+    // keyboard submit reaches here directly. Two binds racing would write two
+    // different providers through `/config/set_provider` and leave whichever
+    // landed second as the global default.
+    if (switching) return;
     setAttemptedSubmit(true);
+    setSubmitError(null);
     const isFormValid = validateForm();
+    if (!isFormValid) return;
 
-    if (isFormValid) {
+    setSwitching(true);
+    try {
       let modelObj: Model;
 
       if (usePredefinedModels && selectedPredefinedModel) {
@@ -389,6 +409,13 @@ export const SwitchModelModal = ({
 
       const changed = await changeModel(sessionId, modelObj);
       if (!changed) {
+        // `changeModel` has already raised the toast that explains *why* — a
+        // privacy barrier, a missing user proof, a provider failure. This says
+        // the far plainer thing the toast cannot, in the place the user is
+        // looking: the dialog is still open because nothing was switched.
+        setSubmitError(
+          'The model was not switched. See the notification for what went wrong, then try again.'
+        );
         return;
       }
 
@@ -396,6 +423,18 @@ export const SwitchModelModal = ({
         onModelSelected(modelObj.name);
       }
       onClose();
+    } catch (error) {
+      // ⚠ This arm is why the dialog could hang silently. `handleSubmit` is
+      // wired straight to `onClick`, so nothing holds the promise it returns: a
+      // throw anywhere above became an *unhandled rejection*, the dialog
+      // stayed open, and not one pixel changed. Anything that can throw here —
+      // a provider-metadata fetch, an unreachable daemon — now lands in the
+      // dialog instead of in the console.
+      setSubmitError(
+        error instanceof Error ? error.message : `The model could not be switched: ${String(error)}`
+      );
+    } finally {
+      setSwitching(false);
     }
   };
 
@@ -855,6 +894,16 @@ export const SwitchModelModal = ({
           )}
         </div>
 
+        {submitError && (
+          <div
+            data-testid="switch-model-submit-error"
+            role="alert"
+            className="rounded-container border border-border-subtle bg-background-muted px-3 py-2.5 text-sm leading-relaxed text-text-danger [overflow-wrap:anywhere]"
+          >
+            {submitError}
+          </div>
+        )}
+
         <DialogFooter className="pt-4 flex-col sm:flex-row gap-3">
           <a
             href={QUICKSTART_GUIDE_URL}
@@ -869,8 +918,8 @@ export const SwitchModelModal = ({
             <Button variant="outline" onClick={handleClose} type="button">
               Cancel
             </Button>
-            <Button onClick={handleSubmit} disabled={!isValid || hostManaged}>
-              Select model
+            <Button onClick={handleSubmit} disabled={!isValid || hostManaged || switching}>
+              {switching ? 'Switching\u2026' : 'Select model'}
             </Button>
           </div>
         </DialogFooter>

--- a/ui/desktop/src/utils/catalogSubscription.test.ts
+++ b/ui/desktop/src/utils/catalogSubscription.test.ts
@@ -52,6 +52,15 @@ function scripted(deltas: CatalogDelta[]) {
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+/**
+ * The loop keeps a small floor under one iteration (`MIN_INTERVAL_MS`) so a
+ * subscription answered without parking cannot become a busy wait on the
+ * daemon. These tests are about *sequencing*, not wall-clock, so they hand it a
+ * sleep that resolves at once — the ordering they assert is unchanged, and they
+ * do not have to sit through the floor or encode its value.
+ */
+const immediate = () => Promise.resolve();
+
 afterEach(() => vi.clearAllMocks());
 
 describe('subscribeToCatalog (issue #112)', () => {
@@ -59,7 +68,7 @@ describe('subscribeToCatalog (issue #112)', () => {
     const onChange = vi.fn();
     const { poll, seen } = scripted([delta(1, ['bioroffice']), delta(2, ['markitdown'])]);
 
-    const stop = subscribeToCatalog({ onChange, poll });
+    const stop = subscribeToCatalog({ onChange, poll, sleep: immediate });
     await flush();
     await flush();
     stop();
@@ -115,7 +124,7 @@ describe('subscribeToCatalog (issue #112)', () => {
       delta(1, ['markitdown']),
     ]);
 
-    const stop = subscribeToCatalog({ onChange, poll });
+    const stop = subscribeToCatalog({ onChange, poll, sleep: immediate });
     await flush();
     await flush();
     await flush();

--- a/ui/desktop/src/utils/catalogSubscription.ts
+++ b/ui/desktop/src/utils/catalogSubscription.ts
@@ -31,17 +31,46 @@ export interface CatalogSubscriptionOptions {
   /** Called for every delta that reports a change. */
   onChange: (delta: CatalogDelta) => void;
   /** Injected in tests. Defaults to the generated client. */
-  poll?: (since: number) => Promise<CatalogDelta | undefined>;
+  poll?: (since: number, signal?: AbortSignal) => Promise<CatalogDelta | undefined>;
   /** Injected in tests. */
   sleep?: (ms: number) => Promise<void>;
   /** How long to wait after a failed poll before trying again. */
   retryDelayMs?: number;
+  /**
+   * The revision to resume from. Defaults to 0, which asks the daemon for the
+   * current revision without waiting — correct for a genuinely fresh client,
+   * and the thing a *restarting* one must not do. See {@link MIN_INTERVAL_MS}.
+   */
+  since?: number;
 }
 
 const DEFAULT_RETRY_MS = 5000;
 
-const defaultPoll = async (since: number): Promise<CatalogDelta | undefined> => {
-  const response = await catalogChanges({ query: { since } });
+/**
+ * The floor under one turn of the loop.
+ *
+ * ⚠ This is a blast-radius bound, not a performance tweak, and it exists
+ * because of what a poll at `since = 0` costs. A caller that is behind is
+ * answered **immediately** rather than parked — correct, and it means a
+ * subscription which keeps restarting issues requests as fast as the loopback
+ * will carry them. Chromium allows six sockets per host; at a ~1 ms round trip
+ * they are all claimed almost at once, and every other request the renderer
+ * makes — the model picker's bind, provider model lists, the diagnostics
+ * bundle, the chat reply — then queues behind them and never runs. The window
+ * stays up and answers nothing.
+ *
+ * `ConfigContext` no longer restarts the subscription (its effect is
+ * mount-once), so nothing should reach this floor. It is kept anyway: this
+ * module is exported, the failure it bounds is a dead renderer rather than a
+ * slow one, and 40 ms is far below any interval a human perceives.
+ */
+const MIN_INTERVAL_MS = 40;
+
+const defaultPoll = async (
+  since: number,
+  signal?: AbortSignal
+): Promise<CatalogDelta | undefined> => {
+  const response = await catalogChanges({ query: { since }, signal });
   return response.data;
 };
 
@@ -60,13 +89,19 @@ export function subscribeToCatalog(options: CatalogSubscriptionOptions): () => v
   const retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_MS;
 
   let stopped = false;
-  let since = 0;
+  let since = options.since ?? 0;
+  // ⚠ Stopping must RELEASE the request, not merely ignore its answer. A parked
+  // poll holds one of the renderer's six sockets to the daemon for up to 25
+  // seconds after the subscription that opened it is gone; without this, a
+  // torn-down subscription leaks a socket for every teardown.
+  const controller = new AbortController();
 
   const run = async () => {
     while (!stopped) {
+      const startedAt = Date.now();
       let delta: CatalogDelta | undefined;
       try {
-        delta = await poll(since);
+        delta = await poll(since, controller.signal);
       } catch {
         // The daemon is restarting, or the machine slept. Back off rather than
         // spinning; the next successful poll re-establishes the cursor.
@@ -92,12 +127,20 @@ export function subscribeToCatalog(options: CatalogSubscriptionOptions): () => v
         options.onChange(delta);
         dispatchCatalogChanged(delta);
       }
+
+      // Answered without parking — the caller was behind. Keep a floor under
+      // the loop so this can never become a busy wait on the daemon.
+      const elapsed = Date.now() - startedAt;
+      if (!stopped && elapsed < MIN_INTERVAL_MS) {
+        await sleep(MIN_INTERVAL_MS - elapsed);
+      }
     }
   };
 
   void run();
   return () => {
     stopped = true;
+    controller.abort();
   };
 }
 


### PR DESCRIPTION
Blocks the re-release of 1.89.5, which is now back to a **draft** (public `latest` is `v1.89.4` again, so the auto-updater no longer offers it).

## What was reported

Four separate-looking failures, all on 1.89.5:

- the model picker's **"Select model" button did nothing** — reported as *"froze without telling me why"*
- **"Backend disconnected — your message was kept"** in chat
- **provider model lists failed to load**
- the **diagnostics bundle span at "Generating…" forever**

## They are one bug, and it is not in the backend

The daemon was healthy throughout. `POST /agent/update_provider` with `versa_azure` against the reporting machine's live daemon answered correctly in **129 ms**. Nothing is wrong with Versa.

#112's catalogue subscription is started from a `useEffect` in `ConfigProvider` whose dependencies include `refreshExtensions` — and `refreshExtensions` was `useCallback(..., [extensionsList])` while *ending* in `setExtensionsList(<array parsed from the response body>)`. That array is never reference-equal to the one in state, so **every successful refresh minted a new `refreshExtensions`**, which re-ran the effect, which tore the subscription down and started a new one from `since = 0`.

**A poll at zero is not parked.** The caller is behind, so the daemon answers immediately — measured on the reporting machine: `revision 4, 4 changes, 1 ms`. Restart → instant answer → handler → refresh → restart, with a loopback round trip as the only brake.

Chromium allows **six sockets per host**, and `stop()` did not abort the request already on the wire (a parked poll holds its socket for up to 25 s). Once the pool was claimed, **every other request the renderer made queued behind it and never ran**: the model picker's bind, the provider model lists, the diagnostics bundle, the chat reply.

Observed on the reporting machine: **7 ESTABLISHED sockets** from the Electron network process to the daemon, renderer idle at **6 % CPU**. A starve, not a spin. That is why the button looked frozen — the bind never reached the network — and why the failures that did surface came back as `TypeError: Failed to fetch`.

The thread that located it was one log line:

```
[UNHANDLED REJECTION] TypeError: Cannot read properties of undefined (reading 'status')
```

`ConfigContext` read `result.response.status` unguarded. On a network failure the generated client returns `response: undefined` (`api/client/client.gen.ts` returns `response: undefined as any` from its fetch catch), and the bare `void refreshExtensions()` made the resulting TypeError an unhandled rejection rather than a handled failure.

## The fix

- `refreshExtensions` no longer depends on `extensionsList` — a ref serves the one fallback that needed it, so its identity is stable for the life of the provider.
- The subscription effect is **mount-once**, with its handler in a ref. A re-subscribe costs a cursor reset, so it must not be triggered by a function identity moving.
- `subscribeToCatalog` **aborts its in-flight poll on stop** instead of leaking a parked socket, accepts a resume cursor, and keeps a 40 ms floor under one iteration as a blast-radius bound.
- `result.response?.status` is guarded; `void` → `.catch`.

Separately, the dialog had no way to say any of this: no pending state across two round trips, no inline report when the bind failed (the sole report was a toast in the opposite corner of the screen), and `handleSubmit` was wired straight to `onClick` so a throw became an unhandled rejection and not one pixel moved. It now shows **"Switching…"**, refuses a concurrent submit (two racing binds write two providers through `/config/set_provider` and the loser wins), and writes the failure into the dialog.

## Why the shipped tests missed it

Two reasons, both worth keeping in mind:

1. `catalogSubscription.test.ts` scripts its poll to **park after the last scripted delta specifically so the loop cannot spin** — reasonable for keeping a test fast, and it makes the runaway structurally unreachable there.
2. It used `mockResolvedValue`, which hands every caller back the **same object**, so `setExtensionsList` receives an array React is already holding, `Object.is` says equal, and React bails out of the very re-render the runaway is made of.

The loop only exists once the module is wired to a React effect, so the regression test lives in `ConfigContext.test.tsx` and models a response parsed fresh on every call. It **times out at 30 s** against the old code.

## Verification

- New regression tests fail against the unfixed code and pass against the fix (confirmed by stashing each fix in turn).
- Full frontend suite: **352 files / 3485 tests pass**.
- `tsc --noEmit` clean, eslint clean at `--max-warnings 0`.
- Confirmed in a running Electron app — see the comment below for the before/after socket and poll-rate measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
