### PR TITLE
Desktop: warn when the viewport is pinned by DevTools emulation, and ship a viewport check script

### DIFF
--- a/docs/desktop-ui/agent-browser-debugging.md
+++ b/docs/desktop-ui/agent-browser-debugging.md
@@ -75,6 +75,55 @@ print the canonical workflows and the full command reference.
 If the app was already running on the wrong port, quit it and relaunch — the
 `--remote-debugging-port` switch is only read at startup.
 
+## Reset the viewport you set
+
+> **Rule.** Any driver that sets the viewport — `agent-browser set_viewport`,
+> Playwright's `setViewportSize`, DevTools device mode — **must reset it before it
+> detaches.** Leaving it set is the single most expensive mistake available at
+> this endpoint.
+
+All three apply `Emulation.setDeviceMetricsOverride`, which pins the renderer's
+viewport to a fixed size regardless of the real window. **The override outlives
+your `agent-browser close`** — measured: a viewport pinned at 1440×900 was still
+pinned after the session that set it had closed. Detaching does not undo the
+emulation, it only removes the one session that could have. What the next person
+sees is an app that no longer scales with its window, with a blank band below and
+to the right of the page. It reads as a CSS regression and is not one. This repo
+has burned hours on it at least twice; the full story, and the measurements, are
+in [When the app "stops scaling with the window"](window-scaling-regressions.md),
+under *Viewport emulation pins `innerWidth`*.
+
+Worse, an **orphaned** override freezes `outerWidth` as well as `innerWidth`, so
+the page reports a window size that the window manager disagrees with — the OS
+resize really happened, and the page denies it. That is why the reset belongs in
+the session that set it, while it still can.
+
+How to reset, in order of preference:
+
+```bash
+# 1. Best: in the SAME session that set it, before detaching.
+agent-browser set_viewport 0 0        # or the tool's own clear/reset
+# 2. Check any instance at any time — exit 0 clean, 1 pinned, 2 harness problem.
+cd ui/desktop && npm run cdp:viewport-check -- 9333
+# 3. Stopgap only, from another session. Read the caveat below first.
+npm run cdp:viewport-check -- 9333 --clear
+```
+
+⚠ **A clear from a *different* CDP session is not a cure — it is a coin flip.**
+Chromium keeps emulation state per DevTools session, so a foreign session has to
+apply its own override before it can drop one, and what it hands back is not the
+state the page started in. Measured 2026-09-08 on the affected instance: the
+clear restored `inner == outer` immediately and left the renderer
+**half-frozen**, following the next OS resize once and then stopping with
+`outerWidth` stale. Measured on a fresh instance pinned the same way: it
+recovered completely. Nothing visible tells the two apart, and the clean-looking
+outcome is the one that costs you the next hour. **Restart the instance** unless
+a restart would cost you the state you are debugging.
+
+In a development build the app now warns about this itself — a `Viewport pinned
+at …` line in the renderer console — so a driver that forgets the reset at least
+leaves evidence for whoever finds the app next.
+
 ## Optional: the agent-browser MCP server
 
 `.mcp.json` also registers an `agent-browser` MCP server (`agent-browser mcp --tools
@@ -83,6 +132,7 @@ session start; use the `connect` or `cdp` tools at runtime to point it at port 9
 
 ## Related documentation
 
+- [When the app "stops scaling with the window"](window-scaling-regressions.md) — the impostor a forgotten `set_viewport` creates, and how to tell it from a real layout bug.
 - [Diverge behavior checklist](diverge-behavior-checklist.md) — the desktop QA script whose `[UI]` items you drive with exactly this setup.
 - [Environment variables](../configuration/environment-variables.md) — reference for `PLAYWRIGHT_CDP_PORT`, `BIOROUTER_PATH_ROOT`, and the other knobs used above.
 - [Diagnostics and bug reports](../troubleshooting/diagnostics-and-bug-reports.md) — what to collect once you have reproduced a GUI failure.

--- a/docs/desktop-ui/window-scaling-regressions.md
+++ b/docs/desktop-ui/window-scaling-regressions.md
@@ -14,7 +14,11 @@ triage below before changing any CSS.
 
 ## Triage: two minutes, in this order
 
-Run these against the dev GUI over CDP (see
+**Read the renderer's console first.** In a development build the app diagnoses
+the commonest of these itself: a line beginning `Viewport pinned at …` means the
+tooling pinned the viewport and no reading below can be trusted — skip straight
+to *Viewport emulation*, and do not open the CSS. Then run these against the dev
+GUI over CDP (see
 [Debugging the dev GUI with agent-browser](agent-browser-debugging.md)).
 
 ```js
@@ -32,7 +36,7 @@ getComputedStyle(document.documentElement).getPropertyValue('--measure-chat')
 |---------|-----------|
 | `text` is `Loading BioRouter…` and the console is EMPTY | **Not a layout bug.** The renderer's assets 404'd — see *`--base ./`* below. |
 | `text` empty, or `hash` is `#/pair` | **Not a layout bug.** The app is not rendering — see *A dead daemon* below. |
-| `inner` ≠ `outer` | **Not a layout bug.** Your tooling pinned the viewport — see *Viewport emulation* below. |
+| `inner` ≠ `outer`, or the console carries `Viewport pinned at …` | **Not a layout bug.** Your tooling pinned the viewport — confirm with `npm run cdp:viewport-check -- <port>` and see *Viewport emulation* below. |
 | `inner` = `outer`, and neither changes when you resize | **Not a layout bug.** Your resize command silently did nothing — see *AppleScript* below. |
 | Everything tracks, but the view is **Settings**, **Home**, **Chat history** or a saved/shared transcript, and its column stops at 760px | **Not a layout bug.** All of them read the chat measure by decision — see *Settings and Chat history, on the chat measure* below. |
 | Everything tracks, but content stays the same width | **The real one.** A fixed pixel cap — see below. |
@@ -235,12 +239,134 @@ the running app.
 the renderer's viewport regardless of the real window. Resizing the OS window
 then changes nothing on screen and every measurement lies.
 
+**This repo has now hit it at least twice**, and the second time it arrived as a
+bug report about the merged `main` — "weird empty space at the bottom", "the app
+doesn't scale with the window", with a screenshot of Provider Configuration
+ending at a fixed area inside a larger window. The three subsections below are
+what that recurrence bought: a warning the app prints itself, a script that
+answers the question in one command, and the measurement that settles which cure
+actually works.
+
 **Tell:** `outerWidth` moves and `innerWidth` does not. Observed as
 `outer: [800, 600]` with `inner: [1400, 900]` — a round 1400×900 that nobody set
 is itself the giveaway.
 
-**Fix:** use a fresh session with no override, or set the viewport explicitly to
-the size you mean to test.
+#### First line of defence: the app says so itself
+
+In a **development** build the renderer checks its own viewport against its
+window on load and after every (debounced) resize, and `console.warn`s once per
+distinct pinned size:
+
+> Viewport pinned at 1440×900 while the window is 1638×963: a DevTools
+> device-metrics override (agent-browser set_viewport, Playwright
+> setViewportSize, or DevTools device mode) is holding the renderer, so the
+> layout cannot follow the window and every measurement lies — this is NOT a
+> layout bug. …
+
+The decision lives in `ui/desktop/src/utils/viewportPin.ts`
+(`describeViewportPin`), a module with no React and no DOM, unit-tested in
+`viewportPin.test.ts`; `renderer.tsx` installs it behind `import.meta.env.DEV`,
+so it is dropped from a packaged bundle entirely. It is a console line and
+nothing else — never a toast, never a throw. A user who has never opened
+DevTools cannot cause this and is never shown it.
+
+The tolerances are the tell above, made precise: macOS windows have **no side
+frame**, so any width difference at all is emulation; the height may differ by
+the title bar (40px allowed, ~28px real); Windows and Linux get 16px more on
+both axes for their frame. The comparison is signed, so a viewport *larger* than
+its window is a pin on every platform.
+
+#### Diagnosis: one command
+
+```bash
+cd ui/desktop
+npm run cdp:viewport-check -- 9333          # exit 0 = clean, 1 = PINNED, 2 = harness
+npm run cdp:viewport-check -- 9333 --json
+npm run cdp:viewport-check -- 9333 --clear  # attempt the clear too; read the caveat below
+```
+
+`scripts/cdp-viewport-check.mjs` prints `inner`, `outer` and `client` for the
+Biorouter page and applies the same tolerances as the renderer's warning. Node
+≥ 22, no dependencies — deliberately, because the thing being debugged is the
+tooling.
+
+#### Fix: restart the instance
+
+Use a fresh session with no override, or set the viewport explicitly to the size
+you mean to test. Once an override is already stuck, **restart the instance** —
+or have the driver session that set it clear it before detaching (see
+[Debugging the dev GUI with agent-browser](agent-browser-debugging.md), "Reset
+the viewport you set").
+
+⚠ **Clearing the override from a *different* CDP session is unreliable — it is
+not the cure, even when it looks like one.** Chromium keeps emulation state per
+DevTools session, so a foreign session has to apply its own override before it
+can drop one, and what it hands back is not the state the page started in. Both
+outcomes have been measured:
+
+- On the operator's affected instance (2026-09-08) the clear restored
+  `inner == outer` at once and left the renderer **half-frozen** — it followed
+  the next OS resize once and then stopped, with `outerWidth` stale.
+- On a fresh instance pinned and cleared the same way while building this guard,
+  the clear recovered fully and the next three OS resizes tracked exactly.
+
+You cannot tell from inside which one you got, and the second is the dangerous
+one: it looks fixed. A **restart**, with no emulation ever applied, tracked OS
+resizes exactly at 1200×800, 1900×1050 and 1440×1000 in both runs. `--clear`
+exists only for the case where a restart would cost you the state you are
+debugging; it is a stopgap, and the script says so.
+
+#### The measurements
+
+The two affected instances, over CDP, with the layout correct throughout
+(2026-09-08):
+
+| Instance | `inner` | `outer` | Verdict |
+|---|---|---|---|
+| A | 1440×900 | 1638×963 | pinned — width differs at all on macOS |
+| B | 1440×900 | 1440×1000 | pinned — width *matched*, height off by 100 |
+
+Instance B is the one worth remembering: a check that compares widths alone
+passes it. The override came from an `agent-browser set_viewport(1440, 900)`
+during a post-merge test drive, which is why the rule in
+[agent-browser-debugging.md](agent-browser-debugging.md) now names resetting it
+as part of the call.
+
+**A live override and an orphaned one are not the same state**, which is most of
+why this is so confusing to look at. Both were reproduced on a dev instance
+while building the guard:
+
+| State | `inner` | `outer` on an OS resize |
+|---|---|---|
+| Override live, setting session still attached | pinned | **follows the window** |
+| Override orphaned — setting session detached | pinned | **freezes too** |
+
+So an override survives `agent-browser close`; detaching does not undo it, it
+only takes the last thing that could. In the orphaned state the window really
+does move — `get size of window 1` reads back the new size — while the page
+insists on both numbers it had at the moment it was orphaned. That stale
+`outerWidth` is the reading that makes people doubt the OS resize itself.
+
+⚠ **Two blind spots, stated so nobody assumes the warning's silence is an
+all-clear.** The check script is the backstop for both — it measures on demand
+and depends on no event.
+
+1. **A pin at exactly the window size, then orphaned.** Warning and script both
+   compare `inner` against `outer`, and an orphaned override freezes both, so
+   they stop moving while still agreeing and the page has nothing to disagree
+   with. While the setting session is still attached this resolves itself:
+   measured, a 1440×1000 pin on a 1440×1000 window was invisible until the window
+   moved, at which point `outer` followed to 1200×800 and the warning fired. The
+   uncoverable combination needs a driver to pin the window's exact current size
+   *and* detach, which neither recurrence did.
+2. **A `resize` Chromium never emits.** The warning runs on load and on resize,
+   so it is only as reliable as that event. Measured: a fresh instance pinned by
+   a driver fires one and the warning appears (reproduced twice), but an override
+   *stacked on an already-emulated page* did not always emit one, and the warning
+   stayed silent until something else caused a resize — while
+   `npm run cdp:viewport-check` reported the pin correctly throughout. **If the
+   symptom is there and the console is quiet, run the script before believing the
+   silence.**
 
 ### `osascript … set size of front window` silently no-ops
 

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -47,7 +47,8 @@
     "check:contrast": "node scripts/check-contrast.mjs",
     "check:tokens": "node scripts/check-token-mirrors.mjs",
     "themes": "node scripts/generate-themes.mjs",
-    "check:themes": "node scripts/generate-themes.mjs --check"
+    "check:themes": "node scripts/generate-themes.mjs --check",
+    "cdp:viewport-check": "node scripts/cdp-viewport-check.mjs"
   },
   "dependencies": {
     "@aiden0z/pptx-renderer": "^1.2.4",

--- a/ui/desktop/scripts/cdp-viewport-check.mjs
+++ b/ui/desktop/scripts/cdp-viewport-check.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// Is a DevTools emulation override pinning the dev GUI's viewport?
+//
+//   node scripts/cdp-viewport-check.mjs [port]          # default 9333
+//   npm run cdp:viewport-check -- 9333
+//   npm run cdp:viewport-check -- 9333 --clear          # also try to clear it
+//   npm run cdp:viewport-check -- 9333 --json
+//
+// Exit 0 = the viewport follows the window · 1 = PINNED · 2 = harness problem
+// (no CDP endpoint, no page target).
+//
+// WHY THIS EXISTS. `agent-browser set_viewport`, Playwright's `setViewportSize`
+// and DevTools device mode all apply `Emulation.setDeviceMetricsOverride`, which
+// fixes the renderer's viewport regardless of the real window. Resizing the OS
+// window then changes nothing on screen, a blank band opens below and to the
+// right of the page, and every measurement taken afterwards is a lie. It reads
+// exactly like a layout regression and is not one — see
+// docs/desktop-ui/window-scaling-regressions.md, "Viewport emulation pins
+// innerWidth". Measured on 2026-09-08 across two running instances:
+// inner 1440×900 against outer 1638×963 and outer 1440×1000, with the layout
+// correct throughout.
+//
+// THE TELL. macOS windows have no side frame, so `outerWidth` and `innerWidth`
+// agree exactly on an unpinned window and any width difference at all is
+// emulation; the height differs by the title bar (~28px). This script applies
+// the same tolerances as the renderer's own dev-time warning
+// (src/utils/viewportPin.ts) — 40px of title bar everywhere, plus 16px of frame
+// on Windows and Linux.
+//
+// --clear IS NOT THE CURE, AND SAYS SO. Chromium keeps emulation state per
+// DevTools session, so a session that never enabled emulation is a no-op on
+// clear — hence the apply-then-clear dance below, which is what actually resets
+// the widget. A foreign clear is UNRELIABLE, and both outcomes are measured:
+// on the affected instance (2026-09-08) it restored `inner === outer` at once
+// and left the renderer half-frozen — one more OS resize, then nothing, with
+// `outerWidth` stale; on a fresh instance pinned and cleared the same way it
+// recovered fully. You cannot tell from inside which you got, and the good
+// outcome is the dangerous one because it looks fixed. A clean restart, with no
+// emulation ever applied, tracked OS resizes exactly at 1200×800, 1900×1050 and
+// 1440×1000 in both runs. **Restart the instance.**
+//
+// KNOWN BLIND SPOT. `inner` vs `outer` cannot see a pin applied at exactly the
+// window size and then ORPHANED by a driver that detaches: an orphaned override
+// freezes `outerWidth` too, so both numbers stop moving while still agreeing.
+// While the setting session is attached, `outer` follows the window and the next
+// resize exposes it. Neither real recurrence took that shape. The ground truth is
+// the window manager — on macOS, compare against
+//   osascript -e 'tell application "System Events" to tell (first process whose
+//     unix id is <pid>) to get size of window 1'
+// and remember to READ THE SIZE BACK after any resize you command.
+//
+// Node ≥ 22 (global `fetch` and `WebSocket`); no dependencies, deliberately —
+// this has to run when the thing you are debugging is the tooling itself.
+
+const args = process.argv.slice(2);
+const port = args.find((a) => /^\d+$/.test(a)) ?? '9333';
+const shouldClear = args.includes('--clear');
+const asJson = args.includes('--json');
+
+/** Height the window chrome may legitimately eat. Mirrors TITLE_BAR_SLACK_PX. */
+const TITLE_BAR_SLACK_PX = 40;
+/** Side/bottom frame allowance on Windows and Linux. Mirrors WINDOW_FRAME_SLACK_PX. */
+const WINDOW_FRAME_SLACK_PX = 16;
+
+const die = (code, message) => {
+  console.error(message);
+  process.exit(code);
+};
+
+let list;
+try {
+  list = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+} catch (err) {
+  die(2, `could not reach CDP on :${port} — is the dev GUI running there?\n${err.message}`);
+}
+
+const page = list.find(
+  (t) => t.type === 'page' && !t.url.startsWith('chrome-extension') && !t.url.startsWith('devtools')
+);
+if (!page) die(2, `no page target on CDP port ${port}`);
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise((resolve, reject) => {
+  ws.onopen = resolve;
+  ws.onerror = () => reject(new Error(`could not open a CDP session on :${port}`));
+}).catch((err) => die(2, err.message));
+
+let nextId = 0;
+const send = (method, params = {}) =>
+  new Promise((resolve, reject) => {
+    const id = ++nextId;
+    const onMessage = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.id !== id) return;
+      ws.removeEventListener('message', onMessage);
+      msg.error ? reject(new Error(`${method}: ${msg.error.message}`)) : resolve(msg.result);
+    };
+    ws.addEventListener('message', onMessage);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+
+const measure = async () => {
+  const { result } = await send('Runtime.evaluate', {
+    expression: `JSON.stringify({
+      inner: [innerWidth, innerHeight],
+      outer: [outerWidth, outerHeight],
+      client: [document.documentElement.clientWidth, document.documentElement.clientHeight],
+      dpr: devicePixelRatio,
+      platform: (window.electron && window.electron.platform) || 'unknown'
+    })`,
+    returnByValue: true,
+  });
+  return JSON.parse(result.value);
+};
+
+/**
+ * The same signed comparison the renderer makes. Signed, not absolute: window
+ * chrome only ever makes `outer` bigger, so a viewport LARGER than its window
+ * can only have come from emulation, however small the difference.
+ */
+function diagnose(m) {
+  const [iw, ih] = m.inner;
+  const [ow, oh] = m.outer;
+  if (![iw, ih, ow, oh].every((v) => Number.isFinite(v) && v > 0)) {
+    return { pinned: false, note: 'a dimension read as zero — window hidden or minimized' };
+  }
+  const framed = m.platform !== 'darwin';
+  const widthSlack = framed ? WINDOW_FRAME_SLACK_PX : 0;
+  const heightSlack = TITLE_BAR_SLACK_PX + (framed ? WINDOW_FRAME_SLACK_PX : 0);
+  const dw = ow - iw;
+  const dh = oh - ih;
+  const pinned = dw < 0 || dw > widthSlack || dh < 0 || dh > heightSlack;
+  return { pinned, deltas: [dw, dh], slack: [widthSlack, heightSlack] };
+}
+
+const fmt = (m) =>
+  `inner ${m.inner[0]}×${m.inner[1]}  outer ${m.outer[0]}×${m.outer[1]}  ` +
+  `client ${m.client[0]}×${m.client[1]}  dpr ${m.dpr}  platform ${m.platform}`;
+
+const before = await measure();
+const verdict = diagnose(before);
+
+let after = null;
+if (shouldClear && verdict.pinned) {
+  // Apply, then clear: a DevTools session that never enabled emulation is a
+  // no-op on clear, so this session has to own an override before it can drop one.
+  await send('Emulation.setDeviceMetricsOverride', {
+    width: 0,
+    height: 0,
+    deviceScaleFactor: 0,
+    mobile: false,
+  });
+  await send('Emulation.clearDeviceMetricsOverride');
+  await new Promise((r) => setTimeout(r, 300)); // let the renderer relayout
+  after = await measure();
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ port, title: page.title, before, after, ...verdict }, null, 2));
+} else {
+  console.log(`port ${port} (${page.title})`);
+  console.log(`  ${fmt(before)}`);
+  if (after) console.log(`  after clear: ${fmt(after)}`);
+  if (verdict.note) console.log(`  ${verdict.note}`);
+  if (verdict.pinned) {
+    console.log('');
+    console.log('PINNED: a DevTools device-metrics override is holding the viewport.');
+    console.log(
+      `  outer − inner = ${verdict.deltas[0]}×${verdict.deltas[1]}px, past the ` +
+        `${verdict.slack[0]}×${verdict.slack[1]}px this platform's window chrome can explain.`
+    );
+    console.log('  The layout is NOT at fault. Do not go looking in the CSS.');
+    console.log('');
+    if (after) {
+      console.log(
+        'A clear was attempted from THIS session, and even when it restores inner === outer'
+      );
+      console.log(
+        "it is not a fix: clearing another session's override was measured on 2026-09-08 to"
+      );
+      console.log(
+        'leave the renderer HALF-FROZEN — it followed the next OS resize once and then stopped,'
+      );
+      console.log('with outerWidth stale.');
+    }
+    console.log('The sure cure is to RESTART the instance (no emulation ever applied), or to');
+    console.log('have the driver session that set the override clear it before detaching.');
+  } else {
+    console.log('  viewport follows the window');
+  }
+}
+
+ws.close();
+process.exit(verdict.pinned ? 1 : 0);

