### PR TITLE
Settings on the chat measure (760px)

### DIFF
--- a/docs/design/astryx-adoption/astryx-ui-adoption-design.md
+++ b/docs/design/astryx-adoption/astryx-ui-adoption-design.md
@@ -83,7 +83,7 @@ Everything below 11px is deleted, not migrated. Body line-height moves from the 
 | Table row | 36px | one value with the list row |
 | Icon-label gap | 8px | everywhere; retires 7px and 6px |
 | Sidebar width | 240px | unchanged (Astryx's 260 is a docs rail, not an app rail) |
-| Reading column | 760px chat · 1120px pages | unchanged; the 896px replay fork is deleted |
+| Reading column | 760px chat · 1120px pages | unchanged; the 896px replay fork is deleted. **Settings joined the 760px chat column on 2026-09-07** — it is a stack of labelled rows, not a document, so page width separated each control from its label rather than showing more. The page measure now governs sessions, extensions, skills, schedules, workflows and applications only. |
 
 **A-03** is the content-row change: 40 → 36px contradicts D-12·B, which fixed 40px as "one rhythm, no compact mode". The rhythm survives — it just tightens by one grid step, and the app gains ~10% more rows per screen.
 

--- a/docs/desktop-ui/window-scaling-regressions.md
+++ b/docs/desktop-ui/window-scaling-regressions.md
@@ -34,6 +34,7 @@ getComputedStyle(document.documentElement).getPropertyValue('--measure-chat')
 | `text` empty, or `hash` is `#/pair` | **Not a layout bug.** The app is not rendering — see *A dead daemon* below. |
 | `inner` ≠ `outer` | **Not a layout bug.** Your tooling pinned the viewport — see *Viewport emulation* below. |
 | `inner` = `outer`, and neither changes when you resize | **Not a layout bug.** Your resize command silently did nothing — see *AppleScript* below. |
+| Everything tracks, but the view is **Settings** (or Home) and its column stops at 760px | **Not a layout bug.** Both read the chat measure by decision — see *Settings, on the chat measure* below. |
 | Everything tracks, but content stays the same width | **The real one.** A fixed pixel cap — see below. |
 
 ## The real product cause: a fixed pixel cap
@@ -43,13 +44,20 @@ a wider window buys **margin**, not content: at 1800px the chat column sat at
 760px with roughly 400px of dead band on each side, which is exactly what
 "doesn't scale with the window" looks like to someone dragging the edge.
 
-The fix is that every measure is a `clamp()` whose middle term is a
+The fix was to make the **page** measure a `clamp()` whose middle term is a
 **percentage**:
 
 ```css
---measure-chat: clamp(760px, 78%, 1180px);
 --measure-page: clamp(1120px, 88%, 1720px);
 ```
+
+⚠ **The chat measure is NOT one of them, and this block listed it as
+`clamp(760px, 78%, 1180px)` until 2026-09-07.** It was briefly widened that way
+on the reasoning above, and reverted: a 1180px composer is not a more capable
+composer, it is a line of prose the eye has to track back across. It is a flat
+`--measure-chat: 760px`, and `styles/measures.test.ts` asserts that literal
+string precisely so a re-widening cannot land quietly. Read main.css before
+quoting either value.
 
 Two invariants, both learned the hard way:
 
@@ -126,6 +134,43 @@ and Dock are removed — a worse bug than the one being fixed. The heatmap keeps
 its chrome locked to its own grid instead (`UsageHeatmap`'s `heatStyle` sets the
 block's width from the fitted footprint), so a compressed grid stays a coherent
 block rather than leaving its labels and legend pinned to the old edge.
+
+### Not this: Settings, on the chat measure by decision (2026-09-07)
+
+**Settings stops widening at 760px, and that is the intended behaviour** — not
+the fixed-cap bug above, and not a measure someone forgot to clamp. All three of
+its reading columns (header, tab strip, scrolling body) are
+`<ReadableContent size="chat">` in `components/settings/SettingsView.tsx`, so
+Settings, Home, the chat transcript and the composer share one left edge and one
+width at every window size.
+
+The distinction that decides which of the two you are looking at is **what the
+extra width would have bought**, not whether the column moved:
+
+- A **document-shaped** view — sessions, extensions, skills, schedules,
+  workflows, applications — gains real content from a wider window: more table
+  columns, more cards per row. Those stay on `--measure-page` and a flat cap
+  there is the regression this page is about.
+- **Settings is a column of labelled rows**: a label on the left, the control it
+  names on the right, one per row. Widening the column adds nothing to either
+  half — it only pushes them apart, so at 1800px the Local Model Inventory's
+  Install button sat about a foot from the model it installs. That is the same
+  "margin, not content" failure as the fixed cap, arriving from the opposite
+  direction.
+
+So a report of the form *"Settings doesn't use my big monitor"* is expected and
+closes as working-as-intended; a report of the form *"Settings truncates / hides
+something at 760px"* is a real bug, and the fix belongs in the section that
+truncates — `min-w-0`, `flex-wrap`, or letting a line wrap — never in the
+measure. (One such fix shipped with the move: the model inventory's metadata
+line was `truncate`, which at the 508px label block ate the context window and
+the model id; it wraps now.)
+
+⚠ **jsdom cannot see any of this**, exactly as with the fixed cap: there is no
+layout engine and Tailwind never runs, so `SettingsView.test.tsx` asserts the
+`data-size` attribute and its count, and `styles/measures.test.ts` asserts at the
+source that no `<ReadableContent` in that file is left on the default size. The
+widths themselves were measured in the running app.
 
 ## The four impostors
 

--- a/ui/desktop/src/components/Layout/ReadableContent.tsx
+++ b/ui/desktop/src/components/Layout/ReadableContent.tsx
@@ -11,8 +11,18 @@ type ReadableContentProps = {
  * (`max-w-measure-chat`, see BaseChat.tsx / ChatInput.tsx). A view that sits
  * directly above the composer — Home — must use it, or its edges will not line
  * up. It names the TOKEN rather than a literal precisely so that alignment
- * survives the measure changing, which it since has: the flat 760px this line
- * used to quote is now the floor of a clamp.
+ * survives the measure changing.
+ *
+ * Two views read it: **Home** (SessionsInsights.tsx) and **Settings**
+ * (settings/SettingsView.tsx, all three of its boxes). Home is the alignment
+ * case above — it sits directly over the composer. Settings is a different
+ * argument for the same measure and does not depend on adjacency: it is a
+ * column of labelled rows, so width beyond the measure separates each control
+ * from the label it names instead of showing more (operator decision,
+ * 2026-09-07; see the `--measure-page` note in main.css).
+ *
+ * Everything else — sessions, extensions, skills, schedules, workflows,
+ * applications — is document-shaped and stays on the fluid page measure below.
  */
 /**
  * ⚠ Every one of these is a CLAMP, not a flat cap, for the reason spelled out

--- a/ui/desktop/src/components/settings/SettingsView.test.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.test.tsx
@@ -85,3 +85,51 @@ describe('SettingsView', () => {
     expect(await screen.findByRole('switch', { name: /Privacy tiers/ })).toBeInTheDocument();
   });
 });
+
+/**
+ * Settings reads the CHAT measure (760px), not the fluid page measure
+ * (operator decision, 2026-09-07): it is a column of labelled rows, so width
+ * beyond the measure separates each control from the label it names instead of
+ * showing more.
+ *
+ * ⚠ **What this can and cannot see.** jsdom has no layout engine and never runs
+ * Tailwind, so `getBoundingClientRect()` here is zero for every box and the
+ * WIDTH is unassertable — the alignment was measured in a real browser instead
+ * (see the PR). What is assertable is the attribute that selects the width, and
+ * that all three boxes agree on it: the header, the tab strip and the scrolling
+ * body are three separate `ReadableContent`s meeting at one left edge, so a
+ * size on one and not its siblings is a visible step in that edge rather than
+ * an invisible inconsistency. The count is pinned so that a fourth column added
+ * on the default size fails here rather than shipping a step, and
+ * `styles/measures.test.ts` closes the remaining case this file cannot see: a
+ * `<ReadableContent` written with no `size` prop at all.
+ */
+describe('SettingsView sits on the chat measure', () => {
+  const readableColumns = () =>
+    [...document.querySelectorAll('.biorouter-readable-content')] as HTMLElement[];
+
+  it('renders exactly three reading columns, all of them the chat size', () => {
+    renderSettings();
+
+    const columns = readableColumns();
+    expect(columns).toHaveLength(3);
+    for (const column of columns) expect(column.dataset.size).toBe('chat');
+  });
+
+  /**
+   * The tab strip and the body are inside `Tabs`, so switching tabs re-renders
+   * the body. Asserted on the App tab as well because that is the tab with the
+   * most sections under it, and the one a later edit is most likely to wrap in
+   * a column of its own.
+   */
+  it('keeps every column on the chat size after switching tabs', async () => {
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByTestId('settings-app-tab'));
+    await screen.findByRole('switch', { name: /Privacy tiers/ });
+
+    const columns = readableColumns();
+    expect(columns).toHaveLength(3);
+    for (const column of columns) expect(column.dataset.size).toBe('chat');
+  });
+});

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -82,7 +82,23 @@ export default function SettingsView({
               ReadableContent itself, so it stopped at the reading column while
               every other view's ran edge to edge. */}
           <div className="flex-shrink-0 border-b border-border-subtle">
-            <ReadableContent className="px-8 pt-12 pb-6">
+            {/* ⚠ All THREE of this view's `ReadableContent`s are `size="chat"`,
+                and they move together or not at all. Settings is a column of
+                labelled rows — a label on the left, a control on the right —
+                and at the page measure a wider window bought margin between
+                the two rather than content, dragging every control away from
+                the thing it names. The chat measure is what Home already uses
+                (SessionsInsights.tsx), so Settings, Home, the transcript and
+                the composer are one edge.
+
+                The header, the tab strip and the scrolling body are three
+                separate boxes precisely because the hairline under the header
+                is full-bleed (the §4.2 note just above), so a size on one and
+                not the others is a visible step in that shared left edge
+                rather than a mistake in a single component. `measures.test.ts`
+                asserts at the source that no `<ReadableContent` here is left
+                without it. */}
+            <ReadableContent size="chat" className="px-6 pt-12 pb-6">
               <h1 className="text-title mb-1 page-transition">Settings</h1>
               <p className="text-secondary text-text-muted">
                 Manage models, chat behavior, and app preferences
@@ -96,7 +112,7 @@ export default function SettingsView({
               onValueChange={handleTabChange}
               className="h-full flex flex-col"
             >
-              <ReadableContent className="px-8 pt-4">
+              <ReadableContent size="chat" className="px-6 pt-4">
                 {/* §4.2 — one rule, not two. `TabsList` carries its own bottom
                     hairline, which landed a few pixels under the header's and
                     read as a double rule unique to Settings. */}
@@ -129,7 +145,7 @@ export default function SettingsView({
               </ReadableContent>
 
               <ScrollArea className="flex-1" paddingX={1}>
-                <ReadableContent className="px-8 py-5">
+                <ReadableContent size="chat" className="px-6 py-5">
                   <TabsContent value="models" className="mt-0">
                     <ModelsSection setView={setView} />
                   </TabsContent>

--- a/ui/desktop/src/components/settings/models/LocalModelInventory.tsx
+++ b/ui/desktop/src/components/settings/models/LocalModelInventory.tsx
@@ -492,7 +492,19 @@ export default function LocalModelInventory() {
                         {fitLabel(model)}
                       </span>
                     </div>
-                    <p className="mt-1 truncate text-xs text-text-muted">
+                    {/* ⚠ WRAPS, never truncates. This line was `truncate`,
+                        which was survivable while Settings read the fluid page
+                        measure and the label block was ~1000px wide. On the
+                        chat measure the block is 508px (measured, 712px column
+                        minus the action group and the row's own padding) and
+                        the longest catalog entry needs 680 — so an ellipsis ate
+                        the last two fields, which are the two that identify the
+                        model: its context window and its `ollama_name`/`hf_spec`.
+                        Truncation is for a NAME whose head identifies it; this
+                        is a sentence whose tail does, so it wraps to a second
+                        line instead. The name above still truncates, correctly:
+                        the chips beside it wrap first. */}
+                    <p className="mt-1 text-xs leading-5 text-text-muted">
                       {model.family} · {model.download_size} · {model.speed_hint} ·{' '}
                       {formatContext(model.context_limit)} context ·{' '}
                       {model.ollama_name ?? model.hf_spec}

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -464,13 +464,25 @@
      (docs/design/astryx-adoption/astryx-ui-adoption-design.md §1), so 760 is
      the measure, not the floor of one.
 
-     `--measure-page` stays FLUID. It governs settings, sessions and the other
-     document-shaped views, where a wide window genuinely does buy content
-     (more table columns, more cards per row) rather than a longer line.
-     PERCENTAGES, not `vw`, for the reason that has not changed: a percentage
-     resolves against the containing block, which is the content pane, while
-     `vw` is the whole viewport and would over-count by the sidebar's width —
-     widening the column exactly when the sidebar opened and took the room away.
+     `--measure-page` stays FLUID. It governs the document-shaped views —
+     sessions, extensions, skills, schedules, workflows, applications — where a
+     wide window genuinely does buy content (more table columns, more cards per
+     row) rather than a longer line. PERCENTAGES, not `vw`, for the reason that
+     has not changed: a percentage resolves against the containing block, which
+     is the content pane, while `vw` is the whole viewport and would over-count
+     by the sidebar's width — widening the column exactly when the sidebar
+     opened and took the room away.
+
+     ⚠ **Settings is NOT in that list any more** (operator decision,
+     2026-09-07), and this paragraph used to name it first. Settings is not a
+     document, it is a column of labelled rows: a label on the left and the
+     control it names on the right. A wider window therefore buys the SAME
+     rows with more space between the two halves — margin, not content — and
+     pushes each control away from its own label, which is exactly the failure
+     the fluid measure exists to prevent everywhere else. All three of its
+     `ReadableContent`s (header, tab strip, scrolling body) read the chat
+     measure now, so Settings, Home, the transcript and the composer share one
+     left edge. See components/settings/SettingsView.tsx.
 
      Nothing narrow changes either way: `max-width` never forces a box wider
      than its parent, so below 760px the chat column is simply pane-wide. */

--- a/ui/desktop/src/styles/measures.test.ts
+++ b/ui/desktop/src/styles/measures.test.ts
@@ -16,11 +16,19 @@ import {
  * The reading measures. **The two are governed by opposite rules, and that is
  * the whole point of this file.**
  *
- * `--measure-page` must stay FLUID. It governs settings, sessions and the other
- * document-shaped views, where a wider window genuinely buys content — more
- * table columns, more cards per row. It was once a flat cap, and the symptom was
- * reported as "the app doesn't rescale with the window": dragging the window
- * wider bought margin rather than content.
+ * `--measure-page` must stay FLUID. It governs the document-shaped views —
+ * sessions, extensions, skills, schedules, workflows, applications — where a
+ * wider window genuinely buys content: more table columns, more cards per row.
+ * It was once a flat cap, and the symptom was reported as "the app doesn't
+ * rescale with the window": dragging the window wider bought margin rather than
+ * content.
+ *
+ * ⚠ **Settings is no longer one of them** (operator decision, 2026-09-07), and
+ * this paragraph named it first until that date. Settings is a column of
+ * labelled rows rather than a document, so the extra width a wide window hands
+ * it lands BETWEEN each label and the control it names — margin again, just
+ * distributed differently. It reads the chat measure now, which is why the
+ * last describe block in this file guards that at the source.
  *
  * `--measure-chat` must stay FLAT at 760px. It was briefly widened into a clamp
  * on the same reasoning, and that was wrong for this measure specifically: a
@@ -44,6 +52,10 @@ import {
 const CSS = readFileSync(join(__dirname, 'main.css'), 'utf8');
 const READABLE = readFileSync(join(__dirname, '../components/Layout/ReadableContent.tsx'), 'utf8');
 const MAIN = readFileSync(join(__dirname, '../main.ts'), 'utf8');
+const SETTINGS_VIEW = readFileSync(
+  join(__dirname, '../components/settings/SettingsView.tsx'),
+  'utf8'
+);
 
 function declaration(name: string): string {
   const match = CSS.match(new RegExp(`--${name}:\\s*([^;]+);`));
@@ -196,5 +208,43 @@ describe('the minimum window width is derived from the sidebar and the chat meas
    */
   it('is expressed in content coordinates', () => {
     expect(MAIN).toMatch(/useContentSize: true/);
+  });
+});
+
+/**
+ * Settings reads the CHAT measure, not the page measure (operator decision,
+ * 2026-09-07). The reasoning is in the header of this file and in the
+ * `--measure-page` note in main.css; what is asserted here is only that the
+ * view has not drifted back.
+ *
+ * ⚠ **Asserted at the SOURCE, for the same reason every other assertion in
+ * this file is.** jsdom has no layout engine and never runs Tailwind, so a test
+ * that renders SettingsView and reads a column's `getBoundingClientRect()` sees
+ * zero whatever the size prop says — the widths this guards are only real in a
+ * browser against the built stylesheet. The neighbouring
+ * `SettingsView.test.tsx` asserts the rendered `data-size` attribute and its
+ * count, which is the strongest statement a DOM test can make; this one closes
+ * the case that test cannot see, a `<ReadableContent` added to the JSX with no
+ * `size` at all, since the prop DEFAULTS to the page measure and so a
+ * forgotten size is silently the wrong one.
+ */
+describe('Settings sits on the chat measure', () => {
+  const OPENING_TAGS = SETTINGS_VIEW.match(/<ReadableContent\b[^>]*>/g) ?? [];
+
+  /**
+   * Guards against the vacuous pass: with no matches the loop below asserts
+   * nothing, and renaming or removing the component would look like success.
+   */
+  it('renders the reading column at all', () => {
+    expect(OPENING_TAGS.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Every one, not "the body one". The header, the tab strip and the scrolling
+   * body are three separate boxes sharing one left edge, so a size on one and
+   * not its siblings is a visible step in that edge.
+   */
+  it('gives every reading column the chat size, none left on the default', () => {
+    for (const tag of OPENING_TAGS) expect(tag).toContain('size="chat"');
   });
 });


### PR DESCRIPTION
## Why

Settings spanned the whole pane: it read the fluid page measure
(`clamp(1120px, 88%, 1720px)`), so at a wide window it kept the same rows and
simply put more space between them. That is the wrong measure for what Settings
actually is.

Settings is not a document — it is a **column of labelled rows**: a label on the
left, the control it names on the right, one per row. A document-shaped view
gains real content from a wider window (more table columns, more cards per row);
Settings gains only *distance between a control and its own label*. At 1800px
the Local Model Inventory's Install button sat most of a screen away from the
model it installs. That is the same "margin, not content" failure the fluid
measure exists to prevent everywhere else, arriving from the opposite direction.

Operator decision, 2026-09-07: Settings joins Home on the 760px chat column.

## What changed

**`SettingsView.tsx`** — all three reading columns (header, tab strip, scrolling
body) become `size="chat"`. They move together or not at all: the hairline under
the header is full-bleed, so the three are separate boxes meeting at one
continuous left edge, and a size on one and not its siblings is a visible step.

**Inset: `px-6`, not `px-8`** — a measurement, not a preference. Home already
reads the chat measure at `sm:px-6`, and the window minimum is 1048, so `sm:`
always applies. Measured in the running app, content-box left edge:

| window | Settings text edge (`px-6`) | Home greeting edge | composer card edge | `px-8` would be |
|---|---|---|---|---|
| 1048 (minimum) | **168** | 168 | 144 | 176 |
| 1440 | **508** | 508 | 484 | 516 |
| 1680 | **628** | 628 | 604 | **636** (measured) |

`px-6` lands Settings' text edge on Home's exactly at every attainable width;
`px-8` would sit 8px right of it at every one. All three Settings columns measure
760px box / 712px content at every width, identical to Home's two.

**Neither `--measure-chat` nor `--measure-page` is touched.** The rationale
comments on both are rewritten, because the paragraph naming Settings as a
page-measure view is now false. The page measure still governs sessions,
extensions, skills, schedules, workflows and applications.

**`LocalModelInventory.tsx`** — the one section that had assumed the wide column.
Its metadata line (`family · size · speed · context · model id`) carried
`truncate`. Survivable at a ~1000px label block; on the chat measure the block is
508px and the longest catalog entry needs 680, so the ellipsis ate the last two
fields — the context window and the model id, the two that identify the model.
Truncation suits a *name*, whose head identifies it; this is a sentence whose
tail does, so it wraps to a second line. The model name above still truncates,
correctly (the chips beside it wrap first, and it was measured not to truncate
here).

**Tests** — jsdom has no layout engine and never runs Tailwind, so no rendered
test can measure a column's width. Two assertions split the job:
`SettingsView.test.tsx` asserts the rendered DOM (exactly three
`.biorouter-readable-content`, all `data-size="chat"`, before and after a tab
switch — the count pinned so a fourth column on the default size fails), and
`measures.test.ts` asserts at the source that no `<ReadableContent` in that file
is left with *no* `size` at all, which the DOM test cannot see because the prop
DEFAULTS to the page measure.

**Docs** — `window-scaling-regressions.md` gains a triage row and a "Not this"
section, so a report that Settings stops widening closes as working-as-intended
while a report that it *truncates* stays a real bug. That file also quoted a
stale `--measure-chat: clamp(760px, 78%, 1180px)` two paragraphs above the new
section — a widening that was reverted — so it is corrected rather than left to
contradict the new text. `astryx-ui-adoption-design.md` §2.3's "Reading column"
row is amended.

## Screenshots

All at `~/biorouter-runs/settings-chat-measure/shots/`.

Parchment, dark, three tabs × three widths:
- `parchment-dark-1048-{models,chat,app}.png`
- `parchment-dark-1280-{models,chat,app}.png`
- `parchment-dark-1440-{models,chat,app}.png`
- `parchment-dark-1680-{models,chat,app}.png`

Parchment, light, three tabs × three widths:
- `parchment-light-1048-{models,chat,app}.png`
- `parchment-light-1280-{models,chat,app}.png`
- `parchment-light-1680-{models,chat,app}.png`

Edge agreement (Settings vs the chat column):
- `parchment-dark-1440-home-for-edge-comparison.png`
- `parchment-dark-1440-newchat-for-edge-comparison.png`
- `parchment-light-1680-home-for-edge-comparison.png`

Other theme families (Settings → App → Theme → Palette):
- `alma-mater-dark-1440-app-theme-palette.png`
- `roche-limit-dark-1440-app-theme-palette.png`

## Verification

Ran in a dev instance built from this branch (frozen Vite, restarted after every
edit), driven over CDP.

```
$ cd ui/desktop && npx vitest run src/components/settings src/styles
 Test Files  59 passed (59)
      Tests  428 passed (428)
   Duration  3.73s
```

```
$ cd ui/desktop && npm run lint:check      # exit 0
OK — generated artifacts are current (3 themes)
OK — all 332 contrast assertions pass
OK — every semantic colour token used by a utility has a @theme inline mirror
```

```
$ cd ui/desktop && npx prettier --check \
    src/components/settings/SettingsView.tsx \
    src/components/settings/SettingsView.test.tsx \
    src/components/Layout/ReadableContent.tsx \
    src/styles/main.css \
    src/styles/measures.test.ts \
    src/components/settings/models/LocalModelInventory.tsx
Checking formatting...
All matched files use Prettier code style!
```

The two changed Markdown files under `docs/` fail `prettier --check`, and they
**already fail identically on `main`** (verified by checking the files out at
HEAD and re-running). Prettier reflows hand-wrapped prose, so running `--write`
would rewrite whole documents and bury the change; left alone deliberately.

**The new guards were checked against a plausible wrong implementation.** With
one column reverted to the default size, 3 of the new tests fail
(`gives every reading column the chat size, none left on the default`,
`renders exactly three reading columns, all of them the chat size`,
`keeps every column on the chat size after switching tabs`) and pass again on
revert.

**Overflow audit, measured in the browser** — every descendant of the scrolling
body checked for `scrollWidth > clientWidth` and for spilling past the column's
content box, on all three tabs:

| | before | after |
|---|---|---|
| Models @1440 | 1 (the truncated meta line) | **0** |
| Chat @1440 | 0 | 0 |
| App @1440 | 0 | 0 |
| App @1048 / @1680 | — | **0** |
| App @1440, Roche Limit | — | **0** |

The long Qwen3.6 line now measures 40px tall (two lines at `leading-5`) instead
of one truncated line; every other row stays at 20px. The three-button
"installed" row state needs a downloaded model, which the testing rules forbid,
so it was measured by injecting the extra buttons into a live row: at a 317px
action group and a 359px label nothing truncates and every button stays on one
row.

Checked and needing no change at 712px, each measured rather than reasoned about:

- `AppSettingsSection` theme selectors — the Palette row (Parchment / Alma Mater
  / Roche Limit) and the Mode row both fit; see the two theme screenshots.
- `MemorySection` — its `max-w-2xl` header paragraph renders at 672px inside the
  712px column, no overflow. The cap is *below* the column, so it narrows the
  line rather than fighting it.
- `ResetPanel` — the `max-w-xl` (576px) warning renders at 406px; what binds is
  its 430px flex parent, shared with the two Reset buttons, not the cap. The
  `sm:grid-cols-2` grid lives inside a `sm:max-w-[520px]` dialog and never sees
  the column.
- `PrivacyPanel` and `UpdateSection` — 0 overflowing elements on the App tab
  sweep at every width.

## Follow-ups

- The other document views (sessions, extensions, skills, schedules, workflows,
  applications) stay fluid **by design** and are untouched. If any of them turns
  out to be a labelled-row column rather than a document, it is the same
  argument and a separate PR.
- `settings/providers/ProviderSettingsPage.tsx` is deliberately untouched — a
  separate PR rebuilds it — and so is settings row/banner styling.
- `LocalModelInventory`'s row uses a `lg:` (viewport ≥1024px) breakpoint to
  decide whether the label and the action group sit side by side. With the
  column now a constant ~712px at every window the app permits, that breakpoint
  is always satisfied and no longer tracks the space actually available; it is
  vacuous rather than wrong today (the row fits at 712, measured), but a
  container query would be the honest expression. Left out of this PR as
  restyling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
