### PR TITLE
Refresh the Claude Code and Codex model catalogs to what the CLIs serve today

### DIFF
--- a/crates/biorouter-cli/src/cli.rs
+++ b/crates/biorouter-cli/src/cli.rs
@@ -275,7 +275,7 @@ pub struct ModelOptions {
     #[arg(
         long = "model",
         value_name = "MODEL",
-        help = "Specify the model to use (e.g., 'gpt-5.6', 'claude-sonnet-4-6')",
+        help = "Specify the model to use (e.g., 'claude-fable-5-1', 'gpt-6-astra')",
         long_help = "Override the BIOROUTER_MODEL environment variable for this run. The model must be supported by the specified provider."
     )]
     pub model: Option<String>,

--- a/crates/biorouter-cli/src/cli.rs
+++ b/crates/biorouter-cli/src/cli.rs
@@ -275,7 +275,7 @@ pub struct ModelOptions {
     #[arg(
         long = "model",
         value_name = "MODEL",
-        help = "Specify the model to use (e.g., 'claude-fable-5-1', 'gpt-6-astra')",
+        help = "Specify the model to use (e.g., 'claude-opus-5', 'gpt-5.5')",
         long_help = "Override the BIOROUTER_MODEL environment variable for this run. The model must be supported by the specified provider."
     )]
     pub model: Option<String>,