--- a/ui/desktop/src/renderer.tsx
+++ b/ui/desktop/src/renderer.tsx
@@ -14,6 +14,10 @@ import { wrapArtifactForBrowser } from './utils/artifactSecurity';
 // detects. `utils/surface.ts` imports nothing and touches only `document`, so
 // pulling it in here cannot disturb the polyfill above.
 import { BROWSER_SURFACE_BODY_CLASS, BROWSER_SURFACE_MARKER } from './utils/surface';
+// Development-only self-diagnosis for the "app doesn't scale with the window"
+// impostor. Like `utils/surface`, this module has no top-level side effects and
+// touches no global at import time, so it cannot disturb the polyfill above.
+import { installViewportPinWarning } from './utils/viewportPin';
 
 const App = lazy(() => import('./App'));
 
@@ -535,6 +539,17 @@ if (needsHeadlessElectron || typeof window.appConfig === 'undefined') {
 }
 
 (async () => {
+  // Say so in the console when a DevTools device-metrics override has pinned the
+  // viewport, so the next report of "the app doesn't scale with the window" does
+  // not cost anyone an hour in the CSS. Development only — `import.meta.env.DEV`
+  // is a build-time constant, so the call and the module behind it are dropped
+  // from a packaged bundle entirely. Installed BEFORE the daemon handshake below
+  // on purpose: a pinned viewport is worth knowing about even on the path where
+  // the backend never comes up and this function returns early.
+  if (import.meta.env.DEV) {
+    installViewportPinWarning();
+  }
+
   // Check if we're in the launcher view (doesn't need biorouterd connection)
   const isLauncher = window.location.hash === '#/launcher';
 

--- a/ui/desktop/src/utils/viewportPin.test.ts
+++ b/ui/desktop/src/utils/viewportPin.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  TITLE_BAR_SLACK_PX,
+  WINDOW_FRAME_SLACK_PX,
+  createViewportPinReporter,
+  describeViewportPin,
+  installViewportPinWarning,
+  type ViewportMetrics,
+} from './viewportPin';
+
+/**
+ * The decision this file guards is the one thing about the viewport warning
+ * that can be wrong in a way nobody notices: it fires on tooling state, in
+ * development only, so a false alarm lands squarely in front of a developer who
+ * is already hunting a layout bug, and a miss puts them back into the CSS for an
+ * hour. Both failure modes are cheap to assert here and expensive to discover
+ * in a running app, which is exactly why the arithmetic lives in a module with
+ * no React and no DOM.
+ *
+ * The sizes below are the ones actually measured on 2026-09-08 (see the module
+ * header), not invented ones.
+ */
+
+const mac = (over: Partial<ViewportMetrics> = {}): ViewportMetrics => ({
+  innerWidth: 1440,
+  innerHeight: 900,
+  outerWidth: 1440,
+  outerHeight: 928,
+  platform: 'darwin',
+  ...over,
+});
+
+describe('describeViewportPin', () => {
+  it('reports the real 2026-09-08 pin: inner 1440×900 inside a 1638×963 window', () => {
+    const message = describeViewportPin(mac({ outerWidth: 1638, outerHeight: 963 }));
+    expect(message).not.toBeNull();
+    expect(message).toContain('1440×900');
+    expect(message).toContain('1638×963');
+  });
+
+  it('reports the second instance too, where only the height differed (1440×1000)', () => {
+    // Width matched exactly, so a width-only check would have missed this one.
+    const message = describeViewportPin(mac({ outerWidth: 1440, outerHeight: 1000 }));
+    expect(message).not.toBeNull();
+    expect(message).toContain('1440×900');
+    expect(message).toContain('1440×1000');
+  });
+
+  it('names both sizes, the check command and the restart cure', () => {
+    const message = describeViewportPin(mac({ outerWidth: 1638, outerHeight: 963 }))!;
+    expect(message).toContain('1440×900');
+    expect(message).toContain('1638×963');
+    expect(message).toContain('npm run cdp:viewport-check');
+    expect(message).toContain('restart');
+    // The line exists to stop someone editing CSS, so it must say so outright.
+    expect(message).toContain('NOT a layout bug');
+  });
+
+  it('stays silent when the viewport matches the window exactly', () => {
+    expect(describeViewportPin(mac({ innerHeight: 928, outerHeight: 928 }))).toBeNull();
+  });
+
+  it('stays silent for a macOS title bar alone', () => {
+    // 28px of title bar, no side frame — the ordinary unpinned macOS reading.
+    expect(describeViewportPin(mac({ outerHeight: 928 }))).toBeNull();
+    // The boundary is inclusive: exactly the slack is still not a pin.
+    expect(describeViewportPin(mac({ outerHeight: 900 + TITLE_BAR_SLACK_PX }))).toBeNull();
+    expect(describeViewportPin(mac({ outerHeight: 900 + TITLE_BAR_SLACK_PX + 1 }))).not.toBeNull();
+  });
+
+  it('treats ANY width difference on macOS as a pin, because there is no side frame', () => {
+    expect(describeViewportPin(mac({ outerWidth: 1441 }))).not.toBeNull();
+    expect(describeViewportPin(mac({ outerWidth: 1448 }))).not.toBeNull();
+  });
+
+  it('allows a side frame on Windows and Linux', () => {
+    for (const platform of ['win32', 'linux']) {
+      const framed = {
+        platform,
+        outerWidth: 1440 + WINDOW_FRAME_SLACK_PX,
+        outerHeight: 900 + TITLE_BAR_SLACK_PX + WINDOW_FRAME_SLACK_PX,
+      };
+      expect(describeViewportPin(mac(framed))).toBeNull();
+      // One pixel past the frame allowance is a pin on those platforms too.
+      expect(
+        describeViewportPin(mac({ ...framed, outerWidth: 1440 + WINDOW_FRAME_SLACK_PX + 1 }))
+      ).not.toBeNull();
+      expect(
+        describeViewportPin(
+          mac({ ...framed, outerHeight: 900 + TITLE_BAR_SLACK_PX + WINDOW_FRAME_SLACK_PX + 1 })
+        )
+      ).not.toBeNull();
+    }
+  });
+
+  it('treats a viewport LARGER than its window as a pin on every platform', () => {
+    // Window chrome only ever makes `outer` bigger, so this direction can only
+    // come from emulation — and the signed comparison is what catches it inside
+    // the Windows frame allowance, where an absolute difference would not.
+    expect(describeViewportPin(mac({ innerWidth: 1450 }))).not.toBeNull();
+    expect(
+      describeViewportPin(mac({ platform: 'win32', innerWidth: 1450, outerWidth: 1440 }))
+    ).not.toBeNull();
+    expect(
+      describeViewportPin(mac({ platform: 'win32', innerHeight: 940, outerHeight: 928 }))
+    ).not.toBeNull();
+  });
+
+  it('says nothing when a dimension is unmeasurable', () => {
+    // A minimized or not-yet-shown window reports 0 for `outer`; reading that as
+    // "the viewport is larger than the window" would warn on a state that is not
+    // a pin at all.
+    expect(describeViewportPin(mac({ outerWidth: 0, outerHeight: 0 }))).toBeNull();
+    expect(describeViewportPin(mac({ innerWidth: 0 }))).toBeNull();
+    expect(describeViewportPin(mac({ outerHeight: Number.NaN }))).toBeNull();
+    expect(describeViewportPin(mac({ innerHeight: Number.POSITIVE_INFINITY }))).toBeNull();
+    expect(describeViewportPin(mac({ outerWidth: -1638 }))).toBeNull();
+  });
+
+  it('treats an unknown platform as framed rather than as macOS', () => {
+    // Guessing "no side frame" for a platform we have never measured would turn
+    // every window on it into a false alarm.
+    expect(
+      describeViewportPin(mac({ platform: 'freebsd', outerWidth: 1440 + WINDOW_FRAME_SLACK_PX }))
+    ).toBeNull();
+  });
+});
+
+describe('createViewportPinReporter', () => {
+  it('warns once per distinct pinned size, not once per resize event', () => {
+    const warn = vi.fn();
+    const report = createViewportPinReporter(warn);
+    const pinned = mac({ outerWidth: 1638, outerHeight: 963 });
+
+    report(pinned);
+    report(pinned);
+    report(pinned);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // A different window size around the same pinned viewport is a new reading.
+    report(mac({ outerWidth: 1900, outerHeight: 1050 }));
+    expect(warn).toHaveBeenCalledTimes(2);
+
+    // ...and a different pinned viewport is a second, separate mistake.
+    report(mac({ innerWidth: 1280, innerHeight: 800, outerWidth: 1900, outerHeight: 1050 }));
+    expect(warn).toHaveBeenCalledTimes(3);
+  });
+
+  it('never warns for an unpinned window, however many times it is asked', () => {
+    const warn = vi.fn();
+    const report = createViewportPinReporter(warn);
+    for (let i = 0; i < 50; i += 1) report(mac());
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('installViewportPinWarning', () => {
+  function fakeWindow(metrics: Omit<ViewportMetrics, 'platform'>) {
+    const listeners = new Set<() => void>();
+    return {
+      ...metrics,
+      addEventListener: (type: string, fn: () => void) => {
+        if (type === 'resize') listeners.add(fn);
+      },
+      removeEventListener: (type: string, fn: () => void) => {
+        if (type === 'resize') listeners.delete(fn);
+      },
+      fireResize: () => listeners.forEach((fn) => fn()),
+      listenerCount: () => listeners.size,
+    };
+  }
+
+  it('checks on install and again after a debounced resize', () => {
+    vi.useFakeTimers();
+    const warn = vi.fn();
+    const win = fakeWindow({
+      innerWidth: 1440,
+      innerHeight: 900,
+      outerWidth: 1440,
+      outerHeight: 928,
+    });
+
+    const teardown = installViewportPinWarning({
+      win: win as unknown as Window,
+      warn,
+      platform: 'darwin',
+      debounceMs: 400,
+    });
+    expect(warn).not.toHaveBeenCalled();
+
+    // The window grows; the emulated viewport does not follow.
+    win.outerWidth = 1638;
+    win.outerHeight = 963;
+    win.fireResize();
+    win.fireResize();
+    win.fireResize();
+    expect(warn).not.toHaveBeenCalled(); // still inside the debounce window
+    vi.advanceTimersByTime(400);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('1638×963');
+
+    // Further resizes at the same reading stay quiet.
+    win.fireResize();
+    vi.advanceTimersByTime(400);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    teardown();
+    expect(win.listenerCount()).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('defaults to the real window, and its teardown detaches from it', () => {
+    // jsdom reports inner === outer, i.e. an unpinned window, so this asserts the
+    // wiring itself: it attaches to the ambient window with no options at all and
+    // removes exactly what it added.
+    const warn = vi.fn();
+    const added = vi.spyOn(window, 'addEventListener');
+    const removed = vi.spyOn(window, 'removeEventListener');
+
+    const teardown = installViewportPinWarning({ warn });
+    expect(added).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(warn).not.toHaveBeenCalled();
+
+    teardown();
+    expect(removed).toHaveBeenCalledWith('resize', added.mock.calls[0][1]);
+
+    added.mockRestore();
+    removed.mockRestore();
+  });
+});

--- a/ui/desktop/src/utils/viewportPin.ts
+++ b/ui/desktop/src/utils/viewportPin.ts
@@ -1,0 +1,251 @@
+/**
+ * "The app doesn't scale with the window" — the impostor, caught by the app itself.
+ *
+ * A driver that calls `agent-browser set_viewport`, Playwright's
+ * `setViewportSize`, or DevTools device mode applies
+ * `Emulation.setDeviceMetricsOverride`, which pins the renderer's viewport to a
+ * fixed size regardless of the real window. The window then grows and the
+ * layout does not follow it, leaving a blank band below and to the right of the
+ * page. Every measurement taken afterwards is a lie, and the report that
+ * reaches a developer is "the app stopped rescaling" — which sends them into
+ * the CSS, where nothing is wrong.
+ *
+ * This has now been diagnosed at least twice in this repo. On **2026-09-08** two
+ * running instances both measured `inner 1440×900` against `outer 1638×963` and
+ * `outer 1440×1000`; a clean restart of one of them, with no emulation ever
+ * applied, tracked OS resizes exactly at 1200×800, 1900×1050 and 1440×1000. The
+ * layout was correct throughout. The full triage — and the four other ways this
+ * symptom arrives — is `docs/desktop-ui/window-scaling-regressions.md`, under
+ * "Viewport emulation pins `innerWidth`".
+ *
+ * ⚠ **Two things this cannot see**, stated here so nobody reads its silence as an
+ * all-clear. `scripts/cdp-viewport-check.mjs` is the backstop for both: it
+ * measures on demand and depends on no event at all.
+ *
+ *   1. **A pin at exactly the window size, then orphaned.** An orphaned override
+ *      (the driver that set it has detached) freezes `outerWidth` as well as
+ *      `innerWidth`, so both numbers stop moving while still agreeing and there
+ *      is nothing left inside the page to compare. While the setting session is
+ *      still attached the case resolves itself — `outer` follows the next resize
+ *      and the warning fires. Neither real recurrence took this shape: both
+ *      pinned a round 1440×900 that never matched the window.
+ *   2. **A `resize` that Chromium never emits.** The check runs on load and on
+ *      `resize`, so it is only as reliable as that event. Measured: a fresh page
+ *      pinned by a driver fires one and the warning appears; but an override
+ *      *stacked on an already-emulated page* did not always emit one, and the
+ *      warning stayed silent until something else caused a resize. Load plus
+ *      resize is still the right trigger set — a poll would burn a timer forever
+ *      to catch a case the script already covers.
+ *
+ * `outer` is the best reference available from inside the renderer either way;
+ * the ground truth is the window manager, which only the script's caller can ask.
+ *
+ * So the app says so itself, in development, the moment it can see the
+ * discrepancy. This module is the whole decision, and it is deliberately free of
+ * React, of the DOM and of any global: a diagnosis you can only exercise by
+ * launching an Electron app and pinning its viewport is a diagnosis nobody
+ * re-tests. `installViewportPinWarning` below is the only part that touches a
+ * window, and it decides nothing.
+ *
+ * Three rules govern what this may do, all for the same reason — the warning
+ * fires on *tooling* state, not on user state, so it must never cost the user
+ * anything:
+ *
+ *   * **Development only.** Never in a packaged app. A user who has never opened
+ *     DevTools cannot cause this and must never be shown it.
+ *   * **`console.warn`, never a toast and never a throw.** The audience is the
+ *     developer or agent whose own driver left the override behind, and the
+ *     console is where they are already looking.
+ *   * **Once per distinct pinned size.** A `resize` handler that warns on every
+ *     event buries the console under hundreds of identical lines during a single
+ *     window drag, which is how a real warning stops being read.
+ */
+
+export interface ViewportMetrics {
+  /** `window.innerWidth` — the renderer's viewport, which emulation overrides. */
+  innerWidth: number;
+  innerHeight: number;
+  /** `window.outerWidth` — the real OS window, which emulation cannot touch. */
+  outerWidth: number;
+  outerHeight: number;
+  /** `process.platform` / `window.electron.platform`: `darwin`, `win32`, `linux`. */
+  platform: string;
+}
+
+/**
+ * Height the window chrome may legitimately eat, on every platform.
+ *
+ * The real title bar is about 28px; 40 leaves room for a menu bar, a slightly
+ * different OS theme, and rounding, because the cost of the two errors is not
+ * symmetric. A tolerance that is too tight cries "pinned" at a window that is
+ * merely framed — a false alarm in the exact place a developer is looking for a
+ * layout bug, which is worse than silence. A tolerance that is too loose misses
+ * a pin of under 40px, and no override anyone has ever set by hand is that
+ * close to the window: the sizes that cause this are round ones like 1440×900.
+ */
+export const TITLE_BAR_SLACK_PX = 40;
+
+/**
+ * Extra slack for a platform whose windows have a side and bottom frame.
+ *
+ * macOS gets **none of it on the width axis**, and that is the sharpest signal
+ * this module has: a macOS window has no side frame at all, so `outerWidth` and
+ * `innerWidth` agree exactly on an unpinned window, and *any* width difference
+ * is emulation. Windows and Linux draw a border of a few pixels, plus a resize
+ * grip; 16 covers both without approaching the size of a real pin.
+ */
+export const WINDOW_FRAME_SLACK_PX = 16;
+
+interface Slack {
+  width: number;
+  height: number;
+}
+
+function slackFor(platform: string): Slack {
+  // The frame is on all four sides where it exists at all, so a platform that
+  // pays for it on the width axis pays for it on the height axis too — on top
+  // of the title bar, which every platform has.
+  if (platform === 'darwin') return { width: 0, height: TITLE_BAR_SLACK_PX };
+  return {
+    width: WINDOW_FRAME_SLACK_PX,
+    height: TITLE_BAR_SLACK_PX + WINDOW_FRAME_SLACK_PX,
+  };
+}
+
+function isMeasurable(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+/**
+ * The diagnosis, or `null` when the viewport plausibly follows the window.
+ *
+ * Pure. Returns `null` — never a false alarm — whenever it cannot tell:
+ *
+ *   * any dimension is zero or not finite. A minimized, hidden or not-yet-shown
+ *     window reports `outer` as `0`, and treating that as "the viewport is
+ *     larger than the window" would warn on a state that is not a pin at all.
+ *
+ * The comparison is **signed**, not absolute. Chrome only ever makes `outer`
+ * larger than `inner`, so a viewport that is *bigger* than its window can only
+ * have been set by emulation and is a pin on every platform, however small the
+ * difference — using `Math.abs` here would have let a 10px oversize through the
+ * 16px Windows frame allowance.
+ */
+export function describeViewportPin(metrics: ViewportMetrics): string | null {
+  const { innerWidth, innerHeight, outerWidth, outerHeight, platform } = metrics;
+
+  if (
+    !isMeasurable(innerWidth) ||
+    !isMeasurable(innerHeight) ||
+    !isMeasurable(outerWidth) ||
+    !isMeasurable(outerHeight)
+  ) {
+    return null;
+  }
+
+  const slack = slackFor(platform);
+  const widthDelta = outerWidth - innerWidth;
+  const heightDelta = outerHeight - innerHeight;
+  const pinned =
+    widthDelta < 0 || widthDelta > slack.width || heightDelta < 0 || heightDelta > slack.height;
+
+  if (!pinned) return null;
+
+  return (
+    `Viewport pinned at ${innerWidth}×${innerHeight} while the window is ` +
+    `${outerWidth}×${outerHeight}: a DevTools device-metrics override ` +
+    `(agent-browser set_viewport, Playwright setViewportSize, or DevTools device mode) ` +
+    `is holding the renderer, so the layout cannot follow the window and every ` +
+    `measurement lies — this is NOT a layout bug. Diagnose with ` +
+    `\`npm run cdp:viewport-check -- <cdp-port>\`; the sure cure is to restart this ` +
+    `instance, because clearing the override from a different CDP session was measured ` +
+    `to leave the renderer half-frozen (docs/desktop-ui/window-scaling-regressions.md).`
+  );
+}
+
+/**
+ * A reporter that warns at most once per distinct pinned size.
+ *
+ * Keyed on the *sizes*, not on "have I warned yet": a driver that pins 1440×900,
+ * is cleared, and later pins 1280×800 is two separate mistakes and deserves two
+ * lines, while a single drag of the window edge fires `resize` dozens of times
+ * at one pinned size and deserves one. Pure apart from the `warn` sink, so the
+ * dedup is testable without a DOM.
+ */
+export function createViewportPinReporter(
+  warn: (message: string) => void
+): (metrics: ViewportMetrics) => void {
+  const seen = new Set<string>();
+  return (metrics) => {
+    const message = describeViewportPin(metrics);
+    if (message === null) return;
+    const key = `${metrics.innerWidth}x${metrics.innerHeight}@${metrics.outerWidth}x${metrics.outerHeight}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    warn(message);
+  };
+}
+
+/** How long the window must be still before the check runs again. */
+export const VIEWPORT_PIN_DEBOUNCE_MS = 400;
+
+interface InstallOptions {
+  win?: Window;
+  warn?: (message: string) => void;
+  platform?: string;
+  debounceMs?: number;
+}
+
+/**
+ * Wire the check to a real window: once on install, and after every `resize`.
+ *
+ * The caller is responsible for the development guard — see `renderer.tsx`,
+ * which calls this behind `import.meta.env.DEV` so the whole thing is dropped
+ * from a production bundle. Returns a teardown function; the renderer never
+ * calls it, but a test does.
+ *
+ * Debounced because `resize` fires continuously while the edge is under the
+ * user's hand, and the interesting reading is the one taken after the window has
+ * settled — a mid-drag sample can differ from `outer` by more than the slack for
+ * a frame or two on its own.
+ */
+export function installViewportPinWarning(options: InstallOptions = {}): () => void {
+  const win = options.win ?? (typeof window === 'undefined' ? undefined : window);
+  if (!win) return () => {};
+
+  const warn = options.warn ?? ((message: string) => console.warn(message));
+  // `window.electron.platform` is the preload's `process.platform`. When it is
+  // missing the fallback must be the LENIENT (framed) reading, not `darwin`:
+  // guessing "no side frame" for a platform we cannot identify would turn every
+  // ordinary Windows window into a false alarm, and the pins actually observed
+  // here are hundreds of pixels wide — far past either tolerance.
+  const platform =
+    options.platform ??
+    (win as Window & { electron?: { platform?: string } }).electron?.platform ??
+    'unknown';
+  const debounceMs = options.debounceMs ?? VIEWPORT_PIN_DEBOUNCE_MS;
+  const report = createViewportPinReporter(warn);
+
+  const check = () =>
+    report({
+      innerWidth: win.innerWidth,
+      innerHeight: win.innerHeight,
+      outerWidth: win.outerWidth,
+      outerHeight: win.outerHeight,
+      platform,
+    });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const onResize = () => {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(check, debounceMs);
+  };
+
+  check();
+  win.addEventListener('resize', onResize);
+
+  return () => {
+    if (timer !== undefined) clearTimeout(timer);
+    win.removeEventListener('resize', onResize);
+  };
+}


### PR DESCRIPTION
## Why

"The app doesn't scale with the window", with weird empty space at the bottom, was reported again on the merged `main` — a screenshot of Provider Configuration ending at a fixed area inside a larger window. Measured over CDP on both running instances:

| Instance | `inner` | `outer` | Verdict |
|---|---|---|---|
| A | 1440×900 | 1638×963 | pinned — width differs at all on macOS |
| B | 1440×900 | 1440×1000 | pinned — width **matched**, height off by 100 |

That is impostor #2 in `docs/desktop-ui/window-scaling-regressions.md` — a DevTools `Emulation.setDeviceMetricsOverride` left behind by an `agent-browser set_viewport(1440, 900)` during a post-merge test drive. **The layout was correct throughout.** A clean restart, with no emulation ever applied, tracked OS resizes exactly at 1200×800, 1900×1050 and 1440×1000.

At least the second time this repo has paid for it. So this PR hardens the repo so the impostor is caught immediately next time — by the app itself and by the tooling — and says plainly that the sure cure is to restart the instance.

Instance B is the one worth remembering: its width matched exactly, so a check that compares widths alone passes it.

## What changed

**1. A dev-only viewport-pin warning.** `ui/desktop/src/utils/viewportPin.ts` holds the whole decision as a pure function — no React, no DOM — and `renderer.tsx` installs it behind `import.meta.env.DEV`, so it is dropped from a packaged bundle entirely. It is a `console.warn`, once per distinct pinned size: never a toast, never a throw, never in production. A user who has never opened DevTools cannot cause this and is never shown it.

The tolerances are the tell made precise. macOS windows have no side frame, so **any** width difference is emulation; height may differ by the title bar (40px allowed, ~28px real); Windows and Linux get 16px more on both axes. The comparison is **signed** rather than absolute, so a viewport *larger* than its window is a pin on every platform — an absolute difference would have let a 10px oversize through the Windows frame allowance.

**2. `ui/desktop/scripts/cdp-viewport-check.mjs`**, with `npm run cdp:viewport-check`. Prints `inner` / `outer` / `client`, exits **1** on a pin and **2** on a harness problem. Node ≥ 22, no dependencies, deliberately — the thing being debugged is the tooling. `--clear` attempts the apply-then-clear reset and then re-measures, but reports in so many words that it is a stopgap.

`package-lock.json` is untouched; the lock's root entry records no `scripts` key, and `npm ci --dry-run` against the modified `package.json` still succeeds.

**3. Docs.** The recurrence and its measurements, the warning as the first line of defence, the script as the diagnosis, and **restart** as the cure. One line in the two-minute triage points at the console warning. `agent-browser-debugging.md` gains the rule the recurrence earns: any driver that sets the viewport must reset it before detaching.

### Four things measured while building this, rather than assumed

Two of them correct what the earlier account implied:

- **A foreign-session `--clear` is a coin flip, not a cure.** It left the operator's renderer half-frozen (one more OS resize, then nothing, with `outerWidth` stale) and recovered a fresh instance completely. Nothing visible separates the two, and the clean-looking outcome is the one that costs the next hour.
- **A live override and an orphaned one are different states.** An override **survives `agent-browser close`** — detaching does not undo it, it only removes the one session that could. While the setting session is attached, `outer` follows the window; once orphaned, `outer` freezes too, so the page reports a size the window manager disagrees with. That stale `outerWidth` is what makes people doubt the OS resize itself.
- **Two blind spots**, documented at the top of `viewportPin.ts` so the warning's silence is never read as an all-clear: a pin at *exactly* the window size that is then orphaned, and a `resize` Chromium never emits. The script covers both.

## Tests

New: `src/utils/viewportPin.test.ts`, 14 tests — the two real 2026-09-08 pins, macOS title-bar-only (not pinned), the inclusive slack boundary, Windows/Linux frame tolerance and one pixel past it, a viewport larger than its window, unmeasurable dimensions, an unknown platform, the once-per-distinct-size dedup, and the debounced install/teardown.

```
npx vitest run src/utils/viewportPin.test.ts src/styles
 Test Files  17 passed (17)
      Tests  240 passed (240)

npm run test:run
 Test Files  422 passed (422)
      Tests  4739 passed | 1 skipped (4740)
test:run exit=0

npm run lint:check          exit=0
npx prettier --check <every changed file>   All matched files use Prettier code style!
npm ci --dry-run (isolated copy of the modified package.json + untouched lock)
                            added 1612 packages in 553ms, exit 0
```

## Verification

Driven against a dev instance built from this branch, on its own CDP port.

**The warning, observed in the real renderer console** after a single `agent-browser set_viewport(1440, 900)` on a freshly started instance (reproduced twice):

```
[warning] Viewport pinned at 1440×900 while the window is 1900×1050: a DevTools
device-metrics override (agent-browser set_viewport, Playwright setViewportSize, or
DevTools device mode) is holding the renderer, so the layout cannot follow the window
and every measurement lies — this is NOT a layout bug. Diagnose with
`npm run cdp:viewport-check -- <cdp-port>`; the sure cure is to restart this instance,
because clearing the override from a different CDP session was measured to leave the
renderer half-frozen (docs/desktop-ui/window-scaling-regressions.md).
```

The first run reproduced instance B exactly — `1440×900` pinned inside a `1440×1000` window, width matching.

**Dedup, in the real app:** three `set_viewport` calls (1440×900 → 1280×800 → back to 1440×900) produced exactly **two** warnings, one per distinct pinned size. The repeat was silent.

**The script, on a pinned page:**

```
port 9335 (Biorouter)
  inner 1440×900  outer 1440×1000  client 1440×900  dpr 1  platform darwin

PINNED: a DevTools device-metrics override is holding the viewport.
  outer − inner = 0×100px, past the 0×40px this platform's window chrome can explain.
  The layout is NOT at fault. Do not go looking in the CSS.
EXIT=1
```

**…and on an unpinned one:**

```
port 9335 (Biorouter)
  inner 1440×1000  outer 1440×1000  client 1440×1000  dpr 1  platform darwin
  viewport follows the window
EXIT=0
```

`--json` returns the same verdict with deltas and slack; a missing CDP endpoint exits **2**.

**The restart cure**, after the instance was pinned. Each size commanded with `osascript … tell window 1 to set size to {w, h}` and **read back** with `get size of window 1`:

```
  asked {1200, 800} | window readback {1200, 800} | inner [1200,800]  outer [1200,800]
  asked {1900, 1050}| window readback {1900, 1050}| inner [1900,1050] outer [1900,1050]
  asked {1440, 1000}| window readback {1440, 1000}| inner [1440,1000] outer [1440,1000]
```

The same three resizes **before** the restart, with the override orphaned, moved the window (readback confirms) while the page insisted on `inner [1440,900] outer [1440,1000]` throughout — the frozen state this PR is about.

## Out of scope

**No CSS or layout change, and none is needed.** The measurements above are the argument: the same instance that "would not scale" tracked 1200×800, 1900×1050 and 1440×1000 exactly after a restart, with no stylesheet touched. `--measure-chat` and `--measure-page` are untouched and `styles/measures.test.ts` still passes.

Also out of scope: the launcher script outside the repo, and any change to `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
