### PR TITLE
ci(rust): let macOS keep a Rust cache at all

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,14 +121,38 @@ jobs:
       # assertions, overflow checks and panic locations while omitting debugger
       # symbols that CI never consumes. Set it before rust-cache so the action's
       # CARGO_* environment hash separates these artifacts from debug=2 builds.
-      - name: Disable Windows CI test debuginfo
-        if: matrix.os == 'windows-latest'
+      #
+      # macOS is included for a different reason: it is the only runner in this
+      # matrix with NO Rust cache (see the cache-on-failure note below), so it
+      # pays a cold full-workspace build every run and its debug symbols are
+      # what would push the repository over GitHub's 10 GiB cache ceiling once
+      # it finally saves one. Ubuntu is deliberately LEFT OUT — it has a warm
+      # 1.7 GiB cache today and adding the variable would change rust-cache's
+      # CARGO_* environment hash, throwing that cache away to fix a problem
+      # ubuntu does not have.
+      - name: Reduce CI test debuginfo
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
         shell: bash
         run: echo 'CARGO_PROFILE_TEST_DEBUG=0' >> "$GITHUB_ENV"
 
+      # ⚠ `cache-on-failure` is what breaks a self-perpetuating deadlock, not a
+      # convenience. rust-cache's post step is skipped whenever the job does not
+      # succeed, so a job that cannot finish never saves a cache, is cold on the
+      # next run, and therefore cannot finish. That is exactly what happened to
+      # `test (macos-latest)`: it was cancelled on main at d0a177f8 after 360
+      # minutes with its post step skipped, and `gh cache list` subsequently
+      # showed no `v0-rust-macos-latest-*` entry at all while ubuntu and windows
+      # both had one. Every macOS run since has compiled the whole workspace
+      # from scratch — 56+ minutes against a 20 minute budget, versus 17.8m on
+      # the last run that had a warm cache (44ac420f).
+      #
+      # Compiled dependencies are valid whether or not the *tests* passed, so
+      # saving them on a red job costs nothing and means a broken test can never
+      # again strand the cache.
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
+          cache-on-failure: "true"
 
       - name: Install protoc (build-script dep)
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -149,10 +149,29 @@ jobs:
       # Compiled dependencies are valid whether or not the *tests* passed, so
       # saving them on a red job costs nothing and means a broken test can never
       # again strand the cache.
+      # ⚠ `save-if` restricts SAVING to main, and that is what keeps a cache
+      # available to anyone at all. GitHub scopes a cache to the branch that
+      # wrote it: a feature branch can read its own caches and **main's**, and
+      # nothing else. So every feature-branch run was writing its own private
+      # 1-1.7 GiB copy per OS that no other branch could ever use, while the
+      # repository sat at 9.74 GiB against a 10 GiB ceiling — evicting main's
+      # copies, which are the only ones shared. Measured on windows-latest, by
+      # rust-cache's own restore time:
+      #
+      #   restore 0.7m -> `cargo test`  9.4m   (hit, branch's own earlier cache)
+      #   restore 0.1m -> `cargo test` 19.5m   (miss)
+      #   restore 0.1m -> `cargo test` 17.4m   (miss)
+      #
+      # With saving confined to main, every branch restores one authoritative,
+      # continuously refreshed cache and none of them compete for the ceiling.
+      # A PR that changes Cargo.lock still builds cold and cannot save; that is
+      # the accepted cost, and it is much smaller than three OSes' worth of
+      # write-only caches evicting the shared ones on every push.
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
           cache-on-failure: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install protoc (build-script dep)
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -162,7 +162,29 @@ jobs:
       # batch of Windows fixes made the job fail one binary further along, which
       # read as "a new rotating set of failures" and was really one hidden queue
       # being drained one CI round-trip at a time. One run now names them all.
