### PR TITLE
fix(privacy): the private-session refusal names the header, not just the concept

### DIFF
--- a/crates/biorouter-server/src/routes/session_reach.rs
+++ b/crates/biorouter-server/src/routes/session_reach.rs
@@ -24,9 +24,23 @@
 //!   inert there;
 //! * it still reaches every session-addressing route NOT on
 //!   [the gated list](self#the-gated-list). `POST /interrupt` and `POST
-//!   /agent/cancel` now require user-action proof; `POST /agent/resume`,
-//!   `GET /sessions/{id}/extensions`, `PUT /sessions/{id}/name` and
-//!   `DELETE /sessions/{id}` remain open. The list began as the five
+//!   /agent/cancel` now require user-action proof; `GET
+//!   /sessions/{id}/extensions`, `GET /sessions/{id}/usage`, `PUT
+//!   /sessions/{id}/name`, `PUT /sessions/{id}/user_workflow_values` and
+//!   `DELETE /sessions/{id}` remain open, as do `GET /active_work` and `POST
+//!   /active_work/{id}/cancel` — which name no session id in their path and so
+//!   enumerate, in the manner of `GET /sessions` below, but carry a `title` and
+//!   `detail` holding the SHELL COMMAND or TASK PROMPT of every running job.
+//!   That is content rather than metadata, and it is the one row here that a
+//!   reader should not file mentally beside "titles and directories".
+//!   ⚠ **This bullet listed `POST /agent/resume` as open until 2026-09-04, and
+//!   it was wrong** — measured against a live private session, `/agent/resume`
+//!   answers 403 without the capability header and 200 with it, because
+//!   `resume_agent` has called [`session_reach`] directly since before this
+//!   sentence was last touched. A residual that names a route which is in fact
+//!   guarded is worse than one that omits it: it invites someone to "close" a
+//!   gate that is already there, and it makes the rest of the enumeration read
+//!   as measured when it is remembered. The list began as the five
 //!   the ruling named, and `/reply` dominates them, but "dominates" is an
 //!   argument about capability rather than a proof about every route — which is
 //!   how `/export` and `/events` sat outside it while returning the same bytes
@@ -131,6 +145,19 @@
 //! | `POST /agent/update_working_dir` | Repoints the session at a directory of the caller's choosing and restarts its agent. |
 //! | `POST /agent/add_extension` | Attaches tools to the session. |
 //! | `GET|POST /knowledge/active` | Reads or repoints the session's knowledge bases and write target. |
+//! | `POST /agent/resume` | Loads the session's stored conversation into a live agent. Gates directly, like the rows above. |
+//! | `POST /agent/continuation/recover` | Resumes a parked continuation in the named session. Gates directly. |
+//! | `POST /agent/update_from_session` | Adopts another session's provider configuration. Gates directly. |
+//! | `POST /agent/update_provider` · `restart` · `stop` · `remove_extension` | Gate through [`authorize_agent_control`](../agent/fn.authorize_agent_control.html), which calls [`session_reach`] and then reads the row. |
+//!
+//! ⚠ **Two spellings, one list.** The last row reaches the gate through a helper
+//! rather than by naming it, which is why a scan for the literal `session_reach(`
+//! reports those four as ungated and why the ordering test below uses two of them
+//! as over-read controls. They are NOT exempt — measured live, each answers 403
+//! without the capability header and proceeds with it. A future sweep that greps
+//! for the call must follow `authorize_agent_control` too, or it will "discover"
+//! four holes that are not there and, worse, trust the same grep when it reports
+//! a real one.
 //!
 //! # Why `X-User-Action` and not a new mechanism, for the proof half
 //!
@@ -171,6 +198,15 @@ use biorouter_server::auth::{user_action_proof, UserActionProof};
 /// the gate can express the rule the ruling actually states, *caller capability
 /// ≥ target classification*, instead of the proxy it used to enforce.
 ///
+/// ⚠ **It has a prose home now, and it did not before.** The header shipped
+/// documented only here, in the source of the gate that reads it — which is
+/// exactly the wrong place for its only reader, a person or a program writing
+/// automation against the daemon. `docs/deployment/programmatic-session-access.md`
+/// is the user-facing page: the fail-safe table, `curl` for the JSON read and the
+/// SSE stream, and a per-route audit of what this gate does and does not cover.
+/// Keep the two in step — the doc states the resolution rules this function
+/// implements, so a change here is a change there.
+///
 /// [#47]: https://github.com/BaranziniLab/biorouter/issues/47
 pub const CALLER_PROVIDER_HEADER: &str = "X-Caller-Provider";
 
@@ -187,12 +223,42 @@ pub const CALLER_PROVIDER_HEADER: &str = "X-Caller-Provider";
 /// It forecloses the retry for the reason every refusal in this feature does: a
 /// model that reads a refusal as transient loops on it.
 ///
-/// ⚠ **It now names BOTH ways through**, because there are two and a refusal
-/// that named one would send half its readers somewhere that cannot help them.
-/// The old wording said only "this request carried no proof it came from the
+/// ⚠ **It names BOTH ways through**, because there are two and a refusal that
+/// named one would send half its readers somewhere that cannot help them. The
+/// oldest wording said only "this request carried no proof it came from the
 /// person at the keyboard", which was the whole defect: a terminal running
 /// Versa was told to go and be a human, when what it needed was to be told it
 /// already had the capability and merely was not saying so.
