### PR TITLE
fix(composer): a failed Stop no longer pins the working edge on forever

### DIFF
--- a/ui/desktop/src/hooks/chatStreamStore.observe.test.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.observe.test.tsx
@@ -1454,7 +1454,10 @@ describe('ChatStreamController.observeSession — the Stop gate (#166)', () => {
       mocks.observeSessionEvents.mockResolvedValue({ stream: observed.stream });
       mocks.resumeAgent.mockResolvedValue({ data: { session: session('stale-gate-observer') } });
       // Never resolves: the gate stays armed for `turn-stopped` for good.
-      mocks.cancelTurn.mockReturnValue(deferred().promise);
+      mocks.cancelTurn.mockReturnValue(
+        deferred<{ data: { cancelled: boolean; settled: boolean; continuation_lease: string } }>()
+          .promise
+      );
 
       const controller = registry.getController('stale-gate-observer');
       void controller.observeSession();
@@ -1472,9 +1475,11 @@ describe('ChatStreamController.observeSession — the Stop gate (#166)', () => {
       void controller.stopStreaming();
       await vi.advanceTimersByTimeAsync(0);
       expect(mocks.cancelTurn).toHaveBeenCalledTimes(1);
-      expect(
-        (mocks.cancelTurn.mock.calls[0][0].body as Record<string, unknown>).expected_turn_id
-      ).toBe('turn-stopped');
+      expect(mocks.cancelTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ expected_turn_id: 'turn-stopped' }),
+        })
+      );
 
       // The server names a different, later turn as the active one...
       observed.push({

--- a/ui/desktop/src/hooks/chatStreamStore.observe.test.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.observe.test.tsx
@@ -1435,3 +1435,72 @@ describe('ChatStreamController.observeSession: the reconnect backoff', () => {
     }
   });
 });