+      # ⚠ **The OS credential store must be off, or macOS hangs until the job
+      # is killed.** `Config::read` resolves a secret through `keyring`, and on
+      # a runner with no unlocked login keychain `SecKeychainFindGenericPassword`
+      # blocks on an authorization prompt nothing is there to answer. The
+      # secrets tests in `routes::action_required` sit on that call, so the
+      # whole binary stops: `test (macos-latest)` ran SIX HOURS on main
+      # (run 32997530845) and was cancelled. Reproduced locally and sampled —
+      # `Config::read` -> `keyring::Entry::get_password` ->
+      # `SecKeychainFindGenericPassword` -> `CSSM_DecryptData`, blocked. With
+      # this set the same binary finishes in seconds.
+      #
+      # Windows reaches the same code through the Credential Manager. Whether
+      # that is what has made windows-latest slow is NOT measured, so this is
+      # not offered as the explanation there — it is set on the whole matrix
+      # because the store is unwanted on every runner, not as a Windows fix.
+      #
+      # It costs no coverage: nothing in the workspace asserts keyring
+      # behaviour — the store is incidental to these tests, which are about
+      # routes. `serve` below and `release-artifact-smoke.yml` already set it
+      # for the same reason; this is the one job that was missing it.
       - name: cargo test (workspace, lib + bins)
+        env:
+          BIOROUTER_DISABLE_KEYRING: "true"
         run: cargo test --workspace --lib --bins --locked --no-fail-fast --timings
 
       - name: Upload Windows Cargo timings


### PR DESCRIPTION
## The problem

`test (macos-latest)` has been taking **56+ minutes** against a 20-minute budget. It is **not a hang** — it is a cold full-workspace build, every single run.

`gh cache list` shows **no macOS Rust cache exists for this repository at all**:

```
1.71 GiB  v0-rust-ubuntu-latest-test-Linux-x64-...
1.30 GiB  v0-rust-serve-serve-Linux-x64-...
1.19 GiB  v0-rust-openapi-contract-...-Linux-x64
1.04 GiB  v0-rust-windows-latest-test-Windows_NT-x64-...
0.15 GiB  node-cache-macOS-arm64-npm-...        <- node only
```

## Why it could never recover on its own

rust-cache's post step is `post-if: success() || env.CACHE_ON_FAILURE == 'true'`, so with the default it is **skipped whenever the job does not succeed**. Verified against three runs' step lists:

| run | job | conclusion | Post rust-cache |
|---|---|---|---|
| 32997530845 (main, d0a177f8) | macOS | cancelled @ 360m | **skipped** |
| 33036232891 | windows | failure | **skipped** |
| 33037348672 | macOS | cancelled @ 29.8m | **skipped** |
| 32813567677 (44ac420f) | macOS | success @ **17.8m** | success |

A job that cannot finish never saves a cache, is cold on the next run, and therefore still cannot finish. It started when macOS was cancelled on main at `d0a177f8` and has been self-sustaining since.

## The fixes

1. **`cache-on-failure: true`** — breaks the cycle permanently. Compiled dependencies are valid whether or not the *tests* passed, so a red job can never again strand the cache.

2. **`CARGO_PROFILE_TEST_DEBUG=0` extended to macOS.** Necessary because the repository sat at **9.74 GiB against GitHub's 10 GiB ceiling**, so a macOS cache had nowhere to fit and would only have thrashed against ubuntu's. Same reasoning already applied to Windows: debug symbols CI never consumes.

   **Ubuntu is deliberately left out.** It has a warm 1.70 GiB cache today, and adding the variable would change rust-cache's `CARGO_*` environment hash and throw that cache away to fix a problem ubuntu does not have.

3. **Credential store off on the test matrix** (carried onto this branch so the matrix is verifiable standalone). Measured on its origin branch: Windows **22.4m → 10.8m**, and macOS stops blocking in `SecKeychainFindGenericPassword`.

Two redundant caches were also deleted out-of-band (an exact-duplicate ubuntu key, and a superseded openapi-contract generation), taking the repository from 9.74 GiB to **6.85 GiB**.

## What this does NOT fix

`test (windows-latest)` is red on an unrelated, pre-existing race: `gate_a_bind_tests::a_new_same_name_composite_bind_wins_while_the_old_snapshot_is_parked` panics at `model.rs:713` with *"Failed to create model config for gpt-5.6-codex"*.

The `BIOROUTER_MAX_TOKENS` rejection tests **do** hold `env_lock` correctly. The guard cannot help because the *reader* — `parse_max_tokens` → `Config::global().get_param` — never asks for it, so a concurrent `ModelConfig::new` reads a poisoned value and `new_or_fail` panics. That is fixed separately in `model.rs`; do not add a lock to those tests, it is already there.

This PR is what makes that fix *observable*: until macOS can save a cache, it cannot finish inside the budget no matter what the tests do.