+///
+/// ⚠ **…and it names the MECHANISM, not only the concept — that fix went
+/// halfway once already.** Naming "a session running a private model" repaired
+/// the register but left the one operative fact out: the reader who receives
+/// this 403 is overwhelmingly a program (a script, a monitor, a scheduled job),
+/// and the only thing such a reader can act on is the header name and a value
+/// to put in it. The measured cost of leaving it implicit is not hypothetical —
+/// a capable agent read this refusal end to end, concluded the daemon had no
+/// programmatic channel into a private session at all, and filed the absence of
+/// a capability that has always shipped. Naming the concept tells a reader what
+/// state to be in; naming [`CALLER_PROVIDER_HEADER`] tells it what to *send*.
+///
+/// ⚠ **The added sentence is about the CALLER'S OWN credentials and nothing
+/// else**, which is the line [`SESSION_REACH_NO_KEY`] already walks and the
+/// only line on which this constant may grow. It is fixed text: it does not
+/// vary with the target, is not derived from it, and is emitted identically for
+/// `Private` and for [`TargetTier::Unreadable`], so the byte-for-byte
+/// indistinguishability that keeps this refusal from being a per-id oracle is
+/// untouched. Anything that named the chat — even to say the header would have
+/// worked for it — would rebuild the oracle in the act of being helpful.
+///
+/// ⚠ **It is NOT a bypass, and must not be reworded into one.** The header
+/// carries a provider *name* that this daemon resolves against its own registry
+/// ([`caller_capability`]); an unknown name resolves [`ProviderTier::Public`]
+/// and changes nothing. A caller that holds the daemon secret could already
+/// spell an installed provider's name here — the module header records that
+/// residual, which is [#47] — so this sentence discloses no reach that the
+/// header's own doc comment does not, and grants none at all.
+///
+/// [#47]: https://github.com/BaranziniLab/biorouter/issues/47
 pub const SESSION_OUT_OF_REACH: &str =
     "That chat is private, or there is no chat with that id. This request was made on a public \
      model and carried no proof it came from the person at the keyboard, and the two answers are \
@@ -200,8 +266,14 @@ pub const SESSION_OUT_OF_REACH: &str =
      nothing was changed. Do not retry as you are; the same call will be refused again, and no \
      setting, hook or permission mode changes it. A private chat is reachable from a session \
      running a private model, one the institution hosts or one that runs on this machine, or \
-     from the desktop app when the person at the keyboard acts. If this task genuinely needs \
-     that chat, stop and ask the user to open it for you.";
+     from the desktop app when the person at the keyboard acts. If you are a program that is \
+     already running under such a model — a script, a monitor, a scheduled job — then you are \
+     not lacking the capability, only failing to state it: declare the provider you are running \
+     by sending the header `X-Caller-Provider: <provider name>` on this request, for example \
+     `X-Caller-Provider: versa_azure`. That header carries a provider NAME and this daemon \
+     resolves it against its own registry, so a name this install does not publish resolves as \
+     public and changes nothing. If this task genuinely needs that chat and you have no such \
+     model to declare, stop and ask the user to open it for you.";
 
 /// …and when this daemon was handed no user-action key at all.
 ///
@@ -769,6 +841,107 @@ mod tests {
         assert!(SESSION_OUT_OF_REACH.contains("Do not retry"));
     }
 