+
+describe('ChatStreamController.observeSession — the Stop gate (#166)', () => {
+  it('lets a LATER observed turn end while a stale Stop gate names an older one (#166)', async () => {
+    // Belt and braces for #166. `stopPending` is a single process-wide latch:
+    // a Stop whose cancel never resolves used to pin EVERY subsequent terminal
+    // frame at its running value, so the composer's working edge swept on over
+    // turns the stopped one had nothing to do with. Scoping the gate to the
+    // generation it was armed for bounds that to one turn.
+    //
+    // The observer is the reachable path for it: a driving submit is refused
+    // while the gate is armed, but the observed active turn advances on the
+    // server's own say-so.
+    vi.useFakeTimers();
+    try {
+      const registry = new ChatStreamRegistry();
+      const observed = createControlledStream();
+      mocks.observeSessionEvents.mockResolvedValue({ stream: observed.stream });
+      mocks.resumeAgent.mockResolvedValue({ data: { session: session('stale-gate-observer') } });
+      // Never resolves: the gate stays armed for `turn-stopped` for good.
+      mocks.cancelTurn.mockReturnValue(deferred().promise);
+
+      const controller = registry.getController('stale-gate-observer');
+      void controller.observeSession();
+      await vi.advanceTimersByTimeAsync(0);
+      await controller.loadSession();
+      await vi.advanceTimersByTimeAsync(0);
+
+      observed.push({
+        type: 'TurnState',
+        active_turn_id: 'turn-stopped',
+      } as unknown as MessageEvent);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(controller.getSnapshot().chatState).toBe(ChatState.Streaming);
+
+      void controller.stopStreaming();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mocks.cancelTurn).toHaveBeenCalledTimes(1);
+      expect(
+        (mocks.cancelTurn.mock.calls[0][0].body as Record<string, unknown>).expected_turn_id
+      ).toBe('turn-stopped');
+
+      // The server names a different, later turn as the active one...
+      observed.push({
+        type: 'TurnStarted',
+        turn_id: 'turn-much-later',
+      } as unknown as MessageEvent);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // ...and THAT turn ending is not the stopped generation's business.
+      observed.push(
+        observerFrame(
+          { type: 'Finish', reason: 'done', token_state: tokenState } as MessageEvent,
+          'turn-much-later',
+          1
+        )
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(controller.getSnapshot().chatState).toBe(ChatState.Idle);
+      expect(isRunningState(controller.getSnapshot().chatState)).toBe(false);
+
+      controller.stopObserving();
+      observed.close();
+      await vi.advanceTimersByTimeAsync(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/ui/desktop/src/hooks/chatStreamStore.test.ts
+++ b/ui/desktop/src/hooks/chatStreamStore.test.ts
@@ -1749,7 +1749,7 @@ describe('ChatStreamRegistry', () => {
     ).toBe('lease-upgrade');
   });
 
-  it('keeps the stopped turn generation gated after a stale cancel is refused', async () => {
+  it('retries the stopped generation after an untyped cancel failure (#166)', async () => {
     const registry = new ChatStreamRegistry();
     const controlled = createControlledStream();
     const firstCancellation = deferred<{ data: { cancelled: boolean; settled: boolean } }>();
@@ -1768,7 +1768,10 @@ describe('ChatStreamRegistry', () => {
     firstCancellation.reject(new Error('409: a different turn is active'));
     await expect(stopped).resolves.toBe(false);
 
-    // A later terminal frame still cannot override the failed server barrier.
+    // #166 — the cancel request has RESOLVED (unsuccessfully), so the race the
+    // gate exists to bridge is over and a terminal frame is free to land the
+    // turn. Before the fix the gate stayed armed here for the rest of the
+    // chat's life and the composer's working edge swept over a finished turn.
     controlled.push({
       type: 'Finish',
       reason: 'cancelled',
@@ -1777,10 +1780,11 @@ describe('ChatStreamRegistry', () => {
     controlled.close();
     await firstSubmit;
 
-    expect(controller.getSnapshot().chatState).toBe(ChatState.Streaming);
-    await expect(controller.handleSubmit('must remain queued')).resolves.toBe(false);
-    expect(reply).toHaveBeenCalledTimes(1);
+    expect(controller.getSnapshot().chatState).toBe(ChatState.Idle);
 
+    // The generation itself is NOT forgotten: a retry still cancels the exact
+    // turn the user stopped, and still carries the Stop-and-Send intent that
+    // the failed attempt was made with.
     vi.mocked(cancelTurn).mockResolvedValueOnce({
       data: { cancelled: false, settled: true, continuation_lease: 'lease-retry' },
     } as never);
@@ -1793,6 +1797,96 @@ describe('ChatStreamRegistry', () => {
       continuation_owner_id: 'test-window-owner',
     });
     expect(controller.getSnapshot().chatState).toBe(ChatState.Idle);
+  });
+
+  /**
+   * #166 — the composer's working edge is `isRunningState(chatState)`, so a
+   * `chatState` that never returns to Idle is a figure that animates forever
+   * over a finished turn. Each case below is one exit from the stop machinery
+   * that used to leave the gate armed with nothing left to disarm it.
+   */
+  describe.each([
+    {
+      name: 'a cancel that rejects',
+      continuationPending: false,
+      arrange: () =>
+        vi.mocked(cancelTurn).mockRejectedValueOnce(new Error('network died mid-cancel')),
+    },
+    {
+      name: 'a cancel that reports settled: false',
+      continuationPending: false,
+      arrange: () =>
+        vi.mocked(cancelTurn).mockResolvedValueOnce({
+          data: { cancelled: true, settled: false },
+        } as never),
+    },
+    {
+      name: 'a Stop-and-Send response with no continuation lease',
+      continuationPending: true,
+      arrange: () =>
+        vi.mocked(cancelTurn).mockResolvedValueOnce({
+          data: { cancelled: true, settled: true },
+        } as never),
+    },
+  ])('after $name, the finished turn still returns to Idle (#166)', (scenario) => {
+    it('leaves the composer idle rather than animating forever', async () => {
+      const registry = new ChatStreamRegistry();
+      const controlled = createControlledStream();
+      vi.mocked(resumeAgent).mockResolvedValue({
+        data: { session: session('stranded-stop') },
+      } as never);
+      vi.mocked(reply).mockResolvedValue({ stream: controlled.stream } as never);
+      scenario.arrange();
+
+      const controller = registry.getController('stranded-stop');
+      const submit = controller.handleSubmit('long task');
+      await vi.waitFor(() => expect(reply).toHaveBeenCalledTimes(1));
+
+      await expect(controller.stopStreaming(scenario.continuationPending)).resolves.toBe(false);
+      expect(cancelTurn).toHaveBeenCalledTimes(1);
+
+      controlled.push({
+        type: 'Finish',
+        reason: 'done',
+        token_state: tokenState,
+      } as MessageEvent);
+      controlled.close();
+      await submit;
+
+      expect(controller.getSnapshot().chatState).toBe(ChatState.Idle);
+      expect(isRunningState(controller.getSnapshot().chatState)).toBe(false);
+    });
+
+    it('lets the user send again instead of bricking the chat', async () => {
+      const registry = new ChatStreamRegistry();
+      const controlled = createControlledStream();
+      vi.mocked(resumeAgent).mockResolvedValue({
+        data: { session: session('stranded-stop-resend') },
+      } as never);
+      vi.mocked(reply).mockResolvedValue({ stream: controlled.stream } as never);
+      scenario.arrange();
+
+      const controller = registry.getController('stranded-stop-resend');
+      const submit = controller.handleSubmit('long task');
+      await vi.waitFor(() => expect(reply).toHaveBeenCalledTimes(1));
+      await expect(controller.stopStreaming(scenario.continuationPending)).resolves.toBe(false);
+
+      controlled.push({
+        type: 'Finish',
+        reason: 'done',
+        token_state: tokenState,
+      } as MessageEvent);
+      controlled.close();
+      await submit;
+
+      vi.mocked(reply).mockResolvedValue({
+        stream: (async function* () {
+          yield { type: 'Finish', reason: 'done', token_state: tokenState } as MessageEvent;
+        })(),
+      } as never);
+      await expect(controller.handleSubmit('the chat still works')).resolves.toBe(true);
+      expect(reply).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('adopts the authoritative successor after a typed stale-Stop mismatch', async () => {

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -648,11 +648,27 @@ class ChatStreamController {
   /** Whether the request currently on the wire already acquired a continuation lease. */
   private stopInFlightContinuationPending = false;
   /**
-   * A Stop whose server barrier has not succeeded yet. Unlike `stopInFlight`,
-   * this survives a failed HTTP attempt so a terminal SSE frame cannot reopen
-   * submission without proof that the exact stopped turn released its slot.
+   * A Stop whose server barrier has not resolved yet, so a terminal SSE frame
+   * may not reopen submission without proof that the exact stopped turn
+   * released its slot.
+   *
+   * #166 — this is a bridge across the microtask race between a terminal frame
+   * and the cancel response, NOT a durable claim that the daemon is still
+   * running the turn. It is cleared as soon as the cancel request resolves,
+   * whichever way it resolved: see `settleStoppedTurn`, whose `finally` is the
+   * only reason a failed cancel can no longer pin the composer at "working"
+   * for the rest of the chat's life.
    */
   private stopPending = false;
+  /**
+   * The exact turn generation the current (or last unsettled) Stop named.
+   *
+   * It deliberately OUTLIVES `stopPending` on a failure, so a retry cancels the
+   * generation the user actually stopped instead of guessing at whatever is
+   * running now. `stopStreaming` prefers a live `activeTurnId` over it, and a
+   * new turn supersedes it outright, so it can never name a stale generation
+   * while a real one exists.
+   */
   private stopExpectedTurnId: string | null = null;
   /** Stop-and-Send intent, retained when the exact-generation cancel is retried. */
   private stopContinuationPending = false;
@@ -1684,7 +1700,11 @@ class ChatStreamController {
     // outliving the turn is the same bug in two shapes: a stale handle sends a
     // reopened tab attaching to a turn that is over, and a stale high-water mark
     // makes the NEXT turn's `seq: 0` look like a duplicate and swallows it.
-    if (!this.stopPending) this.retireActiveTurn();
+    //
+    // Sampled once, above the retirement, because `stopGateHolds()` reads
+    // `activeTurnId` and `retireActiveTurn()` clears it.
+    const stopGateHolds = this.stopGateHolds();
+    if (!stopGateHolds) this.retireActiveTurn();
 
     const timeSinceLastInteraction = Date.now() - this.lastInteractionTime;
     if (!error && timeSinceLastInteraction > 60000) {
@@ -1759,7 +1779,7 @@ class ChatStreamController {
       // A terminal frame can beat the cancel HTTP response by a few
       // microtasks. Keep the composer gated until that response confirms the
       // server-side turn slot has actually been released.
-      chatState: this.stopPending ? prev.chatState : ChatState.Idle,
+      chatState: stopGateHolds ? prev.chatState : ChatState.Idle,
       turnStartedAt: undefined,
       lastMessageAt: undefined,
       // The turn it was aimed at is over; whether or not we saw the echo, there
@@ -2692,12 +2712,14 @@ class ChatStreamController {
       return;
     }
 
+    // Sampled before the retirement, for the reason `stopGateHolds()` documents.
+    const stopGateHolds = this.stopGateHolds();
     this.rememberRetiredObservedTurn(this.activeTurnId);
     this.retireActiveTurn();
     this.ambiguousRetryTurnId = null;
     this.updateSnapshot((prev) => ({
       ...prev,
-      chatState: this.stopPending ? prev.chatState : ChatState.Idle,
+      chatState: stopGateHolds ? prev.chatState : ChatState.Idle,
       turnStartedAt: undefined,
       lastMessageAt: undefined,
       pendingSteer: undefined,
@@ -2782,6 +2804,12 @@ class ChatStreamController {
     this.seqTurnId = turnId;
     this.lastAppliedSeq = -1;
     this.reattachesThisTurn = 0;
+    // #166 — a new turn supersedes the generation a previous failed Stop kept
+    // naming for its retry. Without this the retained id survives past the turn
+    // it belonged to and a much later Stop-and-Send, made with nothing running,
+    // would cancel a generation that has been dead for several turns.
+    this.stopExpectedTurnId = null;
+    this.stopContinuationPending = false;
 
     try {
       // The transcript paints before the agent's model + extensions are up, so
@@ -3159,6 +3187,26 @@ class ChatStreamController {
     }
   };
 
+  /**
+   * Whether the Stop gate still speaks for the turn that is ending right now.
+   *
+   * #166 belt-and-braces. `stopPending` alone is a process-wide latch: any path
+   * that arms it and then fails to resolve pins EVERY later terminal frame at
+   * its running value, which is the composer's working edge sweeping forever
+   * over a finished chat. Scoping it to the generation it was armed for bounds
+   * that blast radius to one turn — a terminal frame for a different, later
+   * turn always returns to Idle, whatever the latch says.
+   *
+   * Evaluate this BEFORE `retireActiveTurn()`: retiring nulls `activeTurnId`,
+   * and a null there reads as "cannot disprove the gate", so a check made
+   * afterwards answers the opposite of one made before.
+   */
+  private stopGateHolds(): boolean {
+    if (!this.stopPending) return false;
+    if (!this.stopExpectedTurnId || !this.activeTurnId) return true;
+    return this.stopExpectedTurnId === this.activeTurnId;
+  }
+
   private requestExactTurnSettlement = async (
     turnId: string,
     continuationPending: boolean
@@ -3255,9 +3303,31 @@ class ChatStreamController {
     stoppedTurnId: string,
     requestContinuationPending: boolean
   ): Promise<boolean> => {
-    if (!(await this.requestExactTurnSettlement(stoppedTurnId, requestContinuationPending))) {
-      return false;
+    let settled = false;
+    try {
+      settled = await this.requestExactTurnSettlement(stoppedTurnId, requestContinuationPending);
+    } finally {
+      // #166 — the gate exists to bridge the microtask race between a terminal
+      // SSE frame and the cancel response. Once that response has resolved the
+      // race is over, whichever way it went, and holding the gate past it buys
+      // nothing: a Stop whose cancel timed out or came back unconfirmed used to
+      // latch `stopPending` true for the rest of the chat's life, so every
+      // later terminal frame left `chatState` pinned at its running value. The
+      // composer's working edge swept on over a finished turn and the composer
+      // never offered Send again — the whole of #166.
+      //
+      // A `finally` rather than a branch on `settled`, so no early return added
+      // here later can reintroduce the strand.
+      //
+      // `stopExpectedTurnId` and `stopContinuationPending` are deliberately NOT
+      // cleared: they are the memory a retry needs to name the exact generation
+      // the user stopped (and their Stop-and-Send intent), and dropping them
+      // would turn a retry into a session-only cancel that fails closed. They
+      // are superseded by a live turn rather than by this failure — see
+      // `stopStreaming` and `submitPreparedMessage`.
+      this.stopPending = false;
     }
+    if (!settled) return false;
 
     this.activeStreamId += 1;
     this.abortController?.abort();
@@ -3333,7 +3403,12 @@ class ChatStreamController {
     const observedLookupStop = this.stopAfterObservedLookup(continuationPending);
     if (observedLookupStop) return observedLookupStop;
 
-    if (!this.stopPending && !this.activeTurnId) {
+    // A live turn always outranks the generation a previous failed Stop named;
+    // the retained id only speaks when nothing is running, which is exactly the
+    // retry-after-a-failed-cancel case (#166).
+    const targetTurnId = this.activeTurnId ?? this.stopExpectedTurnId;
+
+    if (!this.stopPending && !targetTurnId) {
       // An ordinary Stop may have settled in the microtask immediately before
       // Stop-and-Send. The daemon retains that exact generation specifically so
       // this second admission can acquire the continuation lease without
@@ -3348,9 +3423,15 @@ class ChatStreamController {
     }
 
     if (!this.stopPending) {
+      // Retrying the retained generation carries the original Stop-and-Send
+      // intent forward; naming a live turn is a fresh Stop and takes only the
+      // intent of this call, so a stale `true` cannot make an ordinary Stop
+      // acquire a continuation lease nobody asked for.
+      const retryingRetainedGeneration = !this.activeTurnId && !!this.stopExpectedTurnId;
       this.stopPending = true;
-      this.stopExpectedTurnId = this.activeTurnId;
-      this.stopContinuationPending = continuationPending;
+      this.stopExpectedTurnId = targetTurnId;
+      this.stopContinuationPending =
+        continuationPending || (retryingRetainedGeneration && this.stopContinuationPending);
     } else if (continuationPending) {
       this.stopContinuationPending = true;
     }


### PR DESCRIPTION
Closes #166

## The defect

The composer card's sweeping "working edge" is `data-working={isRunningState(chatState)}` ([ChatInput.tsx:376](ui/desktop/src/components/ChatInput.tsx#L376), CSS at `main.css:2006`). So anything that stops `chatState` returning to `Idle` leaves it animating over a finished turn.

`stopPending` was that thing. `settleStoppedTurn` early-returned whenever `requestExactTurnSettlement` failed, and **all three** of its failure exits left the latch armed:

1. a Stop-and-Send response with no continuation lease,
2. a cancel that came back `settled: false`,
3. any thrown error (the generic `catch`).

`trackStopOperation`'s `.finally()` clears `stopInFlight` and `stopInFlightContinuationPending` — never `stopPending`. So one Stop press whose cancel failed latched it true for the rest of the chat's life, and both terminal-frame paths (`finishCurrentStream`, `applyObservedTurnState`) then pinned `chatState` at its running value forever. The edge swept on, and the composer showed Stop instead of Send. This fits the reporting session, which recorded a `platform__report_bug` timeout — a stalled turn is exactly when someone presses Stop.

## The fix

**The latch is cleared in a `finally`.** The comment it guards says what it is for: bridging the microtask race between a terminal SSE frame and the cancel response. It is not a durable claim that the daemon is still running the turn, and once the request resolves — either way — that race is over. A `finally` rather than a branch on the result, so no early return added later can reintroduce the strand.

**The generation is deliberately *not* cleared with it.** `stopExpectedTurnId` and `stopContinuationPending` are the memory a retry needs to cancel the exact turn the user stopped rather than guessing at whatever is running now; dropping them turns a retry into a session-only cancel that fails closed. `stopStreaming` now prefers a live `activeTurnId` over the retained id, and a new turn supersedes it outright, so it can never name a dead generation while a real one exists.

**Belt and braces:** `stopGateHolds()` scopes the latch to the generation it was armed for, so a gate that nothing ever disarms can pin one turn instead of every turn that follows. It is sampled *above* `retireActiveTurn()` in both terminal paths, because retiring nulls the id the check reads and a check made afterwards answers the opposite of one made before.

`isRunningState` is untouched.

## One existing assertion changes

`keeps the stopped turn generation gated after a stale cancel is refused` asserted that after an **untyped** cancel failure the composer stays pinned at Streaming and refuses a successor — which is precisely the behaviour #166 reports as the bug.

That test simulated "a different turn is active" with a plain `Error`, so it exercised the generic `catch`. The realistic version of that case is the **typed mismatch** branch, which already clears the latch and adopts the named successor, and which has its own test immediately below (`adopts the authoritative successor after a typed stale-Stop mismatch`). The generic catch retaining the latch forever was never what protected against a live successor.

The valuable half of the old test — that a retry still names the exact stopped generation and carries the original Stop-and-Send intent — is kept and still asserted. It is renamed to `retries the stopped generation after an untyped cancel failure (#166)`.

## Tests

- Three failure exits x two properties: the finished turn returns to `Idle` (and `isRunningState` is false), and the chat can still send.
- The observer path for the scoped gate: a later observed turn ends even while a stale gate names an older one.
- The retained-generation retry, unchanged in substance.
- The success path was already covered by `does not admit a successor before the cancellation barrier settles` — a terminal frame arriving while the cancel is *in flight* still keeps the composer gated and refuses a successor. It passes unchanged, which is the guard against regressing the original fix.

**All eight of the new/changed tests fail against the unfixed store** (verified by setting the source change aside and re-running).

## Verification

- `npm run test:run` — 407 files, **4498 passed**, 1 skipped.
- `npm run lint:check` — exit 0.
- `npm run format:check` — the three changed files are clean. The 5 files it still flags are the pre-existing failures documented in `CLAUDE.md`; none are touched here.

The AI co-author trailer is omitted from the commit because `.github/workflows/check-commits.yml` rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)