### PR TITLE
feat(skills): bundle the knowledge skills into one "Knowledge" Context

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -162,7 +162,29 @@ jobs:
       # batch of Windows fixes made the job fail one binary further along, which
       # read as "a new rotating set of failures" and was really one hidden queue
       # being drained one CI round-trip at a time. One run now names them all.
+      # ⚠ **The OS credential store must be off, or macOS hangs until the job
+      # is killed.** `Config::read` resolves a secret through `keyring`, and on
+      # a runner with no unlocked login keychain `SecKeychainFindGenericPassword`
+      # blocks on an authorization prompt nothing is there to answer. The
+      # secrets tests in `routes::action_required` sit on that call, so the
+      # whole binary stops: `test (macos-latest)` ran SIX HOURS on main
+      # (run 32997530845) and was cancelled. Reproduced locally and sampled —
+      # `Config::read` -> `keyring::Entry::get_password` ->
+      # `SecKeychainFindGenericPassword` -> `CSSM_DecryptData`, blocked. With
+      # this set the same binary finishes in seconds.
+      #
+      # Windows reaches the same code through the Credential Manager. Whether
+      # that is what has made windows-latest slow is NOT measured, so this is
+      # not offered as the explanation there — it is set on the whole matrix
+      # because the store is unwanted on every runner, not as a Windows fix.
+      #
+      # It costs no coverage: nothing in the workspace asserts keyring
+      # behaviour — the store is incidental to these tests, which are about
+      # routes. `serve` below and `release-artifact-smoke.yml` already set it
+      # for the same reason; this is the one job that was missing it.
       - name: cargo test (workspace, lib + bins)
+        env:
+          BIOROUTER_DISABLE_KEYRING: "true"
         run: cargo test --workspace --lib --bins --locked --no-fail-fast --timings
 
       - name: Upload Windows Cargo timings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -899,9 +899,32 @@ read `useSkillCatalog`.
   Precedence: skill `add` > skill `remove` > **bundle** `add` > bundle `remove`
   > machine-wide. The bundle arms are load-bearing — without them a per-chat
   bundle toggle writes a name no skill matches.
-- ⚠ `CatalogSkill.builtin` answers "did Biorouter put this here?". The
+- ⚠ `CatalogSkill.builtin` answers "did Biorouter put this here?", and
+  `CatalogBundle.builtin` answers it for a bundle **row**, which is a different
+  control over a different directory — a seeded bundle without it renders a
+  Trash that succeeds, toasts, and is undone by the next startup. The
   hand-synced `skillUtils.BUILTIN_SKILL_NAMES` copy is gone; `contexts.test.ts`
-  now asserts it has not come back.
+  now asserts it has not come back. The single refusal that makes "no seeded
+  skill can be deleted" true on **every** surface — GUI Trash and
+  `biorouter skill remove` alike — is `refuse_shipped` in
+  `skill_package/install.rs`, scoped to Biorouter's own skills root.
+- **A Context row may name a bundle, not a skill.** The four knowledge-format
+  skills plus `update-soul` are seeded into `<skills root>/knowledge-bases/` and
+  offered as *one* switch, "Knowledge". Three consequences, each of which was a
+  bug in the shape it prevents: `compose_state` and `enabled_skill_entries` test
+  a skill's **bundle** against the hidden-Context set as well as its own name
+  (`skills_extension::context_ids` is the list, and it holds `KNOWLEDGE_BUNDLE`,
+  not five skill names); the renderer's filters take the bundle too
+  (`isContextSkill(name, bundle)`, `isContextBundle(name)`, and the shared
+  `pickerBundles(view)` that the composer, the `@`-mention list and the workflow
+  picker all read); and every surface that enumerates *directory entries* rather
+  than skills — `count_user_skills`, the CLI status line — must ask
+  `is_shipped_entry_name`, because `is_builtin_skill_name` does not know the
+  bundle directory and reads it as one skill the user installed.
+  ⚠ `ensure_soul_skill` and `ensure_builtin_skills` both delete the flat
+  directories a pre-bundle install left behind. That is not tidiness: discovery
+  keys by frontmatter `name`, so a flat copy and a bundled copy are two
+  candidates for one map key and `read_dir` order decides.
 
 **One import pipeline** — `crates/biorouter/src/agents/skill_package/`, reached
 from Add Skill (URL or `.zip`), the marketplace, the `importSkillPackage` MCP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -901,13 +901,19 @@ read `useSkillCatalog`.
   bundle toggle writes a name no skill matches.
 - ⚠ `CatalogSkill.builtin` answers "did Biorouter put this here?", and
   `CatalogBundle.builtin` answers it for a bundle **row**, which is a different
-  control over a different directory — a seeded bundle without it renders a
-  Trash that succeeds, toasts, and is undone by the next startup. The
+  control over a different directory. That second field is defence in depth —
+  the one shipped bundle is a Context and `pickerBundles` strips Contexts before
+  a row renders — so do not mistake it for the thing that closes the
+  delete-succeeds-then-reverts hole; that is `refuse_shipped`, below. The
   hand-synced `skillUtils.BUILTIN_SKILL_NAMES` copy is gone; `contexts.test.ts`
   now asserts it has not come back. The single refusal that makes "no seeded
   skill can be deleted" true on **every** surface — GUI Trash and
   `biorouter skill remove` alike — is `refuse_shipped` in
-  `skill_package/install.rs`, scoped to Biorouter's own skills root.
+  `skill_package/install.rs`, scoped to Biorouter's own skills root and called
+  from **both** `remove` and `install`. ⚠ Guarding only `remove` is worse than
+  guarding neither: an install that shadows a shipped name renames the seeded
+  directory aside and deletes it, the seeder then writes `SKILL.md` back inside
+  the user's package, and `remove` refuses to uninstall the result.
 - **A Context row may name a bundle, not a skill.** The four knowledge-format
   skills plus `update-soul` are seeded into `<skills root>/knowledge-bases/` and
   offered as *one* switch, "Knowledge". Three consequences, each of which was a
@@ -921,10 +927,17 @@ read `useSkillCatalog`.
   than skills — `count_user_skills`, the CLI status line — must ask
   `is_shipped_entry_name`, because `is_builtin_skill_name` does not know the
   bundle directory and reads it as one skill the user installed.
-  ⚠ `ensure_soul_skill` and `ensure_builtin_skills` both delete the flat
-  directories a pre-bundle install left behind. That is not tidiness: discovery
-  keys by frontmatter `name`, so a flat copy and a bundled copy are two
-  candidates for one map key and `read_dir` order decides.
+  ⚠ `ensure_soul_skill` and `ensure_builtin_skills` both **move** — not delete
+  — the flat directories a pre-bundle install left behind, and both do the move
+  *before* seeding. Two reasons, and flattening them is how the first draft got
+  it wrong. Relocating at all is not tidiness: discovery keys by frontmatter
+  `name`, so a flat copy and a bundled copy are two candidates for one map key
+  and `read_dir` order decides. Moving rather than deleting is because the
+  seeder writes exactly one file per skill, `SKILL.md` — every *other* file in
+  that directory is a supporting file the user may have put there, which
+  `find_supporting_files` serves to the model, and which `remove_dir_all` would
+  take with it. A failed move leaves the old copy alone: a duplicate row is
+  visible and fixable, a deleted file is not.
 
 **One import pipeline** — `crates/biorouter/src/agents/skill_package/`, reached
 from Add Skill (URL or `.zip`), the marketplace, the `importSkillPackage` MCP

--- a/Justfile
+++ b/Justfile
@@ -429,7 +429,6 @@ run-dev:
 # Install all dependencies (run once after fresh clone)
 install-deps:
     cd ui/desktop && npm ci
-    cd documentation && yarn
 
 ensure-release-branch:
     #!/usr/bin/env bash

--- a/crates/biorouter-cli/src/commands/skill.rs
+++ b/crates/biorouter-cli/src/commands/skill.rs
@@ -801,8 +801,19 @@ fn enable_with(skills: &[InstalledSkill], path: &Path, query: &str) -> Result<()
 /// deleting it — so it leaves the catalog's view in one step rather than
 /// emptying out underneath a scan in flight.
 pub async fn handle_remove(slug: String) -> Result<()> {
-    let removed = biorouter::agents::skill_package::remove(&slug, &skills_root())
-        .map_err(|e| anyhow!("{e:#}. Run `biorouter skill list`."))?;
+    let removed = biorouter::agents::skill_package::remove(&slug, &skills_root()).map_err(|e| {
+        // ⚠ Only add the separator when the message does not already end a
+        // sentence. Some of these are one clause ("no package named `x` is
+        // installed") and some are several sentences of advice; appending
+        // unconditionally gave the latter a visible `..`.
+        let message = format!("{e:#}");
+        let separator = if message.trim_end().ends_with(['.', '!', '?']) {
+            ""
+        } else {
+            "."
+        };
+        anyhow!("{message}{separator} Run `biorouter skill list`.")
+    })?;
     println!(
         "  {} removed {}",
         style("✓").green(),

--- a/crates/biorouter-cli/src/session/tui/mod.rs
+++ b/crates/biorouter-cli/src/session/tui/mod.rs
@@ -1482,14 +1482,18 @@ fn list_skills() -> Vec<String> {
     crate::session::completion::list_skill_reference_names()
 }
 
-/// ⚠ **User-installed skills only** (#77). The five that ship with Biorouter
-/// are Contexts, managed in Settings -> Chat, and the GUI already excludes them
+/// ⚠ **User-installed skills only** (#77). What ships with Biorouter is offered
+/// as Contexts, managed in Settings -> Chat, and the GUI already excludes them
 /// from its chip. Counting them here made the two surfaces disagree about the
 /// same word — exactly the drift the capability exclusion below was written to
 /// fix for extensions.
 ///
-/// `is_builtin_skill_name` is the same predicate the seeder and the reset path
-/// use, rather than a second list that would drift from it.
+/// ⚠ **`is_shipped_entry_name`, not `is_builtin_skill_name`.** The list this
+/// filters is [`list_skills`], which names a bundle by its *directory* and
+/// never by a member (`completion.rs`) — so the skill-only predicate would let
+/// `KNOWLEDGE_BUNDLE` through as one skill the user installed, on every
+/// install. It is the same predicate the seeder, the reset path and the count
+/// in the GUI use, rather than a second list that would drift from them.
 ///
 /// Split from [`count_skills`] so the exclusion can be exercised on a list this
 /// test can name. Counting the real directory cannot check it: on a machine with
@@ -1498,7 +1502,7 @@ fn list_skills() -> Vec<String> {
 fn count_user_skills_in(names: &[String]) -> usize {
     names
         .iter()
-        .filter(|name| !biorouter::agents::skills_extension::is_builtin_skill_name(name))
+        .filter(|name| !biorouter::agents::skills_extension::is_shipped_entry_name(name))
         .count()
 }
 
@@ -2291,21 +2295,35 @@ mod tests {
     /// changes no number a test of that function could see.
     #[test]
     fn the_status_line_counts_only_user_installed_skills() {
-        let names: Vec<String> = biorouter::agents::skills_extension::context_skill_names()
+        // ⚠ Exactly the shape `list_skills` produces: flat skills by their own
+        // name, and a bundle by its DIRECTORY name — never by a member. That is
+        // what makes `is_shipped_entry_name` the right predicate here, and a
+        // fixture of skill names only could not tell the two apart.
+        let shipped: Vec<String> = biorouter::agents::skills_extension::context_ids()
             .map(str::to_string)
+            .collect();
+        let names: Vec<String> = shipped
+            .iter()
+            .cloned()
             .chain(["ggplot".to_string(), "single-cell".to_string()])
             .collect();
 
         assert_eq!(count_user_skills_in(&names), 2);
-        // Every shipped Context, and only those: a list of nothing else is zero.
-        let only_contexts: Vec<String> = biorouter::agents::skills_extension::context_skill_names()
-            .map(str::to_string)
-            .collect();
         assert!(
-            only_contexts.len() >= 5,
+            shipped.contains(&biorouter::agents::skills_extension::KNOWLEDGE_BUNDLE.to_string()),
+            "the knowledge bundle left the Context list; this test no longer covers a bundle row"
+        );
+        assert!(
+            shipped.len() >= 5,
             "the Context list emptied out; this test would then pass on any input"
         );
-        assert_eq!(count_user_skills_in(&only_contexts), 0);
+        assert_eq!(count_user_skills_in(&shipped), 0);
+        // A bundle MEMBER can reach this list from another surface, and is also
+        // not the user's.
+        assert_eq!(
+            count_user_skills_in(&["knowledge-lint".to_string(), "update-soul".to_string()]),
+            0
+        );
         // The trap: a user skill whose name merely resembles a Context's.
         assert_eq!(
             count_user_skills_in(&["about-biorouter-notes".to_string()]),

--- a/crates/biorouter-mcp/src/knowledge/schema_biookf.md
+++ b/crates/biorouter-mcp/src/knowledge/schema_biookf.md
@@ -95,9 +95,10 @@ edge.
 
 ## Edges
 
-**Only `edges:` entries are part of the graph.** Prose may restate a
-relationship and markdown links are fine for navigation, but a relationship you
-want in the graph goes in `edges:`.
+**Only `edges:` entries carry a predicate and provenance.** Bundle-local
+markdown links and `[[…]]` links are recorded as graph edges too, but as
+*untyped* ones — so a relationship you want typed, attributed and queryable goes
+in `edges:`. A typed entry wins the tie-break against a prose link restating it.
 
 Predicates:
 

--- a/crates/biorouter/src/agents/builtin_skills/about-biorouter/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/about-biorouter/SKILL.md
@@ -8,7 +8,7 @@ description: "Built-in self-knowledge about Biorouter. Load this skill whenever 
 This is the authoritative self-knowledge reference for Biorouter. Use it to answer
 questions about Biorouter accurately instead of guessing from general knowledge.
 If a question goes deeper than this document, point the user to the documentation
-at <http://biorouter.ucsf.edu/docs>.
+at <https://biorouter.ucsf.edu/docs>.
 
 ## What Biorouter is
 
@@ -18,10 +18,10 @@ unifies commercial, institution-hosted, and local LLMs, AI agents, MCP-based
 extensions, personal knowledge bases, and customizable workflows into one
 extensible tool for exploratory analysis, prototyping, and automation.
 
-- Website: <http://biorouter.ucsf.edu/>
-- Extension & skill marketplace (BAAM): <http://biorouter.ucsf.edu/baam>
-- Documentation: <http://biorouter.ucsf.edu/docs>
-- Downloads: <http://biorouter.ucsf.edu/download>
+- Website: <https://biorouter.ucsf.edu/>
+- Extension & skill marketplace (BAAM): <https://biorouter.ucsf.edu/baam>
+- Documentation: <https://biorouter.ucsf.edu/docs>
+- Downloads: <https://biorouter.ucsf.edu/download>
 
 ## Architecture
 
@@ -35,7 +35,8 @@ Three layers:
 
 The desktop app spawns a local REST/WebSocket server (`biorouterd`) and talks to
 it over a generated, type-safe API client. The CLI calls the agent library
-directly. Sessions are persisted under `~/.config/biorouter/sessions/`.
+directly. Sessions are persisted in the **data** directory, not the config one:
+`~/.local/share/biorouter/sessions/` on macOS and Linux.
 
 ## The major pillars
 
@@ -43,23 +44,24 @@ directly. Sessions are persisted under `~/.config/biorouter/sessions/`.
 
 Capabilities are the tools compiled into Biorouter. **Developer**, **Computer
 Controller**, **Auto Visualiser**, **Code Execution**, **Extension Manager**,
-**Skills**, **Todo**, **Memory**, **Knowledge**, and **Agent Drafter** are enabled
-by default. **Chat Recall** and **Tutorial** are disabled by default.
-Manage them in **Settings → Chat → Capabilities**.
+**Skills**, **Todo**, **Memory**, **Knowledge**, **Workspace Control**, and
+**Agent Drafter** are enabled by default. **Chat Recall** and **Tutorial** are
+disabled by default. Manage them in **Settings → Chat → Capabilities**.
 
 User-installed extensions are MCP servers added through `stdio` (external
 process), `streamable_http` (remote), or `inline_python`. Manage them from the
 **Extensions** page in the desktop sidebar, via `biorouter configure`, ad-hoc with
 `biorouter session --with-extension <cmd>`, or in
 `~/.config/biorouter/config.yaml` under the `extensions:` key.
-- Third-party extensions are browsable at <http://biorouter.ucsf.edu/baam>.
+- Third-party extensions are browsable at <https://biorouter.ucsf.edu/baam>.
 
 ### Skills
 
 Skills are reusable instruction sets: a folder containing a `SKILL.md` file
 with YAML frontmatter (`name`, `description`) followed by markdown
-instructions. The agent sees the list of enabled skills and loads one with the
-`loadSkill` tool when relevant.
+instructions. The always-on system prompt carries only a **count** of the
+enabled skills, not their names; the agent finds a skill with `searchSkills`,
+pages the catalog with `listSkills`, and pulls in one body with `loadSkill`.
 
 - Primary location: `~/.config/biorouter/skills/<slug>/SKILL.md`. Also
   discovered from `~/.claude/skills`, `~/.config/agents/skills`, extension
@@ -70,8 +72,21 @@ instructions. The agent sees the list of enabled skills and loads one with the
 - Toggles persist in `~/.config/biorouter/skills-config.json`, written by both
   the GUI toggle and `biorouter skill enable|disable` (which accept a skill
   name, bundle name, or directory slug).
-- This `about-biorouter` skill is built in: it ships with Biorouter, can be
-  toggled off, and is restored automatically if its folder is removed.
+- A **bundle** is a directory of skills installed, listed and toggled as one
+  unit: `<root>/<bundle>/<slug>/SKILL.md`. Disabling the bundle by name disables
+  every member.
+- Skills that ship with Biorouter are **Contexts**, switched in
+  **Settings → Chat → Contexts** rather than offered per chat, and excluded from
+  the "N skills enabled" counts because the user did not install them. There are
+  five rows over nine shipped skills: `about-biorouter`, `develop-biorouter`,
+  `develop-biorouter-extension`, `develop-biorouter-skill`, and **Knowledge** —
+  one row over the `knowledge-bases` bundle, whose members are
+  `knowledge-choose-a-format`, `knowledge-ingest-okf`, `knowledge-ingest-biookf`,
+  `knowledge-lint` and `update-soul`.
+- This `about-biorouter` skill is one of them: it ships with Biorouter, can be
+  toggled off, cannot be deleted from any surface, and is restored automatically
+  if its folder is removed. Switching a Context off stops it being *surfaced* in
+  the catalog; it stays loadable by exact name.
 
 ### Workflows
 
@@ -85,17 +100,20 @@ text with `{{ name }}` Jinja syntax), `extensions`, `skills`,
 schema for structured output), `sub_workflows`, and `retry`.
 
 - Manage from the **Workflows** page in the sidebar.
-- CLI: `biorouter run --workflow my.yaml --param key=value`,
-  `biorouter workflow validate <file>`, `biorouter workflow list`.
+- CLI: `biorouter run --workflow my.yaml --params key=value` (repeat `--params`
+  for each one), plus `biorouter workflow install|validate|deeplink|open|list`.
 
 ### Scheduler
 
 The scheduler runs workflows on a cron cadence (standard 5-field cron, e.g.
-`0 9 * * 1` = 9am Mondays). Jobs persist in `~/.config/biorouter/schedule.json`
-and always run headless, so the workflow must define a `prompt`.
+`0 9 * * 1` = 9am Mondays). Jobs persist in `schedule.json` in the **data**
+directory (`~/.local/share/biorouter/schedule.json`) and always run headless, so
+the workflow must define a `prompt`.
 
 - Manage from the **Scheduler** page in the sidebar (create, pause, resume,
-  edit, delete, run-now) or with `biorouter schedule list|delete|cron-help`.
+  edit, delete, run-now) or with
+  `biorouter schedule add|list|remove|sessions|run-now|cron-help` (aliased
+  `biorouter sched`). The subcommand is `remove`, not `delete`.
 - The agent itself can manage schedules via the platform schedule-management
   tool (list, create, run_now, pause, unpause, delete, inspect, sessions).
 
@@ -103,9 +121,19 @@ and always run headless, so the workflow must define a `prompt`.
 
 Personal, LLM-maintained knowledge bases backed by markdown page trees with
 full git history. Each KB lives at `~/.config/biorouter/knowledge/<kb-id>/`
-with `raw/` (original sources), `knowledge/` (curated pages cross-linked with
-`[[wiki-links]]`), `index.md`, `log.md`, and `schema.md` (editable conventions
-that steer the ingestion sub-agent).
+with `raw/` (original sources), `knowledge/` (curated, cross-linked pages),
+`index.md`, `log.md`, and `schema.md` (editable conventions that steer the
+ingestion sub-agent). New bases are written in the **Open Knowledge Format**
+(OKF v0.2) or its strict biomedical profile **BioOKF v0.5**, where a
+cross-reference is an ordinary markdown link to the target page's path (BioOKF
+additionally declares graph relations as typed `edges:` in the frontmatter).
+Two different things are called "legacy" here, and only one of them still
+works. A base in the retired **pre-OKF format** (`title:`/`kind:` frontmatter)
+is purged on startup and refused by every knowledge tool until it has been —
+tell the user to restart Biorouter rather than trying to repair it. Untyped
+`[[double bracket]]` **links** inside a current OKF or BioOKF page are a
+different matter: they are still read, permanently, so do not rewrite an old
+page — just stop writing new ones.
 
 - Ingest sources (URLs, pasted text, PDFs, HTML, DOCX, CSV) from the
   **Knowledge** page in the sidebar, with live streaming progress. Sources are
@@ -114,8 +142,8 @@ that steer the ingestion sub-agent).
 - In chat, the Knowledge extension provides `kb_search` (BM25 over curated
   pages), `kb_read_page`, `kb_write_page`, graph view, history/restore, and
   `.brkb` export/import for sharing whole KBs.
-- A graph view visualizes pages as nodes connected by their `[[…]]`
-  cross-references. An "active KB" can be selected per session from the chat
+- A graph view visualizes pages as nodes connected by those cross-references.
+  An "active KB" can be selected per session from the chat
   composer.
 - **Soul** is a built-in personal KB (`kb_id` "soul") installed on first run. It
   holds durable facts about the user (how they work, tools/commands they prefer,
@@ -126,11 +154,22 @@ that steer the ingestion sub-agent).
 
 ### Models & providers
 
-Biorouter supports 17+ LLM providers: Anthropic, OpenAI, Azure OpenAI, AWS
-Bedrock, GCP Vertex AI, Google, Ollama (local), OpenRouter, Databricks,
-SageMaker, Snowflake, GitHub Copilot, LiteLLM, xAI, institution-hosted Versa
-(UCSF), and more.
+Biorouter registers 23 built-in providers, plus any declarative custom provider
+the user adds: Anthropic, Azure OpenAI, AWS Bedrock, Versa Azure and Versa
+Bedrock (institution-hosted, UCSF), Claude Code, Codex, Databricks, GCP Vertex
+AI, GitHub Copilot, Google, LiteLLM, Llama Server, Ollama, OpenAI, OpenRouter,
+SageMaker TGI, Snowflake, Tetrate, Venice, xAI, Xiaomi MiMo, and Z.ai. (Three of
+them — Bedrock, Versa Bedrock and SageMaker TGI — sit behind the
+`aws-providers` build feature.)
 
+- **Local models need no setup: Llama Server** (`llamacpp`) runs a llama.cpp
+  server bundled with the desktop app and downloads models on first use;
+  **Ollama** drives a separate Ollama install. Local providers rank ahead of
+  institutional and commercial ones everywhere in the UI.
+- **Claude Code** and **Codex** run inference on the user's *own* vendor
+  subscription by driving a coding-agent CLI they already installed and signed
+  in to. Biorouter never sees a credential — there is no base URL and no API
+  key. Both are Public-tier, so they must not be used with private data.
 - Defaults are set with the `BIOROUTER_PROVIDER` and `BIOROUTER_MODEL` config
   keys; workflows can override per-run in their `settings` block.
 - Configure in **Settings → Providers/Models** in the desktop app, or via CLI:
@@ -140,46 +179,73 @@ SageMaker, Snowflake, GitHub Copilot, LiteLLM, xAI, institution-hosted Versa
 
 ### Secrets
 
-API keys are stored via a pluggable secrets backend (`secrets_backend` in
-config.yaml or `BIOROUTER_SECRETS_BACKEND`):
+API keys and other secrets are resolved in this order:
 
-- `keyring` (default): OS credential store (macOS Keychain, Windows
-  Credential Manager, Linux Secret Service); read once per process.
-- `encrypted-file`: passphrase-encrypted `secrets.enc` (Argon2id +
-  XChaCha20-Poly1305).
-- `file`: plaintext `secrets.yaml` (for headless/dev use).
+1. **Environment variable**, exact key match (e.g. `OPENAI_API_KEY`). This wins
+   over everything else.
+2. **The OS credential store** via the `keyring` crate — macOS Keychain,
+   Windows Credential Manager, Linux Secret Service. This is the default store.
+   It is read **at most once per process** and cached in memory, so macOS shows
+   at most one Keychain authorization prompt per run; tell users to click
+   **Always Allow**. Authorization is per binary, so the desktop backend
+   (`biorouterd`) and the CLI (`biorouter`) each get their own grant.
+3. **Plaintext `~/.config/biorouter/secrets.yaml`**, used when the keyring is
+   switched off with `BIOROUTER_DISABLE_KEYRING=true`, or when the platform
+   store is unavailable (headless Linux, SSH, WSL, no Secret Service daemon),
+   where Biorouter falls back to it automatically.
 
-Environment variables (e.g. `OPENAI_API_KEY`) override the backend entirely.
+There is no configurable "secrets backend" key and no encrypted-file store.
+On Windows a large secret set is transparently chunked across several
+credentials to stay under the 2560-byte per-credential limit.
+See `docs/security/secret-storage.md`.
 
 ## Interfaces
 
 ### Desktop app
 
-Left sidebar navigation: **Chat** (conversation), **History** (past sessions),
-**Workflows**, **Scheduler**, **Extensions**, **Skills**, **Knowledge**,
-**Apps** (MCP apps), and **Settings** (providers, models, permissions, theme).
-Chat renders markdown, syntax-highlighted code, inline visualizations, and
-expandable tool-call messages.
+The left sidebar leads with **Home** and **New chat**. Everything else sits
+behind a **Components** disclosure — collapsed by default, and remembered —
+holding **Workflows**, **Scheduler**, **Extensions**, **Skills**, **Knowledge**,
+**Built apps** (apps built with Agent Drafter) and **MCP apps** (apps advertised
+by installed extensions, shown only when some extension provides one). Below
+that is a **Recents** list of recent chats with a "view all" link to the full
+session history, and **Settings** (providers, models, permissions, theme) is
+pinned at the bottom. Chat renders markdown, syntax-highlighted code and
+expandable tool-call messages; figures, reports and other artifacts the agent
+creates open in the **artifact side panel** on the right, never inline.
 
 ### CLI
 
-Main commands: `biorouter session` (interactive chat, `--name`/`--resume`),
-`biorouter run` (headless: `--text "prompt"` or `--workflow file.yaml --param
-k=v`), `biorouter configure` (interactive setup), `biorouter models …`,
-`biorouter schedule …`, `biorouter workflow …`, `biorouter skill …`,
-`biorouter session-list`, `biorouter info`, `biorouter setup-path`.
+Main commands: `biorouter session` (interactive chat, `--name`/`--resume`;
+aliases `s` and `sessions`, with subcommands such as `session list`, `send`,
+`watch`, `cancel` — there is no `session-list`), `biorouter run` (headless:
+`--text "prompt"` or `--workflow file.yaml --params k=v`), `biorouter configure`
+(interactive setup), `biorouter models …`, `biorouter schedule …` (alias
+`sched`), `biorouter workflow …`, `biorouter skill …`, `biorouter extension …`
+(alias `ext`), `biorouter knowledge …` (alias `kb`), `biorouter apps …`,
+`biorouter serve` (alias `headless`: run Biorouter and reach it from a browser),
+`biorouter usage` (token and cost report), `biorouter doctor` (check
+prerequisites; `--fix <dep>` hands the failure to the agent), `biorouter info`,
+`biorouter project`/`projects`, `biorouter term` (terminal-integrated session),
+`biorouter completion`, `biorouter acp`, `biorouter mcp <server>`,
+`biorouter bench …`, and `biorouter setup-path` (alias `install-cli`).
 
 ## Configuration file map
 
+Two roots, and the split matters: **config** is `~/.config/biorouter/`, **data**
+is `~/.local/share/biorouter/`.
+
 | Path | Purpose |
 |---|---|
-| `~/.config/biorouter/config.yaml` | Providers, model defaults, extensions, secrets backend |
-| `~/.config/biorouter/sessions/` | Session history |
+| `~/.config/biorouter/config.yaml` | Providers, model defaults, extensions |
+| `~/.config/biorouter/secrets.yaml` | Plaintext secrets, only when the OS keyring is off or unavailable |
 | `~/.config/biorouter/skills/` | Installed skills |
 | `~/.config/biorouter/workflows/` | Workflows |
 | `~/.config/biorouter/knowledge/` | Knowledge bases |
-| `~/.config/biorouter/schedule.json` | Scheduled jobs |
+| `~/.config/biorouter/extensions/<name>/` | Installed `.brxt` extensions |
 | `~/.config/biorouter/skills-config.json` | Skill enable/disable state |
+| `~/.local/share/biorouter/sessions/` | Session history (**data** dir) |
+| `~/.local/share/biorouter/schedule.json` | Scheduled jobs (**data** dir) |
 | `.biorouterhints` / `AGENTS.md` (project) | Project-specific agent guidance |
 | `.biorouterignore` (project) | Files the agent must not read |
 
@@ -189,4 +255,4 @@ When answering questions about Biorouter, ground your answer in this document.
 If the user wants hands-on guidance, suggest enabling the **Tutorial**
 extension, which offers interactive walkthroughs (getting started, knowledge
 bases, workflows, scheduling, skills, and building MCP extensions). For
-anything not covered here, refer them to <http://biorouter.ucsf.edu/docs>.
+anything not covered here, refer them to <https://biorouter.ucsf.edu/docs>.

--- a/crates/biorouter/src/agents/builtin_skills/about-biorouter/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/about-biorouter/SKILL.md
@@ -129,8 +129,12 @@ cross-reference is an ordinary markdown link to the target page's path (BioOKF
 additionally declares graph relations as typed `edges:` in the frontmatter).
 Two different things are called "legacy" here, and only one of them still
 works. A base in the retired **pre-OKF format** (`title:`/`kind:` frontmatter)
-is purged on startup and refused by every knowledge tool until it has been —
-tell the user to restart Biorouter rather than trying to repair it. Untyped
+is purged on startup, and until it has been, every tool that WRITES or
+validates refuses it — `kb_write_page`, `kb_add_raw_source`, `kb_validate_page`, `kb_lint`,
+`kb_begin_txn` and `kb_append_log`. The read-only tools
+(`kb_read_page`, `kb_list_pages`, `kb_search`, `kb_get_graph`, `kb_list_history`,
+`kb_export`) still work, so the user can get their content out. Tell them to
+restart Biorouter rather than trying to repair the base. Untyped
 `[[double bracket]]` **links** inside a current OKF or BioOKF page are a
 different matter: they are still read, permanently, so do not rewrite an old
 page — just stop writing new ones.
@@ -160,7 +164,8 @@ Bedrock (institution-hosted, UCSF), Claude Code, Codex, Databricks, GCP Vertex
 AI, GitHub Copilot, Google, LiteLLM, Llama Server, Ollama, OpenAI, OpenRouter,
 SageMaker TGI, Snowflake, Tetrate, Venice, xAI, Xiaomi MiMo, and Z.ai. (Three of
 them — Bedrock, Versa Bedrock and SageMaker TGI — sit behind the
-`aws-providers` build feature.)
+`aws-providers` build feature, which is **on by default**, so a shipped build
+has all 23.)
 
 - **Local models need no setup: Llama Server** (`llamacpp`) runs a llama.cpp
   server bundled with the desktop app and downloads models on first use;
@@ -190,9 +195,11 @@ API keys and other secrets are resolved in this order:
    **Always Allow**. Authorization is per binary, so the desktop backend
    (`biorouterd`) and the CLI (`biorouter`) each get their own grant.
 3. **Plaintext `~/.config/biorouter/secrets.yaml`**, used when the keyring is
-   switched off with `BIOROUTER_DISABLE_KEYRING=true`, or when the platform
-   store is unavailable (headless Linux, SSH, WSL, no Secret Service daemon),
-   where Biorouter falls back to it automatically.
+   switched off with `BIOROUTER_DISABLE_KEYRING`, or when the platform store is
+   unavailable (headless Linux, SSH, WSL, no Secret Service daemon), where
+   Biorouter falls back to it automatically. ⚠ **Any value switches it off** —
+   the check is on the variable's presence, so `BIOROUTER_DISABLE_KEYRING=false`
+   disables the keyring exactly as `=true` does. Unset it to re-enable.
 
 There is no configurable "secrets backend" key and no encrypted-file store.
 On Windows a large secret set is transparently chunked across several
@@ -208,7 +215,7 @@ behind a **Components** disclosure — collapsed by default, and remembered —
 holding **Workflows**, **Scheduler**, **Extensions**, **Skills**, **Knowledge**,
 **Built apps** (apps built with Agent Drafter) and **MCP apps** (apps advertised
 by installed extensions, shown only when some extension provides one). Below
-that is a **Recents** list of recent chats with a "view all" link to the full
+that is a **Recents** list of recent chats with a **See all** link to the full
 session history, and **Settings** (providers, models, permissions, theme) is
 pinned at the bottom. Chat renders markdown, syntax-highlighted code and
 expandable tool-call messages; figures, reports and other artifacts the agent

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter-extension/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter-extension/SKILL.md
@@ -52,9 +52,18 @@ install` CLI.
 }
 ```
 
-**Required fields:** `name`, `display_name`, `description`, `version`,
-`entry_point`, `repository`, and `env_vars`. The first six must be non-empty
-strings; `env_vars` must be a JSON array (use `[]` if the extension needs none).
+**Required to be present:** `name`, `display_name`, `description`, `version`,
+`entry_point`, `repository`. All six are plain (non-defaulted) string fields, so
+the manifest fails to parse at all if any one is missing.
+
+**Checked non-empty:** only `name` and `entry_point`. The other four may be
+empty strings and still install — ship real values anyway, because they are what
+the user reads in the Extensions page.
+
+**Optional:** `env_vars` (defaults to an empty list, so it may be omitted
+entirely; write `[]` for clarity if you prefer) and `tools_count`. Inside an
+`env_vars` entry only `key` is required; `required`, `auto_propagate`,
+`description`, `secret` and `default` all default.
 
 **`env_vars` field reference:**
 
@@ -176,12 +185,17 @@ Each `SKILL.md` must begin with valid YAML frontmatter:
 
 ```markdown
 ---
-name: My Skill Name
+name: my-skill-slug
 description: One-line description of what this skill does.
 ---
 
 Skill body in markdown...
 ```
+
+**`name` must equal the skill's folder slug** — lowercase, hyphenated, no
+spaces. A title-cased display name in `name` does not match the directory it
+sits in, and the two views of the catalog then disagree about what the skill is
+called.
 
 Skills install to `~/.config/biorouter/extensions/<name>/skills/<slug>/SKILL.md`
 and are auto-discovered by the agent on startup (Biorouter scans the `skills/`
@@ -212,18 +226,25 @@ Exclude `.venv/`, `__pycache__/`, and any build artifacts.
 
 Biorouter installs by:
 1. Unzipping all contents to `~/.config/biorouter/extensions/<name>/`.
-2. Running `uv sync` (timeout: 10 minutes, generous so a legitimate
-   from-source build of a dependency has time to finish) to build the virtual
-   environment. If `uv sync` fails, Biorouter surfaces uv's output along with a
-   hint for common causes (missing/broken Rust toolchain, no wheel for the
-   platform).
+2. Running `uv sync` to build the virtual environment. If it fails, Biorouter
+   surfaces uv's output along with a hint for common causes (missing/broken
+   Rust toolchain, no wheel for the platform).
 3. Registering a stdio MCP extension that runs `uv run --directory <dir>
    <entry_point>`, storing any secret env vars in the OS keyring.
 
-Both the desktop app and the `biorouter extension install` CLI follow this same
-flow. Uninstallation removes the entire
-`~/.config/biorouter/extensions/<name>/` directory, including any bundled
-skills.
+The desktop app and the `biorouter extension install` CLI run the same three
+steps and share the same four-entry validation, but they **differ on the `uv
+sync` timeout**: the desktop app caps it at 10 minutes (generous, so a
+legitimate from-source build has time to finish) and reports a timeout as such;
+the CLI runs `uv sync` to completion with no timeout at all, so a wedged
+resolve there hangs until you interrupt it.
+
+**Uninstalling does not delete files by default.** Removing an extension from
+the desktop **Extensions** page, or `biorouter extension remove <name>`,
+*unregisters* it — the entry leaves the config and the server stops being
+launched, while `~/.config/biorouter/extensions/<name>/` (the venv, the source
+and any bundled skills) stays on disk. Pass `biorouter extension remove <name>
+--purge` to delete that directory as well.
 
 ## Validation Checklist
 
@@ -234,12 +255,14 @@ Before distributing a `.brxt`, verify:
 [ ] ZIP contains README.md at root
 [ ] ZIP contains pyproject.toml at root
 [ ] ZIP contains src/ directory
-[ ] manifest.json has all required fields (name, display_name, description,
-    version, entry_point, repository, env_vars)
-[ ] env_vars is a JSON array (even if empty: [])
+[ ] manifest.json has all six required keys present (name, display_name,
+    description, version, entry_point, repository), with name and entry_point
+    non-empty and the other four filled in for the user's sake
+[ ] env_vars, if present, is a JSON array; omit it or use [] when there are none
 [ ] pyproject.toml declares [project.scripts] with an entry whose name equals
     manifest.json's entry_point (Biorouter runs `uv run <entry_point>`)
-[ ] Each SKILL.md has --- frontmatter with name and description
+[ ] Each SKILL.md has --- frontmatter with name and description, and name is
+    the folder slug (lowercase, hyphenated)
 [ ] .venv/ and __pycache__/ are excluded from the ZIP
 [ ] uv sync completes cleanly from the unzipped directory
 [ ] Every dependency has a wheel for each target platform, OR a marker-scoped

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter-extension/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter-extension/SKILL.md
@@ -52,16 +52,22 @@ install` CLI.
 }
 ```
 
-**Required to be present:** `name`, `display_name`, `description`, `version`,
-`entry_point`, `repository`. All six are plain (non-defaulted) string fields, so
-the manifest fails to parse at all if any one is missing.
+**Required:** `name`, `display_name`, `description`, `version`, `entry_point`,
+`repository` — all six present and non-empty — plus `env_vars` as a JSON array
+(`[]` when the extension needs none).
 
-**Checked non-empty:** only `name` and `entry_point`. The other four may be
-empty strings and still install — ship real values anyway, because they are what
-the user reads in the Extensions page.
+⚠ **Three code paths validate this and they do not agree.** Author to the strict
+rule above, because it is the only one that works everywhere:
 
-**Optional:** `env_vars` (defaults to an empty list, so it may be omitted
-entirely; write `[]` for clarity if you prefer) and `tools_count`. Inside an
+| Path | What it enforces |
+| --- | --- |
+| Desktop app (`ui/desktop/src/main.ts`) | all six non-empty, `env_vars` must be an array |
+| `POST` install over HTTP (`routes/shell.rs`, `require_manifest_fields`) | the same |
+| `biorouter extension install` (`extension_install/brxt.rs`) | serde needs the six *keys* to exist; only `name` and `entry_point` are checked non-empty, and `env_vars` is `#[serde(default)]` |
+
+A bundle that omits `env_vars`, or leaves `description` blank, installs from the
+terminal and is then rejected by the app the user actually runs — so the CLI's
+laxity is a trap, not a licence. `tools_count` is genuinely optional. Inside an
 `env_vars` entry only `key` is required; `required`, `auto_propagate`,
 `description`, `secret` and `default` all default.
 
@@ -233,11 +239,12 @@ Biorouter installs by:
    <entry_point>`, storing any secret env vars in the OS keyring.
 
 The desktop app and the `biorouter extension install` CLI run the same three
-steps and share the same four-entry validation, but they **differ on the `uv
-sync` timeout**: the desktop app caps it at 10 minutes (generous, so a
-legitimate from-source build has time to finish) and reports a timeout as such;
-the CLI runs `uv sync` to completion with no timeout at all, so a wedged
-resolve there hangs until you interrupt it.
+steps and both require the same four archive entries, but they diverge in two
+places. Manifest validation is one (see the table above). The other is the `uv
+sync` timeout: the desktop app caps it at 10 minutes — generous, so a legitimate
+from-source build has time to finish — and reports a timeout as such, while the
+CLI runs `uv sync` to completion with no timeout at all, so a wedged resolve
+there hangs until you interrupt it.
 
 **Uninstalling does not delete files by default.** Removing an extension from
 the desktop **Extensions** page, or `biorouter extension remove <name>`,
@@ -255,10 +262,10 @@ Before distributing a `.brxt`, verify:
 [ ] ZIP contains README.md at root
 [ ] ZIP contains pyproject.toml at root
 [ ] ZIP contains src/ directory
-[ ] manifest.json has all six required keys present (name, display_name,
-    description, version, entry_point, repository), with name and entry_point
-    non-empty and the other four filled in for the user's sake
-[ ] env_vars, if present, is a JSON array; omit it or use [] when there are none
+[ ] manifest.json has all six required keys, each non-empty (name, display_name,
+    description, version, entry_point, repository)
+[ ] env_vars is present and is a JSON array (use [] when there are none) — the
+    desktop app and the HTTP install path both reject a manifest without it
 [ ] pyproject.toml declares [project.scripts] with an entry whose name equals
     manifest.json's entry_point (Biorouter runs `uv run <entry_point>`)
 [ ] Each SKILL.md has --- frontmatter with name and description, and name is

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter-skill/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter-skill/SKILL.md
@@ -22,10 +22,15 @@ package one well.
 Biorouter uses **progressive disclosure**: load the cheap thing always, the
 expensive thing on demand:
 
-1. **Metadata (always loaded).** At session start the agent sees only each
-   skill's `name` + `description`. This is the entire always-on cost, so the
-   description must do all the triggering work.
-2. **Body (loaded on trigger).** When a description matches the task, the agent
+1. **Discovery (always on, and it is one sentence).** The always-on system
+   prompt carries a *count* of the enabled skills and the names of the tools
+   that reach them — not the catalog. The agent finds a skill by calling
+   **`searchSkills`** (or **`listSkills`** to page the catalog), and what it
+   matches against there is the `name` + `description`. So the description
+   still does all the triggering work; it simply has to survive a search rather
+   than sit permanently in front of the model, which makes concrete trigger
+   keywords more important, not less.
+2. **Body (loaded on trigger).** Once a description matches the task, the agent
    calls the **`loadSkill`** tool to pull in the full `SKILL.md` body. Keep it
    lean, because it competes with the live conversation for context.
 3. **Supporting files (loaded as needed).** Files next to `SKILL.md` are listed
@@ -74,8 +79,16 @@ as `user-invocable: true` are tolerated and ignored by the loader):
 
 | Field | Required | Standard |
 |---|---|---|
-| `name` | yes | Must equal the folder slug. Lowercase letters, numbers, hyphens; ≤ 64 chars. Avoid reserved words "anthropic"/"claude". Prefer a gerund or action phrase (`analyzing-spreadsheets`, `figure-style`), never `helper`/`utils`/`tools`. |
+| `name` | yes | Make it equal the folder slug. Lowercase letters, numbers, hyphens; ≤ 64 chars. Avoid reserved words "anthropic"/"claude". Prefer a gerund or action phrase (`analyzing-spreadsheets`, `figure-style`), never `helper`/`utils`/`tools`. |
 | `description` | yes | Non-empty, ≤ ~1024 chars. **Third person.** State both *what it does* and *when to use it*, with concrete trigger keywords. |
+
+⚠ **Those standards are authoring conventions, not validation.** The loader
+requires exactly two things: that the frontmatter parses and that `name` is
+non-empty. Nothing checks the length of `name` or `description`, nothing rejects
+a reserved word, and nothing enforces that `name` matches the folder — a skill
+whose `name` disagrees with its directory installs happily and then answers to a
+different label than the one on disk. Hold yourself to the table; the tooling
+will not.
 
 **Body standards:**
 - Keep the body **under ~500 lines**. Past that, split detail into supporting
@@ -208,6 +221,17 @@ Share a skill by zipping its folder. Accepted layouts:
 - **Single skill:** `SKILL.md` at the zip root, **or** one folder deep
   `<slug>/SKILL.md`.
 - **Bundle:** `<bundle>/<slug>/SKILL.md` (two levels deep).
+- **Declared by a manifest:** a `biorouter-package.json`,
+  `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json` or
+  `skills-manifest.json` names the components explicitly, and that beats the
+  shape on disk.
+- **Ambiguous — refused until you answer:** two or more skill folders sitting
+  *loose at the archive root* with **no** manifest. That is equally the shape of
+  one package and of a folder somebody happened to zip, so Biorouter asks
+  instead of guessing. Resolve it with `--as bundle` or `--as individual` (over
+  HTTP the question comes back as a 200 with `needsChoice`, not an error). A
+  named parent directory is **not** ambiguous — putting the skills inside
+  `my-bundle/` has already said they belong together.
 
 ```bash
 # Single skill
@@ -220,9 +244,15 @@ zip -r my-skill.zip my-skill/
 Install it with the CLI or the GUI:
 
 ```bash
-biorouter skill install my-skill.zip          # add --force to overwrite an existing slug
-biorouter skill list                           # verify it registered
+biorouter skill install my-skill.zip                    # a local .zip
+biorouter skill install https://github.com/you/skills   # or a repository URL
+biorouter skill install my-skills.zip --as bundle       # answer the ambiguity above
+biorouter skill list                                    # verify it registered
 ```
+
+`install` takes one `source` argument — a path to a `.zip` **or** a repository
+URL — plus `--force` to replace an already-installed slug and
+`--as bundle|individual` for a source that could be either.
 
 In the desktop app, the **Skills** page → **Add Skill** (or drag the zip in)
 does the same, unpacking into `~/.config/biorouter/skills/<slug>/`. You can also
@@ -242,6 +272,8 @@ quickly.
 [ ] Trigger-tested in a fresh session without naming the skill (and a
     negative case), repeated for consistency
 [ ] Critical steps emit visible output so execution can be verified
-[ ] Packs as SKILL.md at root or <slug>/SKILL.md; installs cleanly via
-    `biorouter skill install`
+[ ] Packs as SKILL.md at root, <slug>/SKILL.md, or a named parent for a
+    bundle — never several skills loose at the zip root with no manifest,
+    which install refuses as ambiguous
+[ ] Installs cleanly via `biorouter skill install <zip-or-repo-url>`
 ```

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter-skill/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter-skill/SKILL.md
@@ -83,8 +83,10 @@ as `user-invocable: true` are tolerated and ignored by the loader):
 | `description` | yes | Non-empty, ≤ ~1024 chars. **Third person.** State both *what it does* and *when to use it*, with concrete trigger keywords. |
 
 ⚠ **Those standards are authoring conventions, not validation.** The loader
-requires exactly two things: that the frontmatter parses and that `name` is
-non-empty. Nothing checks the length of `name` or `description`, nothing rejects
+requires the frontmatter to parse with both `name` and `description` present —
+`SkillMetadata` has neither as an `Option`, so serde rejects a missing one — and
+its line-based fallback parser additionally requires `name` to be non-empty.
+That is all. Nothing checks the length of `name` or `description`, nothing rejects
 a reserved word, and nothing enforces that `name` matches the folder — a skill
 whose `name` disagrees with its directory installs happily and then answers to a
 different label than the one on disk. Hold yourself to the table; the tooling

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter/SKILL.md
@@ -32,7 +32,7 @@ read as application bugs, not version problems.
 After a fresh clone, install the frontend dependencies once:
 
 ```bash