+    /// **The mechanism, not only the concept.** The reader who receives this
+    /// 403 is overwhelmingly a program, and the one fact it can act on is the
+    /// header name plus a value to put in it.
+    ///
+    /// ⚠ This exists because naming the concept alone has already failed once
+    /// in production, in a way no test could see: an agent read the refusal in
+    /// full, took "reachable from a session running a private model" to describe
+    /// a state it had no way to enter, and reported the absence of a channel
+    /// that has always shipped. `contains("private model")` would have passed
+    /// throughout. So the assertion is on the *actionable* half — the literal
+    /// header, an example value that resolves Private on a real install, and the
+    /// register that stops a model reading it as a sanctioned bypass.
+    #[test]
+    fn the_refusal_tells_a_program_which_header_to_send() {
+        assert!(
+            SESSION_OUT_OF_REACH.contains(CALLER_PROVIDER_HEADER),
+            "the refusal names the capability but not the header that declares it, which is the \
+             one thing a script, a monitor or a CI job can act on"
+        );
+        // An example, not just the header name: a caller that must guess the
+        // VALUE has been handed half a mechanism. `versa_azure` is the name the
+        // registry test next door pins as Private, so this example is one that
+        // actually works rather than a plausible-looking placeholder.
+        assert!(
+            SESSION_OUT_OF_REACH.contains("versa_azure"),
+            "the refusal names `{CALLER_PROVIDER_HEADER}` without an example value"
+        );
+        // …and it says the daemon resolves the NAME, so a reader cannot take
+        // the sentence as an invitation to assert a tier it does not have.
+        assert!(
+            SESSION_OUT_OF_REACH.contains("provider NAME"),
+            "the refusal offers the header without saying the daemon resolves it, which reads \
+             as a tier the caller may assert"
+        );
+    }
+
+    /// **Point 2: the hint belongs to exactly one of the two arms.**
+    ///
+    /// [`SESSION_REACH_NO_KEY`] is a different state — this daemon was handed no
+    /// user-action key at all (`just run-server`, a hand-run `biorouterd
+    /// agent`) — and the header does not help there for the caller that arm is
+    /// written for. Putting it in both would re-create the original defect in
+    /// mirror image: the keyless arm would start answering a question its reader
+    /// did not ask, exactly as the reach arm used to answer "be a human" to a
+    /// caller that merely was not declaring itself.
+    ///
+    /// ⚠ Not a claim that a capable caller is refused on a keyless daemon — it
+    /// is not: [`refuse_unless_reachable`] admits on capability *before* it ever
+    /// looks at the proof, so such a caller never reaches this string. That is
+    /// precisely why the string has no reason to mention the header.
+    #[test]
+    fn the_keyless_arm_does_not_borrow_the_capability_hint() {
+        assert!(
+            !SESSION_REACH_NO_KEY.contains(CALLER_PROVIDER_HEADER),
+            "the keyless refusal is answering a question its reader did not ask"
+        );
+        // The two arms stay distinguishable, which is open question 23's whole
+        // point and which a copy-paste of the hint would erode.
+        assert_ne!(SESSION_OUT_OF_REACH, SESSION_REACH_NO_KEY);
+    }
+
+    /// **The oracle property, restated against the sentence that was added.**
+    ///
+    /// [`no_such_session_and_a_private_session_are_the_same_refusal`] already
+    /// asserts the two answers are equal at every (capability, proof) pair. This
+    /// asserts the other half of why that holds and will keep holding: the hint
+    /// is CONSTANT text about the caller's own credentials, so there is no input
+    /// from which a future edit could make it vary with the target. A sentence
+    /// like "the header would have worked for this chat" would satisfy the
+    /// equality test only until someone made it conditional.
+    #[test]
+    fn the_capability_hint_is_constant_and_never_derived_from_the_target() {
+        for capability in CAPABILITIES {
+            for proof in PROOFS {
+                let private = refuse_unless_reachable(true, TargetTier::Private, capability, proof);
+                let absent =
+                    refuse_unless_reachable(true, TargetTier::Unreadable, capability, proof);
+                assert_eq!(private, absent);
+                if let Err(refusal) = private {
+                    // Whatever it says, it is one of the two constants — the
+                    // `&'static str` in `SessionOutOfReach` is what makes that
+                    // checkable, and it is why the type does not carry a String.
+                    assert!(
+                        refusal.message == SESSION_OUT_OF_REACH
+                            || refusal.message == SESSION_REACH_NO_KEY,
+                        "a refusal composed per-request can vary with the target"
+                    );
+                }
+            }
+        }
+        // The hint names no part of a session. These are the four fields
+        // `SessionSummary` carries; the refusal may not have acquired a way to
+        // spell any of them.
+        for leak in ["session_id", "working_dir", "privacy_tier", "\"name\""] {
+            assert!(
+                !SESSION_OUT_OF_REACH.contains(leak),
+                "the refusal now names `{leak}`, which is a fact about the chat"
+            );
+        }
+    }
+
     /// Issue #56 Task 58, Step 3: **resolve the tier before doing anything
     /// else.** The half [`refuse_unless_reachable`]'s own tests cannot see.
     ///
@@ -871,10 +1044,22 @@ mod tests {
             );
         }
 
-        // The negative controls, so the scan is provably not vacuous: a handler
-        // in each file that is NOT on the gated list must come back without the
-        // gate, or `body_of` is over-reading past a function end and every
+        // The OVER-READ controls, so the scan is provably not vacuous: a handler
+        // in each file whose body does not name the gate must come back without
+        // it, or `body_of` is over-reading past a function end and every
         // assertion above is passing on someone else's body.
+        //
+        // ⚠ **"Does not name the gate" is not "is not gated", and two of these
+        // rows are the difference.** `update_agent_provider` and
+        // `agent_remove_extension` ARE gated — through
+        // `agent::authorize_agent_control`, which calls `session_reach` and then
+        // reads the row — and measured live against a private session each
+        // answers 403 without the capability header and proceeds with it. They
+        // are controls for the EXTRACTOR, not exemptions from the gate, and the
+        // comment here said otherwise until 2026-09-04. `interrupt` and
+        // `get_session_extensions` are the genuinely ungated pair: `interrupt`
+        // requires the user's proof instead, and `get_session_extensions` is on
+        // the module header's open residual.
         //
         // BOTH sides in `agent.rs`: `agent_remove_extension` sits after the two
         // gated handlers' neighbourhood and `update_agent_provider` before it,

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Two kinds of document live here, and the difference matters more than any other 
 | Resume, export or prune your past work | [Managing sessions](getting-started/managing-sessions.md) |
 | Run several conversations at once, or delegate to a subagent you can watch | [Workspace control](agent-loop/workspace-control.md) |
 | Use Biorouter in a web browser, on your own machine or a shared host | [Reaching Biorouter from a browser](deployment/browser-access.md) — then [Headless Linux deployment](deployment/headless-linux.md) if it should run as a server |
