### PR TITLE
Transcript views survive a message without metadata

### DIFF
--- a/ui/desktop/src/components/artifacts/artifactFileProvenance.test.ts
+++ b/ui/desktop/src/components/artifacts/artifactFileProvenance.test.ts
@@ -128,4 +128,38 @@ describe('file-link reliability: provenance boundaries', () => {
     }
     expect(filePathsBeforeMessage([request, response], 2, 'local', '/work')).toEqual([]);
   });
+
+  // The index is built for EVERY message of both transcript renderers, so it is
+  // the first thing a shared transcript from a remote `base_url` reaches — and
+  // `message.metadata.provenance` was read there without a guard. Measured in a
+  // running dev GUI: a shared transcript whose messages carried no `metadata`
+  // replaced the whole page with the app's error boundary. The payload is
+  // repaired at the boundary now (`sharedSessions.normalizeSharedMessages`);
+  // this pins the module itself as total, so the repair is belt and braces
+  // rather than the only thing standing between a reader and a blank page.
+  it('indexes nothing, and throws nothing, for a message missing metadata or content', () => {
+    const noMetadata = {
+      id: 'no-metadata',
+      role: 'assistant',
+      created: 1,
+      content: [{ type: 'text', text: 'Created `/remote/report.md`.' }],
+    } as unknown as Message;
+    const noContent = {
+      id: 'no-content',
+      role: 'assistant',
+      created: 2,
+      metadata: { userVisible: true, agentVisible: true },
+    } as unknown as Message;
+    const wellFormed: Message = {
+      id: 'well-formed',
+      role: 'assistant',
+      created: 3,
+      metadata: { userVisible: true, agentVisible: true },
+      content: [{ type: 'text', text: 'Created `/work/kept.md`.' }],
+    };
+
+    const messages = [noMetadata, noContent, wellFormed];
+    expect(filePathsBeforeMessage(messages, 3, 'local', '/work')).toEqual(['/work/kept.md']);
+    expect(filePathLookupBeforeMessage(messages, 3, 'local', '/work')('report.md')).toEqual([]);
+  });
 });

--- a/ui/desktop/src/components/artifacts/artifactFileProvenance.ts
+++ b/ui/desktop/src/components/artifacts/artifactFileProvenance.ts
@@ -12,8 +12,14 @@ type PathIndex = { paths: KnownPath[]; byBasename: Map<string, KnownPath[]> };
 type ProvenanceIndex = PathIndex & { sessionId: string; workingDir?: string };
 const provenanceCache = new WeakMap<readonly Message[], ProvenanceIndex>();
 
+// Belt and braces for the shape `sharedSessions.normalizeSharedMessages` fills
+// in at the boundary. This index is built for EVERY message of both transcript
+// renderers, so it is the first thing a malformed shared transcript reaches —
+// and it is where the error boundary was measured. `?.` here contradicts the
+// generated `Message` type on purpose: the type is a promise about the local
+// daemon's payload, not about a remote one.
 function localOrigin(message: Message, sessionId: string): boolean {
-  const origin = message.metadata.provenance?.fromSessionId;
+  const origin = message.metadata?.provenance?.fromSessionId;
   return !origin || origin === sessionId;
 }
 