--- a/crates/biorouter-server/tests/knowledge_macro_live_bridge.rs
+++ b/crates/biorouter-server/tests/knowledge_macro_live_bridge.rs
@@ -145,8 +145,10 @@ async fn ingest_under(provider: Arc<dyn Provider>, label: &str) {
 #[ignore = "needs the `claude` CLI installed and signed in; spends the user's own plan quota"]
 async fn a_real_ingest_macro_runs_on_claude_code() {
     use biorouter::providers::claude_code::ClaudeCodeProvider;
+    // Haiku 4.5: the cheapest advertised model, served by both CLI generations
+    // on this machine (2.1.235 and 2.1.260) with no version floor of its own.
     let provider =
-        ClaudeCodeProvider::from_env(ModelConfig::new("claude-sonnet-4-6").expect("a known model"))
+        ClaudeCodeProvider::from_env(ModelConfig::new("claude-haiku-4-5").expect("a known model"))
             .await
             .expect("the claude CLI is installed");
     ingest_under(Arc::new(provider), "claude_code").await;

--- a/crates/biorouter/src/model.rs
+++ b/crates/biorouter/src/model.rs
@@ -274,10 +274,12 @@ static MODEL_CONTEXT_WINDOWS: Lazy<HashMap<&'static str, usize>> = Lazy::new(|| 
 static MODEL_SPECIFIC_LIMITS: Lazy<Vec<(&'static str, usize)>> = Lazy::new(|| {
     vec![
         // openai
-        // `gpt-5` does not match `gpt-6-astra`, so nothing shadows it today;
-        // this exists for the dated variants a future catalog may carry
-        // (`gpt-6-astra-2026-xx-xx`), which have no exact entry.
-        ("gpt-6", 1_050_000),
+        // Scoped to Astra rather than to the whole `gpt-6` generation. It
+        // exists only for the dated variants a future catalog may carry
+        // (`gpt-6-astra-2026-xx-xx`), which have no exact entry; a bare
+        // `"gpt-6"` would additionally hand 1,050,000 to an unreleased
+        // `gpt-6-mini`, which is a claim nothing has measured.
+        ("gpt-6-astra", 1_050_000),
         ("gpt-5.6", 1_050_000), // covers gpt-5.6 and its -sol/-terra/-luna variants
         ("gpt-5.5", 1_050_000), // covers gpt-5.5 and gpt-5.5-pro
         ("gpt-5.4-mini", 400_000),
@@ -1228,9 +1230,12 @@ mod tests {
         );
         // The two ids the coding-agent providers now default to. Both are
         // advertised, so both must resolve from the exact registry rather than
-        // from a pattern: "gpt-6" would answer for Astra either way, but
-        // "claude-fable-5" is a prefix of "claude-fable-5-1", and a prefix
-        // answering for its successor is how a wrong window goes unnoticed.
+        // from a pattern — and for each one a pattern would answer with the
+        // same number ("gpt-6-astra" and "claude-fable-5" are each a prefix of
+        // the id asked about), so `context_window_for` alone cannot tell an
+        // exact entry from an inherited one. That is precisely how a wrong
+        // window goes unnoticed, which is why `has_declared_context_window`
+        // below is the assertion that separates them.
         assert_eq!(ModelConfig::context_window_for("gpt-6-astra"), 1_050_000);
         assert_eq!(
             ModelConfig::context_window_for("claude-fable-5-1"),

--- a/crates/biorouter/src/model.rs
+++ b/crates/biorouter/src/model.rs
@@ -95,6 +95,10 @@ static MODEL_CONTEXT_WINDOWS: Lazy<HashMap<&'static str, usize>> = Lazy::new(|| 
         ("gpt-5.6-luna", 1_050_000),
         ("gpt-5.6-sol", 1_050_000),
         ("gpt-5.6-terra", 1_050_000),
+        // OpenAI's published figure for Astra (max output 128,000). Codex's
+        // `model/list` carries no context-window field, so this cannot come
+        // from the CLI probe that establishes the rest of that catalog.
+        ("gpt-6-astra", 1_050_000),
         ("o3", 200_000),
         ("o3-2025-04-16", 200_000),
         // ── Anthropic ──
@@ -104,6 +108,7 @@ static MODEL_CONTEXT_WINDOWS: Lazy<HashMap<&'static str, usize>> = Lazy::new(|| 
         ("anthropic/claude-sonnet-5", 1_000_000),
         ("claude-4-sonnet", 200_000),
         ("claude-fable-5", 1_000_000),
+        ("claude-fable-5-1", 1_000_000),
         ("claude-haiku-4-5", 200_000),
         ("claude-haiku-4-5-20251001", 200_000),
         ("claude-haiku-4-5@20251001", 200_000),
@@ -269,6 +274,10 @@ static MODEL_CONTEXT_WINDOWS: Lazy<HashMap<&'static str, usize>> = Lazy::new(|| 
 static MODEL_SPECIFIC_LIMITS: Lazy<Vec<(&'static str, usize)>> = Lazy::new(|| {
     vec![
         // openai
+        // `gpt-5` does not match `gpt-6-astra`, so nothing shadows it today;
+        // this exists for the dated variants a future catalog may carry
+        // (`gpt-6-astra-2026-xx-xx`), which have no exact entry.
+        ("gpt-6", 1_050_000),
         ("gpt-5.6", 1_050_000), // covers gpt-5.6 and its -sol/-terra/-luna variants
         ("gpt-5.5", 1_050_000), // covers gpt-5.5 and gpt-5.5-pro
         ("gpt-5.4-mini", 400_000),
@@ -1217,6 +1226,18 @@ mod tests {
             ModelConfig::context_window_for("claude-sonnet-5"),
             1_000_000
         );
+        // The two ids the coding-agent providers now default to. Both are
+        // advertised, so both must resolve from the exact registry rather than
+        // from a pattern: "gpt-6" would answer for Astra either way, but
+        // "claude-fable-5" is a prefix of "claude-fable-5-1", and a prefix
+        // answering for its successor is how a wrong window goes unnoticed.
+        assert_eq!(ModelConfig::context_window_for("gpt-6-astra"), 1_050_000);
+        assert_eq!(
+            ModelConfig::context_window_for("claude-fable-5-1"),
+            1_000_000
+        );
+        assert!(ModelConfig::has_declared_context_window("gpt-6-astra"));
+        assert!(ModelConfig::has_declared_context_window("claude-fable-5-1"));
         // An id nobody declared still falls back to the pattern table.
         assert_eq!(ModelConfig::context_window_for("qwen3.6:latest"), 262_144);
         // And an id nothing matches gets the default.

--- a/crates/biorouter/src/providers/base.rs
+++ b/crates/biorouter/src/providers/base.rs
@@ -1376,8 +1376,12 @@ mod type_level_institution_tests {
         // and declaring "ucsf" must produce the same id, or a catalog would show
         // two groups for one institution while the gates saw one.
         assert_eq!(
-            ProviderMetadata::empty().with_institution("UCSF").institutions,
-            ProviderMetadata::empty().with_institution("ucsf").institutions
+            ProviderMetadata::empty()
+                .with_institution("UCSF")
+                .institutions,
+            ProviderMetadata::empty()
+                .with_institution("ucsf")
+                .institutions
         );
     }
 
@@ -1389,7 +1393,8 @@ mod type_level_institution_tests {
     /// claim where it asked for an instance-resolved one.
     #[test]
     fn the_type_level_claim_does_not_serialise_under_the_instance_level_key() {
-        let json = serde_json::to_value(ProviderMetadata::empty().with_institution("ucsf")).unwrap();
+        let json =
+            serde_json::to_value(ProviderMetadata::empty().with_institution("ucsf")).unwrap();
         assert!(json.get("affiliation").is_none());
         assert_eq!(json["institutions"][0]["id"], "ucsf");
         assert_eq!(json["institutions"][0]["display_name"], "UCSF");

--- a/crates/biorouter/src/providers/claude_code.rs
+++ b/crates/biorouter/src/providers/claude_code.rs
@@ -109,7 +109,28 @@ const KIND: CodingAgentKind = CodingAgentKind::ClaudeCode;
 ///
 /// `with_unlisted_models` still lets a user type `sonnet` by hand, and the CLI
 /// accepts both spellings — verified against `claude` 2.1.235.
-pub const CLAUDE_CODE_DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+///
+/// # Why Fable 5.1 is the default
+///
+/// Measured 2026-09-08: `claude --model claude-fable-5-1 -p … --output-format
+/// json` answers on `claude` 2.1.260 (the binary the desktop app bundles) with
+/// `modelUsage["claude-fable-5-1"].contextWindow` = 1,000,000, and both the
+/// `fable` and `best` aliases resolve to it. It is Anthropic's current flagship
+/// and the operator's own default.
+///
+/// ⚠ It needs a recent CLI. On `claude` 2.1.235 (the copy that was on this
+/// machine's PATH) the API refuses it outright:
+///
+/// > 400 Claude Code 2.1.235 does not support this model; version **2.1.251**
+/// > or newer is required. Run 'claude update', or update the Claude desktop
+/// > app, then try again.
+///
+/// Anthropic's own model-config page says 2.1.255; the API's error is the
+/// tighter, measured floor, so both numbers are recorded rather than averaged.
+/// That failure is *actionable* — Biorouter surfaces the vendor sentence
+/// verbatim, naming the installed version and the fix — which is why a default
+/// that requires a current CLI is acceptable rather than a trap.
+pub const CLAUDE_CODE_DEFAULT_MODEL: &str = "claude-fable-5-1";
 
 pub const CLAUDE_CODE_DOC_URL: &str = "https://code.claude.com/docs/en/headless";
 
@@ -124,25 +145,46 @@ fn known_models() -> Vec<ModelInfo> {
     // Each window must equal the one `MODEL_CONTEXT_WINDOWS` declares, because
     // `tests/context_windows.rs::provider_declared_windows_match_the_registry`
     // compares the two.
-    // Verified against the installed CLI (claude 2.1.235) on 2026-08-27 by
-    // running each id and checking the answer, not by reading a changelog.
+    //
+    // Anthropic's **current** lineup, and nothing else. Measured 2026-09-08
+    // against two CLIs rather than read off a changelog: `claude` 2.1.235 (the
+    // copy on this machine's PATH) for the first three plus Haiku, and `claude`
+    // 2.1.260 (the binary the desktop app bundles) for `claude-fable-5-1`,
+    // which 2.1.235 cannot run at all. Each window below is the number the CLI
+    // itself reported in `modelUsage[<id>].contextWindow` for a real one-turn
+    // completion, and it matches
+    // https://platform.claude.com/docs/en/about-claude/models/overview, which
+    // also states that every current model takes text *and* image input —
+    // hence `with_vision()` on all four.
+    //
+    // ⚠ Fable 5.1 needs a recent CLI: **2.1.251 or newer** per the API's own
+    // 400 on 2.1.235 (Anthropic's model-config page says 2.1.255). See
+    // `CLAUDE_CODE_DEFAULT_MODEL` — the refusal is surfaced verbatim, so it
+    // reads as "update the CLI", not as a Biorouter fault.
     //
     // ⚠ The probe has to be checked before it is trusted: `claude --model X -p`
     // ACCEPTS an unknown id and merely warns —
     //   "X" is not a model this version of Claude Code recognizes, so
     //   auto-compact will keep this session within 200k tokens
     // — so "it ran" proves nothing on its own. `definitely-not-a-model`,
-    // `claude-opus-99` and `gpt-4` each produce that warning; the five below
+    // `claude-opus-99` and `gpt-4` each produce that warning; the four below
     // produce a clean answer, which is what makes the list evidence.
     //
-    // `claude-sonnet-5` was absent here while being a real, current model — the
-    // CLI's own `--help` names `fable`, `opus` and `sonnet` as the aliases for
-    // the latest models.
+    // Two ids that used to be here are gone, and only one of them was merely
+    // stale:
+    //
+    //   * `claude-fable-5` — legacy, superseded at the same tier by Fable 5.1.
+    //     Anthropic still serves it, and `with_unlisted_models` still lets a
+    //     user type it, so nothing breaks; it just is not advertised.
+    //   * `claude-sonnet-4-6` — legacy, and its declared 1,000,000 was a live
+    //     **defect**. A bare `claude-sonnet-4-6` runs at **200,000** on this
+    //     plan (measured); Sonnet 4.6's 1M window needs the `[1m]` id suffix
+    //     plus usage credits on Max, so the picker was showing a budget five
+    //     times the one the agent actually had.
     vec![
+        ModelInfo::new("claude-fable-5-1", 1_000_000).with_vision(),
         ModelInfo::new("claude-opus-5", 1_000_000).with_vision(),
-        ModelInfo::new("claude-fable-5", 1_000_000).with_vision(),
         ModelInfo::new("claude-sonnet-5", 1_000_000).with_vision(),
-        ModelInfo::new("claude-sonnet-4-6", 1_000_000).with_vision(),
         ModelInfo::new("claude-haiku-4-5", 200_000).with_vision(),
     ]
 }
@@ -2053,6 +2095,63 @@ mod tests {
                 .all(|model| model.supports_vision == Some(true)),
             "every current Claude model accepts image inputs"
         );
+    }
+
+    /// The advertised catalog is Anthropic's *current* lineup and nothing else.
+    ///
+    /// Pinned as an exact list rather than as "contains X", because the failure
+    /// this guards against is an id staying behind after it stops being
+    /// current: a legacy model in the picker is not neutral, and one of the two
+    /// removed here (`claude-sonnet-4-6`) was showing a 1,000,000 window for a
+    /// model the CLI runs at 200,000 on this plan.
+    #[test]
+    fn the_catalog_is_anthropics_current_lineup_and_defaults_to_fable_5_1() {
+        let m = ClaudeCodeProvider::metadata();
+        let advertised: Vec<&str> = m.known_models.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(
+            advertised,
+            [
+                "claude-fable-5-1",
+                "claude-opus-5",
+                "claude-sonnet-5",
+                "claude-haiku-4-5",
+            ],
+            "measured 2026-09-08 against `claude` 2.1.235 (and 2.1.260 for \
+             Fable 5.1) plus Anthropic's model overview"
+        );
+        assert_eq!(
+            m.default_model, CLAUDE_CODE_DEFAULT_MODEL,
+            "the picker's default is the constant, not a second opinion"
+        );
+        assert_eq!(m.default_model, "claude-fable-5-1");
+
+        // Legacy ids a user may still type by hand, and which must not be
+        // advertised. `with_unlisted_models` is what keeps them reachable.
+        for legacy in ["claude-fable-5", "claude-sonnet-4-6", "claude-opus-4-8"] {
+            assert!(
+                !advertised.contains(&legacy),
+                "{legacy} is a legacy model and must not be in the picker"
+            );
+        }
+        assert!(
+            m.allows_unlisted_models,
+            "…which is only acceptable because an unlisted id can still be typed"
+        );
+
+        // The window each entry declares is the one the CLI itself reported.
+        // Haiku differing from the rest is the point: a blanket 1M would be a
+        // 5x overstatement for it.
+        let window = |id: &str| {
+            m.known_models
+                .iter()
+                .find(|i| i.name == id)
+                .unwrap_or_else(|| panic!("{id} is advertised"))
+                .context_limit
+        };
+        assert_eq!(window("claude-fable-5-1"), 1_000_000);
+        assert_eq!(window("claude-opus-5"), 1_000_000);
+        assert_eq!(window("claude-sonnet-5"), 1_000_000);
+        assert_eq!(window("claude-haiku-4-5"), 200_000);
     }
 
     #[test]

--- a/crates/biorouter/src/providers/claude_code.rs
+++ b/crates/biorouter/src/providers/claude_code.rs
@@ -134,13 +134,20 @@ pub const CLAUDE_CODE_DEFAULT_MODEL: &str = "claude-fable-5-1";
 
 pub const CLAUDE_CODE_DOC_URL: &str = "https://code.claude.com/docs/en/headless";
 
-/// Models advertised in the picker, with the context window each alias resolves
-/// to today.
+/// Models advertised in the picker, with each id's measured context window.
 ///
-/// `ProviderMetadata::with_models` is used rather than `::new` on purpose: `::new`
-/// derives each limit by looking the *name* up as a model id, and these are
-/// aliases rather than ids, so every one of them would silently take the default
-/// limit and the settings UI would display a wrong window.
+/// `ProviderMetadata::with_models` is used rather than `::new` because `::new`
+/// hard-codes `supports_vision: None` (see `base.rs`), and this catalog carries a
+/// per-model vision answer: all four of these take image input, and Codex's
+/// `gpt-5.3-codex-spark` next door does not — recording a known fact as unknown is
+/// its own defect.
+///
+/// The windows are *not* the reason. These are concrete ids rather than the CLI's
+/// `sonnet`/`opus` aliases (see `CLAUDE_CODE_DEFAULT_MODEL` above on why), each
+/// with its own exact `MODEL_CONTEXT_WINDOWS` entry, so `::new`'s
+/// `ModelConfig::new_or_fail(name).context_limit()` would resolve every one of
+/// them correctly — and `tests/context_windows.rs` pins them under either
+/// constructor.
 fn known_models() -> Vec<ModelInfo> {
     // Each window must equal the one `MODEL_CONTEXT_WINDOWS` declares, because
     // `tests/context_windows.rs::provider_declared_windows_match_the_registry`
@@ -148,10 +155,11 @@ fn known_models() -> Vec<ModelInfo> {
     //
     // Anthropic's **current** lineup, and nothing else. Measured 2026-09-08
     // against two CLIs rather than read off a changelog: `claude` 2.1.235 (the
-    // copy on this machine's PATH) for the first three plus Haiku, and `claude`
-    // 2.1.260 (the binary the desktop app bundles) for `claude-fable-5-1`,
-    // which 2.1.235 cannot run at all. Each window below is the number the CLI
-    // itself reported in `modelUsage[<id>].contextWindow` for a real one-turn
+    // copy on this machine's PATH) for `claude-opus-5`, `claude-sonnet-5` and
+    // `claude-haiku-4-5`, and `claude` 2.1.260 (the binary the desktop app
+    // bundles) for `claude-fable-5-1`, which 2.1.235 cannot run at all. Each
+    // window below is the number the CLI itself reported in
+    // `modelUsage[<id>].contextWindow` for a real one-turn
     // completion, and it matches
     // https://platform.claude.com/docs/en/about-claude/models/overview, which
     // also states that every current model takes text *and* image input —
@@ -176,11 +184,21 @@ fn known_models() -> Vec<ModelInfo> {
     //   * `claude-fable-5` — legacy, superseded at the same tier by Fable 5.1.
     //     Anthropic still serves it, and `with_unlisted_models` still lets a
     //     user type it, so nothing breaks; it just is not advertised.
-    //   * `claude-sonnet-4-6` — legacy, and its declared 1,000,000 was a live
-    //     **defect**. A bare `claude-sonnet-4-6` runs at **200,000** on this
-    //     plan (measured); Sonnet 4.6's 1M window needs the `[1m]` id suffix
-    //     plus usage credits on Max, so the picker was showing a budget five
-    //     times the one the agent actually had.
+    //   * `claude-sonnet-4-6` — legacy, and the 1,000,000 this catalog
+    //     declared for it was a live **defect** in the picker. A bare
+    //     `claude-sonnet-4-6` runs at **200,000** on this plan (measured);
+    //     Sonnet 4.6's 1M window needs the `[1m]` id suffix plus usage credits
+    //     on Max, so the picker was offering a budget five times the one the
+    //     agent actually had.
+    //
+    //     ⚠ Dropping it from this list fixes the **picker** and nothing else.
+    //     `MODEL_CONTEXT_WINDOWS` still declares `("claude-sonnet-4-6",
+    //     1_000_000)`, because the anthropic, Bedrock and Databricks providers
+    //     genuinely serve that id at 1M and need the entry; and
+    //     `with_unlisted_models` still lets a user type it here. So a
+    //     hand-typed `claude-sonnet-4-6` on *this* provider still shows 1M
+    //     against a CLI serving 200k. The window is a per-provider fact, and a
+    //     registry keyed on the model name alone has no way to say so.
     vec![
         ModelInfo::new("claude-fable-5-1", 1_000_000).with_vision(),
         ModelInfo::new("claude-opus-5", 1_000_000).with_vision(),

--- a/crates/biorouter/src/providers/codex.rs
+++ b/crates/biorouter/src/providers/codex.rs
@@ -57,7 +57,19 @@ use crate::model::ModelConfig;
 
 const KIND: CodingAgentKind = CodingAgentKind::Codex;
 
-pub const CODEX_DEFAULT_MODEL: &str = "gpt-5.5";
+/// The model a Codex session starts on.
+///
+/// Astra is the vendor's own bundled default: codex-cli 0.153.4's changelog
+/// entry is "Fixed Astra's visibility in the bundled model picker and made it
+/// the bundled default", and `model/list` on 0.153.4 returns it first with
+/// `isDefault: true` (measured 2026-09-08). It is also what the operator's own
+/// `~/.codex/config.toml` selects.
+///
+/// ⚠ It needs **codex-cli 0.153.4 or newer**. On 0.147.0 the request is
+/// refused with `400 The 'gpt-6-astra' model requires a newer version of Codex.
+/// Please upgrade to the latest app or CLI and try again.` — which Biorouter
+/// surfaces verbatim, so a stale CLI fails actionably rather than silently.
+pub const CODEX_DEFAULT_MODEL: &str = "gpt-6-astra";
 pub const CODEX_DOC_URL: &str = "https://developers.openai.com/codex/cli";
 
 /// How long the turn will wait for the app server to say which account it bills.
@@ -165,36 +177,55 @@ fn link_codex_auth(source: &Path, target: &Path) -> std::io::Result<()> {
 fn known_models() -> Vec<ModelInfo> {
     // Read from the CLI itself, not from a blog post: `codex app-server`
     // answers `model/list` with the catalog the signed-in account actually
-    // has. Measured against codex-cli 0.147.0 on 2026-08-27 —
+    // has. Measured against codex-cli **0.153.4** on 2026-09-08, from an
+    // isolated `CODEX_HOME` holding only `auth.json` — exactly what this
+    // provider does at runtime, so the list is the one a Biorouter turn sees:
     //
-    //   gpt-5.6-sol          GPT-5.6-Sol    text+image   (account default)
+    //   gpt-6-astra          GPT-6-Astra    text+image   (bundled default)
+    //   gpt-5.6-sol          GPT-5.6-Sol    text+image
     //   gpt-5.6-terra        GPT-5.6-Terra  text+image
     //   gpt-5.6-luna         GPT-5.6-Luna   text+image
     //   gpt-5.5              GPT-5.5        text+image
-    //   gpt-5.4              GPT-5.4        text+image
-    //   gpt-5.4-mini         GPT-5.4-Mini   text+image
     //   gpt-5.3-codex-spark  Spark          TEXT ONLY
     //
-    // Two corrections fall out of that, and both were live defects:
+    // codex-cli 0.147.0 (the copy on this machine's PATH) answers with the
+    // same six **minus Astra**, and makes `gpt-5.6-sol` the default instead;
+    // `codex exec -m gpt-6-astra` there fails `400 … requires a newer version
+    // of Codex`. So Astra needs **0.153.4 or newer** — see
+    // `CODEX_DEFAULT_MODEL`.
     //
-    //   * `gpt-5.3-codex` was offered and DOES NOT EXIST. The real id gained a
-    //     `-spark` suffix; choosing the old one could only ever fail.
+    // Two ids that used to be advertised here are **retired**, not merely
+    // stale: OpenAI's models page gives `gpt-5.4` and `gpt-5.4-mini` an
+    // end-of-life of 2026-08-31 (replacements `gpt-5.6-terra` and
+    // `gpt-5.6-luna`), both have left `model/list` on *both* CLI versions, and
+    // `codex exec -m gpt-5.4` now fails `400 The 'gpt-5.4' model is not
+    // supported when using Codex with a ChatGPT account`. Offering either
+    // could only ever fail.
+    //
+    // Facts about the surviving entries, each of which was or would have been
+    // a live defect:
+    //
+    //   * `gpt-5.3-codex` DOES NOT EXIST. The real id gained a `-spark`
+    //     suffix; choosing the old one could only ever fail.
     //   * `gpt-5.3-codex-spark` is text-only, so it must NOT be marked
-    //     `with_vision()` — the other six are.
+    //     `with_vision()` — the other five are.
+    //   * Astra's 1,050,000 window is OpenAI's published figure
+    //     (developers.openai.com/api/docs/models/gpt-6-astra; max output
+    //     128,000). `model/list` carries no context-window field on either CLI
+    //     version, so the window can never come from the probe.
     //
-    // `gpt-5.6-pro` appears in the binary's strings but is absent from the
-    // catalog, so it is deliberately not offered: a model the account cannot
-    // select is worse than one missing from the list.
+    // `gpt-5.6`, `gpt-5.6-pro`, `gpt-6` and `codex-auto-review` are absent from
+    // the catalog and deliberately not offered: a model the account cannot
+    // select from the picker is worse than one missing from the list.
     //
     // Re-derive rather than trusting this comment:
     //   codex app-server --strict-config   # then: {"id":1,"method":"model/list"}
     vec![
+        ModelInfo::new("gpt-6-astra", 1_050_000).with_vision(),
         ModelInfo::new("gpt-5.6-sol", 1_050_000).with_vision(),
         ModelInfo::new("gpt-5.6-terra", 1_050_000).with_vision(),
         ModelInfo::new("gpt-5.6-luna", 1_050_000).with_vision(),
         ModelInfo::new("gpt-5.5", 1_050_000).with_vision(),
-        ModelInfo::new("gpt-5.4", 1_050_000).with_vision(),
-        ModelInfo::new("gpt-5.4-mini", 400_000).with_vision(),
         // ⚠ `without_vision()`, not a bare `new()`. A bare one leaves vision
         // UNKNOWN, and `model/list` told us the answer: inputModalities is
         // `["text"]`. Recording a known fact as unknown is its own defect.
@@ -2428,7 +2459,9 @@ for line in sys.stdin:
             "the hint must name the model that was asked for: {hint}"
         );
         assert!(
-            hint.contains("gpt-5.5") && hint.contains("gpt-5.3-codex"),
+            hint.contains("gpt-6-astra")
+                && hint.contains("gpt-5.5")
+                && hint.contains("gpt-5.3-codex-spark"),
             "and the ones that exist, so the fix is in the message: {hint}"
         );
         assert!(
@@ -2515,12 +2548,35 @@ for line in sys.stdin:
             "`gpt-5.3-codex` is not a real model id any more — `model/list` \
              reports only `gpt-5.3-codex-spark`, so offering it can only fail"
         );
-        for id in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+        for id in [
+            "gpt-6-astra",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "gpt-5.3-codex-spark",
+        ] {
             assert!(
                 m.known_models.iter().any(|model| model.name == id),
                 "{id} is in the live catalog and must be offered"
             );
         }
+        // ⚠ Retired, not merely superseded. OpenAI's models page ends both on
+        // 2026-08-31; they have left `model/list` on codex-cli 0.147.0 and
+        // 0.153.4 alike, and `codex exec -m gpt-5.4` answers `400 … not
+        // supported when using Codex with a ChatGPT account`. Advertising
+        // either offers the user a choice that can only fail.
+        for retired in ["gpt-5.4", "gpt-5.4-mini"] {
+            assert!(
+                !m.known_models.iter().any(|model| model.name == retired),
+                "{retired} retired on 2026-08-31 and must not be offered"
+            );
+        }
+        assert_eq!(
+            m.default_model, "gpt-6-astra",
+            "Astra is the vendor's own bundled default from codex-cli 0.153.4 \
+             (`model/list` returns it first with isDefault: true)"
+        );
     }
 }
 

--- a/crates/biorouter/src/providers/codex.rs
+++ b/crates/biorouter/src/providers/codex.rs
@@ -214,9 +214,21 @@ fn known_models() -> Vec<ModelInfo> {
     //     128,000). `model/list` carries no context-window field on either CLI
     //     version, so the window can never come from the probe.
     //
-    // `gpt-5.6`, `gpt-5.6-pro`, `gpt-6` and `codex-auto-review` are absent from
-    // the catalog and deliberately not offered: a model the account cannot
-    // select from the picker is worse than one missing from the list.
+    // Four ids are deliberately not offered, for two different reasons — and
+    // the two must not be collapsed, because only the first group is a model
+    // the account cannot select:
+    //
+    //   * `gpt-5.6`, `gpt-5.6-pro` and `gpt-6` are **refused by the account**.
+    //     `codex exec -m <id>` fails on both CLI versions with `400 The
+    //     '<id>' model is not supported when using Codex with a ChatGPT
+    //     account`. Putting one in the picker would only ever produce that.
+    //   * `codex-auto-review` **runs**: `codex exec -m codex-auto-review` is
+    //     accepted on both 0.147.0 and 0.153.4. It is absent from `model/list`
+    //     on both, so it is a *hidden review model* rather than an unselectable
+    //     one, and advertising a model the vendor does not list would be a
+    //     guess about a surface that can change with no notice. Its absence
+    //     from `model/list` is also why its effort ladder cannot be read — see
+    //     `CODEX_MODELS_WITH_MAX` in `coding_agent/effort.rs`.
     //
     // Re-derive rather than trusting this comment:
     //   codex app-server --strict-config   # then: {"id":1,"method":"model/list"}
@@ -2458,10 +2470,19 @@ for line in sys.stdin:
             hint.contains("gpt-5.5-codex"),
             "the hint must name the model that was asked for: {hint}"
         );
+        // ⚠ Assert against the parenthesised catalog only, never against the
+        // whole hint. The hint embeds the id that was asked for, and
+        // `gpt-5.5-codex` *contains* `gpt-5.5` — so a bare
+        // `hint.contains("gpt-5.5")` passes on a hint that lists no models at
+        // all.
+        let catalog = hint
+            .split_once('(')
+            .unwrap_or_else(|| panic!("the hint must carry a parenthesised catalog: {hint}"))
+            .1;
         assert!(
-            hint.contains("gpt-6-astra")
-                && hint.contains("gpt-5.5")
-                && hint.contains("gpt-5.3-codex-spark"),
+            catalog.contains("gpt-6-astra")
+                && catalog.contains("gpt-5.5")
+                && catalog.contains("gpt-5.3-codex-spark"),
             "and the ones that exist, so the fix is in the message: {hint}"
         );
         assert!(

--- a/crates/biorouter/src/providers/coding_agent/effort.rs
+++ b/crates/biorouter/src/providers/coding_agent/effort.rs
@@ -5,9 +5,11 @@
 //!
 //! The shared helper maps `Quick -> low`, `Deep -> high`, `Normal -> None`, which
 //! is right for an API where `high` is the top of the scale. Both coding-agent
-//! CLIs have a taller ladder — `low, medium, high, xhigh, max` — so `Deep` landing
-//! on `high` would leave two rungs unused and make "deep" mean *less* here than the
-//! word implies. These providers therefore climb their own ladder:
+//! CLIs have a taller ladder — `low, medium, high, xhigh, max`, and Codex alone
+//! adds `ultra` above `max`, which `Deep` deliberately does not reach (see
+//! `CODEX_MODELS_WITH_MAX`) — so `Deep` landing on `high` would leave two rungs
+//! unused and make "deep" mean *less* here than the word implies. These providers
+//! therefore climb their own ladder:
 //!
 //! | BioRouter | Claude Code | Codex |
 //! |---|---|---|
@@ -20,7 +22,8 @@
 //! **The default is no longer silent.** Elsewhere in Biorouter `Normal` means "say
 //! nothing and let the model decide". Here it emits `high`, so *every* turn from a
 //! user who never touched `/effort` asks for more reasoning than the vendor default
-//! (`medium` on `gpt-5.5`). That is a deliberate product choice — a coding agent is
+//! (`model/list`'s own `defaultReasoningEffort`: `medium` on `gpt-6-astra`, `low`
+//! on `gpt-5.6-sol`). That is a deliberate product choice — a coding agent is
 //! reached for when the work is hard — and it costs thinking tokens against the
 //! user's own subscription on every turn.
 //!
@@ -167,6 +170,26 @@ mod tests {
         }
     }
 
+    /// `codex-auto-review` must stay OFF `CODEX_MODELS_WITH_MAX`.
+    ///
+    /// It needs its own assertion because
+    /// `codex_deep_never_exceeds_what_the_model_advertises` cannot see it: that
+    /// test walks the *advertised* catalog, and this model is advertised
+    /// nowhere, so re-adding it to the const table would break nothing.
+    ///
+    /// The reason it does not belong there: `codex exec -m codex-auto-review`
+    /// is accepted on both 0.147.0 and 0.153.4, but the id is absent from
+    /// `model/list` on **both**, so its `supportedReasoningEfforts` cannot be
+    /// read and the `max` it used to be given was never evidence.
+    #[test]
+    fn codex_auto_review_gets_the_safe_rung_because_no_model_list_declares_it() {
+        assert_eq!(
+            codex_effort(Some(ReasoningEffort::Deep), "codex-auto-review"),
+            "xhigh",
+            "absent from `model/list` on 0.147.0 and 0.153.4, so its ladder is unverifiable"
+        );
+    }
+
     /// An unknown or user-typed model gets the safe floor rather than a guess —
     /// `with_unlisted_models` means anything can arrive here.
     #[test]
@@ -187,6 +210,12 @@ mod tests {
 
     /// `ultra` is the delegating tier above the ordinary ladder. `/effort deep`
     /// must not silently buy it on the models that have it.
+    ///
+    /// ⚠ This guards the *values* in the const tables above — `CLAUDE_TOP`,
+    /// `CODEX_SAFE_TOP` and the `"max"` literal — not the mapping logic:
+    /// `codex_top_rung` can only ever return one of those two strings, so the
+    /// assertion cannot fail while they say what they say. It is a tripwire on
+    /// someone editing a constant, not evidence that the ladder is right.
     #[test]
     fn deep_never_reaches_ultra() {
         for model in ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5"] {

--- a/crates/biorouter/src/providers/coding_agent/effort.rs
+++ b/crates/biorouter/src/providers/coding_agent/effort.rs
@@ -13,7 +13,7 @@
 //! |---|---|---|
 //! | `Quick` | `low` | `low` |
 //! | `Normal` (and unset) | `high` | `high` |
-//! | `Deep` | `max` | the model's top rung, usually `xhigh` |
+//! | `Deep` | `max` | the model's own top rung: `max` on Astra and 5.6, else `xhigh` |
 //!
 //! # Two consequences worth knowing before changing this
 //!
@@ -45,8 +45,8 @@ const CLAUDE_TOP: &str = "max";
 ///
 /// `xhigh` is the highest rung **every** model in the live catalogue advertises,
 /// which is what makes it the safe floor: `max` and `ultra` exist only on part of
-/// the 5.6 family, and Biorouter's own four advertised models (`gpt-5.5`,
-/// `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`) top out here.
+/// the 5.6 family and on Astra, and the two advertised models that stop here are
+/// `gpt-5.5` and `gpt-5.3-codex-spark`.
 const CODEX_SAFE_TOP: &str = "xhigh";
 
 /// Codex models known to advertise `max`, from `model/list`'s
@@ -56,16 +56,25 @@ const CODEX_SAFE_TOP: &str = "xhigh";
 /// would otherwise pay on every turn, and being wrong in the safe direction costs
 /// one rung. Re-derive it with
 /// `codex app-server` → `model/list` → `supportedReasoningEfforts` when the
-/// catalogue moves.
+/// catalogue moves. Measured against codex-cli 0.153.4 on 2026-09-08: Astra,
+/// Sol and Terra advertise `low, medium, high, xhigh, max, ultra`; Luna stops at
+/// `max`; `gpt-5.5` and `gpt-5.3-codex-spark` stop at `xhigh`.
 ///
-/// ⚠ Deliberately **not** reaching for `ultra`, which two of these also advertise.
-/// `Deep` is the strongest ordinary tier; `ultra` is the delegating mode above it
-/// and is not what `/effort deep` should silently buy.
+/// ⚠ Deliberately **not** reaching for `ultra`, which three of these also
+/// advertise. `Deep` is the strongest ordinary tier; `ultra` is the delegating
+/// mode above it and is not what `/effort deep` should silently buy.
+///
+/// ⚠ `codex-auto-review` used to sit here and has been removed. It is a hidden
+/// review model: `codex exec -m codex-auto-review` is accepted on both 0.147.0
+/// and 0.153.4, but it is absent from `model/list` on **both**, so its
+/// `supportedReasoningEfforts` cannot be read and the `max` claim was never
+/// evidence. Dropping it costs one rung on a model no picker offers — `Deep`
+/// now sends `xhigh`, which every Codex model accepts.
 const CODEX_MODELS_WITH_MAX: &[&str] = &[
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",
-    "codex-auto-review",
 ];
 
 /// The `--effort` value for a Claude Code turn. Always emits: see the module
@@ -135,19 +144,25 @@ mod tests {
         assert_eq!(claude_effort(None), "high");
     }
 
-    /// Codex's ladder is per-model, and Biorouter's own four advertised models all
-    /// stop at `xhigh`. Sending `max` to one of them is accepted but not
-    /// observably applied, so `Deep` must not reach for it.
+    /// Codex's ladder is per-model, and two of Biorouter's advertised models —
+    /// `gpt-5.5` and `gpt-5.3-codex-spark` — stop at `xhigh`. Sending `max` to
+    /// one of them is accepted but not observably applied, so `Deep` must not
+    /// reach for it.
     #[test]
     fn codex_deep_never_exceeds_what_the_model_advertises() {
-        for advertised in ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"] {
+        for advertised in ["gpt-5.5", "gpt-5.3-codex-spark"] {
             assert_eq!(
                 codex_effort(Some(ReasoningEffort::Deep), advertised),
                 "xhigh",
                 "{advertised} does not advertise `max`"
             );
         }
-        for taller in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+        for taller in [
+            "gpt-6-astra",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        ] {
             assert_eq!(codex_effort(Some(ReasoningEffort::Deep), taller), "max");
         }
     }
@@ -174,7 +189,7 @@ mod tests {
     /// must not silently buy it on the models that have it.
     #[test]
     fn deep_never_reaches_ultra() {
-        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5"] {
+        for model in ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5"] {
             assert_ne!(codex_effort(Some(ReasoningEffort::Deep), model), "ultra");
         }
         assert_ne!(claude_effort(Some(ReasoningEffort::Deep)), "ultra");

--- a/crates/biorouter/tests/coding_agent_live_streaming.rs
+++ b/crates/biorouter/tests/coding_agent_live_streaming.rs
@@ -122,8 +122,14 @@ async fn claude_code_streams_a_real_turn() {
 #[tokio::test]
 #[ignore = "spends the user's own ChatGPT subscription quota; run deliberately"]
 async fn codex_streams_a_real_turn() {
+    // The small, cheap rung, to keep the quota spend low. Was `gpt-5.4-mini`,
+    // which OpenAI retired on 2026-08-31 — `codex exec -m gpt-5.4-mini` now
+    // fails `400 … not supported when using Codex with a ChatGPT account`, so
+    // this test could no longer pass. `gpt-5.6-luna` is OpenAI's own named
+    // replacement for it, and unlike `gpt-6-astra` it needs no particular CLI
+    // version: it is listed by codex-cli 0.147.0 and 0.153.4 alike.
     let provider = biorouter::providers::codex::CodexProvider::from_env(
-        ModelConfig::new("gpt-5.4-mini").unwrap(),
+        ModelConfig::new("gpt-5.6-luna").unwrap(),
     )
     .await
     .expect("the `codex` CLI must be installed and signed in");

--- a/crates/biorouter/tests/context_windows.rs
+++ b/crates/biorouter/tests/context_windows.rs
@@ -80,7 +80,10 @@ async fn same_family_models_with_different_windows_stay_distinct() {
         // GPT-6: Astra is 1.05M, and "gpt-5"/"gpt-5.6" must not claim it.
         ("gpt-6-astra", 1_050_000),
         // Claude: 4.6+ and the 5 series are 1M; the 4.5 tier and Haiku are 200k.
-        // Fable 5.1 is its own entry, not one inherited from `claude-fable-5`.
+        // Fable 5.1's 1M is the same number the `claude-fable-5` pattern would
+        // hand it, so this case cannot tell an exact entry from an inherited
+        // one — `every_advertised_model_has_its_own_declared_window` above is
+        // what pins the exact entry.
         ("claude-fable-5-1", 1_000_000),
         ("claude-opus-5", 1_000_000),
         ("claude-opus-4-6", 1_000_000),

--- a/crates/biorouter/tests/context_windows.rs
+++ b/crates/biorouter/tests/context_windows.rs
@@ -77,7 +77,11 @@ async fn same_family_models_with_different_windows_stay_distinct() {
         ("gpt-5.4-pro", 1_050_000),
         ("gpt-5.4-mini", 400_000),
         ("gpt-5.4-nano", 400_000),
+        // GPT-6: Astra is 1.05M, and "gpt-5"/"gpt-5.6" must not claim it.
+        ("gpt-6-astra", 1_050_000),
         // Claude: 4.6+ and the 5 series are 1M; the 4.5 tier and Haiku are 200k.
+        // Fable 5.1 is its own entry, not one inherited from `claude-fable-5`.
+        ("claude-fable-5-1", 1_000_000),
         ("claude-opus-5", 1_000_000),
         ("claude-opus-4-6", 1_000_000),
         ("claude-sonnet-5", 1_000_000),

--- a/docs/providers/coding-agents/README.md
+++ b/docs/providers/coding-agents/README.md
@@ -47,7 +47,7 @@ machine holding credentials you care about.
 
 | Document | What it covers |
 | --- | --- |
-| [How the coding-agent providers work](how-it-works.md) | The mechanism: what each provider spawns, where each vendor's credential lives, how the binary is found without spawning anything, how the conversation becomes one prompt, and how usage is accounted for a run that billed no tokens. |
+| [How the coding-agent providers work](how-it-works.md) | The mechanism: what each provider spawns, which models each advertises and the CLI version each of those needs, where each vendor's credential lives, how the binary is found without spawning anything, how the conversation becomes one prompt, and how usage is accounted for a run that billed no tokens. |
 | [Installing and signing in](installing-and-signing-in.md) | The user-facing setup: install each CLI, sign in by running the vendor's own command yourself, the four states the settings card can show, and the `CLAUDE_CODE_COMMAND` / `CODEX_COMMAND` escape hatch when the binary lives somewhere BioRouter does not search. |
 | [The tool bridge](tool-bridge.md) | How the audited Workspace and Knowledge subsets, plus bounded workflow-owned tools, reach the child over MCP while BioRouter still executes them behind its gates; and why arbitrary host-reading extensions are deliberately excluded. |
 | [What the child agent may not do](child-agent-isolation.md) | The isolation flags, each of which is security-relevant rather than hygiene: the hostile-fixture result behind `--setting-sources ""`, the measured MCP leak behind `--strict-mcp-config`, why `--tools ""` is not a substitute for either, and why `--bare` must never be passed. |

--- a/docs/providers/coding-agents/how-it-works.md
+++ b/docs/providers/coding-agents/how-it-works.md
@@ -76,11 +76,18 @@ and `best` both resolve to `claude-fable-5-1`, `opus` to `claude-opus-5`, `sonne
 `claude-sonnet-5`, and `haiku` to `claude-haiku-4-5-20251001`. Advertising concrete ids rather than
 these aliases is the context-window decision above, not a claim that aliases are unsupported.
 
-> **Why `claude-sonnet-4-6` is no longer advertised.** It still runs if you type it, but its entry
-> was wrong. A bare `claude-sonnet-4-6` gets a **200,000**-token window on a Max plan, not the 1M
-> this table used to claim: the million needs the `[1m]` suffix *and* usage credits, so the gauge
-> was showing a number the CLI does not honour. `claude-fable-5` left for a duller reason — Fable
-> 5.1 supersedes it at the same tier — and it too remains usable by hand.
+> **Why `claude-sonnet-4-6` is no longer advertised.** A bare `claude-sonnet-4-6` gets a
+> **200,000**-token window on a Max plan, not the 1M this table used to claim: the million needs
+> the `[1m]` suffix *and* usage credits. What this change does is take the id out of the
+> **picker**, and nothing more. Typed by hand it still runs, and its gauge still reads 1M, because
+> the window comes from `MODEL_CONTEXT_WINDOWS` in
+> [`crates/biorouter/src/model.rs`](../../../crates/biorouter/src/model.rs), which is keyed by
+> model name alone: the anthropic, Bedrock and Databricks providers serve that id at a genuine 1M,
+> and one shared entry cannot say "1M there, 200k here". Keeping the claim that narrow is the
+> point — an id nobody is offered is better than one offered with a number the CLI does not
+> honour, and the typed case stays wrong until the window becomes a per-provider fact.
+> `claude-fable-5` left for a duller reason — Fable 5.1 supersedes it at the same tier — and it
+> too remains usable by hand.
 
 On the Codex side, `gpt-5.4` and `gpt-5.4-mini` were **retired by OpenAI on 2026-08-31**, with
 `gpt-5.6-terra` and `gpt-5.6-luna` named as their replacements. They no longer appear in

--- a/docs/providers/coding-agents/how-it-works.md
+++ b/docs/providers/coding-agents/how-it-works.md
@@ -1,10 +1,10 @@
 # How the coding-agent providers work
 
 > **What this is.** The mechanism behind the two subscription-billed providers — what each one
-> spawns, where each vendor's credential lives and who reads it, how the CLI is located without
-> spawning anything, how a BioRouter conversation becomes one prompt, how a turn streams and its
-> tool calls are mirrored into the transcript, and how usage is accounted for a turn that billed no
-> tokens.
+> spawns, which models each advertises and the CLI version each of those needs, where each vendor's
+> credential lives and who reads it, how the CLI is located without spawning anything, how a
+> BioRouter conversation becomes one prompt, how a turn streams and its tool calls are mirrored into
+> the transcript, and how usage is accounted for a turn that billed no tokens.
 > **Status:** Current.
 > **Audience:** developers working on the provider layer, and maintainers verifying the
 > integration.
@@ -25,8 +25,8 @@ compliance boundary is on [the compliance page](compliance.md).
 | Executable | `claude` | `codex` |
 | Config key naming the executable | `CLAUDE_CODE_COMMAND` | `CODEX_COMMAND` |
 | Surface driven | `claude -p` (headless) | `codex app-server` (JSON-RPC over stdio) |
-| Default model | `claude-sonnet-4-6` | `gpt-5.5` |
-| Advertised models | `claude-sonnet-4-6`, `claude-opus-5`, `claude-fable-5` (1M window each), `claude-haiku-4-5` (200k) | `gpt-5.5`, `gpt-5.4` (1,050,000 each), `gpt-5.4-mini`, `gpt-5.3-codex` (400,000 each) |
+| Default model | `claude-fable-5-1` | `gpt-6-astra` |
+| Advertised models | `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5` (1,000,000 each), `claude-haiku-4-5` (200,000) — all accept images | `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5` (1,050,000 each), `gpt-5.3-codex-spark` (400,000, **text only** — no images) |
 | Unlisted models | Accepted — a user may type an alias such as `sonnet` by hand | Accepted |
 | Vendor documentation | [Claude Code headless mode](https://code.claude.com/docs/en/headless) | [Codex CLI](https://developers.openai.com/codex/cli) |
 | Privacy tier | `Public`, not `runs_locally` | `Public`, not `runs_locally` |
@@ -51,6 +51,50 @@ when a user types one; only the advertised set is pinned. The authoritative cata
 [`crates/biorouter/src/providers/claude_code.rs`](../../../crates/biorouter/src/providers/claude_code.rs)
 and [`crates/biorouter/src/providers/codex.rs`](../../../crates/biorouter/src/providers/codex.rs),
 not on this page.
+
+## Which models you can pick depends on the CLI version
+
+Both catalogues track the vendor's current lineup, and the newest model in each needs a recent CLI.
+The floors are the vendor's, not BioRouter's:
+
+| Model | Minimum CLI | What an older CLI says |
+| --- | --- | --- |
+| `claude-fable-5-1` | `claude` **2.1.251** | `400 Claude Code 2.1.235 does not support this model; version 2.1.251 or newer is required. Run 'claude update', or update the Claude desktop app, then try again.` |
+| `gpt-6-astra` | `codex-cli` **0.153.4** | `The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.` |
+
+BioRouter surfaces that text **verbatim** and stops the turn. It does not quietly retry on an older
+model: the vendor's message already names the fix, and answering from a model you did not pick is
+worse than an error you can act on. Every other advertised model in both catalogues answered on the
+older CLI as well as the newer one, so the gate is per-model, not per-catalogue.
+
+> **Note.** The two sources for the Claude floor disagree by four patch versions — Anthropic's
+> model-configuration page says v2.1.255, the API's own 400 says 2.1.251. BioRouter documents the
+> number the API returns, because that is the one a user will read on their own screen.
+
+Aliases still work, and on a CLI new enough for Fable 5.1 they land where you would expect: `fable`
+and `best` both resolve to `claude-fable-5-1`, `opus` to `claude-opus-5`, `sonnet` to
+`claude-sonnet-5`, and `haiku` to `claude-haiku-4-5-20251001`. Advertising concrete ids rather than
+these aliases is the context-window decision above, not a claim that aliases are unsupported.
+
+> **Why `claude-sonnet-4-6` is no longer advertised.** It still runs if you type it, but its entry
+> was wrong. A bare `claude-sonnet-4-6` gets a **200,000**-token window on a Max plan, not the 1M
+> this table used to claim: the million needs the `[1m]` suffix *and* usage credits, so the gauge
+> was showing a number the CLI does not honour. `claude-fable-5` left for a duller reason — Fable
+> 5.1 supersedes it at the same tier — and it too remains usable by hand.
+
+On the Codex side, `gpt-5.4` and `gpt-5.4-mini` were **retired by OpenAI on 2026-08-31**, with
+`gpt-5.6-terra` and `gpt-5.6-luna` named as their replacements. They no longer appear in
+`model/list`, and a turn on one fails with
+`400 The '<id>' model is not supported when using Codex with a ChatGPT account`. `gpt-5.3-codex`
+was rejected by that same 400 and is listed as deprecated by OpenAI; the surviving member of that
+family is the text-only research preview `gpt-5.3-codex-spark`, which is a **different id** rather
+than a rename BioRouter could have followed.
+
+Measured on 2026-09-08 against `claude` 2.1.235 and 2.1.260, and `codex-cli` 0.147.0 and 0.153.4,
+by running every id through the CLI itself. The Claude windows are what the CLI reports back in
+`modelUsage`; Codex's `model/list` carries no context-window field on either version, so those
+windows come from OpenAI's published model pages and only the *existence* and effort ladder of each
+id is a local measurement.
 
 ## Where each credential lives, and who reads it
 
@@ -318,27 +362,33 @@ Both CLIs expose a taller reasoning scale than the API providers do —
 | --- | --- | --- |
 | `quick` | `low` | `low` |
 | *default* | `high` | `high` |
-| `deep` | `max` | the model's top rung — usually `xhigh` |
+| `deep` | `max` | the model's top rung — `max` on `gpt-6-astra` and the 5.6 family, `xhigh` elsewhere |
 
 Three things follow that are worth knowing before you rely on it.
 
 **The default is no longer silent.** Everywhere else in BioRouter the default effort means "say
 nothing and let the model choose". Here it emits `high`, so every turn — including from someone who
 has never typed `/effort` — asks for more reasoning than the vendor default (`medium` on
-`gpt-5.5`). That is deliberate: a coding agent is what you reach for when the work is hard. It also
-costs thinking tokens against your own subscription on every turn, which is the trade being made.
+`gpt-6-astra`, `low` on `gpt-5.6-sol`). That is deliberate: a coding agent is what you reach for
+when the work is hard. It also costs thinking tokens against your own subscription on every turn,
+which is the trade being made.
 
-**Codex's ladder is per-model, so `deep` lands differently.** `max` and `ultra` exist only on part
-of the 5.6 family; BioRouter's own four advertised Codex models (`gpt-5.5`, `gpt-5.4`,
-`gpt-5.4-mini`, `gpt-5.3-codex`) all stop at `xhigh`. Sending an unadvertised rung is *accepted*
-rather than rejected — measured on `gpt-5.5`, which has no `max` — so the failure mode is a silent
-clamp or a silent ignore, and there is no way to tell which from the outside. An ignore would fall
-back to the model's default and quietly deliver *less* than `deep` asked for, so BioRouter sends
-only what the model advertises.
+**Codex's ladder is per-model, so `deep` lands differently.** Four of the six advertised Codex
+models advertise `max` and get it — `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra` and
+`gpt-5.6-luna`; `gpt-5.5` and `gpt-5.3-codex-spark` stop at `xhigh`. Sending an unadvertised rung
+is *accepted* rather than rejected — measured on `gpt-5.5`, which has no `max` — so the failure
+mode is a silent clamp or a silent ignore, and there is no way to tell which from the outside. An
+ignore would fall back to the model's default and quietly deliver *less* than `deep` asked for, so
+BioRouter sends only what the model advertises.
 
-**`deep` is not `ultra`.** Two Codex models advertise an `ultra` rung above `max`, and Claude Code
-has no such level at all (passing one makes the CLI warn and fall back to its default, which is a
-silent downgrade rather than an error). `deep` is the strongest *ordinary* tier; the delegating mode
+That rule is also why the hidden review model `codex-auto-review` is not on the `max` list. It
+answers a turn on every CLI version probed, but it appears in no `model/list` response, so its
+ladder cannot be read — and a rung nobody can verify is exactly the silent-clamp case above.
+
+**`deep` is not `ultra`.** Three Codex models advertise an `ultra` rung above `max` — `gpt-6-astra`,
+`gpt-5.6-sol` and `gpt-5.6-terra` — and Claude Code has no such level at all (passing one makes the
+CLI warn and fall back to its default, which is a silent downgrade rather than an error). `deep` is
+the strongest *ordinary* tier; the delegating mode
 above it is not something `/effort deep` should buy without being asked for.
 
 ## Using one for a single task, without rebinding the chat

--- a/docs/providers/coding-agents/installing-and-signing-in.md
+++ b/docs/providers/coding-agents/installing-and-signing-in.md
@@ -55,6 +55,14 @@ Choose **Claude Code** or **Codex** in the model picker or in provider settings,
 would any other provider. There is no key to enter. The only setting either provider has is the
 name or path of its executable, which defaults to `claude` and `codex` respectively.
 
+> **Note — which models you can pick depends on your CLI version.** The newest model in each
+> catalogue has a vendor-set version floor: `claude-fable-5-1` needs `claude` **2.1.251** or newer,
+> and `gpt-6-astra` needs `codex-cli` **0.153.4** or newer. On an older CLI the turn fails with the
+> vendor's own upgrade message, which BioRouter shows you verbatim; `claude update`, or re-running
+> the `npm install -g` line in step 1, fixes it. Every other advertised model works on older CLIs
+> too. Details, including the exact messages, are on
+> [which models you can pick depends on the CLI version](how-it-works.md#which-models-you-can-pick-depends-on-the-cli-version).
+
 ## The four states a card can show
 
 BioRouter asks each CLI what it thinks its own situation is, over

--- a/docs/providers/coding-agents/installing-and-signing-in.md
+++ b/docs/providers/coding-agents/installing-and-signing-in.md
@@ -58,9 +58,10 @@ name or path of its executable, which defaults to `claude` and `codex` respectiv
 > **Note — which models you can pick depends on your CLI version.** The newest model in each
 > catalogue has a vendor-set version floor: `claude-fable-5-1` needs `claude` **2.1.251** or newer,
 > and `gpt-6-astra` needs `codex-cli` **0.153.4** or newer. On an older CLI the turn fails with the
-> vendor's own upgrade message, which BioRouter shows you verbatim; `claude update`, or re-running
-> the `npm install -g` line in step 1, fixes it. Every other advertised model works on older CLIs
-> too. Details, including the exact messages, are on
+> vendor's own upgrade message, which BioRouter shows you verbatim. Each CLI has its own remedy:
+> for Claude Code, `claude update` (or updating the Claude desktop app); for Codex, `codex update`,
+> or re-running step 1's `npm install -g @openai/codex@latest`. Every other advertised model works
+> on older CLIs too. Details, including the exact messages, are on
 > [which models you can pick depends on the CLI version](how-it-works.md#which-models-you-can-pick-depends-on-the-cli-version).
 
 ## The four states a card can show


### PR DESCRIPTION
Refreshes the model catalogs of the two coding-agent providers (`claude_code`, `codex`) so they match what the vendor CLIs serve today, measured on 2026-09-08 against the real CLIs and the vendors' current documentation — not a changelog.

## What the CLIs serve today (measured)

**Claude Code** — probed with `claude --model <id> -p "Reply with the single word ready." --output-format json`; the JSON's `modelUsage` names the id actually served and its `contextWindow`.

| id | answers on claude 2.1.235 (PATH) | answers on claude 2.1.260 | window the CLI reports |
| --- | --- | --- | --- |
| `claude-fable-5-1` | ✗ `400 Claude Code 2.1.235 does not support this model; version 2.1.251 or newer is required. Run 'claude update'…` | ✓ (`fable` and `best` both resolve to it) | 1,000,000 |
| `claude-opus-5` | ✓ (`opus` alias) | — | 1,000,000 |
| `claude-sonnet-5` | ✓ (`sonnet` alias) | — | 1,000,000 |
| `claude-haiku-4-5` | ✓ (`haiku` → `claude-haiku-4-5-20251001`) | — | 200,000 |
| `claude-fable-5` | ✓ (legacy) | — | 1,000,000 |
| `claude-sonnet-4-6`, `claude-opus-4-6` | ✓ (legacy) | — | **200,000** — the 1M window needs the `[1m]` suffix plus usage credits on Max |
| `claude-opus-4-8`, `-4-7`, `-4-5`, `claude-sonnet-4-5` | ✓ (legacy) | — | 1M / 1M / 200k / 200k |
| `claude-mythos-5-1`, `claude-opus-5-1`, `claude-sonnet-5-1` | ✗ unrecognized | ✗ | — |

**Codex** — `codex app-server` → `model/list` from an isolated `CODEX_HOME` (exactly what the provider does), plus `codex exec -m <id>` per candidate.

| id | codex-cli 0.147.0 (PATH) | codex-cli 0.153.4 (latest) | modalities | efforts |
| --- | --- | --- | --- | --- |
| `gpt-6-astra` | ✗ `400 The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.` | ✓ listed first, `isDefault: true` | text + image | low…xhigh, max, ultra |
| `gpt-5.6-sol` | ✓ (default on 0.147.0) | ✓ | text + image | low…xhigh, max, ultra |
| `gpt-5.6-terra` | ✓ | ✓ | text + image | low…xhigh, max, ultra |
| `gpt-5.6-luna` | ✓ | ✓ | text + image | low…xhigh, max |
| `gpt-5.5` | ✓ | ✓ | text + image | low…xhigh |
| `gpt-5.3-codex-spark` | ✓ | ✓ | **text only** | low…xhigh |
| `gpt-5.4`, `gpt-5.4-mini` | ✗ gone from `model/list`; `400 … not supported when using Codex with a ChatGPT account` | ✗ | — | — |
| `gpt-5.6`, `gpt-5.6-pro`, `gpt-5.3-codex`, `gpt-6`, `gpt-5.5-codex` | ✗ 400 not supported | — | — | — |
| `codex-auto-review` | ✓ accepted by `exec`, absent from `model/list` | same | — | unverifiable |

Vendor documentation read the same day: Anthropic's [models overview](https://platform.claude.com/docs/en/about-claude/models/overview) (current lineup Fable 5.1 / Opus 5 / Sonnet 5 / Haiku 4.5, all with image input; Fable 5, Opus 4.8–4.5 and Sonnet 4.6/4.5 listed as legacy) and [Claude Code model configuration](https://code.claude.com/docs/en/model-config) (Fable 5.1 needs Claude Code ≥ 2.1.255; `[1m]` rules); OpenAI's [Codex models](https://learn.chatgpt.com/docs/models) (gpt-5.4 and gpt-5.4-mini retired 2026-08-31, gpt-5.3-codex deprecated), [Codex changelog](https://learn.chatgpt.com/docs/changelog) (GPT-6 Astra added in 0.153.1, made the bundled default in 0.153.4) and the [GPT-6 Astra API page](https://developers.openai.com/api/docs/models/gpt-6-astra) (1,050,000-token context, 128K output, text + image).

## Removed

- **Claude Code:** `claude-sonnet-4-6` — legacy, and advertised with a window the CLI does not honour: the CLI runs a bare `claude-sonnet-4-6` at 200,000 on this plan (the 1M needs the `[1m]` suffix plus usage credits). This PR fixes the *picker*; the shared registry still says 1,000,000 because the anthropic, Bedrock and Databricks providers legitimately serve it at 1M, so a hand-typed `claude-sonnet-4-6` in a Claude Code chat still reads 1M — a per-provider window the shared registry cannot express, and the reason it is better unadvertised than advertised. `claude-fable-5` — legacy, superseded by Fable 5.1 at the same tier. Both are still served and can still be typed by hand (`with_unlisted_models`).
- **Codex:** `gpt-5.4`, `gpt-5.4-mini` — retired by OpenAI on 2026-08-31; `model/list` no longer returns them and a turn on either fails with a 400.
- **Effort ladder:** `codex-auto-review` dropped from the models `deep` sends `max` to — absent from `model/list` on both CLI versions, so its ladder cannot be verified; `deep` on it now sends `xhigh`, which every model accepts.

## Added

- **Claude Code:** `claude-fable-5-1` — 1,000,000-token window (the CLI reports it), image input, now the default (the operator's own default). Needs Claude Code ≥ 2.1.251: on an older CLI Biorouter surfaces the vendor's `400 … version 2.1.251 or newer is required. Run 'claude update'` verbatim (measured through `biorouter run`).
- **Codex:** `gpt-6-astra` — 1,050,000-token window (OpenAI API docs), image input, `max` effort (from `model/list`), now the default (the vendor's bundled default since 0.153.4 and what `model/list` marks `isDefault`). Needs codex-cli ≥ 0.153.4: on 0.147.0 Biorouter surfaces `The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade…` verbatim.
- **Registry:** exact `MODEL_CONTEXT_WINDOWS` entries for `claude-fable-5-1` (1,000,000) and `gpt-6-astra` (1,050,000), plus a `gpt-6-astra` fallback pattern for dated variants (deliberately not a bare `gpt-6`, so a future `gpt-6-mini` cannot inherit the flagship window). The CLI `--model` help example now names two current ids that are valid on several providers (`claude-opus-5`, `gpt-5.5`) instead of `gpt-5.6` (not an id either coding-agent CLI accepts) and the no-longer-advertised `claude-sonnet-4-6`.

Not added, deliberately: nothing whose id the CLIs do not know. `claude-mythos-5-1`, `claude-opus-5-1`, `claude-sonnet-5-1`, `gpt-5.6`, `gpt-5.6-pro`, `gpt-6` were all probed and rejected.

## Tests

All run in this worktree after the change (baselines measured on the same tree before it):

| Gate | Result |
| --- | --- |
| `BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib -- providers::claude_code providers::codex providers::coding_agent model::` | **226 passed**, 0 failed (baseline 224; +2 new tests: one pins the Claude catalog as an exact ordered list, the default, the per-model windows and `allows_unlisted_models`; one pins that `codex-auto-review` stays off the `max` list, which the advertised-catalog walk cannot see) |
| `cargo test -p biorouter --test context_windows` | **4 passed** (now also covers `claude-fable-5-1` and `gpt-6-astra` in the same-family-distinct-windows case) |
| `cargo build -p biorouter-cli` | ok |
| `cargo fmt --all -- --check` and `./scripts/clippy-lint.sh` | clean (the two whitespace hunks in `providers/base.rs` are pre-existing drift on `main`, committed separately as `style(providers)`) |
| `cd ui/desktop && npm run test:run` | 422 files, **4739 passed**, 1 skipped — nothing under `ui/` changed; run because the brief asked |
| `cd ui/desktop && npm run lint:check` | clean (typecheck, eslint, themes, 332 contrast assertions, token mirrors) |

The catalog tests are evidence, not tautologies: the Codex metadata test now asserts `gpt-5.4`/`gpt-5.4-mini` are absent and `gpt-6-astra` present with `default_model == "gpt-6-astra"`, and the unknown-model-hint test was tightened twice: from `contains("gpt-5.3-codex")` (satisfied by `-spark` for the wrong reason) to the full ids, and then to assert against the parenthesised catalog only, because the hint also embeds the requested id and `gpt-5.5-codex` contains `gpt-5.5`. An Opus 5 review pass over the diff produced 14 findings; 13 are applied in the follow-up commits and the 14th is the first follow-up below.

## Live verification

One turn per newly added id **through Biorouter itself**, on CLIs that serve them (`biorouter run -t "Reply with the single word ready." --no-session`, isolated `XDG_CONFIG_HOME`):

| Provider / model | CLI driven | Result |
| --- | --- | --- |
| `claude_code` / `claude-fable-5-1` | claude 2.1.260 (desktop-bundled binary, via `CLAUDE_CODE_COMMAND`) | `ready` |
| `codex` / `gpt-6-astra` | codex-cli 0.153.4 (scratch `npm install`, via `CODEX_COMMAND`) | `ready` |
| `claude_code` / `claude-fable-5-1` | claude 2.1.235 (PATH) | fails, vendor text verbatim: `Request failed: API Error: 400 Claude Code 2.1.235 does not support this model; version 2.1.251 or newer is required. Run 'claude update', or update the Claude desktop app, then try again.` |
| `codex` / `gpt-6-astra` | codex-cli 0.147.0 (PATH) | fails, vendor text verbatim: `The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.` |

Every other advertised id (`claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5`; `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.3-codex-spark`) answered `ready` on **both** CLI generations when driven directly (`claude -p` / `codex exec`), with the Claude windows above read back from the CLI's own `modelUsage[<id>].contextWindow`.

⚠ The `claude` (2.1.235) and `codex` (0.147.0) binaries on this machine's PATH are both older than the floors above, so on this machine the two new defaults fail with the vendors' upgrade messages until `claude update` / `codex update` (or `npm i -g @anthropic-ai/claude-code @openai/codex`) is run. The PATH binaries were deliberately not upgraded by this PR; the live turns used the desktop-bundled claude 2.1.260 and a scratch-installed codex 0.153.4 via `CLAUDE_CODE_COMMAND` / `CODEX_COMMAND`.

## Follow-ups noticed, not in this PR

- `crates/biorouter/src/providers/openai.rs` still sets `OPEN_AI_DEFAULT_FAST_MODEL = "gpt-5.4-mini"` and advertises `gpt-5.4`/`gpt-5.4-mini` on the OpenAI *API* provider. The 2026-08-31 retirement above was measured on the Codex surface (ChatGPT account); whether it binds the API surface needs its own measurement before touching that catalog.
- `crates/biorouter/src/providers/anthropic.rs` still tops out at `claude-fable-5`; the registry now has `claude-fable-5-1`, so adding it there is a one-line change once someone confirms the API-key path serves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