+| Read or follow a **private** chat from a script, a dashboard or CI | [Reaching a private chat from a script](deployment/programmatic-session-access.md) — the `X-Caller-Provider` header, and which routes honour it |
 | Fix an error you are hitting right now | [Common problems and fixes](troubleshooting/common-problems-and-fixes.md) |
 | Understand the codebase before changing it | [System overview](architecture/system-overview.md) |
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -24,6 +24,7 @@ any deployment live in [configuration](../configuration/environment-variables.md
 |---|---|
 | [Reaching Biorouter from a browser](browser-access.md) | The user-facing guide to `biorouter serve`: quickstart, the access token, reaching it from another machine and what that exposes, why a browser session cannot change its model, and troubleshooting. Start here. |
 | [Headless Linux deployment](headless-linux.md) | Running `biorouter serve` as a long-lived service on a Linux host with no graphical desktop: the CLI-only packages, the systemd unit, migrating secrets onto the host, and network exposure. |
+| [Reaching a private chat from a script](programmatic-session-access.md) | The `X-Caller-Provider` header: how a monitoring dashboard, a CI job or a shell script reads and follows a **private** conversation over the HTTP API, what the header is not (it is not authentication), and which routes honour it. |
 | [How browser-served Biorouter is built](serve-architecture.md) | Developer-facing architecture: what the daemon does with a web directory, how a browser is authenticated, and what the retired front door was replaced by. |
 | [Decisions behind `biorouter serve`](serve-decisions.md) | The seven decision records governing the serving path — why a browser session cannot change its model, why the bind defaults to loopback, and why the standalone binary was retired. |
 

--- a/docs/deployment/browser-access.md
+++ b/docs/deployment/browser-access.md
@@ -235,6 +235,7 @@ cd ui/desktop && npm run build:web
 
 ## Related documentation
 
+- [Reaching a private chat from a script](programmatic-session-access.md) — the `X-Caller-Provider` header, for automation that must read or follow a private conversation over the API.
 - [Headless Linux deployment](headless-linux.md) — running this as a long-lived service on a Linux server.
 - [Decisions behind `biorouter serve`](serve-decisions.md) — why the browser session is shaped this way.
 - [How browser-served Biorouter is built](serve-architecture.md) — the architecture, for developers.

--- a/docs/deployment/programmatic-session-access.md
+++ b/docs/deployment/programmatic-session-access.md
@@ -1,0 +1,251 @@
+# Reaching a private chat from a script
+
+> **What this is.** How a program — a monitoring dashboard, a CI job, a shell script, an agent
+> running in a terminal — reads or follows a **private** Biorouter conversation over the daemon's
+> HTTP API, using the `X-Caller-Provider` header.
+> **Status:** Current.
+> **Audience:** operators and developers writing automation against a running `biorouterd`.
+
+Biorouter classifies every conversation by the sensitivity of what it has touched. A conversation
+that has run against a private model — one your institution hosts, or one running on the machine
+itself — is marked private for the rest of its life, and the daemon refuses to hand it to a caller
+whose own capability does not cover it. Holding the daemon's secret key is not enough, and that is
+deliberate: [privacy tiers](../security/privacy-tiers.md) exist precisely so that a component with
+the secret cannot launder a private transcript into a public model.
+
+That rule has a consequence people meet as a bug. A script that is *already* running under a
+private model — a dashboard watching a UCSF-hosted run, a CI job driving `versa_azure` — has the
+capability the daemon is asking for, and gets a `403` anyway, because nothing on the request says
+so. The fix is one header. This page is that header.
+
+If you want the interface in a browser rather than the API, read
+[Reaching Biorouter from a browser](browser-access.md) instead.
+
+---
+
+## The short version
+
+```bash
+curl -H "X-Secret-Key: $SECRET" \
+     -H "X-Caller-Provider: versa_azure" \
+     "http://127.0.0.1:$PORT/sessions/$SESSION_ID"
+```
+
+Without the second header that call returns `403`. With it, it returns the transcript — provided
+`versa_azure` really is a private-tier provider on the daemon you are calling.
+
+## What the header is
+
+`X-Caller-Provider` states **the provider the calling program is itself running under**. It carries
+a provider *name*, exactly as it is spelled in `config.yaml` — `versa_azure`, `versa_bedrock`,
+`ollama`, `llamacpp` — and never a tier.
+
+The daemon resolves that name against **its own** installed provider registry and takes the tier
+from there. A caller does not get to say how sensitive it is; it says what it is running, and the
+daemon decides what that means. The rule then applied is the one the whole feature states:
+
+> the caller's capability must be at least the target conversation's classification.
+
+That is the same rule the agent's tool surface applies to a conversation read, and the same rule the
+bind gate applies when a session changes model. Reaching a private chat over HTTP is not a special
+case with its own logic — it is that rule, stated on a request.
+
+The header is read by
+[`crates/biorouter-server/src/routes/session_reach.rs`](../../crates/biorouter-server/src/routes/session_reach.rs);
+`biorouter session watch`, `send` and `attach` already send it, which is why those commands reach a
+private chat from a terminal that can never prove a human is present.
+
+## What the header is *not*
+
+**It is not authentication, and it must not be described as one.** A caller that holds the daemon's
+secret key can spell any installed provider's name here. That is not a hole this header opens — the
+daemon has no principal at all, so such a caller already reaches every public session it can name,
+which is the open residual tracked as
+[issue #47](https://github.com/BaranziniLab/biorouter/issues/47). What the header buys is that the
+gate can *express* the correct rule instead of the proxy it used to enforce (proof-of-a-human),
+which got the answer backwards in both directions: a terminal running an institutional model was
+refused, while the desktop app was admitted for the same chat while running a public one.
+
+**It is not a way to raise or lower a tier.** Reaching a chat and *reclassifying* one are separate
+decisions. Raising a session's classification, declassifying it, and binding a private model all
+still require proof that the person at the keyboard acted (`X-User-Action`), and no header changes
+that. A capability is a fact about a model; neither of those is a decision a model may make.
+
+**It is not a per-request opt-out.** There is no header that turns the gate off. The only
+machine-wide switch is the privacy master switch, which lives in its own record beside
+`config.yaml` and is not an environment variable.
+
+## The fail-safe fallback
+
+Anything the daemon cannot positively resolve to a private provider is treated as **public** — the
+refusing side:
+
+| Header value | Resolves to | Result against a private chat |
+|---|---|---|
+| `versa_azure`, `versa_bedrock`, `ollama`, `llamacpp` | Private | `200` |
+| `anthropic`, `openai`, `claude_code`, … | Public | `403` |
+| `private` (a *tier*, not a provider) | Public | `403` |
+| A name this install does not publish | Public | `403` |
+| Empty or whitespace | Public | `403` |
+| Header absent | Public | `403` |
+
+Two consequences worth internalising. A **typo fails closed** — it does not error, it silently
+resolves public and you get the same `403` as before, so check the spelling against
+`GET /config/providers` before assuming the gate is broken. And every client written before the
+header existed keeps working unchanged, because "absent" and "public" are the same answer.
+
+One caveat: the tier resolved is the provider's **declared** tier, not a live instance's. An
+`ollama` re-pointed off the machine with `OLLAMA_HOST` still declares Private. That residual is
+inherited from how every other surface reasons about provider tiers, not introduced here.
+
+## Recipes
+
+Set these once:
+
+```bash
+export SECRET="$BIOROUTER_SERVER__SECRET_KEY"
+export BASE="http://127.0.0.1:8791"
+export SESSION="20260904_1"
+export CALLER="versa_azure"
+```
+
+### Read the transcript as JSON
+
+```bash
+curl -s -H "X-Secret-Key: $SECRET" -H "X-Caller-Provider: $CALLER" "$BASE/sessions/$SESSION"
+```
+
+### Follow a run live over SSE
+
+`GET /sessions/{id}/events` opens with a snapshot of the whole stored conversation and then tails
+it, so a monitor attaching mid-run sees everything that came before:
+
+```bash
+curl -sN -H "X-Secret-Key: $SECRET" -H "X-Caller-Provider: $CALLER" "$BASE/sessions/$SESSION/events"
+```
+
+Frames arrive as `data: {...}` lines. `TurnStarted` opens a turn, `Message` carries streamed
+content and token counts, `Finish` closes it, and `Error` reports a failure. A minimal monitor:
+
+```bash
+curl -sN -H "X-Secret-Key: $SECRET" -H "X-Caller-Provider: $CALLER" \
+     "$BASE/sessions/$SESSION/events" \
+| while IFS= read -r line; do
+    case "$line" in
+      data:*) printf '%s\n' "${line#data: }" | jq -r 'select(.type) | "\(.type) \(.turn_id // "")"' ;;
+    esac
+  done
+```
+
+### Drive the run as well as watch it
+
+`POST /reply` is gated by the same rule, so a script that starts a turn in a private chat needs the
+header too — not only the one that watches it:
+
+```bash
+curl -sN -H "Content-Type: application/json" \
+        -H "X-Secret-Key: $SECRET" -H "X-Caller-Provider: $CALLER" \
+        -X POST "$BASE/reply" --data @turn.json
+```
+
+### Export the transcript, or pull a diagnostics bundle
+
+```bash
+curl -s  -H "X-Secret-Key: $SECRET" -H "X-Caller-Provider: $CALLER" "$BASE/sessions/$SESSION/export"
+curl -sL -H "X-Secret-Key: $SECRET" -H "X-Caller-Provider: $CALLER" "$BASE/diagnostics/$SESSION" -o bundle.zip
+```
+
+## Which routes honour the header
+
+These consult the reach gate, so the header is what admits a private chat on each of them. Every
+one of them resolves the target's tier **before** it touches the session, so a refusal cannot leak
+"this chat is busy" or "no such extension" as a side channel.
+
+| Route | What it reaches |
+|---|---|
+| `GET /sessions/{id}` | The transcript. |
+| `GET /sessions/{id}/export` | The same transcript, as a download. |
+| `GET /sessions/{id}/events` | The same transcript plus a live tail (SSE). |
+| `GET /diagnostics/{id}` | The same transcript in a zip, with this session's logs. |
+| `POST /reply` | Runs an agent turn, with tools, in the named session. |
+| `POST /agent/continuation/recover` | Resumes a parked continuation. |
+| `POST /agent/resume` · `restart` · `stop` | Lifecycle control of the session's agent. |
+| `POST /agent/update_provider` | Rebinds the model (also needs `X-User-Action` to raise a tier). |
+| `POST /agent/update_from_session` | Adopts another session's provider configuration. |
+| `POST /agent/update_working_dir` | Repoints the session at a directory. |
+| `POST /agent/add_extension` · `remove_extension` | Attaches or detaches tools. |
+| `GET`/`POST /knowledge/active` | Reads or repoints the session's knowledge bases. |
+
+## What the header does *not* cover
+
+Being explicit about this is the point of listing it. These routes address or expose sessions and do
+**not** consult the reach gate. Each is one of three things, and the difference matters:
+
+**Gated by a different, deliberate instrument** — the header is not the mechanism here, and adding
+it would be wrong:
+
+| Route | What guards it instead |
+|---|---|
+| `POST /interrupt`, `POST /agent/cancel`, `POST /agent/continuation/abandon` | `X-User-Action` — steering a turn is the user's decision, not a capability. |
+| `POST /sessions/{id}/declassify`, `POST /sessions/{id}/diverge`, `POST /sessions/{id}/edit_message` | `X-User-Action` — these change or copy a classification, which no model may decide. |
+| `POST /agent/cross_affiliation_grant`, `POST /action-required/tool-confirmation` | `X-User-Action`, plus a decision-authority check on the resolving surface. |
+| `POST /knowledge/bases/{id}/ingest-conversation` | Its own Gate G: capability is derived from the model named in the request body, and every selected conversation is checked against it before a transcript is rendered. |
+| `POST /agent/call_tool` | Privacy Gate C at the extension-manager dispatch point, plus the uninspected-boundary refusals. |
+
+**Ungated, and low-yield.** These name a session but return only its tool surface, not its contents:
+`GET /agent/tools`, `GET /agent/callable_tool_count`, `GET /agent/list_apps`,
+`POST /agent/read_resource`, `GET /skills/catalog`, `POST /skills/refresh`. They are listed as a
+measurement, not as a ruling — nothing in the source records a decision to exempt them, so read this
+row as "not gated" rather than "deliberately not gated".
+
+**Ungated, and a known residual.** These reach or describe a private session without the gate. None
+returns a transcript, so none is the boundary this feature defends — but none is closed either, and
+a reader should not infer from this page that the surface is complete:
+
+| Route | What an ungated caller gets |
+|---|---|
+| `GET /sessions`, `GET /sessions/sidebar` | Every session on the machine — id, name, working directory and tier. Enumerates wholesale; recorded as an open residual in `session_reach.rs`. |
+| `GET /sessions/running` | The ids of sessions with a turn in flight. |
+| `GET /active_work` | Every running background job, subagent, detached turn and scheduled run — with `sessionId`, and a `title`/`detail` that carries the **shell command or task prompt**. This is content rather than metadata, and it is not named in `session_reach.rs`'s residual list. |
+| `POST /active_work/{id}/cancel` | Cancels any of the above by its registry id. The id is not a session id, so the gate cannot be applied without a reverse lookup. |
+| `GET /sessions/{id}/usage` | Per-model token counts for a named session, and a `200`/`404` that tells the caller whether the id exists. |
+| `GET /sessions/{id}/extensions` | The session's enabled extension list. |
+| `PUT /sessions/{id}/name`, `PUT /sessions/{id}/user_workflow_values`, `DELETE /sessions/{id}` | Renames, edits workflow values, or deletes the session. |
+| `POST /skills/session` | Rewrites a session's per-chat skill overrides. |
+| `GET /schedule/{id}/inspect`, `POST /schedule/{id}/run_now`, `POST /schedule/create` | Inspects or launches scheduled work that may run in a private session. |
+
+The daemon has no principal, so none of this is a *tier* bypass in the strict sense — a caller
+holding the secret is already inside. It is the same open problem as
+[#47](https://github.com/BaranziniLab/biorouter/issues/47), and the list above is a snapshot of an
+enumeration rather than a proof of completeness.
+
+## Troubleshooting
+
+**`403` with a long refusal that mentions the header.** You sent no `X-Caller-Provider`, or a value
+that did not resolve private. Check the spelling against `GET /config/providers`. The refusal is
+identical for "this chat is private" and "there is no such chat", deliberately — so a `403` is not
+evidence the session exists.
+
+**`403` saying the daemon was started without a user-action key.** A different state: this daemon
+holds no key with which to verify a human, which is normal for `just run-server`, a hand-run
+`biorouterd agent`, and `biorouter serve`. The capability header is unaffected and still admits a
+private chat on that daemon — a capable caller never reaches this message, because capability is
+checked before proof. If you are seeing it, your caller is public.
+
+**The header worked yesterday and now does not.** The tier came from the daemon's own registry, so a
+provider removed from `config.yaml`, or renamed, now resolves public.
+
+**`200` but a null conversation.** Reach is not the problem — `GET /sessions/{id}` carries the full
+message list once there is one, and reports `null` for a session that has not yet stored a message.
+A session created by `POST /agent/start` is empty until its first turn runs, and it is also still
+*public* until then: the classification ratchets when a turn binds a private model, not when the
+provider is set. So a brand-new session on a private provider is reachable without the header, and
+becomes unreachable after its first turn. That is the ratchet working, not a flapping gate.
+
+## Related documentation
+
+- [Reaching Biorouter from a browser](browser-access.md) — `biorouter serve`, the access token, and why a browser session cannot change its model.
+- [Privacy tiers](../security/privacy-tiers.md) — the classification system this header states a capability against; read its "What shipped, and what did not" section first.
+- [Headless Linux deployment](headless-linux.md) — running the daemon as a long-lived service, which is where most automation points.
+- [How browser-served Biorouter is built](serve-architecture.md) — how the daemon authenticates a request, and what `X-Secret-Key` does and does not prove.
+- [biorouter CLI command reference](../cli/command-reference.md) — `session watch`, `send` and `attach`, which send this header for you.

--- a/docs/deployment/serve-architecture.md
+++ b/docs/deployment/serve-architecture.md
@@ -193,6 +193,7 @@ it finds none, the error names every path it tried.
 
 ## Related documentation
 
+- [Reaching a private chat from a script](programmatic-session-access.md) — what `X-Secret-Key` does *not* prove, and the capability header a private session additionally requires.
 - [Decisions behind `biorouter serve`](serve-decisions.md) — why each of the above was chosen.
 - [Browser access](browser-access.md) — using the command.
 - [Privacy tiers](../security/privacy-tiers.md) — the classification the serving path must not weaken.


### PR DESCRIPTION
## The gap: the refusal was unactionable for a machine

`X-Caller-Provider` already worked, over the whole channel including the live SSE
stream. What did not work was **finding out it existed**. `SESSION_OUT_OF_REACH`
named the *concept* a caller needs — "a session running a private model, one the
institution hosts or one that runs on this machine" — and never the *mechanism*.
For the reader who actually receives this 403 (a script, a monitor, a CI job) the
one actionable fact is the header name and a value to put in it, and it was absent.

That gap has a measured cost: a capable agent read the refusal end to end,
concluded the daemon had no programmatic progress channel for a private session,
and filed the absence of a capability that has always shipped. The doc comment
above the constant already records an earlier wording failing the same way. That
fix went halfway — it added the concept, not the mechanism. This is the other half.

**Nothing about the gate was weakened.** The header still carries a provider NAME
that the daemon resolves against its own registry; unknown, unparseable and absent
all still fall to `ProviderTier::Public`.

## What changed

1. **`SESSION_OUT_OF_REACH` names `X-Caller-Provider`** with a worked example, and
   says the daemon resolves the name — so the sentence cannot be read as a tier a
   caller may assert.
2. **`SESSION_REACH_NO_KEY` is untouched, deliberately.** That arm is a different
   credential state (no user-action key on this daemon) and the header does not
   help its reader. Copying the hint in would re-create the original defect in
   mirror image. A test pins that it stays out.
3. **New prose home**: [`docs/deployment/programmatic-session-access.md`](docs/deployment/programmatic-session-access.md)
   — what the header is, what it is *not* (not authentication; a secret-key holder
   already reaches everything, per #47), the fail-safe fallback table, copy-pasteable
   `curl` for the JSON read *and* the SSE stream, and the per-route audit. Indexed in
   `docs/README.md` and `docs/deployment/README.md`, cross-linked both ways.
4. **Three new tests**, each pinning something the existing suite could not see:
   `the_refusal_tells_a_program_which_header_to_send`,
   `the_keyless_arm_does_not_borrow_the_capability_hint`, and
   `the_capability_hint_is_constant_and_never_derived_from_the_target`.

### The oracle property is preserved

The added sentence is **constant text about the caller's own credentials** — the
line `SESSION_REACH_NO_KEY` already walks. It does not vary with the target, is not
derived from it, and is emitted identically for `Private` and `Unreadable`. The
existing byte-identity tests pass unchanged, and the new one asserts the *reason*
they will keep passing: a refusal can only ever be one of two `&'static str`s, so
there is no input a future edit could make it vary on.

## Route audit

Every session-addressing route was walked. Method: extract each handler body by
brace matching, then follow direct `session_reach(` calls **and** the
`authorize_agent_control` helper. Findings verified live against the private session.

**Honour the header (15).** `GET /sessions/{id}` · `/export` · `/events` ·
`GET /diagnostics/{id}` · `POST /reply` · `/agent/resume` · `/restart` · `/stop` ·
`/update_provider` · `/update_from_session` · `/update_working_dir` ·
`/add_extension` · `/remove_extension` · `/agent/continuation/recover` ·
`GET|POST /knowledge/active` (middleware).

**Deliberate exemptions, gated by a different instrument.** `X-User-Action` for
`/interrupt`, `/agent/cancel`, `/agent/continuation/abandon`, `/declassify`,
`/diverge`, `/edit_message`; Gate G (capability from the body's model) for
`/knowledge/bases/{id}/ingest-conversation`; Gate C at dispatch for `/agent/call_tool`.
`POST /agent/start` needs none — it only ever creates a session.

**Open residual, now written down.** `GET /sessions/{id}/extensions` · `/usage` ·
`PUT /name` · `/user_workflow_values` · `DELETE /sessions/{id}` · `POST /skills/session` ·
`GET /sessions` · `/sessions/sidebar` · `/sessions/running` · `/schedule/{id}/*`.

> ⚠ **One row deserves separating from the rest: `GET /active_work`.** It names no
> session in its path, so it enumerates in the manner of `GET /sessions` — but its
> `title`/`detail` carry the **shell command or task prompt** of every running job,
> plus `sessionId`. That is content, not metadata, and it was in no residual list.
> `POST /active_work/{id}/cancel` cancels any of them by a registry id that is not a
> session id, so the gate cannot be applied without a reverse lookup. Reported, not
> closed — closing it is a listing-route decision, not a reach decision.

### Two stale claims corrected

Both point the same way — they invite someone to "close" a gate already there:

* The module header listed **`POST /agent/resume` as open**. Measured live: `403`
  without the header, `200` with it. `resume_agent` calls `session_reach` directly.
* The ordering test called `update_agent_provider` / `agent_remove_extension` "NOT
  on the gated list". They **are** gated, via `authorize_agent_control`. They are
  controls for the body *extractor*, not exemptions. A grep for the literal
  `session_reach(` reports four false holes unless it follows that helper — and
  would then be trusted when it reports a real one.

## Live verification (not a fixture)

Sandboxed daemon (`BIOROUTER_PATH_ROOT` off the real config, real Keychain), built
from this branch. Session `20260904_1` bound to **`versa_azure`** and ratcheted to
`private` by a **real turn against the live model** — `privacy_tier: private`,
`privacy_reason: turn:versa_azure`.

```
== A. the four acceptance cells ==
  GET  /sessions/{id}          no header : HTTP 403
  GET  /sessions/{id}          + header  : HTTP 200
  GET  /sessions/{id}/events   no header : HTTP/1.1 403 Forbidden
  GET  /sessions/{id}/events   + header  : HTTP/1.1 200 OK (content-type: text/event-stream)
  (transcript returned with header: 5 messages)

== B. the oracle property ==
  private chat            : HTTP 403  1219 bytes
  chat that does not exist: HTTP 403  1219 bytes
  => byte-identical, sha256 7f3c18f1fed1f005f9b564af379cd023

== C. the header is a NAME the daemon resolves ==
  versa_azure        -> HTTP 200      anthropic          -> HTTP 403
  versa_bedrock      -> HTTP 200      claude_code        -> HTTP 403
  ollama             -> HTTP 200      private            -> HTTP 403   <- a TIER, not believed
  llamacpp           -> HTTP 200      no-such-provider   -> HTTP 403
                                      <absent>           -> HTTP 403
```

**A monitoring script following a live private run start-to-finish** (attached with
the header; the same script without it is refused `403`):

```
[  0.03s] attached to 20260904_1 (HTTP 200, text/event-stream)
[  0.03s] snapshot: 5 stored messages
[  1.95s] turn turn-1 STARTED
[  4.07s]   progress: 101 chars streamed, 4979 tokens
[  4.47s]   progress: 203 chars streamed, 4979 tokens
[  4.77s]   progress: 310 chars streamed, 4979 tokens
[  4.80s] turn turn-1 FINISHED reason=stop in=4999 out=85 chars=328
[  4.80s] DONE: followed 1 turn(s) on a private session start-to-finish
```

**The refusal a header-less caller now receives** (tail):

> …If you are a program that is already running under such a model — a script, a
> monitor, a scheduled job — then you are not lacking the capability, only failing
> to state it: declare the provider you are running by sending the header
> `X-Caller-Provider: <provider name>` on this request, for example
> `X-Caller-Provider: versa_azure`. That header carries a provider NAME and this
> daemon resolves it against its own registry, so a name this install does not
> publish resolves as public and changes nothing. …

One thing worth recording, because it cost a debugging cycle and is a real property:
**`POST /reply` is gated too**, so a script that *drives* a private run needs the
header as well as one that watches it. A reply sent without it is refused `403`, and
the monitor then waits forever for a turn that never started.

## Tests

- `cargo test -p biorouter-server --lib -- session_reach` — **23 passed** (20 existing + 3 new)
- `cargo test -p biorouter-server --lib` — **584 passed**
- `cargo test -p biorouter-cli --lib -- session_watch` — **33 passed** (isolated `HOME`; the source guards at `session_reach.rs` that assert the CLI still emits the header)
- `cargo test -p biorouter --test privacy_guard_wiring` — **3 passed**
- `./scripts/clippy-lint.sh` — clean, including the `too_many_lines` baseline
- `cargo fmt` — clean on every file this branch touches. ⚠ `cargo fmt --check` still reports `crates/biorouter/src/config/base.rs:2256`, which is **pre-existing on `main`** (from c7b79989) and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
