### PR TITLE
feat(baam): add Folklore Clinical Variant Interpretation MCP

### DIFF
--- a/landing/baam.html
+++ b/landing/baam.html
@@ -884,16 +884,16 @@
           </div>
           <div class="ext-meta">
             <h3>Folklore Clinical Variant Interpretation MCP</h3>
-            <div class="ext-org">Helena Bioinformatics · v1.3.3</div>
+            <div class="ext-org">Helena Bioinformatics · v1.4.0</div>
           </div>
           <a href="https://github.com/helena-bioinformatics/folklore-mcp" target="_blank" class="ext-gh-link" title="View on GitHub">
             <svg class="icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.49.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.8c.85 0 1.71.11 2.51.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.59 1.03 2.68 1.03 3.84 0 4.68-2.34 4.93-4.57.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10.01 10.01 0 0 0 22 12c0-5.52-4.48-10-10-10z"/></svg>
           </a>
         </div>
-        <p class="ext-desc">Read-only access to public variant evidence, automated ACMG/AMP decision support, variant-linked literature, publication details, and semantic biomedical literature search. Accepts public variant-level queries only, not patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.</p>
+        <p class="ext-desc">Classifies and interprets one supported public GRCh38 germline SNV or simple indel under ACMG/AMP, with structured evidence, provenance, variant-linked literature, publication details, and semantic biomedical literature search. Read-only; accepts no patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.</p>
         <div class="ext-footer">
           <div class="ext-tags"><span class="tag public" data-privacy-badge>Public</span><span class="tag mcp">MCP</span><span class="tag">Variants</span><span class="tag">Literature</span><span class="tag">ACMG/AMP</span><span class="tag">Apache-2.0</span></div>
-          <a href="https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.3.3/folklore-clinical-variant-interpretation-mcp.brxt" class="brxt-chip">
+          <a href="https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.4.0/folklore-clinical-variant-interpretation-mcp.brxt" class="brxt-chip">
             <svg class="icon icon-sm" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             .brxt
           </a>

--- a/landing/baam.html
+++ b/landing/baam.html
@@ -876,6 +876,30 @@
         </div>
       </div>
 
+      <!-- Folklore Clinical Variant Interpretation MCP -->
+      <div class="ext-card" data-license="Apache-2.0">
+        <div class="ext-card-header">
+          <div class="icon-tile">
+            <svg class="icon" viewBox="0 0 24 24"><path d="M4 4h16v16H4z"/><path d="M8 8h8M8 12h8M8 16h5"/></svg>
+          </div>
+          <div class="ext-meta">
+            <h3>Folklore Clinical Variant Interpretation MCP</h3>
+            <div class="ext-org">Helena Bioinformatics · v1.3.3</div>
+          </div>
+          <a href="https://github.com/helena-bioinformatics/folklore-mcp" target="_blank" class="ext-gh-link" title="View on GitHub">
+            <svg class="icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.49.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.8c.85 0 1.71.11 2.51.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.59 1.03 2.68 1.03 3.84 0 4.68-2.34 4.93-4.57.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10.01 10.01 0 0 0 22 12c0-5.52-4.48-10-10-10z"/></svg>
+          </a>
+        </div>
+        <p class="ext-desc">Read-only access to public variant evidence, automated ACMG/AMP decision support, variant-linked literature, publication details, and semantic biomedical literature search. Accepts public variant-level queries only, not patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.</p>
+        <div class="ext-footer">
+          <div class="ext-tags"><span class="tag public" data-privacy-badge>Public</span><span class="tag mcp">MCP</span><span class="tag">Variants</span><span class="tag">Literature</span><span class="tag">ACMG/AMP</span><span class="tag">Apache-2.0</span></div>
+          <a href="https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.3.3/folklore-clinical-variant-interpretation-mcp.brxt" class="brxt-chip">
+            <svg class="icon icon-sm" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            .brxt
+          </a>
+        </div>
+      </div>
+
       <!-- ClinicalVariantAgent -->
       <div class="ext-card" data-license="Apache-2.0">
         <div class="ext-card-header">

--- a/landing/registry.json
+++ b/landing/registry.json
@@ -334,8 +334,8 @@
       "id": "folklore-clinical-variant-interpretation-mcp",
       "name": "Folklore Clinical Variant Interpretation MCP",
       "organization": "Helena Bioinformatics",
-      "version": "v1.3.3",
-      "description": "Read-only access to public variant evidence, automated ACMG/AMP decision support, variant-linked literature, publication details, and semantic biomedical literature search. Accepts public variant-level queries only, not patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.",
+      "version": "v1.4.0",
+      "description": "Classifies and interprets one supported public GRCh38 germline SNV or simple indel under ACMG/AMP, with structured evidence, provenance, variant-linked literature, publication details, and semantic biomedical literature search. Read-only; accepts no patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.",
       "tags": [
         "MCP",
         "Variants",
@@ -344,7 +344,7 @@
         "Apache-2.0"
       ],
       "github": "https://github.com/helena-bioinformatics/folklore-mcp",
-      "download": "https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.3.3/folklore-clinical-variant-interpretation-mcp.brxt",
+      "download": "https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.4.0/folklore-clinical-variant-interpretation-mcp.brxt",
       "filename": "folklore-clinical-variant-interpretation-mcp.brxt",
       "license": "Apache-2.0",
       "privacy": "public"