@@ -69,9 +75,13 @@ function buildIndex(
 
   messages.forEach((message, index) => {
     if (!localOrigin(message, sessionId)) return;
-    if (message.role === 'assistant' && message.metadata.userVisible) {
-      for (const path of referencedFilePaths(getTextContent(message), workingDir)) add(path, index);
-      for (const content of message.content) {
+    // Read once: a message that arrives without content indexes nothing, and
+    // `getTextContent` reads the same field without a guard of its own.
+    const contents = message.content ?? [];
+    if (message.role === 'assistant' && message.metadata?.userVisible) {
+      const text = contents.length ? getTextContent(message) : '';
+      for (const path of referencedFilePaths(text, workingDir)) add(path, index);
+      for (const content of contents) {
         if (content.type !== 'toolRequest') continue;
         const call = content.toolCall as {
           status?: string;
@@ -83,7 +93,7 @@ function buildIndex(
       }
     }
 
-    for (const content of message.content) {
+    for (const content of contents) {
       if (content.type !== 'toolResponse') continue;
       const call = calls.get(content.id);
       if (!call) continue;

--- a/ui/desktop/src/components/sessions/SessionViewComponents.artifactLinks.test.tsx
+++ b/ui/desktop/src/components/sessions/SessionViewComponents.artifactLinks.test.tsx
@@ -69,6 +69,33 @@ describe('file-link reliability: read-only transcript provenance', () => {
     });
   });
 
+  // A shared transcript is fetched from an operator-configured remote
+  // `base_url` and JSON-parsed without validating message shape, so it is the
+  // one `Message[]` that can violate the generated type. Measured in a running
+  // dev GUI on 2026-09-07: rendering `#/shared-session` with messages that
+  // carried no `metadata` replaced the whole page with the app's error boundary
+  // ("Cannot read properties of undefined (reading 'provenance')"). A malformed
+  // message must cost its own provenance, not the transcript.
+  it('renders the transcript when a message carries no metadata at all', async () => {
+    const shapeless = {
+      id: 'shapeless',
+      role: 'assistant',
+      created: 1,
+      content: [{ type: 'text', text: 'Created `/remote/report.md`.' }],
+    } as unknown as Message;
+    const onOpenArtifact = renderMessages([shapeless, assistant('current', '[Open](report.md)')]);
+
+    expect(await screen.findByText(/Created/)).toBeVisible();
+    // Degraded, not crashed: the shapeless message proves no path, so the later
+    // link resolves against the working directory instead of its `/remote` one.
+    fireEvent.click(await screen.findByRole('button', { name: 'Open' }));
+    expect(onOpenArtifact).toHaveBeenCalledWith({
+      kind: 'file',
+      title: 'report.md',
+      path: '/work/report.md',
+    });
+  });
+
   it('keeps an explicit absolute path unchanged', async () => {
     const onOpenArtifact = renderMessages([
       assistant('prior', 'Created `/one/report.md`.'),

--- a/ui/desktop/src/sharedSessions.test.ts
+++ b/ui/desktop/src/sharedSessions.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The shared-transcript fetch is the ONE place a `Message[]` enters the
+ * renderer without having come from the local daemon's typed client: it is read
+ * from an operator-configured remote `base_url` and `safeJsonParse` *asserts*
+ * the `SharedSessionDetails` type rather than checking it.
+ *
+ * Every transcript consumer is compiled against a generated `Message` that
+ * declares `content` and `metadata` as required, and reads them without a
+ * guard. These specs pin the repair that keeps that promise true: a server on
+ * an older schema costs the reader a degraded transcript, never the app's error
+ * boundary.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchSharedSessionDetails, normalizeSharedMessages } from './sharedSessions';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('normalizeSharedMessages', () => {
+  it('fills in the container fields a consumer dereferences', () => {
+    const [message] = normalizeSharedMessages([{ id: 'shapeless', role: 'assistant', created: 7 }]);
+    expect(message.content).toEqual([]);
+    expect(message.metadata).toEqual({ userVisible: true, agentVisible: true });
+    // Scalars are left exactly as they arrived: a missing one degrades a label
+    // rather than throwing, so inventing one would disguise a bad payload.
+    expect(message.id).toBe('shapeless');
+    expect(message.created).toBe(7);
+  });
+
+  it('shows a message with no visibility flag and hides one told to hide', () => {
+    const [absent, explicit] = normalizeSharedMessages([
+      { role: 'assistant', content: [], metadata: {} },
+      { role: 'assistant', content: [], metadata: { userVisible: false, agentVisible: false } },
+    ]);
+    expect(absent.metadata.userVisible).toBe(true);
+    expect(explicit.metadata.userVisible).toBe(false);
+    expect(explicit.metadata.agentVisible).toBe(false);
+  });
+
+  it('preserves the fields the transcript actually renders', () => {
+    const [message] = normalizeSharedMessages([
+      {
+        role: 'assistant',
+        created: 1,
+        content: [{ type: 'text', text: 'hello' }],
+        metadata: {
+          userVisible: true,
+          agentVisible: true,
+          provenance: { kind: 'agent_injection', fromSessionId: 'other' },
+        },
+      },
+    ]);
+    expect(message.content).toEqual([{ type: 'text', text: 'hello' }]);
+    expect(message.metadata.provenance).toEqual({
+      kind: 'agent_injection',
+      fromSessionId: 'other',
+    });
+  });
+
+  it('drops entries that are not messages at all, and a non-array payload', () => {
+    expect(normalizeSharedMessages([null, 'nope', 42, ['also-not']])).toEqual([]);
+    expect(normalizeSharedMessages(undefined)).toEqual([]);
+    expect(normalizeSharedMessages({ messages: [] })).toEqual([]);
+  });
+});
+
+describe('fetchSharedSessionDetails', () => {
+  it('normalizes the messages it hands to the transcript', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          share_token: 'token-1',
+          created_at: 1,
+          base_url: 'https://share.test',
+          description: 'Older schema',
+          working_dir: '/tmp/project',
+          // A server that predates `metadata` — the payload that took the
+          // reader to the error boundary.
+          messages: [{ role: 'assistant', created: 1, content: [{ type: 'text', text: 'hi' }] }],
+          message_count: 1,
+          total_tokens: null,
+        }),
+      })
+    );
+
+    const details = await fetchSharedSessionDetails('https://share.test', 'token-1');
+    expect(details.messages).toHaveLength(1);
+    expect(details.messages[0].metadata).toEqual({ userVisible: true, agentVisible: true });
+  });
+});

--- a/ui/desktop/src/sharedSessions.ts
+++ b/ui/desktop/src/sharedSessions.ts
@@ -1,5 +1,5 @@
 import { safeJsonParse } from './utils/conversionUtils';
-import { Message } from './api';
+import { Message, MessageMetadata } from './api';
 
 export interface SharedSessionDetails {
   share_token: string;
@@ -10,6 +10,57 @@ export interface SharedSessionDetails {
   messages: Message[];
   message_count: number;
   total_tokens: number | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeSharedMessage(message: Record<string, unknown>): Message {
+  const metadata = isRecord(message.metadata) ? message.metadata : {};
+  return {
+    ...(message as unknown as Message),
+    // Only the two CONTAINER fields are filled in, because they are the only
+    // ones a consumer dereferences. A missing scalar (`created`, `role`, `id`)
+    // degrades a label rather than throwing — `formatMessageTimestamp` already
+    // takes an optional — and inventing one would disguise a malformed payload
+    // instead of surviving it.
+    content: Array.isArray(message.content) ? (message.content as Message['content']) : [],
+    metadata: {
+      ...(metadata as Partial<MessageMetadata>),
+      // A shared transcript is what the sharer chose to publish, so a message
+      // arriving without a visibility flag is SHOWN, and hidden only when the
+      // payload says so explicitly. Defaulting to `false` would trade the error
+      // boundary for a silently truncated transcript, which is worse: the
+      // reader cannot tell that anything is missing.
+      userVisible: metadata.userVisible !== false,
+      agentVisible: metadata.agentVisible !== false,
+    },
+  };
+}
+
+/**
+ * Fill in the shape the generated `Message` type promises, for the one
+ * `Message[]` in the renderer that does not come from the local daemon.
+ *
+ * `Message` declares `content` and `metadata` as REQUIRED, so every consumer
+ * downstream — `getTextContent`, `isUserMessage`, `localOrigin` in
+ * `artifacts/artifactFileProvenance.ts`, both transcript renderers — reads them
+ * without a guard, and is right to. But `fetchSharedSessionDetails` reads this
+ * payload from an operator-configured remote `base_url` and `safeJsonParse`
+ * *asserts* the type rather than checking it, so a server on an older schema
+ * (or any malformed response) hands the renderer a message that violates it.
+ * Measured: a transcript whose messages carried no `metadata` replaced the
+ * whole page with the app's error boundary ("Cannot read properties of
+ * undefined (reading 'provenance')").
+ *
+ * Filling the shape once, here, is what keeps that promise true for every
+ * consumer. Guarding each consumer instead is an open-ended list that the next
+ * consumer written against the type would not join.
+ */
+export function normalizeSharedMessages(messages: unknown): Message[] {
+  if (!Array.isArray(messages)) return [];
+  return messages.filter(isRecord).map(normalizeSharedMessage);
 }
 
 /**
@@ -51,7 +102,7 @@ export async function fetchSharedSessionDetails(
       base_url: data.base_url,
       description: data.description,
       working_dir: data.working_dir,
-      messages: data.messages,
+      messages: normalizeSharedMessages(data.messages),
       message_count: data.message_count,
       total_tokens: data.total_tokens,
     };


### PR DESCRIPTION
## Why

`components/artifacts/artifactFileProvenance.ts` read `message.metadata.provenance` with
`metadata` itself unguarded. That function is reached from `filePathLookupBeforeMessage`, which
both transcript renderers call for **every** message, so any `Message` without a `metadata`
property took the whole page down.

Measured in a running dev GUI (this branch's worktree, fresh vite, `origin/main` code): rendering
`#/shared-session` with a `SharedSessionDetails` whose messages carried no `metadata` replaced the
page with the app's error boundary —

```
Honk!
An error occurred.
Cannot read properties of undefined (reading 'provenance')
```

This is not only a synthetic fixture. `fetchSharedSessionDetails` (`src/sharedSessions.ts`) fetches
a shared transcript from an operator-configured **remote** `base_url` and `safeJsonParse` *asserts*
`SharedSessionDetails` rather than checking it. Messages produced by the local daemon always carry
`metadata`, but a shared transcript is the one payload that does not come from the local daemon — so
a server on an older schema, or any malformed response, takes the reader to an error boundary
instead of to a degraded transcript.

## What changed

**The boundary is the primary fix; the consumer guard is belt and braces.**

The generated `Message` (`src/api/types.gen.ts`) declares both `content: Array<MessageContent>` and
`metadata: MessageMetadata` as **required**. Every consumer downstream — `getTextContent`,
`isUserMessage`, `localOrigin`, `ProgressiveMessageList`, `SessionViewComponents` — is compiled
against that promise and reads the fields without a guard, correctly. The problem is not the
consumers; it is that one payload enters the renderer without ever having satisfied the type.

So:

1. **`src/sharedSessions.ts` — `normalizeSharedMessages`.** `fetchSharedSessionDetails` now fills in
   the shape the type promises before handing the transcript on. One place, at the only entry point
   that can violate it.
   - Only the two **container** fields are filled (`content`, `metadata`), because they are the only
     ones a consumer dereferences. Scalars are left exactly as they arrived: a missing `created` or
     `role` degrades a label rather than throwing (`formatMessageTimestamp` already takes an
     optional), and inventing one would disguise a malformed payload instead of surviving it.
   - A message with no visibility flag is **shown**, and hidden only when the payload says
     `userVisible: false` explicitly. Defaulting to `false` would trade the error boundary for a
     silently truncated transcript, which is worse — the reader cannot tell anything is missing.
   - Entries that are not objects, and a non-array `messages`, are dropped rather than propagated.

2. **`src/components/artifacts/artifactFileProvenance.ts`** — `localOrigin` and `buildIndex` are now
   total over message shape (`metadata?.`, and `content` read once into a local that defaults to
   `[]`). `?.` contradicts the generated type on purpose, and the comment says so: the type is a
   promise about the local daemon's payload, not a remote one.

### Why not guard every consumer instead (question 3)

Both, with the boundary as the real fix. Three reasons:

- **The consumer list is open-ended and the type argues against joining it.** `?.` inside a function
  typed `(message: Message)` is a no-op against a non-nullable field. Sprinkling it asserts the type
  is wrong in N places without ever making it right in one, and the next consumer — written against
  the same generated type — will not know to add it.
- **A consumer-only fix does not actually fix the shared view.** `SessionViewComponents.tsx` calls
  `getTextContent(message)` at line 110, nineteen lines *before* it reaches the provenance lookup;
  that reads `message.content` with no guard of its own. Guarding `metadata` alone leaves the
  adjacent field one bad payload away from the same error boundary. Only the boundary closes both
  without editing a shared helper used everywhere.
- **`safeJsonParse<T>` is a cast, not a check** (`return (await response.json()) as T`). Something
  has to actually establish the shape, and the fetch is where the untrusted data arrives.

### Every other unguarded read found, and what was done with it

Grepped `components/artifacts/` and both transcript renderers for `.metadata` and `Message`-shaped
`.content` reads:

| Site | Field | Disposition |
|---|---|---|
| `artifacts/artifactFileProvenance.ts:16` | `message.metadata.provenance` | **Guarded** (the measured failure) |
| `artifacts/artifactFileProvenance.ts:72` | `message.metadata.userVisible` | **Guarded** |
| `artifacts/artifactFileProvenance.ts:74,86` | `message.content` | **Guarded** (read once into a local) |
| `sessions/SessionViewComponents.tsx:110` | `getTextContent` → `message.content` | Normalised at the boundary |
| `sessions/SessionViewComponents.tsx:137,146,147` | `message.content` | Normalised at the boundary |
| `sessions/SessionViewComponents.tsx:172` | `message.metadata?.provenance` | Already guarded before this PR |
| `ProgressiveMessageList.tsx:222` | `message.metadata.userVisible` | **Left as-is, deliberately** |
| `sessions/SessionHistoryView.tsx:53` | `isUserMessage` → `message.content` | **Left as-is, deliberately** |
| `types/message.ts:98,107` | `getTextContent` / `getToolRequests` → `message.content` | **Left as-is, deliberately** |

The three left alone are all on the **saved-transcript / live-chat** path, whose messages come from
the local daemon through the generated client and always satisfy the type. `filePathLookupBeforeMessage`
has exactly two callers — `SessionViewComponents.tsx:129` (the shared, remote transcript) and
`BioRouterMessage.tsx:130` (local) — and `fetchSharedSessionDetails` has exactly one caller
(`sessionLinks.ts:57`), so the remote payload has one funnel and it is now normalised.

Guarding the local-daemon consumers as well would be the N-call-sites drift this PR is arguing
against, and in `ProgressiveMessageList`'s case it would be actively worse: `!m.metadata?.userVisible`
inverts to *hide* a shapeless message, silently swallowing it, and the two lines after it read
`message.content` anyway — converting one crash into a different crash on a path that cannot receive
the payload.

`NotebookPreview.tsx` reads `notebook.metadata?.…` (already optional, and a different type). Every
other `.metadata.` hit in `src/` is `provider.metadata` on `ProviderDetails` from a local config
route — unrelated.

## Tests

Three suites, each falsified against the unguarded code before being kept.

- `src/components/sessions/SessionViewComponents.artifactLinks.test.tsx` — renders a transcript
  containing a message with no `metadata` at all and asserts it still renders, and that the later
  link degrades to the working directory rather than crashing.
- `src/components/artifacts/artifactFileProvenance.test.ts` — the index throws nothing and indexes
  nothing for a message missing `metadata` *or* `content`, while still indexing the well-formed one.
- `src/sharedSessions.test.ts` (new) — `normalizeSharedMessages` fills the container fields, leaves
  scalars alone, shows a message with no visibility flag, honours an explicit `false`, drops
  non-message entries; plus a `fetchSharedSessionDetails` test with a stubbed `fetch` proving the
  normaliser is actually wired into the fetch.

### Falsification (required, and run)

**Reverting `artifactFileProvenance.ts` to `origin/main`:**

```
 × indexes nothing, and throws nothing, for a message missing metadata or content
 × renders the transcript when a message carries no metadata at all
FAIL src/components/artifacts/artifactFileProvenance.test.ts
TypeError: Cannot read properties of undefined (reading 'provenance')
FAIL src/components/sessions/SessionViewComponents.artifactLinks.test.tsx
TypeError: Cannot read properties of undefined (reading 'provenance')
 Test Files  2 failed (2)
      Tests  2 failed | 12 passed (14)
```

Note the error string is the one measured in the GUI, not merely "a failure".

**Reverting `sharedSessions.ts`:** all 5 fail. Four are `normalizeSharedMessages is not a function`
(the export is gone); the fifth is the behavioural one that matters —

```
AssertionError: expected undefined to deeply equal { userVisible: true, …(1) }
```

i.e. `fetchSharedSessionDetails` hands the transcript a message whose `metadata` is `undefined`.

### GUI reproduction (calibrated)

Driven over CDP against the dev GUI built from this worktree, injecting a `SharedSessionDetails`
whose messages carry no `metadata` into `window.history.state` on `#/shared-session`:

| Renderer source | Result |
|---|---|
| `origin/main` (unguarded) | `errorBoundary: true`, `Cannot read properties of undefined (reading 'provenance')`, neither message rendered |
| this branch | `errorBoundary: false`, both messages and the transcript header rendered |

⚠ The first attempt at this check was **un-calibrated and would have been reported as a false pass**:
under `BIOROUTER_NO_HMR=1` vite runs with `watch: { ignored: ['**'] }` and kept serving the cached
transform, so reverting the file on disk changed nothing and the page still rendered. Vite has to be
restarted between arms. Both arms above were taken with a fresh vite process.

## Verification

All commands run in `ui/desktop` on the committed tree.

```
$ npx vitest run src/components/sessions src/components/artifacts
 Test Files  23 passed (23)
      Tests  379 passed (379)

$ npx vitest run src/sharedSessions.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npm run test:run          # whole renderer suite
 Test Files  409 passed (409)
      Tests  4506 passed | 1 skipped (4507)

$ npm run lint:check        # tsc --noEmit + eslint --max-warnings 0 + themes + contrast + tokens
EXIT=0
OK — all 332 contrast assertions pass
OK — every semantic colour token used by a utility has a @theme inline mirror

$ npx prettier --check <the five changed files>
All matched files use Prettier code style!
```

Baseline before the change was 23 files / 377 tests on the first command; the delta is exactly the
seven tests added.

## Follow-ups

- `safeJsonParse<T>` (`utils/conversionUtils.ts`) is a bare `as T` cast used by several remote
  fetches. This PR validates the one payload that reaches the transcript; the pattern is worth a
  look elsewhere, but not in a fix this size.
- `createSharedSession` sends `messages` outward unvalidated. Harmless today (they come from the
  local daemon), and out of scope here.
- `ProgressiveMessageList` / `getTextContent` / `isUserMessage` remain non-total over message shape,
  by the reasoning above. If a second remote `Message[]` source is ever added, it should go through
  a normaliser at *its* boundary rather than making those helpers defensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