-just install-deps             # npm ci in ui/desktop, yarn in documentation
+just install-deps             # npm ci in ui/desktop — the only JS tree in the repo
 ```
 
 ## Repository layout
@@ -142,8 +142,14 @@ cd ui/desktop && npm run test-e2e            # Playwright
 cargo fmt
 ./scripts/clippy-lint.sh
 cd ui/desktop && npm run lint:check
-just check-everything             # what CI gates on; the single precommit entry point
+just check-everything             # every style/lint gate in one command
 ```
+
+`just check-everything` is the single precommit entry point for **style and
+lint** — fmt, clippy, `npm run lint:check`, the OpenAPI schema check, and the
+version, brand, cross-drift and BAAM-registry checks. It runs **no tests**. Run
+`cargo test` and `npm run test:run` yourself as well before you claim a change
+is done.
 
 `npm test` with no arguments is **watch mode and never exits**. Use
 `npm run test:run` in any non-interactive context.
@@ -202,7 +208,11 @@ build.
   `## Related documentation` (see `docs/contributing/documentation-style.md`).
 - The user-facing brand spelling is **Biorouter**, capital B and lowercase r.
   `./scripts/check-brand-consistency.sh` enforces it.
-- Commit messages and PR bodies in this repo reject AI co-author trailers.
+- **Commit messages** in this repo reject AI co-author trailers. The
+  `check-commits` workflow greps every commit message in the push or pull
+  request for a `Co-Authored-By:` line naming anthropic, claude, openai,
+  chatgpt, gemini or copilot, and fails the job on a hit. Only commit messages
+  are inspected — PR bodies are not — but do not put one there either.
 
 ## Code style the reviewers apply
 

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter/SKILL.md
@@ -32,7 +32,8 @@ read as application bugs, not version problems.
 After a fresh clone, install the frontend dependencies once:
 
 ```bash
-just install-deps             # npm ci in ui/desktop — the only JS tree in the repo
+just install-deps             # npm ci in ui/desktop (landing/video is a second,
+                              # unrelated JS tree with its own install)
 ```
 
 ## Repository layout

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-choose-a-format/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-choose-a-format/SKILL.md
@@ -82,11 +82,15 @@ Read its `schema.md` first: `kb_read_page { kb_id: "…", path: "schema.md" }`. 
 which format the base is in and, for BioOKF, carries the full vocabulary. Do not infer
 the format from the pages you happen to have read.
 
-Some bases predate this format entirely. They use `title:` / `kind:` frontmatter and
-`[[wiki links]]`, they keep working exactly as they always did, and Biorouter never
-rewrites them. `kb_validate_page` reports nothing for such a base — that is the correct
-answer for it, not a failure. Match the style already in the base rather than
-introducing a third one.
+Some bases predate both formats — `title:` / `kind:` frontmatter and untyped
+`[[wiki links]]`. That storage is **retired**: Biorouter purges it on startup, and until
+it has, every knowledge tool refuses such a base rather than reading it. `kb_validate_page`,
+`kb_lint` and `kb_add_raw_source` all return "uses the retired pre-OKF format; restart
+Biorouter to finish the legacy purge". If you meet one, stop and tell the user to restart
+Biorouter; do not try to repair the base yourself.
+
+`biorouter kb create` has no `--format` flag, so a base created from the terminal is
+always OKF. Use `kb_create_base` to pick BioOKF.
 
 ## Next
 

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-choose-a-format/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-choose-a-format/SKILL.md
@@ -84,10 +84,13 @@ the format from the pages you happen to have read.
 
 Some bases predate both formats — `title:` / `kind:` frontmatter and untyped
 `[[wiki links]]`. That storage is **retired**: Biorouter purges it on startup, and until
-it has, every knowledge tool refuses such a base rather than reading it. `kb_validate_page`,
-`kb_lint` and `kb_add_raw_source` all return "uses the retired pre-OKF format; restart
-Biorouter to finish the legacy purge". If you meet one, stop and tell the user to restart
-Biorouter; do not try to repair the base yourself.
+it has, every tool that writes or validates refuses it — `kb_write_page`, `kb_add_raw_source`, `kb_validate_page`, `kb_lint`,
+`kb_begin_txn` and `kb_append_log` —
+returning "uses the retired pre-OKF format; restart Biorouter to finish the legacy purge".
+The read-only tools (`kb_read_page`, `kb_search`, `kb_get_graph`, `kb_list_pages`,
+`kb_list_history`, `kb_export`) still work, so the content is recoverable. If you meet
+one, stop and tell the user to restart Biorouter; do not try to repair the base
+yourself.
 
 `biorouter kb create` has no `--format` flag, so a base created from the terminal is
 always OKF. Use `kb_create_base` to pick BioOKF.

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-biookf/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-biookf/SKILL.md
@@ -226,8 +226,10 @@ An IL-6 receptor antagonist, trialled in severe COVID-19.
 - **`identifier` is human-readable and bundle-unique, not a CURIE.** CURIEs go in
   `xref`. Two pages with the same `identifier` is an error; an `object` naming nothing
   is a dangling edge. `kb_validate_page` catches both before the write.
-- **Only `edges:` entries are in the graph.** Prose may restate a relationship and
-  markdown links are fine for navigation, but the graph is built from `edges:`.
+- **Only `edges:` entries carry a predicate and provenance.** Bundle-local markdown
+  links and `[[…]]` links do become graph edges too, but *untyped* ones — so a
+  relationship you want typed, attributed and queryable has to go in `edges:`. A typed
+  entry also wins the tie-break against a prose link that restates it.
 - **Quote any YAML scalar containing `: ` (colon-space)** or the frontmatter will not
   parse. `identifier: Chen 2020 (IL-6 and severe COVID-19)` is fine; anything with a
   colon-space needs quotes.

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-okf/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-okf/SKILL.md
@@ -65,8 +65,10 @@ sympathetic tone.[^pmid-32504360]
 ```
 
 A link to a page that does not exist yet is legal and is recorded — create it when you
-know enough to write it. Do not write `[[double brackets]]`; that retired syntax is not
-part of an OKF or BioOKF knowledge base.
+know enough to write it. Do not write untyped `[[double brackets]]`: pages that already
+carry them are still read, permanently, and must not be rewritten, but do not write new
+ones. (BioOKF has its own `[[predicate:: Object | key=value]]` inline edge form. That is
+a different grammar and belongs only in a BioOKF base.)
 
 **8 — Bookkeep.** Update `index.md` so the new pages are catalogued, then
 `kb_append_log` with `kind: "ingest"` and a one-line summary plus a `delta` like

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
@@ -39,8 +39,9 @@ decide deliberately not to and say why.
 Two corollaries worth internalising:
 
 - A base that predates both formats is not linted at all — `kb_lint` **refuses** it,
-  because that retired pre-OKF storage is purged on startup. If you get that refusal,
-  tell the user to restart Biorouter rather than trying to repair the base.
+  because that retired pre-OKF storage is purged on startup. `kb_read_page` and
+  `kb_search` still work on one, so the content is recoverable; you just cannot lint
+  or repair. Tell the user to restart Biorouter.
 - `kb_lint` caps how many diagnostics it returns. If `total` exceeds the length of
   `items`, fix a batch and run it again rather than assuming you have seen everything.
 

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
@@ -12,13 +12,14 @@ Two tools report the same kind of finding at two scopes:
 - **`kb_lint`** — the whole base. Run it after a batch of edits, and before exporting or
   sharing.
 
-Both return **diagnostics**. Each carries four things, and you act on all four:
+Both return **diagnostics**. Each carries five things, four of them always:
 
 | field | what it is |
 | --- | --- |
 | `rule` | a stable id like `biookf.edge.missing_primary_source`. Match on this, never on the message — messages get reworded. |
 | `severity` | `error`, `warning` or `info`. |
-| `subject` | the page or edge the finding is about. |
+| `subject` | the page or edge the finding is about. Never empty. |
+| `path` | the page's bundle-relative path, when the finding has one. Absent for a base-wide finding, and for a draft that has no path yet. |
 | `message` | what is wrong, in a sentence. |
 
 The rule id's prefix says which layer objected, and that tells you how to read it:
@@ -37,9 +38,9 @@ decide deliberately not to and say why.
 
 Two corollaries worth internalising:
 
-- A base created before this format shipped reports **no** format diagnostics at all.
-  That is the correct answer for it, not a failure: such a base keeps its own
-  `title`/`kind` frontmatter and `[[wiki links]]`, is never rewritten, and works.
+- A base that predates both formats is not linted at all — `kb_lint` **refuses** it,
+  because that retired pre-OKF storage is purged on startup. If you get that refusal,
+  tell the user to restart Biorouter rather than trying to repair the base.
 - `kb_lint` caps how many diagnostics it returns. If `total` exceeds the length of
   `items`, fix a batch and run it again rather than assuming you have seen everything.
 
@@ -67,11 +68,15 @@ and will not be found by anyone navigating it.
 | `okf.footnote.unresolved` | a `[^id]` in the body with no matching `sources[].id` | add the source entry, or remove the footnote |
 | `okf.verified.bare_mapping` | `verified` is a single mapping, not a list | informational; a list is the canonical shape |
 | `okf.attestation.unchecked` | the page declares an attested computation | informational: this build does not verify them, and says so rather than implying it did |
+| `okf.index.frontmatter` | `index.md`'s frontmatter is missing or malformed | a warning about the bundle's own scaffold rather than about a concept page |
+| `okf.log.date_heading` | `log.md` carries an entry with no `## YYYY-MM-DD` heading | give the entry a date heading |
 
 ## The profile rules (`biookf.`) — BioOKF bases only
 
 **Vocabulary**
 
+- `biookf.type.missing` — the page has no `type` at all. Every page in this profile needs
+  one of the 28; this is the distinct case from an invented one.
 - `biookf.type.invalid` — the `type` is not one of the 28. Re-run the typing decision
   procedure in **knowledge-ingest-biookf**; do not invent a 29th type. If genuinely
   nothing fits, `Other` plus a note is the honest answer.

--- a/crates/biorouter/src/agents/skill_catalog.rs
+++ b/crates/biorouter/src/agents/skill_catalog.rs
@@ -265,11 +265,19 @@ pub struct CatalogBundle {
     pub package: Option<PackageSummary>,
     /// Shipped with Biorouter, so the interface offers no Delete for it.
     ///
-    /// ⚠ **The bundle needs its own answer.** `CatalogSkill.builtin` gates the
-    /// Delete on a *skill* row, and a bundle row is a different control on a
-    /// different directory: without this, a seeded bundle rendered a working
-    /// Trash — the delete succeeding, the toast confirming, and the next
-    /// startup rewriting the folder. That is regression 1 of #77, one level up.
+    /// ⚠ **The bundle needs its own answer**, because `CatalogSkill.builtin`
+    /// gates the Delete on a *skill* row and a bundle row is a different
+    /// control over a different directory.
+    ///
+    /// ⚠ **This is defence in depth, not the live fix, and saying otherwise
+    /// invites someone to delete the real one.** Today the only shipped bundle
+    /// is a Context, and `pickerBundles` strips Contexts before `SkillsView`
+    /// renders a row at all, so this flag cannot fire on it. What actually
+    /// closed the "delete succeeds, toast confirms, next startup rewrites it"
+    /// regression on every surface is `skill_package::refuse_shipped`, which
+    /// `biorouter skill remove` bypassed entirely while the interface gate held.
+    /// This field earns its place for the case the filter does not cover: a
+    /// bundle that is seeded but not a Context, should one ever ship.
     pub builtin: bool,
     pub state: SkillState,
 }
@@ -474,7 +482,14 @@ impl SkillCatalog {
                     source: self.source_of(&record.source_root),
                     skills: record.members.clone(),
                     package: record.package.clone(),
-                    builtin: skills_extension::is_shipped_entry_name(name),
+                    // ⚠ `== KNOWLEDGE_BUNDLE`, not `is_shipped_entry_name`.
+                    // That predicate also answers yes for the nine shipped
+                    // SKILL names, and this is a bundle: a user package whose
+                    // directory happens to be called `knowledge-lint` would
+                    // read as built-in, lose its Delete control, and be refused
+                    // by `refuse_shipped` — the same false-positive class the
+                    // predicate's own test rules out one level down.
+                    builtin: name == skills_extension::KNOWLEDGE_BUNDLE,
                     state,
                 }
             })
@@ -658,6 +673,80 @@ mod tests {
 
     fn biorouter_root() -> SkillSource {
         SkillSource::new(SkillSourceKind::Biorouter, None)
+    }
+
+    /// ⚠ **`compose_state`'s bundle arm, tested where it lives.**
+    ///
+    /// `SkillsClient::is_hidden_context` is a *different function on a
+    /// different path*: `is_skill_enabled_for_session` passes an empty hidden
+    /// set, so the two arms are genuinely independent and a test of one says
+    /// nothing about the other. An earlier draft tested only that one and
+    /// claimed both — delete the `|| bundle.is_some_and(...)` clause below and
+    /// every `CatalogSkill` row for a bundle member reports
+    /// `hiddenContext: false, effective: true`, which is the answer the
+    /// INTERFACE renders, with the whole suite green.
+    #[test]
+    fn a_hidden_context_that_names_a_bundle_hides_the_bundles_members() {
+        let none = SessionSkillOverride::default();
+        let machine = HashSet::new();
+        let hidden = HashSet::from(["knowledge-bases".to_string()]);
+
+        let member = compose_state(
+            "knowledge-lint",
+            Some("knowledge-bases"),
+            &machine,
+            &hidden,
+            &none,
+        );
+        assert!(member.hidden_context, "the member escaped its bundle's row");
+        assert!(!member.effective);
+        // The switch is a Context, not a machine-wide disable: the member is
+        // still ENABLED, just not surfaced. Conflating the two is what would
+        // make `handle_load_skill` refuse a skill the system prompt asks for.
+        assert!(member.machine_enabled);
+
+        // The bundle row itself, which `view()` composes with `bundle: None`.
+        let row = compose_state("knowledge-bases", None, &machine, &hidden, &none);
+        assert!(row.hidden_context && !row.effective);
+
+        // A member of some other bundle is untouched, and so is a skill that
+        // merely carries the same name with no bundle on it.
+        assert!(
+            !compose_state(
+                "brainstorming",
+                Some("superpowers"),
+                &machine,
+                &hidden,
+                &none
+            )
+            .hidden_context
+        );
+        assert!(!compose_state("knowledge-lint", None, &machine, &hidden, &none).hidden_context);
+    }
+
+    /// A per-chat grant must not put back something switched off in Settings —
+    /// the `hidden_context` test sits OUTSIDE the session match, and adding the
+    /// bundle arm must not have moved it.
+    #[test]
+    fn a_per_chat_grant_cannot_resurrect_a_hidden_context_bundle() {
+        let machine = HashSet::new();
+        let hidden = HashSet::from(["knowledge-bases".to_string()]);
+        let granted = SessionSkillOverride {
+            add: vec!["knowledge-lint".to_string()],
+            ..Default::default()
+        };
+        let state = compose_state(
+            "knowledge-lint",
+            Some("knowledge-bases"),
+            &machine,
+            &hidden,
+            &granted,
+        );
+        assert_eq!(state.session, SessionState::Added);
+        assert!(
+            !state.effective,
+            "a session grant overrode a Settings switch"
+        );
     }
 
     /// The bundles a temporary root actually contains.

--- a/crates/biorouter/src/agents/skill_catalog.rs
+++ b/crates/biorouter/src/agents/skill_catalog.rs
@@ -263,6 +263,14 @@ pub struct CatalogBundle {
     pub skills: Vec<String>,
     /// The importer's record, when this bundle was installed as a package.
     pub package: Option<PackageSummary>,
+    /// Shipped with Biorouter, so the interface offers no Delete for it.
+    ///
+    /// ⚠ **The bundle needs its own answer.** `CatalogSkill.builtin` gates the
+    /// Delete on a *skill* row, and a bundle row is a different control on a
+    /// different directory: without this, a seeded bundle rendered a working
+    /// Trash — the delete succeeding, the toast confirming, and the next
+    /// startup rewriting the folder. That is regression 1 of #77, one level up.
+    pub builtin: bool,
     pub state: SkillState,
 }
 
@@ -466,6 +474,7 @@ impl SkillCatalog {
                     source: self.source_of(&record.source_root),
                     skills: record.members.clone(),
                     package: record.package.clone(),
+                    builtin: skills_extension::is_shipped_entry_name(name),
                     state,
                 }
             })