--- a/landing/registry.json
+++ b/landing/registry.json
@@ -331,6 +331,25 @@
       "privacy": "public"
     },
     {
+      "id": "folklore-clinical-variant-interpretation-mcp",
+      "name": "Folklore Clinical Variant Interpretation MCP",
+      "organization": "Helena Bioinformatics",
+      "version": "v1.3.3",
+      "description": "Read-only access to public variant evidence, automated ACMG/AMP decision support, variant-linked literature, publication details, and semantic biomedical literature search. Accepts public variant-level queries only, not patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.",
+      "tags": [
+        "MCP",
+        "Variants",
+        "Literature",
+        "ACMG/AMP",
+        "Apache-2.0"
+      ],
+      "github": "https://github.com/helena-bioinformatics/folklore-mcp",
+      "download": "https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.3.3/folklore-clinical-variant-interpretation-mcp.brxt",
+      "filename": "folklore-clinical-variant-interpretation-mcp.brxt",
+      "license": "Apache-2.0",
+      "privacy": "public"
+    },
+    {
       "id": "clinicalvariantagent",
       "name": "ClinicalVariantAgent",
       "organization": "BaranziniLab · BRXT",

--- a/ui/desktop/src/components/baam/registry.fallback.json
+++ b/ui/desktop/src/components/baam/registry.fallback.json
@@ -334,8 +334,8 @@
       "id": "folklore-clinical-variant-interpretation-mcp",
       "name": "Folklore Clinical Variant Interpretation MCP",
       "organization": "Helena Bioinformatics",
-      "version": "v1.3.3",
-      "description": "Read-only access to public variant evidence, automated ACMG/AMP decision support, variant-linked literature, publication details, and semantic biomedical literature search. Accepts public variant-level queries only, not patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.",
+      "version": "v1.4.0",
+      "description": "Classifies and interprets one supported public GRCh38 germline SNV or simple indel under ACMG/AMP, with structured evidence, provenance, variant-linked literature, publication details, and semantic biomedical literature search. Read-only; accepts no patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.",
       "tags": [
         "MCP",
         "Variants",
@@ -344,7 +344,7 @@
         "Apache-2.0"
       ],
       "github": "https://github.com/helena-bioinformatics/folklore-mcp",
-      "download": "https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.3.3/folklore-clinical-variant-interpretation-mcp.brxt",
+      "download": "https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.4.0/folklore-clinical-variant-interpretation-mcp.brxt",
       "filename": "folklore-clinical-variant-interpretation-mcp.brxt",
       "license": "Apache-2.0",
       "privacy": "public"

--- a/ui/desktop/src/components/baam/registry.fallback.json
+++ b/ui/desktop/src/components/baam/registry.fallback.json
@@ -331,6 +331,25 @@
       "privacy": "public"
     },
     {
+      "id": "folklore-clinical-variant-interpretation-mcp",
+      "name": "Folklore Clinical Variant Interpretation MCP",
+      "organization": "Helena Bioinformatics",
+      "version": "v1.3.3",
+      "description": "Read-only access to public variant evidence, automated ACMG/AMP decision support, variant-linked literature, publication details, and semantic biomedical literature search. Accepts public variant-level queries only, not patient or private case data. Results require qualified professional review and are not a diagnosis or treatment recommendation.",
+      "tags": [
+        "MCP",
+        "Variants",
+        "Literature",
+        "ACMG/AMP",
+        "Apache-2.0"
+      ],
+      "github": "https://github.com/helena-bioinformatics/folklore-mcp",
+      "download": "https://github.com/helena-bioinformatics/folklore-mcp/releases/download/folklore-biorouter-v1.3.3/folklore-clinical-variant-interpretation-mcp.brxt",
+      "filename": "folklore-clinical-variant-interpretation-mcp.brxt",
+      "license": "Apache-2.0",
+      "privacy": "public"
+    },
+    {
       "id": "clinicalvariantagent",
       "name": "ClinicalVariantAgent",
       "organization": "BaranziniLab · BRXT",


### PR DESCRIPTION
## Summary

- Add Helena Bioinformatics' Folklore Clinical Variant Interpretation MCP to the BAAM extension catalog.
- Publish the generated registry and bundled fallback entries from the same BAAM card.
- Use the immutable v1.3.3 BRXT release asset: https://github.com/helena-bioinformatics/folklore-mcp/releases/tag/folklore-biorouter-v1.3.3
- State the public, read-only variant-level boundary directly in the catalog: no patient or private case data; results require qualified professional review and are not diagnosis or treatment recommendations.

### Type of Change

- [x] Feature
- [x] Documentation
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other

### AI Assistance

- [x] This PR was created or reviewed with AI assistance

### Testing

- `node landing/scripts/build-registry.mjs --check`
- `node --test landing/scripts/build-registry.test.mjs landing/scripts/check-docs-privacy.test.mjs` (75 tests passed)
- `node landing/scripts/check-consistency.mjs`
- `node landing/scripts/check-docs-privacy.mjs`
- The released BRXT archive was downloaded independently, its ZIP structure verified, and SHA-256 matched the published checksum: `a2689795cce8c39b4badb9695be9db0498303e4011c42e00c5a9fdb8d2000cb9`.