@@ -514,7 +523,11 @@ pub(crate) fn compose_state(
 ) -> SkillState {
     let machine_enabled = !machine_disabled.contains(name)
         && !bundle.is_some_and(|bundle| machine_disabled.contains(bundle));
-    let hidden_context = hidden_contexts.contains(name);
+    // ⚠ Two keys, exactly as above. A Context row may name a whole bundle
+    // (`skills_extension::context_ids`), and a member carries its own `name:` —
+    // so a one-key test would leave the switch moving and the members visible.
+    let hidden_context = hidden_contexts.contains(name)
+        || bundle.is_some_and(|bundle| hidden_contexts.contains(bundle));
 
     let (session, via_bundle) = match over.resolve(name, bundle) {
         OverrideMatch::Added { via_bundle } => (SessionState::Added, via_bundle),
@@ -647,6 +660,21 @@ mod tests {
         SkillSource::new(SkillSourceKind::Biorouter, None)
     }
 
+    /// The bundles a temporary root actually contains.
+    ///
+    /// ⚠ **`add_missing_shipped_skills` injects the shipped skills into every
+    /// scan**, and since they became a bundle that injection contributes a
+    /// `KNOWLEDGE_BUNDLE` row over a directory the temp root does not have. It
+    /// is the right behaviour — the in-memory fallback must place a skill where
+    /// the seeder would have — but it means `view.bundles[0]` no longer names
+    /// what a test wrote. Index by name, not by position.
+    fn authored_bundles(view: &CatalogView) -> Vec<&CatalogBundle> {
+        view.bundles
+            .iter()
+            .filter(|bundle| bundle.name != skills_extension::KNOWLEDGE_BUNDLE)
+            .collect()
+    }
+
     #[test]
     fn a_bundle_is_derived_from_discovery_not_from_a_second_walk() {
         let temp = TempDir::new().unwrap();
@@ -663,9 +691,10 @@ mod tests {
         let catalog = SkillCatalog::scan(vec![root_at(&root, biorouter_root())], 1);
         let view = catalog.view(&SessionSkillOverride::default());
 
-        assert_eq!(view.bundles.len(), 1);
-        assert_eq!(view.bundles[0].name, "pack");
-        assert_eq!(view.bundles[0].skills, vec!["alpha", "beta"]);
+        let bundles = authored_bundles(&view);
+        assert_eq!(bundles.len(), 1);
+        assert_eq!(bundles[0].name, "pack");
+        assert_eq!(bundles[0].skills, vec!["alpha", "beta"]);
         assert!(view.skills.iter().any(|s| s.name == "solo"));
         assert!(!view.skills.iter().any(|s| s.name == "broken"));
     }
@@ -757,7 +786,7 @@ mod tests {
 
         let catalog = SkillCatalog::scan(vec![root_at(&root, biorouter_root())], 1);
         let view = catalog.view(&SessionSkillOverride::default());
-        let bundle = &view.bundles[0];
+        let bundle = authored_bundles(&view)[0];
         assert_eq!(bundle.name, "hyperframes");
         assert_eq!(bundle.display_name, "HyperFrames");
         let package = bundle.package.as_ref().expect("package record read");
@@ -779,8 +808,8 @@ mod tests {
 
         let catalog = SkillCatalog::scan(vec![root_at(&root, biorouter_root())], 1);
         let view = catalog.view(&SessionSkillOverride::default());
-        assert_eq!(view.bundles[0].display_name, "pack");
-        assert!(view.bundles[0].package.is_none());
+        assert_eq!(authored_bundles(&view)[0].display_name, "pack");
+        assert!(authored_bundles(&view)[0].package.is_none());
     }
 
     #[test]

--- a/crates/biorouter/src/agents/skill_package/install.rs
+++ b/crates/biorouter/src/agents/skill_package/install.rs
@@ -80,6 +80,20 @@ pub fn install_root() -> PathBuf {
 /// installer that quietly picked one of the answers would be the flattening
 /// this module exists to remove.
 pub fn install(plan: &ImportPlan, root: &Path) -> Result<InstalledPackage> {
+    install_in(&Paths::config_dir().join("skills"), plan, root)
+}
+
+/// [`install`] against an explicit seeded root.
+///
+/// Split out for the same reason [`refuse_shipped`] takes that root as an
+/// argument: a test can then hold both halves without setting
+/// `BIOROUTER_PATH_ROOT`, whose process-global reach makes a test of it
+/// order-dependent on everything else in the binary.
+pub(super) fn install_in(
+    seeded_root: &Path,
+    plan: &ImportPlan,
+    root: &Path,
+) -> Result<InstalledPackage> {
     if let Some(ambiguity) = &plan.ambiguity {
         bail!(
             "this import needs an answer before it can be installed: {}",
@@ -96,7 +110,7 @@ pub fn install(plan: &ImportPlan, root: &Path) -> Result<InstalledPackage> {
     // Delete control is hidden because `builtin` now reads true; and `remove`
     // REFUSES it. A guard on one side of the pair turns a shadowing bug into
     // something the user cannot uninstall by any means.
-    if let Some(refusal) = refuse_shipped(&Paths::config_dir().join("skills"), root, &plan.id) {
+    if let Some(refusal) = refuse_shipped(seeded_root, root, &plan.id) {
         bail!(refusal);
     }
 
@@ -236,6 +250,11 @@ fn stage(plan: &ImportPlan, staging: &Path) -> Result<()> {
 /// Renamed aside first and then deleted, so the directory disappears from the
 /// catalog's view in one step rather than emptying out under a scan in flight.
 pub fn remove(id: &str, root: &Path) -> Result<PackageSummary> {
+    remove_in(&Paths::config_dir().join("skills"), id, root)
+}
+
+/// [`remove`] against an explicit seeded root. See [`install_in`].
+pub(super) fn remove_in(seeded_root: &Path, id: &str, root: &Path) -> Result<PackageSummary> {
     let sanitized = super::sanitize_package_id(id)
         .ok_or_else(|| anyhow::anyhow!("`{id}` is not a valid package name"))?;
     let directory = root.join(&sanitized);
@@ -243,7 +262,7 @@ pub fn remove(id: &str, root: &Path) -> Result<PackageSummary> {
         bail!("no package named `{sanitized}` is installed");
     }
 
-    if let Some(refusal) = refuse_shipped(&Paths::config_dir().join("skills"), root, &sanitized) {
+    if let Some(refusal) = refuse_shipped(seeded_root, root, &sanitized) {
         bail!(refusal);
     }
 

--- a/crates/biorouter/src/agents/skill_package/install.rs
+++ b/crates/biorouter/src/agents/skill_package/install.rs
@@ -89,6 +89,16 @@ pub fn install(plan: &ImportPlan, root: &Path) -> Result<InstalledPackage> {
     if plan.components.is_empty() {
         bail!("nothing selected to install");
     }
+    // ⚠ **The same guard as `remove`, and it has to be here too.** Installing
+    // over a shipped name renames the seeded directory aside and deletes it,
+    // and then three things compound: the next `ensure_builtin_skills` writes
+    // `SKILL.md` back *inside* the user's package, producing a hybrid; the
+    // Delete control is hidden because `builtin` now reads true; and `remove`
+    // REFUSES it. A guard on one side of the pair turns a shadowing bug into
+    // something the user cannot uninstall by any means.
+    if let Some(refusal) = refuse_shipped(&Paths::config_dir().join("skills"), root, &plan.id) {
+        bail!(refusal);
+    }
 
     std::fs::create_dir_all(root)
         .with_context(|| format!("creating the skills directory {}", root.display()))?;
@@ -263,7 +273,11 @@ pub fn remove(id: &str, root: &Path) -> Result<PackageSummary> {
     Ok(summary)
 }
 
-/// Why removing `id` from `root` is refused, or `None` to go ahead.
+/// Why touching `id` under `root` is refused, or `None` to go ahead.
+///
+/// Called from **both** [`install`] and [`remove`]. Guarding only one of them
+/// is worse than guarding neither: an install that shadows a shipped name then
+/// meets a `remove` that refuses it, and nothing can undo it.
 ///
 /// ⚠ **The one choke point, so the refusal lands on every surface.** Both
 /// `biorouter skill remove` and deleting from the Skills pane arrive at
@@ -285,9 +299,10 @@ pub(super) fn refuse_shipped(seeded_root: &Path, root: &Path, sanitized: &str) -
         return None;
     }
     Some(format!(
-        "`{sanitized}` ships with Biorouter and is restored on every start, so removing it would \
-         not last. Turn it off instead: Settings -> Chat -> Contexts, or \
-         `biorouter skill disable {sanitized}`."
+        "`{sanitized}` is the name of something that ships with Biorouter and is rewritten on \
+         every start, so this would not last. To turn it off, use Settings -> Chat -> Contexts \
+         or `biorouter skill disable {sanitized}`; to install a package of your own, give it \
+         another name."
     ))
 }
 

--- a/crates/biorouter/src/agents/skill_package/install.rs
+++ b/crates/biorouter/src/agents/skill_package/install.rs
@@ -233,6 +233,10 @@ pub fn remove(id: &str, root: &Path) -> Result<PackageSummary> {
         bail!("no package named `{sanitized}` is installed");
     }
 
+    if let Some(refusal) = refuse_shipped(&Paths::config_dir().join("skills"), root, &sanitized) {
+        bail!(refusal);
+    }
+
     let summary = std::fs::read_to_string(directory.join(PACKAGE_RECORD_FILE))
         .ok()
         .and_then(|raw| serde_json::from_str::<PackageSummary>(&raw).ok())
@@ -257,6 +261,34 @@ pub fn remove(id: &str, root: &Path) -> Result<PackageSummary> {
 
     skill_catalog::refresh();
     Ok(summary)
+}
+
+/// Why removing `id` from `root` is refused, or `None` to go ahead.
+///
+/// ⚠ **The one choke point, so the refusal lands on every surface.** Both
+/// `biorouter skill remove` and deleting from the Skills pane arrive at
+/// [`remove`]. Without this, removing a seeded skill or the knowledge bundle
+/// *succeeded*: the directory went, the CLI printed a tick, the toast confirmed
+/// it, and the next startup silently rewrote the folder — a control that reports
+/// success and reverts, which is regression 1 of #77.
+///
+/// ⚠ **Scoped to Biorouter's own skills root**, which is the only root the
+/// seeder writes. A package a user happens to have named `develop-biorouter`
+/// under `~/.claude/skills` is theirs to delete, and refusing that would be this
+/// guard reaching past its own reason to exist.
+///
+/// Takes the seeded root as an argument rather than reading `Paths` itself, so
+/// a test can state both halves without setting `BIOROUTER_PATH_ROOT` — a
+/// process-global whose use here would make the test order-dependent.
+pub(super) fn refuse_shipped(seeded_root: &Path, root: &Path, sanitized: &str) -> Option<String> {
+    if root != seeded_root || !crate::agents::skills_extension::is_shipped_entry_name(sanitized) {
+        return None;
+    }
+    Some(format!(
+        "`{sanitized}` ships with Biorouter and is restored on every start, so removing it would \
+         not last. Turn it off instead: Settings -> Chat -> Contexts, or \
+         `biorouter skill disable {sanitized}`."
+    ))
 }
 
 fn nonce() -> String {

--- a/crates/biorouter/src/agents/skill_package/tests.rs
+++ b/crates/biorouter/src/agents/skill_package/tests.rs
@@ -623,12 +623,15 @@ fn installing_hyperframes_produces_one_expandable_bundle_the_catalog_can_see() {
     }];
     let view = crate::agents::skill_catalog::SkillCatalog::scan(roots, 1)
         .view(&crate::agents::session_skills::SessionSkillOverride::default());
-    assert_eq!(
-        view.bundles.len(),
-        1,
-        "one bundle, not five top-level skills"
-    );
-    let bundle = &view.bundles[0];
+    // ⚠ `KNOWLEDGE_BUNDLE` is injected into every scan by
+    // `add_missing_shipped_skills`, so filter to what this test installed.
+    let bundles: Vec<_> = view
+        .bundles
+        .iter()
+        .filter(|b| b.name != crate::agents::skills_extension::KNOWLEDGE_BUNDLE)
+        .collect();
+    assert_eq!(bundles.len(), 1, "one bundle, not five top-level skills");
+    let bundle = bundles[0];
     assert_eq!(bundle.name, "hyperframes");
     assert_eq!(bundle.skills.len(), 5);
     let package = bundle.package.as_ref().expect("the record was written");
@@ -891,4 +894,53 @@ fn the_groups_map_is_empty_rather_than_absent_when_nothing_declares_one() {
     .unwrap();
     assert_eq!(plan.groups, BTreeMap::new());
     assert!(plan.components.iter().all(|c| c.group.is_none()));
+}
+
+/// ⚠ **A seeded skill or bundle cannot be deleted from ANY surface.**
+///
+/// `biorouter skill remove` and the Skills pane's Trash both land on
+/// `install::remove`, and before this guard both *succeeded* on a shipped
+/// skill: the folder went, the tick and the toast confirmed it, and the next
+/// startup rewrote it. That is regression 1 of #77 — a control that reports
+/// success and reverts is worse than no control — and it survived the fix on
+/// the desktop side because the fix was a UI gate, not a refusal.
+///
+/// Driven through `refuse_shipped` rather than `remove` so both halves can be
+/// stated without setting `BIOROUTER_PATH_ROOT`, whose process-global reach
+/// would make this test depend on what ran before it.
+#[test]
+fn removing_a_shipped_skill_or_bundle_is_refused() {
+    use crate::agents::skills_extension::KNOWLEDGE_BUNDLE;
+
+    let seeded = Path::new("/config/biorouter/skills");
+    let elsewhere = Path::new("/home/someone/.claude/skills");
+
+    for name in [
+        "about-biorouter",
+        "develop-biorouter",
+        "knowledge-lint",
+        "update-soul",
+        KNOWLEDGE_BUNDLE,
+    ] {
+        let refusal = install::refuse_shipped(seeded, seeded, name)
+            .unwrap_or_else(|| panic!("{name} can still be deleted, and the seeder undoes it"));
+        // The refusal has to name what it refused and what to do instead, or it
+        // reads as a bug rather than as a rule.
+        assert!(refusal.contains(name), "{refusal}");
+        assert!(refusal.contains("disable"), "{refusal}");
+
+        // ⚠ The same name under someone else's skills root is THEIRS. The
+        // seeder never writes there, so refusing it would be this guard
+        // reaching past its own reason to exist.
+        assert!(
+            install::refuse_shipped(seeded, elsewhere, name).is_none(),
+            "{name} is refused under a root Biorouter does not seed"
+        );
+    }
+
+    // A user package is removable, so the assertions above are about shipped
+    // entries and not about `remove` having stopped working.
+    assert!(install::refuse_shipped(seeded, seeded, "hyperframes").is_none());
+    // The trap: a name that merely resembles a shipped one.
+    assert!(install::refuse_shipped(seeded, seeded, "about-biorouter-notes").is_none());
 }

--- a/crates/biorouter/src/agents/skill_package/tests.rs
+++ b/crates/biorouter/src/agents/skill_package/tests.rs
@@ -944,3 +944,56 @@ fn removing_a_shipped_skill_or_bundle_is_refused() {
     // The trap: a name that merely resembles a shipped one.
     assert!(install::refuse_shipped(seeded, seeded, "about-biorouter-notes").is_none());
 }
+
+/// ⚠ **The WIRING, not the predicate.** The test above drives
+/// `refuse_shipped` directly, so deleting the `bail!` that calls it from
+/// `remove` leaves it green while restoring the exact regression it describes.
+/// This one goes through `remove` itself, and through `install`, so both call
+/// sites are held.
+///
+/// `BIOROUTER_PATH_ROOT` is process-global, so this serialises through the
+/// repo's `env_lock` rather than assuming it runs alone — the reason
+/// `refuse_shipped` takes the seeded root as an argument in the first place.
+#[test]
+fn remove_refuses_a_shipped_name_through_its_own_entry_point() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(tmp.path().to_str().unwrap()))]);
+
+    let root = crate::config::paths::Paths::config_dir().join("skills");
+    let seeded = root.join("about-biorouter");
+    std::fs::create_dir_all(&seeded).unwrap();
+    std::fs::write(
+        seeded.join("SKILL.md"),
+        "---\nname: about-biorouter\ndescription: Shipped\n---\nBody\n",
+    )
+    .unwrap();
+
+    let error = install::remove("about-biorouter", &root).unwrap_err();
+    let error = format!("{error:#}");
+    assert!(error.contains("ships with Biorouter"), "{error}");
+    assert!(
+        seeded.join("SKILL.md").is_file(),
+        "remove deleted a shipped skill and only the refusal text was missing"
+    );
+
+    // ⚠ And the write side. Installing over a shipped name renames the seeded
+    // directory aside and deletes it; the seeder then writes `SKILL.md` back
+    // inside the user's package, and `remove` above refuses to uninstall the
+    // result. A guard on one half of the pair is worse than a guard on neither.
+    let mine = plan(
+        &[(
+            "about-biorouter/SKILL.md",
+            skill_md("about-biorouter", "Mine"),
+        )],
+        WrapperHint::Infer,
+        &[],
+    )
+    .unwrap();
+    let error = format!("{:#}", install::install(&mine, &root).unwrap_err());
+    assert!(error.contains("ships with Biorouter"), "{error}");
+    assert_eq!(
+        std::fs::read_to_string(seeded.join("SKILL.md")).unwrap(),
+        "---\nname: about-biorouter\ndescription: Shipped\n---\nBody\n",
+        "install overwrote a shipped skill"
+    );
+}

--- a/crates/biorouter/src/agents/skill_package/tests.rs
+++ b/crates/biorouter/src/agents/skill_package/tests.rs
@@ -947,33 +947,32 @@ fn removing_a_shipped_skill_or_bundle_is_refused() {
 
 /// ⚠ **The WIRING, not the predicate.** The test above drives
 /// `refuse_shipped` directly, so deleting the `bail!` that calls it from
-/// `remove` leaves it green while restoring the exact regression it describes.
-/// This one goes through `remove` itself, and through `install`, so both call
-/// sites are held.
+/// `remove` or `install` leaves it green while restoring the exact regression
+/// it describes. This one goes through the function bodies themselves.
 ///
-/// `BIOROUTER_PATH_ROOT` is process-global, so this serialises through the
-/// repo's `env_lock` rather than assuming it runs alone — the reason
-/// `refuse_shipped` takes the seeded root as an argument in the first place.
+/// ⚠ **No `BIOROUTER_PATH_ROOT`.** `install_in`/`remove_in` take the seeded
+/// root as an argument for exactly this reason — the one-line public wrappers
+/// supply `Paths::config_dir()`, and everything below that is pure. A previous
+/// draft set the env var under a global lock, which contradicted the rationale
+/// written on `refuse_shipped` itself and made this test order-dependent on
+/// every other test in the binary.
 #[test]
-fn remove_refuses_a_shipped_name_through_its_own_entry_point() {
+fn remove_and_install_both_refuse_a_shipped_name_through_their_own_bodies() {
     let tmp = TempDir::new().unwrap();
-    let _guard = env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(tmp.path().to_str().unwrap()))]);
+    let seeded = tmp.path().join("biorouter-skills");
+    let package = seeded.join("about-biorouter");
+    std::fs::create_dir_all(&package).unwrap();
+    let shipped = "---\nname: about-biorouter\ndescription: Shipped\n---\nBody\n";
+    std::fs::write(package.join("SKILL.md"), shipped).unwrap();
 
-    let root = crate::config::paths::Paths::config_dir().join("skills");
-    let seeded = root.join("about-biorouter");
-    std::fs::create_dir_all(&seeded).unwrap();
-    std::fs::write(
-        seeded.join("SKILL.md"),
-        "---\nname: about-biorouter\ndescription: Shipped\n---\nBody\n",
-    )
-    .unwrap();
-
-    let error = install::remove("about-biorouter", &root).unwrap_err();
-    let error = format!("{error:#}");
+    let error = format!(
+        "{:#}",
+        install::remove_in(&seeded, "about-biorouter", &seeded).unwrap_err()
+    );
     assert!(error.contains("ships with Biorouter"), "{error}");
     assert!(
-        seeded.join("SKILL.md").is_file(),
-        "remove deleted a shipped skill and only the refusal text was missing"
+        package.join("SKILL.md").is_file(),
+        "remove deleted a shipped skill; only the refusal text was missing"
     );
 
     // ⚠ And the write side. Installing over a shipped name renames the seeded
@@ -989,11 +988,23 @@ fn remove_refuses_a_shipped_name_through_its_own_entry_point() {
         &[],
     )
     .unwrap();
-    let error = format!("{:#}", install::install(&mine, &root).unwrap_err());
+    let error = format!(
+        "{:#}",
+        install::install_in(&seeded, &mine, &seeded).unwrap_err()
+    );
     assert!(error.contains("ships with Biorouter"), "{error}");
     assert_eq!(
-        std::fs::read_to_string(seeded.join("SKILL.md")).unwrap(),
-        "---\nname: about-biorouter\ndescription: Shipped\n---\nBody\n",
+        std::fs::read_to_string(package.join("SKILL.md")).unwrap(),
+        shipped,
         "install overwrote a shipped skill"
     );
+
+    // ⚠ And the same package under a root Biorouter does not seed is THEIRS.
+    // Without this the guard would be a blanket ban on the name.
+    let elsewhere = tmp.path().join("claude-skills");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+    install::install_in(&seeded, &mine, &elsewhere)
+        .expect("a same-named package under another root must install");
+    install::remove_in(&seeded, "about-biorouter", &elsewhere)
+        .expect("and must be removable again");
 }

--- a/crates/biorouter/src/agents/skills_extension.rs
+++ b/crates/biorouter/src/agents/skills_extension.rs
@@ -40,32 +40,51 @@ pub static BUILTIN_SKILLS: &[(&str, &str)] = &[
     ),
 ];
 
-/// Skills that ship with Biorouter and teach the **knowledge-base formats** —
-/// which of OKF and BioOKF to create, how to ingest into each, and how to read a
-/// lint report. Seeded exactly like the array above.
+/// The bundle directory the knowledge skills are seeded into.
 ///
-/// ⚠ **A separate array, and the separation is not cosmetic.** The list above is
-/// also the *Contexts* list: the shipped skills the desktop Settings pane offers
-/// as toggles, hand-synced into two TypeScript copies, and pinned by
-/// `ui/desktop/src/components/settings/contexts/contexts.test.ts`, which reads
-/// **this file's source text** — it slices from the identifier above to its
-/// closing `];` and matches the `("name", include_str!` pairs inside. Adding a
-/// knowledge skill there would make that test fail on a UI this change does not
-/// touch. These four are shipped skills that are not Contexts, which is a real
-/// distinction (they trigger on a task, they are not always-on self-knowledge)
-/// and is why they can live here honestly rather than as a workaround.
+/// A bundle in this codebase is a *directory*: `<root>/<bundle>/<child>/SKILL.md`.
+/// [`SkillsClient::discover_skills_in_directories`] derives `bundle_name` from
+/// that layout and `skills-config.json`'s `disabled[]` accepts a bundle name as
+/// readily as a skill name, so seeding under a shared parent is the whole of
+/// what "make these a bundle" means.
 ///
-/// ⚠ **`BUILTIN_SKILL_NAMES` lists these; `CONTEXTS` must not.** That asymmetry
-/// is the whole point of the split, and it mirrors the two functions below:
-/// `context_skill_names()` is BUILTIN_SKILLS + soul, and `is_builtin_skill_name()`
-/// is over `shipped_skills()`, which includes these four.
+/// ⚠ **Not `knowledge`.** That is already the name of a built-in *extension*,
+/// and the CLI's `@`-reference popup draws skills and extensions into one list
+/// (`completion.rs`), so the shorter name would print twice with two meanings.
+pub const KNOWLEDGE_BUNDLE: &str = "knowledge-bases";
+
+/// Where [`KNOWLEDGE_SKILLS`] and the Soul skill are written, under a given
+/// skills root.
 ///
-/// It was not always so. These shipped without being in either TypeScript list,
-/// so the Skills pane offered a Delete control on a seeded skill: the delete
-/// succeeded, the toast said so, and the next startup rewrote the folder. A
-/// button that reports success and silently reverts is worse than no button.
-/// `contexts.test.ts` could not catch it either — it sliced only the array
-/// above, so the census was blind to exactly the names it needed to see.
+/// Exported because `knowledge::soul` seeds its own member through the same
+/// path and must not spell the join a second time.
+pub fn knowledge_bundle_dir(skills_dir: &Path) -> PathBuf {
+    skills_dir.join(KNOWLEDGE_BUNDLE)
+}
+
+/// Skills that ship with Biorouter and teach the **knowledge bases** — which of
+/// OKF and BioOKF to create, how to ingest into each, how to read a lint
+/// report. Seeded like [`BUILTIN_SKILLS`], but into [`KNOWLEDGE_BUNDLE`] rather
+/// than flat at the skills root.
+///
+/// ⚠ **A separate array, and the separation is not cosmetic.** These five —
+/// the four here plus `update-soul`, which is a Rust string in `soul.rs`
+/// rather than an `include_str!` — are the members of one bundle, and the
+/// bundle, not any member, is the Context row Settings offers. The array above
+/// is the flat, one-skill-per-Context list. `contexts.test.ts` reads **this
+/// file's source text**, slicing each identifier to its closing `];` and
+/// matching the `("name", include_str!` pairs inside, so both arrays and
+/// [`KNOWLEDGE_BUNDLE`] are pinned against the desktop's copy from here.
+///
+/// It was not always so, twice over. These first shipped in neither TypeScript
+/// list, so the Skills pane offered a Delete control on a seeded skill: the
+/// delete succeeded, the toast said so, and the next startup rewrote the
+/// folder. A button that reports success and silently reverts is worse than no
+/// button. `contexts.test.ts` could not catch it either — it sliced only
+/// `BUILTIN_SKILLS`, so the census was blind to exactly the names it needed to
+/// see. Then they were shipped skills that were deliberately *not* Contexts,
+/// which put four rows in every chat's skill picker for a feature the user
+/// either uses or does not. Bundling them answers both: one row, in Settings.
 pub static KNOWLEDGE_SKILLS: &[(&str, &str)] = &[
     (
         "knowledge-choose-a-format",
@@ -99,32 +118,53 @@ pub(crate) fn install_builtin_skills() {
     SkillsClient::ensure_builtin_skills(&Paths::config_dir().join("skills"));
 }
 
-/// Every shipped **Context**, by the `name:` in its `SKILL.md` frontmatter —
-/// which is also its directory name and the key it occupies in the skill map.
+/// Every shipped **Context**, by the identifier its enablement is keyed on.
 ///
-/// The four [`BUILTIN_SKILLS`] plus the Soul skill, which is defined as a Rust
-/// string in `soul.rs` rather than in that array. Hand-synced with
-/// `ui/desktop/src/components/settings/contexts/contexts.ts`, whose
-/// `contexts.test.ts` reads *this file* and asserts the two agree (#77).
+/// ⚠ **These are not all skill names.** A Context is one row in Settings, and a
+/// row may stand for a whole bundle: the four [`BUILTIN_SKILLS`] contribute
+/// their own `name:`, and [`KNOWLEDGE_BUNDLE`] contributes a *directory* name
+/// covering its five members. That is why `compose_state` tests a skill's
+/// bundle against this set as well as the skill's own name — exactly as it
+/// already does for `skills-config.json`'s `disabled[]`, which has always held
+/// both kinds of identifier.
 ///
-/// ⚠ Deliberately **not** [`shipped_skills`]. The two answer different questions
-/// — see [`KNOWLEDGE_SKILLS`] — and widening this one would change what the
-/// Settings pane claims to offer.
-pub fn context_skill_names() -> impl Iterator<Item = &'static str> {
+/// Hand-synced with `ui/desktop/src/components/settings/contexts/contexts.ts`,
+/// whose `contexts.test.ts` reads *this file* and asserts the two agree (#77).
+///
+/// ⚠ Deliberately **not** [`shipped_skills`]. The two answer different
+/// questions — see [`KNOWLEDGE_SKILLS`] — and widening this one would change
+/// what the Settings pane claims to offer.
+pub fn context_ids() -> impl Iterator<Item = &'static str> {
     BUILTIN_SKILLS
         .iter()
         .map(|(name, _)| *name)
-        .chain(std::iter::once(crate::knowledge::soul::SOUL_SKILL_DIR))
+        .chain(std::iter::once(KNOWLEDGE_BUNDLE))
 }
 
-/// Did Biorouter put this skill on disk? Every shipped skill, not only the
+/// Did Biorouter put this **skill** on disk? Every shipped skill, not only the
 /// Contexts — a knowledge skill the seeder wrote is not one the user installed,
-/// so it must not be counted as one by [`count_user_skills`].
+/// so it must not be counted as one by [`count_user_skills`], and the interface
+/// must offer it no Delete.
 pub fn is_builtin_skill_name(name: &str) -> bool {
     shipped_skills()
         .map(|(name, _)| *name)
         .chain(std::iter::once(crate::knowledge::soul::SOUL_SKILL_DIR))
         .any(|builtin_name| builtin_name == name)
+}
+
+/// Did Biorouter put this **entry** on disk, skill or bundle?
+///
+/// ⚠ Distinct from [`is_builtin_skill_name`] for one reason, and it is the
+/// reason a count goes wrong: the callers below enumerate *directory entries at
+/// a skills root* ([`count_user_skills`]) or the CLI's reference list, both of
+/// which name a bundle by its directory and never by a member. Ask the
+/// skill-only question there and [`KNOWLEDGE_BUNDLE`] reads as a skill the user
+/// installed — one phantom entry in every count on every install.
+///
+/// Defined in terms of [`is_builtin_skill_name`] rather than beside it, so the
+/// two cannot drift.
+pub fn is_shipped_entry_name(name: &str) -> bool {
+    name == KNOWLEDGE_BUNDLE || is_builtin_skill_name(name)
 }
 
 /// The config key holding one Context's enablement, as the desktop Settings
@@ -158,7 +198,7 @@ pub fn context_config_key(id: &str) -> String {
 /// ([`SkillsClient::enabled_skill_entries`], and through it `listSkills`,
 /// `searchSkills` and the `{skill_count}` sentence) and nothing else.
 fn hidden_contexts_in(config: &crate::config::Config) -> std::collections::HashSet<String> {
-    context_skill_names()
+    context_ids()
         .filter(|name| {
             // `Err` is "no opinion recorded" (or an unreadable config), which
             // must read as ON — see the absence rule above. Only a literal
@@ -206,7 +246,9 @@ pub fn count_user_skills() -> usize {
         .into_iter()
         .flatten()
         .filter_map(|entry| entry.ok())
-        .filter(|entry| !is_builtin_skill_name(&entry.file_name().to_string_lossy()))
+        // ⚠ [`is_shipped_entry_name`], not [`is_builtin_skill_name`]: these are
+        // directory entries, and the knowledge skills' entry is the BUNDLE.
+        .filter(|entry| !is_shipped_entry_name(&entry.file_name().to_string_lossy()))
         .count()
 }
 
@@ -224,18 +266,29 @@ pub fn reset_to_builtin_skills() -> Result<usize> {
     }
 
     SkillsClient::ensure_builtin_skills(&skills_dir);
-    let soul_skill_dir = skills_dir.join(crate::knowledge::soul::SOUL_SKILL_DIR);
+    let soul_skill_dir =
+        knowledge_bundle_dir(&skills_dir).join(crate::knowledge::soul::SOUL_SKILL_DIR);
     std::fs::create_dir_all(&soul_skill_dir)?;
     std::fs::write(
         soul_skill_dir.join("SKILL.md"),
         crate::knowledge::soul::SOUL_SKILL_MD,
     )?;
 
-    for (name, _) in shipped_skills() {
+    for (name, _) in BUILTIN_SKILLS {
         if !skills_dir.join(name).join("SKILL.md").is_file() {
             anyhow::bail!("failed to restore built-in skill '{name}'");
         }
     }
+    for (name, _) in KNOWLEDGE_SKILLS {
+        if !knowledge_bundle_dir(&skills_dir)
+            .join(name)
+            .join("SKILL.md")
+            .is_file()
+        {
+            anyhow::bail!("failed to restore built-in skill '{name}'");
+        }
+    }
+    skill_catalog::invalidate();
     Ok(removed)
 }
 
@@ -431,20 +484,36 @@ impl SkillsClient {
     /// by [`skill_catalog::SkillCatalog::scan`] so that *every* view of the
     /// catalog has them — not only the one a client happened to build.
     pub(crate) fn add_missing_shipped_skills(skills: &mut HashMap<String, Skill>) {
-        for (name, content) in shipped_skills() {
+        let root = Paths::config_dir().join("skills");
+        // ⚠ The fallback must place each skill where the SEEDER would have, or
+        // the two views disagree about the one field the picker keys on: a
+        // knowledge skill reconstructed here with `bundle_name: None` would be
+        // a standalone row that no bundle toggle reaches, on exactly the
+        // installs (read-only config dir, shadowed slug) where nobody can look
+        // at the disk to see why.
+        let placements = BUILTIN_SKILLS.iter().map(|entry| (entry, None)).chain(
+            KNOWLEDGE_SKILLS
+                .iter()
+                .map(|entry| (entry, Some(KNOWLEDGE_BUNDLE))),
+        );
+        for ((name, content), bundle) in placements {
             if skills.contains_key(*name) {
                 continue;
             }
             if let Ok((metadata, body)) = Self::parse_frontmatter(content) {
+                let directory = match bundle {
+                    Some(bundle) => root.join(bundle).join(name),
+                    None => root.join(name),
+                };
                 skills.insert(
                     metadata.name.clone(),
                     Skill {
                         metadata,
                         body,
-                        directory: Paths::config_dir().join("skills").join(name),
+                        directory,
                         supporting_files: Vec::new(),
-                        bundle_name: None,
-                        source_root: Paths::config_dir().join("skills"),
+                        bundle_name: bundle.map(str::to_string),
+                        source_root: root.clone(),
                     },
                 );
             }
@@ -456,8 +525,19 @@ impl SkillsClient {
     /// rewritten when it differs so app updates propagate. Failures are
     /// non-fatal: the in-memory fallback in `new()` still registers them.
     fn ensure_builtin_skills(skills_dir: &Path) {
-        for (name, content) in shipped_skills() {
-            let dir = skills_dir.join(name);
+        let bundle_dir = knowledge_bundle_dir(skills_dir);
+        let placements = BUILTIN_SKILLS
+            .iter()
+            .map(|entry| (entry, skills_dir.to_path_buf()))
+            .chain(
+                KNOWLEDGE_SKILLS
+                    .iter()
+                    .map(|entry| (entry, bundle_dir.clone())),
+            );
+
+        let mut wrote = false;
+        for ((name, content), parent) in placements {
+            let dir = parent.join(name);
             let file = dir.join("SKILL.md");
             let up_to_date = std::fs::read_to_string(&file)
                 .map(|existing| existing == *content)
@@ -469,8 +549,65 @@ impl SkillsClient {
                 std::fs::create_dir_all(&dir).and_then(|_| std::fs::write(&file, content))
             {
                 tracing::warn!("failed to seed builtin skill '{}': {}", name, e);
+            } else {
+                wrote = true;
             }
         }
+
+        let migrated = Self::remove_pre_bundle_knowledge_skills(skills_dir);
+
+        if wrote || migrated {
+            // ⚠ Not left to the mtime check. Creating `<bundle>/<child>/` bumps
+            // the BUNDLE's mtime, not the root's, and mtime has one-second
+            // granularity — a seed in the same second as the last scan is
+            // invisible. `skill_catalog` says so in its header and asks writers
+            // to say what they did instead of hoping.
+            skill_catalog::invalidate();
+        }
+    }
+
+    /// Delete the flat `<root>/<knowledge skill>/` directories that installs
+    /// predating [`KNOWLEDGE_BUNDLE`] left behind.
+    ///
+    /// ⚠ **Not cosmetic — a stale copy resurrects as the live one.**
+    /// Discovery keys by frontmatter `name`, so a flat `knowledge-lint` and a
+    /// bundled `knowledge-lint` are two candidates for one map key and the
+    /// winner is whichever `read_dir` happens to yield last. Half the installs
+    /// would get a `bundle_name: None` knowledge skill: a standalone picker row
+    /// the bundle's Context toggle does not reach.
+    ///
+    /// Same shape as `soul.rs`'s removal of the renamed-away `soul-writer`
+    /// folder — but **not** the same deletion rule, and the difference is the
+    /// seeder's own semantics. `update-soul` is written with
+    /// `create_built_in_file_if_missing`, so a user's edits to it survive every
+    /// startup and its migration has to *move* the file. These four are
+    /// rewritten whenever their content differs, so the seeder has always owned
+    /// these exact paths and overwritten whatever was at them on every start:
+    /// nothing a user wrote could have survived here to be lost now.
+    ///
+    /// Scoped to `skills_dir`, which is Biorouter's own root. A skill of the
+    /// same name under `~/.claude/skills` is the user's and is not touched.
+    ///
+    /// Returns whether anything was removed, so the caller can invalidate.
+    fn remove_pre_bundle_knowledge_skills(skills_dir: &Path) -> bool {
+        let mut removed = false;
+        for (name, _) in KNOWLEDGE_SKILLS {
+            let stale = skills_dir.join(name);
+            if !stale.is_dir() {
+                continue;
+            }
+            match std::fs::remove_dir_all(&stale) {
+                Ok(()) => {
+                    tracing::info!("removed pre-bundle skill at {}", stale.display());
+                    removed = true;
+                }
+                Err(e) => tracing::warn!(
+                    "failed to remove pre-bundle skill at {}: {e}",
+                    stale.display()
+                ),
+            }
+        }
+        removed
     }
 
     /// Every directory skills are discovered under, in override order (later
@@ -739,6 +876,19 @@ impl SkillsClient {
     /// a switched-off Context stays loadable by exact name (see
     /// [`hidden_contexts_in`] for why that asymmetry is required rather than
     /// merely tolerated).
+    /// Is this skill hidden by a Context switch — its own, or its bundle's?
+    ///
+    /// The same two-key test [`skill_catalog::compose_state`] applies, kept as
+    /// one function so the model-facing filter and the interface's switches
+    /// cannot come to disagree about what a bundle-level Context covers.
+    fn is_hidden_context(
+        name: &str,
+        bundle: Option<&str>,
+        hidden_contexts: &std::collections::HashSet<String>,
+    ) -> bool {
+        hidden_contexts.contains(name) || bundle.is_some_and(|b| hidden_contexts.contains(b))
+    }
+
     fn enabled_skill_entries<'a>(
         skills: &'a HashMap<String, Skill>,
         over: &crate::agents::session_skills::SessionSkillOverride,
@@ -753,7 +903,13 @@ impl SkillsClient {
                 // everything", and a Context the user switched off in Settings
                 // is not something `workspace_set_tools` should be able to put
                 // back into the catalog on the model's say-so.
-                !hidden_contexts.contains(name.as_str())
+                //
+                // ⚠ The BUNDLE is tested too. A Context row may stand for a
+                // whole bundle (see [`context_ids`]), and a member carries its
+                // own `name:` — so matching only on the skill's name would
+                // leave every member of a switched-off bundle in the catalog
+                // the model is told about, while the Settings switch sat off.
+                !Self::is_hidden_context(name, skill.bundle_name.as_deref(), &hidden_contexts)
                     && Self::is_skill_enabled_for_session(name, skill, &disabled, over)
             })
             .collect();
@@ -2884,41 +3040,178 @@ Working dir biorouter content
         );
     }
 
-    /// The knowledge-format skills seed through the same path and are
-    /// recognised as shipped, so `count_user_skills` does not report four
-    /// skills the user never installed.
+    /// The knowledge skills seed into the BUNDLE, are recognised as shipped,
+    /// and are discovered with the bundle name on them.
+    ///
+    /// ⚠ The `bundle_name` assertion is the load-bearing one. Seeding to the
+    /// right path and being read back with `bundle_name: None` would look
+    /// entirely correct on disk while leaving every member a standalone picker
+    /// row that no bundle toggle and no Context switch reaches.
     #[test]
-    fn the_knowledge_skills_ship_and_are_not_counted_as_the_users() {
+    fn the_knowledge_skills_ship_as_one_bundle() {
         let temp_dir = TempDir::new().unwrap();
         let skills_dir = temp_dir.path().join("skills");
         SkillsClient::ensure_builtin_skills(&skills_dir);
+
+        let discovered = SkillsClient::discover_skills_in_directories(&[skills_dir.clone()]);
         for (name, content) in KNOWLEDGE_SKILLS {
-            let seeded = skills_dir.join(name).join("SKILL.md");
-            assert!(seeded.exists(), "{name} should be seeded");
+            let seeded = knowledge_bundle_dir(&skills_dir)
+                .join(name)
+                .join("SKILL.md");
+            assert!(seeded.exists(), "{name} should be seeded into the bundle");
             assert_eq!(fs::read_to_string(seeded).unwrap(), *content);
             assert!(is_builtin_skill_name(name), "{name} reads as a user skill");
+            assert!(
+                !skills_dir.join(name).exists(),
+                "{name} was also seeded flat, which resurrects as a duplicate"
+            );
+            assert_eq!(
+                discovered
+                    .get(*name)
+                    .unwrap_or_else(|| panic!("{name} was not discovered"))
+                    .bundle_name
+                    .as_deref(),
+                Some(KNOWLEDGE_BUNDLE),
+                "{name} is discovered without its bundle, so no bundle toggle reaches it"
+            );
+        }
+
+        // The four `BUILTIN_SKILLS` stay flat — they are one Context each.
+        for (name, _) in BUILTIN_SKILLS {
+            assert!(
+                skills_dir.join(name).join("SKILL.md").is_file(),
+                "{name} should stay flat at the skills root"
+            );
         }
     }
 
-    /// ⚠ **They are shipped, and they are NOT Contexts.** `contexts.test.ts`
-    /// reads this file's source, slices the `BUILTIN_SKILLS` literal, and
-    /// asserts the desktop's two hand-synced copies name exactly those four plus
-    /// `update-soul`. The knowledge skills live in their own array *because* of
-    /// that: they are task-triggered, not always-on self-knowledge, so they do
-    /// not belong in the Settings Contexts pane — and putting them there would
-    /// fail a UI test from a Rust edit. This asserts the separation directly, so
-    /// the reason cannot be lost by someone tidying the two arrays into one.
+    /// An install that predates the bundle keeps its flat directories, and a
+    /// flat copy alongside a bundled one is two candidates for one map key.
+    ///
+    /// ⚠ Asserted through `discover_skills_in_directories`, not by looking at
+    /// the disk: the failure is that discovery picks the *flat* one — whichever
+    /// `read_dir` yields last — so a test that only checked the bundled file
+    /// exists would pass while the picker showed a standalone row.
     #[test]
-    fn a_knowledge_skill_is_shipped_but_is_not_a_context() {
-        let contexts: Vec<&str> = context_skill_names().collect();
+    fn seeding_removes_the_pre_bundle_flat_knowledge_directories() {
+        let temp_dir = TempDir::new().unwrap();
+        let skills_dir = temp_dir.path().join("skills");
+
+        for (name, content) in KNOWLEDGE_SKILLS {
+            let stale = skills_dir.join(name);
+            fs::create_dir_all(&stale).unwrap();
+            fs::write(stale.join("SKILL.md"), content).unwrap();
+        }
+        // A user skill at the same root must survive the migration untouched.
+        let mine = skills_dir.join("my-own-skill");
+        fs::create_dir_all(&mine).unwrap();
+        fs::write(
+            mine.join("SKILL.md"),
+            "---\nname: my-own-skill\ndescription: Mine\n---\nBody\n",
+        )
+        .unwrap();
+
+        SkillsClient::ensure_builtin_skills(&skills_dir);
+
+        for (name, _) in KNOWLEDGE_SKILLS {
+            assert!(
+                !skills_dir.join(name).exists(),
+                "{name} still has its pre-bundle flat directory"
+            );
+        }
+        assert!(mine.join("SKILL.md").is_file(), "a user skill was removed");
+
+        let discovered = SkillsClient::discover_skills_in_directories(&[skills_dir]);
+        for (name, _) in KNOWLEDGE_SKILLS {
+            assert_eq!(
+                discovered[*name].bundle_name.as_deref(),
+                Some(KNOWLEDGE_BUNDLE),
+                "{name} still resolves to the stale flat copy"
+            );
+        }
+    }
+
+    /// ⚠ **The bundle is the Context, and no member is one on its own.**
+    /// `contexts.test.ts` reads this file's source, slices both arrays and
+    /// `KNOWLEDGE_BUNDLE`, and asserts the desktop's copy names exactly the
+    /// four flat skills plus the bundle. Listing a member here as well would
+    /// give the user two switches for one thing, the narrower of which the
+    /// bundle switch silently overrides.
+    #[test]
+    fn the_knowledge_bundle_is_the_context_and_its_members_are_not() {
+        let contexts: Vec<&str> = context_ids().collect();
         assert_eq!(contexts.len(), 5, "the Contexts list moved: {contexts:?}");
+        assert!(
+            contexts.contains(&KNOWLEDGE_BUNDLE),
+            "the knowledge bundle is not offered as a Context: {contexts:?}"
+        );
         for (name, _) in KNOWLEDGE_SKILLS {
             assert!(
                 !contexts.contains(name),
-                "{name} became a Context; ui/desktop's CONTEXTS and \
-                 skillUtils.BUILTIN_SKILL_NAMES must gain it in the same change"
+                "{name} is a Context in its own right as well as a bundle member"
             );
         }
+        assert!(
+            !contexts.contains(&crate::knowledge::soul::SOUL_SKILL_DIR),
+            "update-soul is still its own Context; it is a bundle member now"
+        );
+    }
+
+    /// Switching the bundle off must reach every member, and it is the BUNDLE
+    /// name the config key is derived from.
+    ///
+    /// ⚠ Without the bundle arm in `compose_state` / `is_hidden_context` this
+    /// fails in the most misleading way available: the switch moves, the value
+    /// is stored, and all five skills stay in the catalog the model is told
+    /// about.
+    #[test]
+    fn hiding_the_knowledge_bundle_hides_every_member() {
+        let hidden = std::collections::HashSet::from([KNOWLEDGE_BUNDLE.to_string()]);
+        for (name, _) in KNOWLEDGE_SKILLS {
+            assert!(
+                SkillsClient::is_hidden_context(name, Some(KNOWLEDGE_BUNDLE), &hidden),
+                "{name} survives its bundle's Context switch"
+            );
+            assert!(
+                !SkillsClient::is_hidden_context(name, None, &hidden),
+                "{name} is hidden even when it is not in the bundle"
+            );
+        }
+        assert!(
+            SkillsClient::is_hidden_context(
+                crate::knowledge::soul::SOUL_SKILL_DIR,
+                Some(KNOWLEDGE_BUNDLE),
+                &hidden
+            ),
+            "update-soul survives its bundle's Context switch"
+        );
+        assert!(
+            !SkillsClient::is_hidden_context("single-cell", Some("superpowers"), &hidden),
+            "an unrelated bundle's member is hidden"
+        );
+    }
+
+    /// ⚠ **A bundle directory is not a skill name, and the counts read
+    /// directory entries.** Ask the skill-only question at a skills root and
+    /// [`KNOWLEDGE_BUNDLE`] reads as a skill the user installed — one phantom
+    /// entry in the chip, the CLI status line and the reset dialog, on every
+    /// install, forever.
+    #[test]
+    fn the_bundle_directory_is_shipped_even_though_it_is_not_a_skill() {
+        assert!(
+            !is_builtin_skill_name(KNOWLEDGE_BUNDLE),
+            "the bundle is not a skill and must not answer the skill question"
+        );
+        assert!(is_shipped_entry_name(KNOWLEDGE_BUNDLE));
+        for (name, _) in shipped_skills() {
+            assert!(is_shipped_entry_name(name), "{name}");
+        }
+        assert!(is_shipped_entry_name(
+            crate::knowledge::soul::SOUL_SKILL_DIR
+        ));
+        assert!(!is_shipped_entry_name("single-cell"));
+        // The trap: a user skill whose name merely resembles a shipped one.
+        assert!(!is_shipped_entry_name("knowledge-bases-of-mine"));
     }
 
     /// Every shipped skill parses, and its frontmatter `name` is its directory
@@ -2954,14 +3247,17 @@ Working dir biorouter content
             context_config_key("about-biorouter"),
             "context_about_biorouter"
         );
-        assert_eq!(context_config_key("update-soul"), "context_update_soul");
+        assert_eq!(
+            context_config_key(KNOWLEDGE_BUNDLE),
+            "context_knowledge_bases"
+        );
         assert_eq!(
             context_config_key("develop-biorouter-extension"),
             "context_develop_biorouter_extension"
         );
         // Every shipped Context must produce a plain identifier — the same
         // assertion `contexts.test.ts` makes with /^context_[a-z0-9_]+$/.
-        for name in context_skill_names() {
+        for name in context_ids() {
             let key = context_config_key(name);
             let body = key
                 .strip_prefix("context_")
@@ -3032,7 +3328,7 @@ Working dir biorouter content
 
         // Pin every Context key so the developer's own config cannot decide the
         // outcome either way.
-        let all_on: std::collections::HashMap<String, String> = context_skill_names()
+        let all_on: std::collections::HashMap<String, String> = context_ids()
             .map(|n| (context_config_key(n).to_uppercase(), "true".to_string()))
             .collect();
         let mut about_off = all_on.clone();

--- a/crates/biorouter/src/agents/skills_extension.rs
+++ b/crates/biorouter/src/agents/skills_extension.rs
@@ -3053,7 +3053,8 @@ Working dir biorouter content
         let skills_dir = temp_dir.path().join("skills");
         SkillsClient::ensure_builtin_skills(&skills_dir);
 
-        let discovered = SkillsClient::discover_skills_in_directories(&[skills_dir.clone()]);
+        let discovered =
+            SkillsClient::discover_skills_in_directories(std::slice::from_ref(&skills_dir));
         for (name, content) in KNOWLEDGE_SKILLS {
             let seeded = knowledge_bundle_dir(&skills_dir)
                 .join(name)

--- a/crates/biorouter/src/agents/skills_extension.rs
+++ b/crates/biorouter/src/agents/skills_extension.rs
@@ -199,17 +199,40 @@ pub fn context_config_key(id: &str) -> String {
 /// `searchSkills` and the `{skill_count}` sentence) and nothing else.
 fn hidden_contexts_in(config: &crate::config::Config) -> std::collections::HashSet<String> {
     context_ids()
-        .filter(|name| {
-            // `Err` is "no opinion recorded" (or an unreadable config), which
-            // must read as ON — see the absence rule above. Only a literal
-            // `false` hides a Context.
-            matches!(
-                config.get_param::<bool>(&context_config_key(name)),
-                Ok(false)
-            )
-        })
+        .filter(|name| is_context_off(config, name))
         .map(str::to_string)
         .collect()
+}
+
+/// Has the user switched this Context off?
+///
+/// `Err` is "no opinion recorded" (or an unreadable config), which must read as
+/// ON — see the absence rule on [`hidden_contexts_in`]. Only a literal `false`
+/// hides a Context.
+///
+/// ⚠ **[`KNOWLEDGE_BUNDLE`] falls back to the key its predecessor wrote.**
+/// `update-soul` was a Context in its own right, labelled "Updates", and it is
+/// now a member of this bundle. A user who switched that off had `false` under
+/// `context_update_soul`, and that key is read by nothing any more — so without
+/// this fallback the upgrade silently turns the skill back on, adds four more
+/// beside it, and files them under a row the user has never seen. An opt-out
+/// that reverts itself on upgrade is worse than one that was never offered,
+/// and this one writes to the user's personal knowledge base.
+///
+/// The fallback is one-directional and read-only: an explicit
+/// `context_knowledge_bases` always wins, so the first use of the new switch
+/// ends the inheritance, and the stale key is never written back.
+fn is_context_off(config: &crate::config::Config, name: &str) -> bool {
+    if let Ok(explicit) = config.get_param::<bool>(&context_config_key(name)) {
+        return !explicit;
+    }
+    if name == KNOWLEDGE_BUNDLE {
+        return matches!(
+            config.get_param::<bool>(&context_config_key(crate::knowledge::soul::SOUL_SKILL_DIR)),
+            Ok(false)
+        );
+    }
+    false
 }
 
 /// [`hidden_contexts_in`] against the process's real configuration.
@@ -535,6 +558,15 @@ impl SkillsClient {
                     .map(|entry| (entry, bundle_dir.clone())),
             );
 
+        // ⚠ **Migration runs BEFORE the seed, and it renames.** Both halves
+        // matter. A rename carries the whole directory — including supporting
+        // files, which the seeder has never written and never owned — and it
+        // leaves a `SKILL.md` at the new path for the loop below to refresh.
+        // Deleting after seeding instead would destroy a user's `reference.md`
+        // or `scripts/` beside a skill they never edited, and would delete the
+        // working flat copy even on the runs where the seed had just failed.
+        let migrated = Self::migrate_pre_bundle_knowledge_skills(skills_dir);
+
         let mut wrote = false;
         for ((name, content), parent) in placements {
             let dir = parent.join(name);
@@ -554,8 +586,6 @@ impl SkillsClient {
             }
         }
 
-        let migrated = Self::remove_pre_bundle_knowledge_skills(skills_dir);
-
         if wrote || migrated {
             // ⚠ Not left to the mtime check. Creating `<bundle>/<child>/` bumps
             // the BUNDLE's mtime, not the root's, and mtime has one-second
@@ -566,48 +596,98 @@ impl SkillsClient {
         }
     }
 
-    /// Delete the flat `<root>/<knowledge skill>/` directories that installs
+    /// Relocate the flat `<root>/<knowledge skill>/` directories that installs
     /// predating [`KNOWLEDGE_BUNDLE`] left behind.
     ///
-    /// ⚠ **Not cosmetic — a stale copy resurrects as the live one.**
+    /// ⚠ **Not tidiness — a stale copy resurrects as the live one.**
     /// Discovery keys by frontmatter `name`, so a flat `knowledge-lint` and a
     /// bundled `knowledge-lint` are two candidates for one map key and the
     /// winner is whichever `read_dir` happens to yield last. Half the installs
     /// would get a `bundle_name: None` knowledge skill: a standalone picker row
     /// the bundle's Context toggle does not reach.
     ///
-    /// Same shape as `soul.rs`'s removal of the renamed-away `soul-writer`
-    /// folder — but **not** the same deletion rule, and the difference is the
-    /// seeder's own semantics. `update-soul` is written with
-    /// `create_built_in_file_if_missing`, so a user's edits to it survive every
-    /// startup and its migration has to *move* the file. These four are
-    /// rewritten whenever their content differs, so the seeder has always owned
-    /// these exact paths and overwritten whatever was at them on every start:
-    /// nothing a user wrote could have survived here to be lost now.
+    /// ⚠ **Moved, never deleted, and that is not caution — it is correctness.**
+    /// The seeder writes exactly one file per skill, `SKILL.md`. Every *other*
+    /// file in that directory has survived every startup since the skill
+    /// shipped, and those files are load-bearing: [`Self::find_supporting_files`]
+    /// collects them and `loadSkill` serves them to the model. A `remove_dir_all`
+    /// here would take a user's `reference.md` or `scripts/` with it — which is
+    /// why the earlier draft's claim that "nothing a user wrote could have
+    /// survived here" was false, and why this now does what `soul.rs` does.
+    ///
+    /// A rename that fails leaves the flat copy in place. A duplicate picker
+    /// row is a visible annoyance; a deleted file is not recoverable.
     ///
     /// Scoped to `skills_dir`, which is Biorouter's own root. A skill of the
     /// same name under `~/.claude/skills` is the user's and is not touched.
     ///
-    /// Returns whether anything was removed, so the caller can invalidate.
-    fn remove_pre_bundle_knowledge_skills(skills_dir: &Path) -> bool {
-        let mut removed = false;
+    /// Returns whether anything moved, so the caller can invalidate.
+    fn migrate_pre_bundle_knowledge_skills(skills_dir: &Path) -> bool {
+        let bundle = knowledge_bundle_dir(skills_dir);
+        let mut moved = false;
         for (name, _) in KNOWLEDGE_SKILLS {
-            let stale = skills_dir.join(name);
-            if !stale.is_dir() {
+            let flat = skills_dir.join(name);
+            if !flat.is_dir() {
                 continue;
             }
-            match std::fs::remove_dir_all(&stale) {
+            let target = bundle.join(name);
+            if target.exists() {
+                // Both copies present, which only a hand-assembled tree
+                // produces. The bundled one wins; take anything the flat one
+                // has that it lacks before dropping the duplicate.
+                Self::rescue_supporting_files(&flat, &target);
+                match std::fs::remove_dir_all(&flat) {
+                    Ok(()) => {
+                        tracing::info!("removed duplicate skill at {}", flat.display());
+                        moved = true;
+                    }
+                    Err(e) => tracing::warn!(
+                        "failed to remove duplicate skill at {}: {e}",
+                        flat.display()
+                    ),
+                }
+                continue;
+            }
+            match std::fs::create_dir_all(&bundle).and_then(|()| std::fs::rename(&flat, &target)) {
                 Ok(()) => {
-                    tracing::info!("removed pre-bundle skill at {}", stale.display());
-                    removed = true;
+                    tracing::info!("moved {} into the knowledge bundle", name);
+                    moved = true;
                 }
                 Err(e) => tracing::warn!(
-                    "failed to remove pre-bundle skill at {}: {e}",
-                    stale.display()
+                    "failed to move {} into {}: {e}; leaving the old copy in place",
+                    name,
+                    target.display()
                 ),
             }
         }
-        removed
+        moved
+    }
+
+    /// Move every file beside a `SKILL.md` from `from` into `to`, skipping any
+    /// the destination already has. Best-effort: a file that cannot be moved is
+    /// logged and left where it is, so the caller's `remove_dir_all` is the
+    /// only thing that can lose it — which is why the caller only reaches this
+    /// on the branch where a bundled copy already exists.
+    fn rescue_supporting_files(from: &Path, to: &Path) {
+        let Ok(entries) = std::fs::read_dir(from) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name == "SKILL.md" {
+                continue;
+            }
+            let destination = to.join(&name);
+            if destination.exists() {
+                continue;
+            }
+            if let Err(e) = std::fs::rename(entry.path(), &destination) {
+                tracing::warn!(
+                    "failed to carry {} into the knowledge bundle: {e}",
+                    entry.path().display()
+                );
+            }
+        }
     }
 
     /// Every directory skills are discovered under, in override order (later
@@ -3093,6 +3173,48 @@ Working dir biorouter content
     /// the disk: the failure is that discovery picks the *flat* one — whichever
     /// `read_dir` yields last — so a test that only checked the bundled file
     /// exists would pass while the picker showed a standalone row.
+    /// ⚠ **Supporting files are user data and the migration must carry them.**
+    /// The seeder writes exactly one file per skill, `SKILL.md`; everything
+    /// else in that directory has survived every startup since the skill
+    /// shipped, and `find_supporting_files` serves it to the model. An earlier
+    /// draft `remove_dir_all`'d the flat directory after seeding and asserted
+    /// in its own comment that nothing could be lost — which was false, and
+    /// which no test then contradicted because every fixture wrote only a
+    /// `SKILL.md`.
+    #[test]
+    fn migrating_carries_the_supporting_files_beside_a_knowledge_skill() {
+        let temp_dir = TempDir::new().unwrap();
+        let skills_dir = temp_dir.path().join("skills");
+        let flat = skills_dir.join("knowledge-lint");
+        fs::create_dir_all(flat.join("scripts")).unwrap();
+        fs::write(
+            flat.join("SKILL.md"),
+            "---\nname: knowledge-lint\ndescription: x\n---\nold\n",
+        )
+        .unwrap();
+        fs::write(flat.join("reference.md"), "my notes").unwrap();
+        fs::write(flat.join("scripts").join("fix.sh"), "#!/bin/sh\n").unwrap();
+
+        SkillsClient::ensure_builtin_skills(&skills_dir);
+
+        let moved = knowledge_bundle_dir(&skills_dir).join("knowledge-lint");
+        assert_eq!(
+            fs::read_to_string(moved.join("reference.md")).unwrap(),
+            "my notes",
+            "a supporting file was destroyed by the migration"
+        );
+        assert!(moved.join("scripts").join("fix.sh").is_file());
+        // The SKILL.md itself is seeder-owned and IS refreshed to the shipped
+        // bytes — the rename put it where the seed loop could find it.
+        let shipped = KNOWLEDGE_SKILLS
+            .iter()
+            .find(|(name, _)| *name == "knowledge-lint")
+            .unwrap()
+            .1;
+        assert_eq!(fs::read_to_string(moved.join("SKILL.md")).unwrap(), shipped);
+        assert!(!flat.exists());
+    }
+
     #[test]
     fn seeding_removes_the_pre_bundle_flat_knowledge_directories() {
         let temp_dir = TempDir::new().unwrap();
@@ -3269,6 +3391,50 @@ Working dir biorouter content
                 "{name} derives a key that is not a plain identifier: {key}"
             );
         }
+    }
+
+    /// ⚠ **A user's "Updates" opt-out survives the promotion.**
+    ///
+    /// `update-soul` was a Context of its own before it became a bundle
+    /// member, so a user who switched it off has `context_update_soul: false`
+    /// and nothing reads that key any more. Without the fallback the upgrade
+    /// silently turns the skill back on — and adds four beside it, under a row
+    /// the user has never seen. This is the skill that writes to their personal
+    /// knowledge base as a chat goes on, so an opt-out that reverts itself is
+    /// the worst version available of a silent default change.
+    #[test]
+    fn the_old_updates_opt_out_still_hides_the_knowledge_bundle() {
+        let temp = TempDir::new().unwrap();
+        let config = crate::config::Config::new_with_file_secrets(
+            temp.path().join("config.yaml"),
+            temp.path().join("secrets.yaml"),
+        )
+        .unwrap();
+
+        // The upgraded user: the old key says off, the new key is absent.
+        config.set_param("context_update_soul", false).unwrap();
+        assert!(
+            hidden_contexts_in(&config).contains(KNOWLEDGE_BUNDLE),
+            "the Updates opt-out was discarded by the promotion"
+        );
+
+        // ⚠ The fallback is a fallback. Touching the new switch ends the
+        // inheritance in BOTH directions, so a user who turns Knowledge back on
+        // is not overruled forever by a key no interface shows them.
+        config.set_param("context_knowledge_bases", true).unwrap();
+        assert!(!hidden_contexts_in(&config).contains(KNOWLEDGE_BUNDLE));
+        config.set_param("context_knowledge_bases", false).unwrap();
+        assert!(hidden_contexts_in(&config).contains(KNOWLEDGE_BUNDLE));
+
+        // And it applies to this bundle only — a stale key for some other
+        // Context does not leak sideways.
+        let other = crate::config::Config::new_with_file_secrets(
+            temp.path().join("other.yaml"),
+            temp.path().join("other-secrets.yaml"),
+        )
+        .unwrap();
+        other.set_param("context_update_soul", false).unwrap();
+        assert!(!hidden_contexts_in(&other).contains("about-biorouter"));
     }
 
     /// Absence means ON, `false` means off, and nothing else is consulted.

--- a/crates/biorouter/src/knowledge/soul.rs
+++ b/crates/biorouter/src/knowledge/soul.rs
@@ -12,14 +12,19 @@
 //! [`install`] is idempotent and safe to call on every startup: it only creates
 //! what is missing and never overwrites user edits.
 //!
-//! The skill is named `update-soul` (it was previously `soul-writer`);
-//! [`ensure_soul_skill`] removes the stale `soul-writer` folder on startup so
-//! users don't see a duplicate after upgrading.
+//! The skill is named `update-soul` (it was previously `soul-writer`) and is
+//! seeded as a member of the knowledge skill bundle
+//! ([`crate::agents::skills_extension::KNOWLEDGE_BUNDLE`]), so Settings offers
+//! one "Knowledge" switch over it and the four format skills rather than five.
+//! [`ensure_soul_skill`] removes both directories it used to live in — the old
+//! `soul-writer` name and the old flat placement — so an upgraded user does not
+//! end up with two candidates for one skill name.
 
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::agents::skills_extension;
 use crate::config::paths::Paths;
 use crate::scheduler::ScheduledJob;
 use crate::scheduler_trait::SchedulerTrait;
@@ -614,30 +619,92 @@ fn create_built_in_file_if_missing(path: &std::path::Path, content: &str) -> any
 }
 
 /// Write the update-soul skill if it is not already present.
+///
+/// ⚠ **Into the knowledge bundle, not flat at the skills root.** The skill is a
+/// member of `skills_extension::KNOWLEDGE_BUNDLE` alongside the four
+/// `include_str!`-shipped knowledge skills, and the bundle — not this skill —
+/// is the Context row Settings offers. Seeding it flat would give it a
+/// `bundle_name` of `None`, which is a standalone picker row that the bundle's
+/// Context toggle does not reach.
 pub fn ensure_soul_skill() -> anyhow::Result<()> {
-    // Drop the skill's former directory (`soul-writer`) so upgraded users don't
-    // see a stale duplicate next to the renamed `update-soul` skill. It is a
-    // built-in instruction asset, never user data, so removing it is safe.
-    let legacy = Paths::config_dir()
-        .join("skills")
-        .join(SOUL_SKILL_DIR_LEGACY);
-    if legacy.exists() {
-        if let Err(e) = std::fs::remove_dir_all(&legacy) {
-            tracing::warn!(
-                "Soul: failed to remove legacy skill at {}: {e}",
-                legacy.display()
-            );
-        } else {
-            tracing::info!("Soul: removed legacy skill at {}", legacy.display());
-        }
-    }
-    let dir = Paths::config_dir().join("skills").join(SOUL_SKILL_DIR);
-    let skill_file = dir.join("SKILL.md");
-    std::fs::create_dir_all(&dir)?;
-    if create_built_in_file_if_missing(&skill_file, SOUL_SKILL_MD)? {
-        tracing::info!("Soul: installed skill at {}", skill_file.display());
+    if place_soul_skill(&Paths::config_dir().join("skills"))? {
+        // Creating `<bundle>/<child>/` bumps the bundle's mtime and not the
+        // root's, and mtime is one-second granular — see `skill_catalog`'s
+        // header. A writer says what it did rather than hoping to be noticed.
+        crate::agents::skill_catalog::invalidate();
     }
     Ok(())
+}
+
+/// [`ensure_soul_skill`] against an explicit skills root. Returns whether
+/// anything on disk moved, so the caller knows whether to invalidate.
+///
+/// Split out so a test can drive the migration over a `TempDir` without setting
+/// `BIOROUTER_PATH_ROOT`, whose process-global reach would make it depend on
+/// whatever ran before it.
+fn place_soul_skill(skills_root: &Path) -> anyhow::Result<bool> {
+    let bundle = skills_extension::knowledge_bundle_dir(skills_root);
+
+    let dir = bundle.join(SOUL_SKILL_DIR);
+
+    // Leave neither of the two directories this skill has previously occupied
+    // behind. Not tidiness: discovery keys by frontmatter `name`, so a flat
+    // `update-soul` and a bundled one are two candidates for one map key and
+    // whichever `read_dir` yields last wins — half the installs would get the
+    // stale one, with no bundle on it and so out of reach of the Context
+    // switch.
+    //
+    // ⚠ The flat copy is **moved**, not deleted, when the bundle has no member
+    // yet. This skill is written with `create_built_in_file_if_missing`
+    // precisely so a user's edits to it survive every later startup, and
+    // deleting the file that holds them on the one startup that relocates it
+    // would take back that promise at the worst possible moment. (The four
+    // `include_str!` knowledge skills are rewritten whenever their content
+    // differs, so their migration can simply delete — each migration matches
+    // its own seeder's semantics.)
+    let mut migrated = false;
+    let legacy_flat = skills_root.join(SOUL_SKILL_DIR);
+    if legacy_flat.is_dir() && !dir.exists() {
+        std::fs::create_dir_all(&bundle)?;
+        match std::fs::rename(&legacy_flat, &dir) {
+            Ok(()) => {
+                tracing::info!(
+                    "Soul: moved skill into the knowledge bundle at {}",
+                    dir.display()
+                );
+                migrated = true;
+            }
+            Err(e) => tracing::warn!("Soul: failed to move skill into {}: {e}", dir.display()),
+        }
+    }
+    // Whatever the move did not claim — the pre-rename `soul-writer` folder,
+    // and a flat copy the bundle already had a member for — is a duplicate.
+    for stale in [
+        skills_root.join(SOUL_SKILL_DIR_LEGACY),
+        skills_root.join(SOUL_SKILL_DIR),
+    ] {
+        if !stale.is_dir() {
+            continue;
+        }
+        match std::fs::remove_dir_all(&stale) {
+            Ok(()) => {
+                tracing::info!("Soul: removed stale skill at {}", stale.display());
+                migrated = true;
+            }
+            Err(e) => tracing::warn!(
+                "Soul: failed to remove stale skill at {}: {e}",
+                stale.display()
+            ),
+        }
+    }
+
+    let skill_file = dir.join("SKILL.md");
+    std::fs::create_dir_all(&dir)?;
+    let installed = create_built_in_file_if_missing(&skill_file, SOUL_SKILL_MD)?;
+    if installed {
+        tracing::info!("Soul: installed skill at {}", skill_file.display());
+    }
+    Ok(installed || migrated)
 }
 
 /// Register the daily 3:00 AM Meditation job if it is not already scheduled.
@@ -833,6 +900,106 @@ mod tests {
             .unwrap_or_default()
             .iter()
             .any(|s| s == "update-soul"));
+    }
+
+    /// The skill lands in the knowledge bundle, and a pre-bundle install is
+    /// migrated rather than duplicated.
+    ///
+    /// ⚠ **`bundle_name` is the assertion that matters.** Writing to the right
+    /// path and being read back with `bundle_name: None` looks entirely correct
+    /// on disk while leaving this skill a standalone picker row that the
+    /// bundle's one Settings switch cannot reach — which is the whole point of
+    /// moving it.
+    #[test]
+    fn the_soul_skill_is_seeded_into_the_knowledge_bundle() {
+        use crate::agents::skills_extension::{SkillsClient, KNOWLEDGE_BUNDLE};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+
+        assert!(place_soul_skill(&root).unwrap(), "a first seed is a change");
+        let seeded = root
+            .join(KNOWLEDGE_BUNDLE)
+            .join(SOUL_SKILL_DIR)
+            .join("SKILL.md");
+        assert!(seeded.is_file(), "not seeded into the bundle");
+        assert!(!root.join(SOUL_SKILL_DIR).exists(), "also seeded flat");
+
+        let discovered = SkillsClient::discover_skills_in_directories(&[root.clone()]);
+        assert_eq!(
+            discovered[SOUL_SKILL_DIR].bundle_name.as_deref(),
+            Some(KNOWLEDGE_BUNDLE),
+            "discovered without its bundle, so no bundle toggle reaches it"
+        );
+
+        // Idempotent: a second pass changes nothing.
+        assert!(!place_soul_skill(&root).unwrap());
+    }
+
+    /// ⚠ **The user's edits survive the move.** This skill is written with
+    /// `create_built_in_file_if_missing` so that a user who tailors it keeps
+    /// their version forever; a migration that deleted the flat directory would
+    /// break that promise on the one startup that relocates it, silently, and
+    /// with no way back.
+    #[test]
+    fn migrating_a_pre_bundle_soul_skill_keeps_what_the_user_wrote() {
+        use crate::agents::skills_extension::{SkillsClient, KNOWLEDGE_BUNDLE};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+        let flat = root.join(SOUL_SKILL_DIR);
+        std::fs::create_dir_all(&flat).unwrap();
+        let edited = format!("{SOUL_SKILL_MD}\n\nAlways call the user Dr Gu.\n");
+        std::fs::write(flat.join("SKILL.md"), &edited).unwrap();
+        // The pre-rename folder too, which has no edits worth keeping.
+        let ancient = root.join(SOUL_SKILL_DIR_LEGACY);
+        std::fs::create_dir_all(&ancient).unwrap();
+        std::fs::write(ancient.join("SKILL.md"), "old").unwrap();
+
+        assert!(place_soul_skill(&root).unwrap());
+
+        let moved = root
+            .join(KNOWLEDGE_BUNDLE)
+            .join(SOUL_SKILL_DIR)
+            .join("SKILL.md");
+        assert_eq!(std::fs::read_to_string(&moved).unwrap(), edited);
+        assert!(
+            !flat.exists(),
+            "the flat copy would resurrect as a duplicate"
+        );
+        assert!(!ancient.exists(), "the pre-rename folder is still there");
+
+        // One candidate for the name, and it carries the bundle.
+        let discovered = SkillsClient::discover_skills_in_directories(&[root]);
+        assert_eq!(
+            discovered[SOUL_SKILL_DIR].bundle_name.as_deref(),
+            Some(KNOWLEDGE_BUNDLE)
+        );
+    }
+
+    /// A flat copy alongside an existing bundled one is a duplicate, and the
+    /// bundled one wins. Without this arm the two would race in `read_dir`.
+    #[test]
+    fn a_flat_copy_beside_a_bundled_one_is_removed() {
+        use crate::agents::skills_extension::KNOWLEDGE_BUNDLE;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+        let bundled = root.join(KNOWLEDGE_BUNDLE).join(SOUL_SKILL_DIR);
+        std::fs::create_dir_all(&bundled).unwrap();
+        std::fs::write(bundled.join("SKILL.md"), "the bundled one").unwrap();
+        let flat = root.join(SOUL_SKILL_DIR);
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join("SKILL.md"), "the stale one").unwrap();
+
+        assert!(place_soul_skill(&root).unwrap());
+
+        assert!(!flat.exists());
+        assert_eq!(
+            std::fs::read_to_string(bundled.join("SKILL.md")).unwrap(),
+            "the bundled one",
+            "the stale flat copy overwrote the bundled one"
+        );
     }
 
     #[test]

--- a/crates/biorouter/src/knowledge/soul.rs
+++ b/crates/biorouter/src/knowledge/soul.rs
@@ -925,7 +925,7 @@ mod tests {
         assert!(seeded.is_file(), "not seeded into the bundle");
         assert!(!root.join(SOUL_SKILL_DIR).exists(), "also seeded flat");
 
-        let discovered = SkillsClient::discover_skills_in_directories(&[root.clone()]);
+        let discovered = SkillsClient::discover_skills_in_directories(std::slice::from_ref(&root));
         assert_eq!(
             discovered[SOUL_SKILL_DIR].bundle_name.as_deref(),
             Some(KNOWLEDGE_BUNDLE),

--- a/crates/biorouter/tests/skill_package_live.rs
+++ b/crates/biorouter/tests/skill_package_live.rs
@@ -149,12 +149,19 @@ async fn hyperframes_main_imports_as_one_package_with_every_declared_skill() {
     }];
     let view = biorouter::agents::skill_catalog::SkillCatalog::scan(roots, 1)
         .view(&biorouter::agents::session_skills::SessionSkillOverride::default());
-    assert_eq!(view.bundles.len(), 1);
-    assert_eq!(view.bundles[0].name, "hyperframes");
-    assert_eq!(view.bundles[0].display_name, "HyperFrames by HeyGen");
-    assert_eq!(view.bundles[0].skills.len(), declared.len());
+    // ⚠ `add_missing_shipped_skills` injects `KNOWLEDGE_BUNDLE` into every
+    // scan, so filter to what this test installed before counting or indexing.
+    let bundles: Vec<_> = view
+        .bundles
+        .iter()
+        .filter(|b| b.name != biorouter::agents::skills_extension::KNOWLEDGE_BUNDLE)
+        .collect();
+    assert_eq!(bundles.len(), 1);
+    assert_eq!(bundles[0].name, "hyperframes");
+    assert_eq!(bundles[0].display_name, "HyperFrames by HeyGen");
+    assert_eq!(bundles[0].skills.len(), declared.len());
     assert_eq!(
-        view.bundles[0]
+        bundles[0]
             .package
             .as_ref()
             .and_then(|p| p.entry_point.as_deref()),

--- a/docs/extensions/skill-catalog.md
+++ b/docs/extensions/skill-catalog.md
@@ -207,9 +207,22 @@ refused, which is what makes it safe for this handler to cover
    the switch is the **bundle's**: `knowledge-bases` is one Context row over
    five skills.
 5. `builtin: true` — on a skill row or a bundle row — means Biorouter seeded it,
-   so no surface offers a Delete and `skill_package::remove` refuses one under
-   Biorouter's own skills root. It is restored on every start; disable it
-   instead.
+   so no surface offers a Delete, and `skill_package::remove` **and `install`**
+   both refuse that name under Biorouter's own skills root. It is restored on
+   every start; disable it instead.
+6. ⚠ **A knowledge skill disabled machine-wide before it became a bundle member
+   is honoured but no longer reachable from the interface.** Those four were
+   ordinary picker rows once, so `skills-config.json` may name one directly.
+   Nothing writes that entry any more and no surface renders the member, so the
+   Knowledge Context reads ON while that one skill stays out of the model's
+   catalog. The entry is deliberately **not** discarded on upgrade — silently
+   overruling an explicit choice is the defect, not the fix — and the terminal
+   still shows and clears it:
+
+   ```bash
+   biorouter skill list          # the member shows ○
+   biorouter skill enable knowledge-lint
+   ```
 
 ## Related documentation
 

--- a/docs/extensions/skill-catalog.md
+++ b/docs/extensions/skill-catalog.md
@@ -85,7 +85,10 @@ model's filter and the interface's switch read it:
 1. a Context switched off in Settings → Contexts hides the skill **before**
    anything below is consulted, so a per-chat grant cannot put back something
    the user turned off in Settings (it stays loadable by exact name; see
-   [built-in/skills.md](built-in/skills.md))
+   [built-in/skills.md](built-in/skills.md)). ⚠ A Context id may name a
+   **bundle** — `knowledge-bases` covers the four knowledge-format skills plus
+   `update-soul` — so this step tests a skill's bundle as well as its own name,
+   exactly as step 6 does
 2. the session `add` list names the skill
 3. the session `remove` list names the skill
 4. the session `add` list names the skill's **bundle**
@@ -200,7 +203,13 @@ refused, which is what makes it safe for this handler to cover
    "removed"` means this chat, and `sessionViaBundle: true` means the chat
    turned off the bundle rather than the skill.
 4. `hiddenContext: true` means Settings → Contexts, and the skill is still
-   loadable by exact name — that asymmetry is intentional.
+   loadable by exact name — that asymmetry is intentional. For a bundle member
+   the switch is the **bundle's**: `knowledge-bases` is one Context row over
+   five skills.
+5. `builtin: true` — on a skill row or a bundle row — means Biorouter seeded it,
+   so no surface offers a Delete and `skill_package::remove` refuses one under
+   Biorouter's own skills root. It is restored on every start; disable it
+   instead.
 
 ## Related documentation
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -6344,7 +6344,7 @@
         "properties": {
           "builtin": {
             "type": "boolean",
-            "description": "Shipped with Biorouter, so the interface offers no Delete for it.\n\n⚠ **The bundle needs its own answer.** `CatalogSkill.builtin` gates the\nDelete on a *skill* row, and a bundle row is a different control on a\ndifferent directory: without this, a seeded bundle rendered a working\nTrash — the delete succeeding, the toast confirming, and the next\nstartup rewriting the folder. That is regression 1 of #77, one level up."
+            "description": "Shipped with Biorouter, so the interface offers no Delete for it.\n\n⚠ **The bundle needs its own answer**, because `CatalogSkill.builtin`\ngates the Delete on a *skill* row and a bundle row is a different\ncontrol over a different directory.\n\n⚠ **This is defence in depth, not the live fix, and saying otherwise\ninvites someone to delete the real one.** Today the only shipped bundle\nis a Context, and `pickerBundles` strips Contexts before `SkillsView`\nrenders a row at all, so this flag cannot fire on it. What actually\nclosed the \"delete succeeds, toast confirms, next startup rewrites it\"\nregression on every surface is `skill_package::refuse_shipped`, which\n`biorouter skill remove` bypassed entirely while the interface gate held.\nThis field earns its place for the case the filter does not cover: a\nbundle that is seeded but not a Context, should one ever ship."
           },
           "directory": {
             "type": "string"

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -6338,9 +6338,14 @@
           "sourceRoot",
           "source",
           "skills",
+          "builtin",
           "state"
         ],
         "properties": {
+          "builtin": {
+            "type": "boolean",
+            "description": "Shipped with Biorouter, so the interface offers no Delete for it.\n\n⚠ **The bundle needs its own answer.** `CatalogSkill.builtin` gates the\nDelete on a *skill* row, and a bundle row is a different control on a\ndifferent directory: without this, a seeded bundle rendered a working\nTrash — the delete succeeding, the toast confirming, and the next\nstartup rewriting the folder. That is regression 1 of #77, one level up."
+          },
           "directory": {
             "type": "string"
           },

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -365,6 +365,16 @@ export type CarriedPage = {
  * A directory of skills installed and removed as one unit.
  */
 export type CatalogBundle = {
+    /**
+     * Shipped with Biorouter, so the interface offers no Delete for it.
+     *
+     * ⚠ **The bundle needs its own answer.** `CatalogSkill.builtin` gates the
+     * Delete on a *skill* row, and a bundle row is a different control on a
+     * different directory: without this, a seeded bundle rendered a working
+     * Trash — the delete succeeding, the toast confirming, and the next
+     * startup rewriting the folder. That is regression 1 of #77, one level up.
+     */
+    builtin: boolean;
     directory: string;
     /**
      * The package's own display name when a manifest supplied one, else the

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -368,11 +368,19 @@ export type CatalogBundle = {
     /**
      * Shipped with Biorouter, so the interface offers no Delete for it.
      *
-     * ⚠ **The bundle needs its own answer.** `CatalogSkill.builtin` gates the
-     * Delete on a *skill* row, and a bundle row is a different control on a
-     * different directory: without this, a seeded bundle rendered a working
-     * Trash — the delete succeeding, the toast confirming, and the next
-     * startup rewriting the folder. That is regression 1 of #77, one level up.
+     * ⚠ **The bundle needs its own answer**, because `CatalogSkill.builtin`
+     * gates the Delete on a *skill* row and a bundle row is a different
+     * control over a different directory.
+     *
+     * ⚠ **This is defence in depth, not the live fix, and saying otherwise
+     * invites someone to delete the real one.** Today the only shipped bundle
+     * is a Context, and `pickerBundles` strips Contexts before `SkillsView`
+     * renders a row at all, so this flag cannot fire on it. What actually
+     * closed the "delete succeeds, toast confirms, next startup rewrites it"
+     * regression on every surface is `skill_package::refuse_shipped`, which
+     * `biorouter skill remove` bypassed entirely while the interface gate held.
+     * This field earns its place for the case the filter does not cover: a
+     * bundle that is seeded but not a Context, should one ever ship.
      */
     builtin: boolean;
     directory: string;

--- a/ui/desktop/src/components/MentionPopover.tsx
+++ b/ui/desktop/src/components/MentionPopover.tsx
@@ -16,7 +16,7 @@ import { getInitialWorkingDir } from '../utils/workingDir';
 import { IMAGE_EXTENSIONS } from '../utils/imageFormats';
 import { labelledRefTag, refTag, type RefKind } from '../utils/resourceRefs';
 import { useConfig } from './ConfigContext';
-import { fetchSkillCatalog, standaloneSkills } from './skills/useSkillCatalog';
+import { fetchSkillCatalog, pickerBundles, standaloneSkills } from './skills/useSkillCatalog';
 import bundledExtensionsData from './settings/extensions/bundled-extensions.json';
 
 type DisplayItemType = CommandType | 'Directory' | 'File' | 'KnowledgeBase' | 'Skill' | 'Extension';
@@ -600,7 +600,7 @@ const MentionPopover = forwardRef<
             relativePath: base.id,
           });
         }
-        for (const bundle of skillsResult.bundles) {
+        for (const bundle of pickerBundles(skillsResult)) {
           commandItems.push({
             name: `skill:${bundle.name}`,
             extra: `${bundle.skills.length} skill${bundle.skills.length === 1 ? '' : 's'} in bundle`,

--- a/ui/desktop/src/components/bottom_menu/BottomMenuSkillSelection.test.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuSkillSelection.test.tsx
@@ -66,6 +66,7 @@ function bundle(
     source: { kind: 'biorouter', extension: null, label: 'Biorouter' },
     skills: members,
     package: null,
+    builtin: false,
     state: {
       machineEnabled: true,
       session: 'default',
@@ -396,6 +397,54 @@ describe('BottomMenuSkillSelection', () => {
     // whose write just failed.
     expect(mocks.loadSkillOverrides).toHaveBeenCalled();
     await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
+  });
+
+  /**
+   * ⚠ **The chip counts ROWS, and a Context bundle is a row.**
+   * `activeCount` filters nothing itself — every Context exclusion happens in
+   * `useSkillCatalog`, and until the knowledge skills became a bundle every one
+   * of those tested a skill's own `name`. A bundle carries none of its members'
+   * names, so promoting them put one row back in the picker and +1 on the chip,
+   * for a thing the user manages in Settings.
+   *
+   * The count must therefore be `1` here, not `2`: `example-skill` alone.
+   */
+  it('leaves a Context bundle out of the picker and out of the chip count', async () => {
+    serve(
+      view({
+        skills: [
+          skill('example-skill'),
+          skill('knowledge-lint', { bundle: 'knowledge-bases', builtin: true }),
+          skill('update-soul', { bundle: 'knowledge-bases', builtin: true }),
+        ],
+        bundles: [
+          bundle('knowledge-bases', ['knowledge-lint', 'update-soul'], { builtin: true }),
+        ],
+      })
+    );
+    render(<BottomMenuSkillSelection sessionId={null} />);
+
+    expect(await screen.findByLabelText('Manage skills (1 enabled)')).toBeInTheDocument();
+    const rows = await openMenu();
+    expect(rows).toHaveLength(1);
+    expect(screen.queryByText('knowledge-bases')).not.toBeInTheDocument();
+    expect(screen.queryByText('knowledge-lint')).not.toBeInTheDocument();
+  });
+
+  /**
+   * An installed bundle is still a row and still counted, so the assertion
+   * above is about Contexts and not about bundles generally.
+   */
+  it('still counts an installed bundle as one row', async () => {
+    serve(
+      view({
+        skills: [skill('example-skill'), skill('media-use', { bundle: 'hyperframes' })],
+        bundles: [bundle('hyperframes', ['media-use'])],
+      })
+    );
+    render(<BottomMenuSkillSelection sessionId={null} />);
+
+    expect(await screen.findByLabelText('Manage skills (2 enabled)')).toBeInTheDocument();
   });
 
   it('reports a catalog it could not read instead of claiming there are no skills', async () => {

--- a/ui/desktop/src/components/settings/contexts/contexts.test.ts
+++ b/ui/desktop/src/components/settings/contexts/contexts.test.ts
@@ -1,37 +1,79 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { CONTEXTS, CONTEXT_IDS, contextConfigKey, isContextSkill } from './contexts';
+import {
+  CONTEXTS,
+  CONTEXT_IDS,
+  contextConfigKey,
+  isContextBundle,
+  isContextSkill,
+} from './contexts';
 
 describe('contexts', () => {
   /**
-   * ⚠ These ids are the skills' frontmatter `name:` values, and a typo here is
-   * invisible: the Context row would render and toggle, the skill would simply
-   * never be filtered out, and the counts this exists to fix would stay wrong.
-   * Pinned against the Rust source of truth — `BUILTIN_SKILLS` in
-   * `skills_extension.rs` plus `SOUL_SKILL_DIR` in `soul.rs`.
+   * ⚠ These ids are what enablement is keyed on, and a typo here is invisible:
+   * the Context row would render and toggle, the skill would simply never be
+   * filtered out, and the counts this exists to fix would stay wrong. Pinned
+   * against the Rust source of truth — `BUILTIN_SKILLS` and `KNOWLEDGE_BUNDLE`
+   * in `skills_extension.rs`.
+   *
+   * ⚠ **Four skill names and one BUNDLE directory.** `knowledge-bases` is not a
+   * skill: it is the directory holding the four `KNOWLEDGE_SKILLS` plus
+   * `update-soul`, which used to be a Context of its own labelled "Updates".
+   * Five rows over nine shipped skills.
    *
    * ⚠ Sorted, so `develop-biorouter` sits before its two longer namesakes.
    * The three are distinct skills, not one with variants: this one is about
    * changing Biorouter's own source, the others about authoring a skill and
    * packaging an extension.
    */
-  it('names exactly the five skills that actually ship', () => {
+  it('names exactly the five rows that actually ship', () => {
     expect([...CONTEXT_IDS].sort()).toEqual([
       'about-biorouter',
       'develop-biorouter',
       'develop-biorouter-extension',
       'develop-biorouter-skill',
-      'update-soul',
+      'knowledge-bases',
     ]);
   });
 
   it('recognises a shipped skill and leaves a user skill alone', () => {
     expect(isContextSkill('about-biorouter')).toBe(true);
-    expect(isContextSkill('update-soul')).toBe(true);
     // The trap: a user-installed skill whose name merely resembles one.
     expect(isContextSkill('about-biorouter-notes')).toBe(false);
     expect(isContextSkill('single-cell')).toBe(false);
+  });
+
+  /**
+   * ⚠ **A bundle member is a Context through its bundle, never its own name.**
+   * `update-soul` and the four knowledge skills each carry their own
+   * frontmatter `name:`, and none of them is in `CONTEXT_IDS` any more. A
+   * name-only filter — which is what this function used to be — puts all five
+   * back in the composer picker, the `@`-mention list and the chip count, while
+   * the single Settings switch appears to work.
+   */
+  it('treats a member of a Context bundle as a Context', () => {
+    for (const member of [
+      'update-soul',
+      'knowledge-lint',
+      'knowledge-choose-a-format',
+      'knowledge-ingest-okf',
+      'knowledge-ingest-biookf',
+    ]) {
+      expect(isContextSkill(member), `${member} without its bundle`).toBe(false);
+      expect(isContextSkill(member, 'knowledge-bases'), `${member} in its bundle`).toBe(true);
+    }
+    // A member of some OTHER bundle is not swept up.
+    expect(isContextSkill('brainstorming', 'superpowers')).toBe(false);
+    expect(isContextSkill('anything', null)).toBe(false);
+    expect(isContextSkill('anything', undefined)).toBe(false);
+  });
+
+  it('recognises a Context bundle row and leaves an installed package alone', () => {
+    expect(isContextBundle('knowledge-bases')).toBe(true);
+    expect(isContextBundle('superpowers')).toBe(false);
+    // A member name is not a bundle name.
+    expect(isContextBundle('knowledge-lint')).toBe(false);
   });
 
   /**
@@ -43,6 +85,7 @@ describe('contexts', () => {
    */
   it('derives a config key that is a plain identifier', () => {
     expect(contextConfigKey('about-biorouter')).toBe('context_about_biorouter');
+    expect(contextConfigKey('knowledge-bases')).toBe('context_knowledge_bases');
     for (const c of CONTEXTS) {
       expect(contextConfigKey(c.id)).toMatch(/^context_[a-z0-9_]+$/);
     }
@@ -84,90 +127,129 @@ describe('Settings -> Chat section order', () => {
 });
 
 /**
- * ⚠ **Three copies of this list exist and nothing asserted they agree.**
+ * ⚠ **Copies of this list exist and nothing asserted they agree.**
  *
- * Rust owns the truth: `BUILTIN_SKILLS` in `skills_extension.rs` plus
- * `SOUL_SKILL_DIR` in `soul.rs`, combined by `is_builtin_skill_name`, which is
- * what the seeder, the reset path and now the CLI count all use. The UI carries
- * two more — `skillUtils.BUILTIN_SKILL_NAMES` (for the "Built-in" badge and for
- * hiding Delete) and `CONTEXTS` here (for filtering and the Settings section).
+ * Rust owns the truth. It says it with three names, answering three different
+ * questions, and conflating any two is how this area has broken before:
  *
- * Drift between them is silent and asymmetric, which is what makes it worth a
- * test: a name missing from `CONTEXTS` leaves a shipped skill sitting in the
- * user's skill list and counted; a name missing from Rust means the seeder
- * stops writing a file the UI still advertises.
+ * * `context_ids()` — `BUILTIN_SKILLS` ++ `KNOWLEDGE_BUNDLE`. What Settings
+ *   offers as a switch. `CONTEXTS` here mirrors exactly this.
+ * * `is_builtin_skill_name()` — over `shipped_skills()` (`BUILTIN_SKILLS` ++
+ *   `KNOWLEDGE_SKILLS`) plus `SOUL_SKILL_DIR`. Every SKILL Biorouter seeds,
+ *   which is what hiding Delete and showing the Built-in badge mirror.
+ * * `is_shipped_entry_name()` — the above plus the bundle DIRECTORY, for the
+ *   surfaces that enumerate directory entries rather than skills.
  *
- * ⚠ **There are TWO copies now, not three.** `skillUtils.BUILTIN_SKILL_NAMES`
+ * ⚠ **There are TWO hand-synced copies, not three.** `skillUtils.BUILTIN_SKILL_NAMES`
  * is gone: it answered "did Biorouter put this here?", which the daemon answers
- * directly as `CatalogSkill.builtin`. A pinning test over a list nothing reads
- * guards nothing, so what is asserted below is that the copy has not come
- * back.
+ * directly as `CatalogSkill.builtin` (and `CatalogBundle.builtin` for a bundle
+ * row). A pinning test over a list nothing reads guards nothing, so what is
+ * asserted below is that the copy has not come back.
+ *
+ * ⚠ **The extractors below must see every list Rust seeds from.** They once
+ * sliced `BUILTIN_SKILLS` alone, so the four knowledge skills were invisible to
+ * the census — which is exactly why the Skills pane came to offer a working
+ * Delete on a seeded skill. Every array and constant the seeder reads is parsed
+ * here, and each extractor asserts it found something, so a rename that makes a
+ * regex stop matching fails loudly instead of silently narrowing the census.
  *
  * Reading the Rust source is the only way to check this from here, and it is
  * the same approach `measures.test.ts` takes for a value only the source can
  * settle.
  */
-describe('the built-in skill list, across all three copies', () => {
-  const rustNames = () => {
-    const root = join(__dirname, '..', '..', '..', '..', '..', '..', 'crates', 'biorouter', 'src');
-    const skills = readFileSync(join(root, 'agents', 'skills_extension.rs'), 'utf8');
-    const soul = readFileSync(join(root, 'knowledge', 'soul.rs'), 'utf8');
-
-    // The `("<name>", include_str!(...))` pairs of BUILTIN_SKILLS.
-    const block = skills.slice(
-      skills.indexOf('BUILTIN_SKILLS'),
-      skills.indexOf('];', skills.indexOf('BUILTIN_SKILLS'))
+describe('the built-in skill list, across every copy', () => {
+  const rustSrc = (...parts: string[]) =>
+    readFileSync(
+      join(__dirname, '..', '..', '..', '..', '..', '..', 'crates', 'biorouter', 'src', ...parts),
+      'utf8'
     );
-    // rustfmt breaks each pair across lines, so the name and `include_str!`
-    // are not adjacent. Matching on the name that PRECEDES an include_str! is
-    // what survives that, and it still cannot pick up an unrelated string.
-    const bundled = [...block.matchAll(/"([a-z0-9-]+)",\s*\n?\s*include_str!/g)].map((m) => m[1]);
-
-    const soulMatch = soul.match(/SOUL_SKILL_DIR:\s*&str\s*=\s*"([a-z0-9-]+)"/);
-    expect(soulMatch, 'SOUL_SKILL_DIR not found in soul.rs').not.toBeNull();
-
-    return [...bundled, soulMatch![1]].sort();
-  };
 
   /**
-   * Every skill Biorouter SEEDS, which is a larger set than the Contexts.
+   * The `("<name>", include_str!(...))` pairs of one `&[(&str, &str)]` array.
    *
-   * ⚠ The two lists answer different questions, and asserting both against
-   * `rustNames()` was wrong in a way that could not fail. Rust says it with two
-   * functions: `context_skill_names()` (BUILTIN_SKILLS + soul) is what the
-   * Settings toggles mirror, and `is_builtin_skill_name()` is over
-   * `shipped_skills()` — BUILTIN_SKILLS ++ KNOWLEDGE_SKILLS — which is what
-   * hiding Delete and showing the Built-in badge must mirror.
-   *
-   * Because this helper sliced only `BUILTIN_SKILLS`, the four knowledge skills
-   * were invisible to it: the census could not see the drift it exists to
-   * catch, and the Skills pane offered a working Delete on a seeded skill.
+   * rustfmt breaks each pair across lines, so the name and `include_str!` are
+   * not adjacent. Matching on the name that PRECEDES an `include_str!` is what
+   * survives that, and it still cannot pick up an unrelated string.
    */
-  const shippedNames = () => {
-    const root = join(__dirname, '..', '..', '..', '..', '..', '..', 'crates', 'biorouter', 'src');
-    const skills = readFileSync(join(root, 'agents', 'skills_extension.rs'), 'utf8');
-    const block = skills.slice(
-      skills.indexOf('KNOWLEDGE_SKILLS'),
-      skills.indexOf('];', skills.indexOf('KNOWLEDGE_SKILLS'))
-    );
-    const knowledge = [...block.matchAll(/"([a-z0-9-]+)",\s*\n?\s*include_str!/g)].map((m) => m[1]);
-    expect(knowledge.length, 'KNOWLEDGE_SKILLS not found in skills_extension.rs').toBeGreaterThan(
-      0
-    );
-    return [...rustNames(), ...knowledge].sort();
+  const seededArray = (identifier: string): string[] => {
+    const src = rustSrc('agents', 'skills_extension.rs');
+    const at = src.indexOf(`${identifier}: &[(&str, &str)] = &[`);
+    expect(at, `${identifier} not found in skills_extension.rs`).toBeGreaterThan(-1);
+    const block = src.slice(at, src.indexOf('];', at));
+    const names = [...block.matchAll(/"([a-z0-9-]+)",\s*\n?\s*include_str!/g)].map((m) => m[1]);
+    expect(names.length, `${identifier} yielded no skills`).toBeGreaterThan(0);
+    return names;
   };
 
+  const rustConst = (file: string[], identifier: string): string => {
+    const match = rustSrc(...file).match(
+      new RegExp(`${identifier}:\\s*&str\\s*=\\s*"([a-z0-9-]+)"`)
+    );
+    expect(match, `${identifier} not found in ${file.join('/')}`).not.toBeNull();
+    return match![1];
+  };
+
+  const builtinSkills = () => seededArray('BUILTIN_SKILLS');
+  const knowledgeSkills = () => seededArray('KNOWLEDGE_SKILLS');
+  const knowledgeBundle = () => rustConst(['agents', 'skills_extension.rs'], 'KNOWLEDGE_BUNDLE');
+  const soulSkill = () => rustConst(['knowledge', 'soul.rs'], 'SOUL_SKILL_DIR');
+
+  /** What Rust offers as a Settings switch: `context_ids()`. */
+  const rustContextIds = () => [...builtinSkills(), knowledgeBundle()].sort();
+
+  /**
+   * Every SKILL Biorouter seeds — `is_builtin_skill_name()`. Larger than the
+   * Contexts, and made of different things: five of these nine are reachable
+   * only through the bundle.
+   */
+  const shippedNames = () =>
+    [...builtinSkills(), ...knowledgeSkills(), soulSkill()].sort();
+
   it('CONTEXTS names exactly what Rust offers as a Context', () => {
-    expect([...CONTEXT_IDS].sort()).toEqual(rustNames());
+    expect([...CONTEXT_IDS].sort()).toEqual(rustContextIds());
+  });
+
+  /**
+   * ⚠ The census must be **larger** than the Context list, and every skill in
+   * it must be covered — by its own row if it is flat, by its bundle's row if
+   * it is a member. Asserting only `CONTEXTS === context_ids()` would pass
+   * while the seeder wrote skills no surface here had ever heard of, which is
+   * the state this area shipped in once already.
+   *
+   * ⚠ **Each name is checked against the row that is supposed to cover IT.**
+   * The obvious spelling — `isContextSkill(n) || isContextSkill(n, bundle)` —
+   * is vacuous: the second call is `CONTEXT_IDS.has(n) || CONTEXT_IDS.has(bundle)`,
+   * and the bundle is a Context, so it returns true for every string in
+   * existence. It was written that way here first, and it passed for
+   * `not-a-skill-at-all`.
+   */
+  it('every skill Rust seeds is covered by the Context row that owns it', () => {
+    const flat = builtinSkills();
+    const members = [...knowledgeSkills(), soulSkill()];
+    const bundle = knowledgeBundle();
+    expect([...flat, ...members].length).toBeGreaterThan(CONTEXT_IDS.size);
+
+    for (const name of flat) {
+      expect(isContextSkill(name), `${name} is seeded but no Context row names it`).toBe(true);
+    }
+    for (const member of members) {
+      // Covered ONLY through the bundle — a member listed in CONTEXTS as well
+      // would give the user two switches for one thing, the narrower of which
+      // the bundle switch silently overrides.
+      expect(isContextSkill(member), `${member} is a Context in its own right`).toBe(false);
+      expect(
+        isContextSkill(member, bundle),
+        `${member} is not covered by its bundle's Context row`
+      ).toBe(true);
+    }
+    // The predicate is not a tautology: something Rust does not seed is not a
+    // Context, whatever bundle you hand it.
+    expect(isContextSkill('single-cell', 'superpowers')).toBe(false);
   });
 
   it('the renderer keeps no second list of the skills Rust seeds', () => {
     const source = readFileSync(join(__dirname, '..', '..', 'skills', 'skillUtils.ts'), 'utf8');
-    // `shippedNames()` is still called, so the extractor it exercises stays
-    // honest: a name Rust seeds must be findable from here even though nothing
-    // in the renderer mirrors the list any more.
-    expect(shippedNames().length).toBeGreaterThan(CONTEXT_IDS.size);
-    for (const name of shippedNames()) {
+    for (const name of [...shippedNames(), knowledgeBundle()]) {
       expect(
         source.includes(`'${name}'`),
         `skillUtils.ts names '${name}' again — read CatalogSkill.builtin instead`

--- a/ui/desktop/src/components/settings/contexts/contexts.ts
+++ b/ui/desktop/src/components/settings/contexts/contexts.ts
@@ -17,28 +17,41 @@
  * prompt. Enablement therefore lives in ordinary config keys, so a disabled
  * Context stops being *surfaced* without becoming *unloadable*.
  *
- * ⚠ The Rust side keeps its own list (`skills_extension.rs::is_builtin_skill_name`,
- * i.e. `BUILTIN_SKILLS` plus `soul.rs`'s `SOUL_SKILL_DIR`) and so does
- * `skillUtils.BUILTIN_SKILL_NAMES`. All three are hand-synced, but they are no
- * longer unasserted: `contexts.test.ts` parses the Rust source and fails if
- * either TypeScript copy disagrees with it (#77). Rust owns the truth — the
- * seeder writes those files — so a mismatch is fixed by moving the TS list, not
- * the assertion.
+ * ⚠ The Rust side keeps its own list (`skills_extension.rs::context_ids`, i.e.
+ * `BUILTIN_SKILLS` plus `KNOWLEDGE_BUNDLE`). The two are hand-synced but not
+ * unasserted: `contexts.test.ts` parses the Rust source and fails if this copy
+ * disagrees with it (#77). Rust owns the truth — the seeder writes those files
+ * — so a mismatch is fixed by moving the TS list, not the assertion.
+ *
+ * ⚠ **A Context id is not always a skill name.** One row may stand for a whole
+ * BUNDLE: `knowledge-bases` covers the four knowledge-format skills plus
+ * `update-soul`, which are seeded into `<skills root>/knowledge-bases/<name>/`
+ * and reach the renderer with `CatalogSkill.bundle` set. So every filter here
+ * takes the bundle as well as the name — `isContextSkill(name, bundle)` for a
+ * skill row, `isContextBundle(name)` for a bundle row. Filtering on the name
+ * alone leaves a bundle row in the composer picker and the `@`-mention list,
+ * and — worst of the three — inside "Enable all", which writes to
+ * `skills-config.json` and would make `handle_load_skill` refuse a Context.
  */
 
 export interface ContextMeta {
-  /** The skill's `name:` in its frontmatter, and its directory name. */
+  /**
+   * The identifier enablement is keyed on: a skill's frontmatter `name:` (which
+   * is also its directory name), or a BUNDLE's directory name.
+   */
   id: string;
   label: string;
   description: string;
 }
 
 /**
- * ⚠ Five, and every one of them must exist on the Rust side before it is
- * listed here: `BUILTIN_SKILLS` (`skills_extension.rs`) carries four, plus
- * `update-soul`, which is defined separately as a Rust string in `soul.rs`
- * rather than in that array. A Context whose `SKILL.md` does not ship renders
- * and toggles while pointing at nothing, so add the skill first.
+ * ⚠ Five rows, over nine shipped skills. Every id must exist on the Rust side
+ * before it is listed here: `BUILTIN_SKILLS` (`skills_extension.rs`) carries
+ * four skill names, and `KNOWLEDGE_BUNDLE` carries one *bundle* directory whose
+ * five members are the four `KNOWLEDGE_SKILLS` plus `update-soul` (a Rust
+ * string in `soul.rs` rather than an `include_str!`). A Context whose `SKILL.md`
+ * — or whose bundle directory — does not ship renders and toggles while
+ * pointing at nothing, so add it on the Rust side first.
  */
 export const CONTEXTS: readonly ContextMeta[] = [
   {
@@ -62,16 +75,27 @@ export const CONTEXTS: readonly ContextMeta[] = [
     description: 'Write, test and package a skill.',
   },
   {
-    id: 'update-soul',
-    label: 'Updates',
-    description: 'Keep the personal knowledge base current as a chat goes on.',
+    id: 'knowledge-bases',
+    label: 'Knowledge',
+    description:
+      'Build and maintain knowledge bases: pick a format, ingest sources, read a lint report, and keep the personal base current as a chat goes on.',
   },
 ];
 
 export const CONTEXT_IDS: ReadonlySet<string> = new Set(CONTEXTS.map((c) => c.id));
 
-/** Is this skill a shipped Context rather than one the user installed? */
-export function isContextSkill(name: string): boolean {
+/**
+ * Is this skill a shipped Context rather than one the user installed?
+ *
+ * Pass the skill's `bundle` — a member of a Context bundle is a Context, and
+ * its own name is not in `CONTEXT_IDS`.
+ */
+export function isContextSkill(name: string, bundle?: string | null): boolean {
+  return CONTEXT_IDS.has(name) || (bundle != null && CONTEXT_IDS.has(bundle));
+}
+
+/** Is this bundle row a shipped Context rather than an installed package? */
+export function isContextBundle(name: string): boolean {
   return CONTEXT_IDS.has(name);
 }
 

--- a/ui/desktop/src/components/skills/SkillsView.test.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.test.tsx
@@ -84,6 +84,7 @@ function bundle(
     source: { kind: 'biorouter', extension: null, label: 'Biorouter' },
     skills: members,
     package: null,
+    builtin: false,
     state,
     ...overrides,
   };
@@ -224,5 +225,50 @@ describe('SkillsView', () => {
     mocks.refreshSkillCatalog.mockRejectedValue(new Error('daemon is down'));
     render(<SkillsView />);
     expect(await screen.findByText(/Could not read the skill catalog/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * ⚠ **A seeded BUNDLE must offer no Delete, and its own field is the only
+ * thing that can say so.** `SkillItem` gates its Trash on `CatalogSkill.builtin`
+ * — the daemon's answer, not a list in the renderer — but a bundle row is a
+ * different control over a different directory, and it had no such gate. So a
+ * shipped bundle rendered a working Trash: `removeSkillPackage` succeeded, the
+ * toast confirmed it, and the next startup rewrote the folder. That is exactly
+ * regression 1 of #77, one level up from where it was fixed.
+ *
+ * `CatalogBundle.builtin` is `is_shipped_entry_name` on the Rust side, so this
+ * cannot drift from the seeder.
+ */
+describe('SkillsView built-in bundles', () => {
+  it('offers no Delete on a bundle the daemon says it shipped', async () => {
+    serve({
+      skills: [skill('member', { bundle: 'shipped-bundle', builtin: true })],
+      bundles: [bundle('shipped-bundle', ['member'], { builtin: true })],
+    });
+    render(<SkillsView />);
+
+    const row = (await screen.findByText('shipped-bundle')).closest('.biorouter-list-row')!;
+    expect(
+      within(row as HTMLElement).queryByLabelText(/Delete skill package/)
+    ).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText('Built-in')).toBeInTheDocument();
+  });
+
+  /**
+   * The control is present for an installed package, so the assertion above is
+   * about built-in-ness and not about bundle rows in general.
+   */
+  it('still offers Delete on an installed package', async () => {
+    serve({
+      skills: [skill('media-use', { bundle: 'hyperframes' })],
+      bundles: [bundle('hyperframes', ['media-use'])],
+    });
+    render(<SkillsView />);
+
+    const row = (await screen.findByText('hyperframes')).closest('.biorouter-list-row')!;
+    expect(
+      within(row as HTMLElement).getByLabelText(/Delete skill package/)
+    ).toBeInTheDocument();
   });
 });

--- a/ui/desktop/src/components/skills/SkillsView.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.tsx
@@ -399,10 +399,15 @@ function BundleRow({
   const entryPoint = bundle.package?.entryPoint ?? null;
   // ⚠ From the daemon, not from a list here. Rust owns the seeder, so Rust owns
   // the answer — the same rule `SkillItem` follows for a skill row. A bundle
-  // needs its own answer because this is a different control on a different
-  // directory: `CatalogSkill.builtin` gates the Trash on a member and reaches
-  // nothing here, which left a seeded bundle offering a Delete that succeeded,
-  // toasted, and was silently rewritten on the next start.
+  // needs its own answer because this is a different control over a different
+  // directory; `CatalogSkill.builtin` gates the Trash on a member and reaches
+  // nothing here.
+  //
+  // ⚠ Defence in depth: the one shipped bundle is a Context, and
+  // `pickerBundles` removes Contexts before this component sees a row, so on
+  // today's data this cannot fire. It is here for a seeded bundle that is not
+  // a Context — and the refusal that actually holds on every surface lives in
+  // the daemon, in `skill_package::refuse_shipped`.
   const builtin = bundle.builtin;
   return (
     <div className="biorouter-list-row px-3 py-3 group">

--- a/ui/desktop/src/components/skills/SkillsView.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.tsx
@@ -5,6 +5,7 @@ import { Switch } from '../ui/switch';
 import { ConfirmationModal } from '../ui/ConfirmationModal';
 import { Plus, Upload, Globe, Trash2, ChevronRight } from '../icons/app-icons';
 import SkillItem from './SkillItem';
+import BuiltInBadge from '../ui/BuiltInBadge';
 import AddSkillModal from './AddSkillModal';
 import CustomSkillModal from './CustomSkillModal';
 import BrowseSkillsModal from '../baam/BrowseSkillsModal';
@@ -396,6 +397,13 @@ function BundleRow({
 }: BundleRowProps) {
   const members = skills.filter((skill) => skill.bundle === bundle.name);
   const entryPoint = bundle.package?.entryPoint ?? null;
+  // ⚠ From the daemon, not from a list here. Rust owns the seeder, so Rust owns
+  // the answer — the same rule `SkillItem` follows for a skill row. A bundle
+  // needs its own answer because this is a different control on a different
+  // directory: `CatalogSkill.builtin` gates the Trash on a member and reaches
+  // nothing here, which left a seeded bundle offering a Delete that succeeded,
+  // toasted, and was silently rewritten on the next start.
+  const builtin = bundle.builtin;
   return (
     <div className="biorouter-list-row px-3 py-3 group">
       <div className="flex items-start gap-2">
@@ -437,7 +445,8 @@ function BundleRow({
           )}
         </button>
         <div className="flex items-center gap-2 flex-shrink-0 mt-0.5">
-          {onDelete && (
+          {builtin && <BuiltInBadge />}
+          {onDelete && !builtin && (
             <div
               className="flex gap-1 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
               onClick={(e) => e.stopPropagation()}

--- a/ui/desktop/src/components/skills/useSkillCatalog.test.ts
+++ b/ui/desktop/src/components/skills/useSkillCatalog.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { applyOptimistically, CATALOG_CHANGED_EVENT } from './useSkillCatalog';
+import {
+  applyOptimistically,
+  CATALOG_CHANGED_EVENT,
+  pickerBundles,
+  standaloneSkills,
+} from './useSkillCatalog';
 import type { CatalogBundle, CatalogSkill, CatalogView } from '../../api';
 
 const state = (effective: boolean, machineEnabled = true) => ({
@@ -30,6 +35,7 @@ const bundle = (name: string, members: string[]): CatalogBundle => ({
   source: { kind: 'biorouter', extension: null, label: 'Biorouter' },
   skills: members,
   package: null,
+  builtin: false,
   state: state(true),
 });
 
@@ -78,5 +84,62 @@ describe('applyOptimistically', () => {
 describe('CATALOG_CHANGED_EVENT', () => {
   it('is the name worktree 4 publishes', () => {
     expect(CATALOG_CHANGED_EVENT).toBe('catalog:changed');
+  });
+});
+
+/**
+ * ⚠ **A Context that is a BUNDLE has to be filtered as a bundle.** Every
+ * Context filter used to test a skill's own `name`, and a bundle row carries
+ * none of its members' names — so promoting the knowledge skills to a bundle
+ * put a row back into the composer picker, the `@`-mention list and the
+ * workflow resource picker at once, with `activeCount` up by one to match.
+ *
+ * The composer one is the dangerous one: its rows feed "Enable all", which
+ * writes `skills-config.json`, and `handle_load_skill` refuses anything listed
+ * there — while the system prompt asks for `about-biorouter` on every turn.
+ * That is the failure `contexts.ts` was written to make impossible.
+ */
+describe('Context bundles are not picker rows', () => {
+  const contextView: CatalogView = {
+    generation: 1,
+    roots: [],
+    skills: [
+      skill('solo', null),
+      skill('media-use', 'hyperframes'),
+      skill('knowledge-lint', 'knowledge-bases'),
+      skill('update-soul', 'knowledge-bases'),
+    ],
+    bundles: [
+      bundle('hyperframes', ['media-use']),
+      bundle('knowledge-bases', ['knowledge-lint', 'update-soul']),
+    ],
+  };
+
+  it('drops the Context bundle and keeps an installed package', () => {
+    expect(pickerBundles(contextView).map((b) => b.name)).toEqual(['hyperframes']);
+  });
+
+  /**
+   * The members were already excluded by the `!skill.bundle` clause, so this
+   * would pass with the Context filter deleted. It is here to pin that the two
+   * clauses agree: nothing about the knowledge bundle reaches a skill row.
+   */
+  it('drops the Context bundle members from the standalone list', () => {
+    expect(standaloneSkills(contextView).map((s) => s.name)).toEqual(['solo']);
+  });
+
+  /**
+   * ⚠ The regression this exists for: a member seeded flat rather than into the
+   * bundle — an install that predates the bundle, or a fallback that forgot the
+   * placement — arrives with `bundle: null` and would be a standalone row.
+   * `isContextSkill` covers it by name as well, so it stays out either way.
+   */
+  it('drops a member that arrives without its bundle', () => {
+    const stray: CatalogView = {
+      ...contextView,
+      skills: [skill('solo', null), skill('knowledge-bases', null)],
+      bundles: [],
+    };
+    expect(standaloneSkills(stray).map((s) => s.name)).toEqual(['solo']);
   });
 });

--- a/ui/desktop/src/components/skills/useSkillCatalog.test.ts
+++ b/ui/desktop/src/components/skills/useSkillCatalog.test.ts
@@ -129,17 +129,31 @@ describe('Context bundles are not picker rows', () => {
   });
 
   /**
-   * ⚠ The regression this exists for: a member seeded flat rather than into the
-   * bundle — an install that predates the bundle, or a fallback that forgot the
-   * placement — arrives with `bundle: null` and would be a standalone row.
-   * `isContextSkill` covers it by name as well, so it stays out either way.
+   * ⚠ **A member that reaches the renderer WITHOUT its bundle is not covered,
+   * and this pins that rather than pretending otherwise.**
+   *
+   * It is reachable: the migration logs-and-continues if it cannot move a flat
+   * directory, discovery keys by frontmatter name so the flat copy can win the
+   * race, and a project-local `.claude/skills/knowledge-lint` shadows the
+   * bundled one outright (project roots sort last in `roots()`).
+   *
+   * `isContextSkill('knowledge-lint', null)` is `CONTEXT_IDS.has('knowledge-lint')`,
+   * which is false — the Context row names the BUNDLE. So such a skill is a
+   * standalone picker row with the Knowledge switch showing off. An earlier
+   * draft of this test asserted the opposite and passed, because its fixture
+   * was a skill NAMED `knowledge-bases`, which no code path produces.
+   *
+   * The fix belongs in the migration, not in a name-matching special case here:
+   * a stray copy that shadows the bundled one is a *different* skill on disk
+   * and the renderer cannot tell. Asserted so the gap is visible and a future
+   * change to it is deliberate.
    */
-  it('drops a member that arrives without its bundle', () => {
+  it('cannot cover a member that arrives without its bundle', () => {
     const stray: CatalogView = {
       ...contextView,
-      skills: [skill('solo', null), skill('knowledge-bases', null)],
+      skills: [skill('solo', null), skill('knowledge-lint', null)],
       bundles: [],
     };
-    expect(standaloneSkills(stray).map((s) => s.name)).toEqual(['solo']);
+    expect(standaloneSkills(stray).map((s) => s.name)).toEqual(['solo', 'knowledge-lint']);
   });
 });

--- a/ui/desktop/src/components/skills/useSkillCatalog.ts
+++ b/ui/desktop/src/components/skills/useSkillCatalog.ts
@@ -69,6 +69,14 @@ export interface SkillCatalogState {
   entries: SkillCatalogEntry[];
   /** Every skill, including bundle members — for search and for detail rows. */
   skills: CatalogSkill[];
+  /**
+   * Bundles a picker may show — Contexts already removed.
+   *
+   * ⚠ Filtered, unlike `skills`. An unfiltered list here is a loaded gun
+   * sitting beside the `pickerBundles` helper that exists *because* three call
+   * sites forgot to filter; nothing reads this field today, and the next thing
+   * that does should not have to know.
+   */
   bundles: CatalogBundle[];
   roots: SkillRoot[];
   /** Bumped by the daemon on every rescan. */
@@ -302,7 +310,7 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
   return {
     entries,
     skills: view.skills,
-    bundles: view.bundles,
+    bundles: pickerBundles(view),
     roots: view.roots,
     generation: view.generation,
     loading,

--- a/ui/desktop/src/components/skills/useSkillCatalog.ts
+++ b/ui/desktop/src/components/skills/useSkillCatalog.ts
@@ -49,7 +49,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { CatalogBundle, CatalogSkill, CatalogView, SkillRoot } from '../../api';
 import { refreshSkillCatalog, setSessionSkills, skillCatalogHandler } from '../../api';
-import { isContextSkill } from '../settings/contexts/contexts';
+import { isContextBundle, isContextSkill } from '../settings/contexts/contexts';
 import {
   loadSkillOverrides,
   saveSkillOverrides,
@@ -111,11 +111,35 @@ function errorText(err: unknown): string {
 
 /**
  * Contexts ship with the app, so they are not what a user means by "skills".
- * Filtered here rather than in the daemon: the catalog is also what Settings
- * and the importer read, and both of those legitimately want the full set.
+ * Filtered here rather than in the daemon, because the catalog is also what the
+ * importer and the Settings **Contexts** pane read, and those legitimately want
+ * the full set. (Settings -> Skills reads `entries`, so it is filtered too —
+ * deliberately: a Context's switch lives in the Contexts pane.)
+ *
+ * ⚠ **`skill.bundle` is passed as a belt to the braces, not as the fix.** Both
+ * call sites test `!skill.bundle` first, so today a member never reaches this
+ * function with a bundle set — deleting the argument would fail no test, and
+ * the comment saying otherwise would have been a lie. What it buys is the case
+ * those two clauses do not cover between them: a member the daemon reports with
+ * a bundle from a surface that has not filtered members out. The bundle row
+ * itself is filtered by `pickerBundles`, which IS load-bearing.
  */
 function isPickerSkill(skill: CatalogSkill): boolean {
-  return !isContextSkill(skill.name);
+  return !isContextSkill(skill.name, skill.bundle);
+}
+
+/**
+ * Bundle rows for a picker — every bundle except the ones that are Contexts.
+ *
+ * ⚠ **Exported, and used by all three pickers.** Bundles reached the composer,
+ * the `@`-mention list and the workflow resource picker through three separate
+ * unfiltered `view.bundles` reads. One helper, three callers: a Context bundle
+ * cannot be filtered out of two of them and left in the third. The composer one
+ * matters most — its rows feed "Enable all", which writes `skills-config.json`,
+ * the one file `contexts.ts` forbids a Context from reaching.
+ */
+export function pickerBundles(view: CatalogView): CatalogBundle[] {
+  return view.bundles.filter((bundle) => !isContextBundle(bundle.name));
 }
 
 /**
@@ -136,7 +160,7 @@ export async function fetchSkillCatalog(sessionId?: string | null): Promise<Cata
 
 /** Standalone skills — bundle members are reached through their bundle. */
 export function standaloneSkills(view: CatalogView): CatalogSkill[] {
-  return view.skills.filter((skill) => !skill.bundle && !isContextSkill(skill.name));
+  return view.skills.filter((skill) => !skill.bundle && isPickerSkill(skill));
 }
 
 export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
@@ -253,7 +277,7 @@ export function useSkillCatalog(sessionId: string | null): SkillCatalogState {
   );
 
   const entries = useMemo((): SkillCatalogEntry[] => {
-    const bundles: SkillCatalogEntry[] = view.bundles
+    const bundles: SkillCatalogEntry[] = pickerBundles(view)
       .map((bundle) => ({
         kind: 'bundle' as const,
         key: bundle.name,

--- a/ui/desktop/src/components/workflows/CreateWorkflowFromSessionModal.tsx
+++ b/ui/desktop/src/components/workflows/CreateWorkflowFromSessionModal.tsx
@@ -10,7 +10,7 @@ import { WorkflowParameter } from './shared/workflowFormSchema';
 import { toastError } from '../../toasts';
 import { saveWorkflow } from '../../workflow/workflow_management';
 import type { ExtensionConfig, Manifest } from '../../api';
-import { fetchSkillCatalog, standaloneSkills } from '../skills/useSkillCatalog';
+import { fetchSkillCatalog, pickerBundles, standaloneSkills } from '../skills/useSkillCatalog';
 import type { WorkflowResourceItem } from './shared/WorkflowResourcePicker';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../ui/dialog';
 import { storeSubscriptionCleanup } from '../../utils/storeSubscription';
@@ -132,7 +132,7 @@ export default function CreateWorkflowFromSessionModal({
       fetchSkillCatalog()
         .then((view) => {
           if (cancelled) return;
-          const bundleItems: WorkflowResourceItem[] = view.bundles.map((bundle) => ({
+          const bundleItems: WorkflowResourceItem[] = pickerBundles(view).map((bundle) => ({
             id: bundle.name,
             label: bundle.displayName,
             description: bundle.skills.join(', '),


### PR DESCRIPTION

---

## `test (macos-latest)` — pre-existing, and not from this branch

That job may sit pending. It is **not** this diff. Reproduced locally and sampled:

```
routes::action_required::tests::secrets_tests::…
  → biorouter::config::base::Config::read
    → keyring::Entry::get_password
      → SecKeychainFindGenericPassword
        → CSSM_DecryptData                    [blocked]
```

The secrets tests block on a macOS Keychain authorization prompt that nothing in
a headless run can answer. `action_required.rs` is untouched by this PR, and the
same job on **`main`** ran six hours and was cancelled
([run 32997530845](https://github.com/BaranziniLab/biorouter/actions/runs/32997530845)).

Ruled out the one path by which this branch could have contributed: the
`context_update_soul` fallback adds a second config read per Context, but
`get_param` reads the environment and then the config *file* — only
`Config::read`, the secret path, reaches the keyring.

With the keyring disabled the whole workspace is clean:

```bash
BIOROUTER_DISABLE_KEYRING=1 cargo test --workspace --lib --bins --locked --no-fail-fast
# exit 0 — 0 failed suites, 6173 tests
#   biorouter 3156 · biorouter-mcp 1538 · biorouter-server 544 · biorouter-cli 366 · …
#   biorouter-server finishes in 7s — the module that otherwise hangs
```

Two adjacent traps found while diagnosing, both pre-existing and both left alone:

- `security::policy::tests_platform::platform_matrix` **fails under an isolated
  `HOME`** (`rm -rf ~/Downloads` → expected Allow, got Deny) and passes with a
  real one — while `cargo test -p biorouter-cli` *requires* an isolated `HOME` or
  it deadlocks. The two cannot be satisfied in a single invocation.
- The `--locked` flag resolves a different toolchain than a bare `cargo test`
  here, forcing a full rebuild; a slow first run is that, not a hang.
