### PR TITLE
Desktop: sentence-case the page-header actions and fade the Settings scroll edge

### DIFF
--- a/ui/desktop/src/components/Layout/PageHeader.test.tsx
+++ b/ui/desktop/src/components/Layout/PageHeader.test.tsx
@@ -35,13 +35,13 @@ describe('PageHeader', () => {
       <PageHeader
         title="Skills"
         description="Add and manage skills."
-        actions={<button type="button">Add Skill</button>}
+        actions={<button type="button">Add skill</button>}
       />
     );
 
     const strip = container.querySelector('.biorouter-settings-control-strip');
     expect(strip).not.toBeNull();
-    expect(strip).toContainElement(screen.getByRole('button', { name: 'Add Skill' }));
+    expect(strip).toContainElement(screen.getByRole('button', { name: 'Add skill' }));
     expect(strip).toHaveClass('mt-5');
   });
 

--- a/ui/desktop/src/components/baam/BrowseExtensionsModal.test.tsx
+++ b/ui/desktop/src/components/baam/BrowseExtensionsModal.test.tsx
@@ -307,7 +307,7 @@ describe('BrowseExtensionsModal — marketplace install (issue #116)', () => {
 
     await user.click(screen.getByRole('button', { name: 'Back to marketplace' }));
 
-    await waitFor(() => expect(screen.getByText('Browse Extensions')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Browse extensions')).toBeInTheDocument());
     expect(electron.installBrxtBundle).not.toHaveBeenCalled();
     expect(props.onClose).not.toHaveBeenCalled();
     expect(props.onInstalled).not.toHaveBeenCalled();
@@ -322,7 +322,7 @@ describe('BrowseExtensionsModal — marketplace install (issue #116)', () => {
 
     await user.keyboard('{Escape}');
 
-    await waitFor(() => expect(screen.getByText('Browse Extensions')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Browse extensions')).toBeInTheDocument());
     expect(props.onClose).not.toHaveBeenCalled();
   });
 });

--- a/ui/desktop/src/components/baam/BrowseExtensionsModal.tsx
+++ b/ui/desktop/src/components/baam/BrowseExtensionsModal.tsx
@@ -159,7 +159,7 @@ export default function BrowseExtensionsModal({
         {/* Header */}
         <div className="px-6 pt-5 pb-4 pr-14 border-b border-border-subtle">
           <div>
-            <DialogTitle>Browse Extensions</DialogTitle>
+            <DialogTitle>Browse extensions</DialogTitle>
             <DialogDescription className="text-xs text-text-muted mt-0.5">
               Install MCP extensions from the Biorouter marketplace. Add one at a time. Most need
               credentials configured during install.

--- a/ui/desktop/src/components/baam/BrowseSkillsModal.tsx
+++ b/ui/desktop/src/components/baam/BrowseSkillsModal.tsx
@@ -147,7 +147,7 @@ export default function BrowseSkillsModal({ onClose, onInstalled, installedIds }
         {/* Header */}
         <div className="px-6 pt-5 pb-4 pr-14 border-b border-border-subtle">
           <div>
-            <DialogTitle>Browse Skills</DialogTitle>
+            <DialogTitle>Browse skills</DialogTitle>
             <DialogDescription className="text-xs text-text-muted mt-0.5">
               Install skills from the Biorouter marketplace. Select as many as you like. Skills need
               no setup.

--- a/ui/desktop/src/components/extensions/ExtensionsView.test.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionsView.test.tsx
@@ -120,11 +120,11 @@ describe('ExtensionsView — the shared page header', () => {
   it('puts all three actions in one control strip under the description', async () => {
     renderView();
 
-    const add = await screen.findByRole('button', { name: 'Add Extension' });
+    const add = await screen.findByRole('button', { name: 'Add extension' });
     const strip = add.closest('.biorouter-settings-control-strip');
     expect(strip).not.toBeNull();
-    expect(strip).toContainElement(screen.getByRole('button', { name: 'Browse Extensions' }));
-    expect(strip).toContainElement(screen.getByRole('button', { name: 'Add Custom Extension' }));
+    expect(strip).toContainElement(screen.getByRole('button', { name: 'Browse extensions' }));
+    expect(strip).toContainElement(screen.getByRole('button', { name: 'Add custom extension' }));
   });
 
   /**
@@ -138,7 +138,7 @@ describe('ExtensionsView — the shared page header', () => {
   it('lets the Button primitive own its own layout', async () => {
     renderView();
 
-    for (const name of ['Add Extension', 'Browse Extensions', 'Add Custom Extension']) {
+    for (const name of ['Add extension', 'Browse extensions', 'Add custom extension']) {
       const button = await screen.findByRole('button', { name });
       expect(button.className.split(/\s+/)).not.toContain('flex');
     }

--- a/ui/desktop/src/components/extensions/ExtensionsView.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionsView.tsx
@@ -184,15 +184,15 @@ export default function ExtensionsView({
             <>
               <Button variant="default" onClick={() => setIsBrxtModalOpen(true)}>
                 <Plus />
-                Add Extension
+                Add extension
               </Button>
               <Button variant="outline" onClick={() => setIsBrowseModalOpen(true)}>
                 <Search />
-                Browse Extensions
+                Browse extensions
               </Button>
               <Button variant="outline" onClick={() => setIsAddModalOpen(true)}>
                 <Plus />
-                Add Custom Extension
+                Add custom extension
               </Button>
             </>
           }
@@ -221,7 +221,7 @@ export default function ExtensionsView({
           initialData={getDefaultFormData()}
           onClose={handleModalClose}
           onSubmit={handleAddExtension}
-          submitLabel="Add Extension"
+          submitLabel="Add extension"
           modalType={'add'}
         />
       )}

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -144,7 +144,19 @@ export default function SettingsView({
                 </TabsList>
               </ReadableContent>
 
-              <ScrollArea className="flex-1" paddingX={1}>
+              {/* ⚠ `biorouter-scroll-fade-top` is not decoration — read the
+                  rule's own comment in `main.css`. The tab strip above carries
+                  `border-b-0` deliberately, so this viewport's top edge and the
+                  strip's bottom edge are the SAME y with nothing between them,
+                  and a row clipped to its last pixel lands beside the active
+                  tab's underline as a second, thinner accent rule (the App tab
+                  at `scrollTop` 663, 1440x900: the "Configuration guide" link).
+                  The class fades the clipped edge only while the scroller is
+                  scrolled, so nothing is dimmed on a page nobody has moved.
+                  Guarded at the source by `styles/settingsScrollFade.test.ts`,
+                  because jsdom computes no `mask-image` and would pass either
+                  way. */}
+              <ScrollArea className="biorouter-scroll-fade-top flex-1" paddingX={1}>
                 <ReadableContent size="chat" className="px-6 py-5">
                   <TabsContent value="models" className="mt-0">
                     <ModelsSection setView={setView} />

--- a/ui/desktop/src/components/settings/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings/extensions/ExtensionsSection.tsx
@@ -375,7 +375,7 @@ export default function ExtensionsSection({
               onClick={() => setIsBrxtModalOpen(true)}
             >
               <Plus className="h-4 w-4" />
-              Add Extension
+              Add extension
             </Button>
             <Button
               className="flex items-center gap-2 justify-center"
@@ -383,7 +383,7 @@ export default function ExtensionsSection({
               onClick={() => setIsBrowseModalOpen(true)}
             >
               <Search className="h-4 w-4" />
-              Browse Extensions
+              Browse extensions
             </Button>
             <Button
               className="flex items-center gap-2 justify-center"
@@ -391,7 +391,7 @@ export default function ExtensionsSection({
               onClick={() => setIsAddModalOpen(true)}
             >
               <Plus className="h-4 w-4" />
-              Add Custom Extension
+              Add custom extension
             </Button>
           </div>
         )}
@@ -399,12 +399,12 @@ export default function ExtensionsSection({
         {/* Modal for updating an existing extension */}
         {isModalOpen && selectedExtension && (
           <ExtensionModal
-            title="Update Extension"
+            title="Update extension"
             initialData={extensionToFormData(selectedExtension)}
             onClose={handleModalClose}
             onSubmit={handleUpdateExtension}
             onDelete={handleDeleteExtension}
-            submitLabel="Save Changes"
+            submitLabel="Save changes"
             modalType={'edit'}
           />
         )}
@@ -416,7 +416,7 @@ export default function ExtensionsSection({
             initialData={getDefaultFormData()}
             onClose={handleModalClose}
             onSubmit={handleAddExtension}
-            submitLabel="Add Extension"
+            submitLabel="Add extension"
             modalType={'add'}
           />
         )}
@@ -431,7 +431,7 @@ export default function ExtensionsSection({
             } as FixedExtensionEntry)}
             onClose={handleModalClose}
             onSubmit={handleAddExtension}
-            submitLabel="Add Extension"
+            submitLabel="Add extension"
             modalType={'add'}
           />
         )}

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.test.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.test.tsx
@@ -34,7 +34,7 @@ describe('ExtensionModal', () => {
         initialData={initialData}
         onClose={mockOnClose}
         onSubmit={mockOnSubmit}
-        submitLabel="Add Extension"
+        submitLabel="Add extension"
         modalType="add"
       />
     );
@@ -172,7 +172,7 @@ describe('ExtensionModal', () => {
         initialData={initialData}
         onClose={vi.fn()}
         onSubmit={vi.fn()}
-        submitLabel="Add Extension"
+        submitLabel="Add extension"
         modalType="add"
       />
     );

--- a/ui/desktop/src/components/skills/AddSkillModal.tsx
+++ b/ui/desktop/src/components/skills/AddSkillModal.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 /**
- * Add Skill.
+ * Add skill.
  *
  * ⚠ **Nothing here parses an archive.** The modal used to read a `.md` in the
  * renderer and hand a `.zip` to a depth-counting daemon parser, and it had no
@@ -142,7 +142,7 @@ export default function AddSkillModal({ onClose, onSaved }: Props) {
         className={`flex max-h-[80vh] flex-col gap-0 overflow-hidden p-0 ${MODAL_SIZE.lg}`}
       >
         <div className="px-6 pt-5 pb-4 pr-14 border-b border-border-subtle">
-          <DialogTitle>Add Skill</DialogTitle>
+          <DialogTitle>Add skill</DialogTitle>
         </div>
 
         <div className="p-6 flex flex-col gap-4 overflow-y-auto">
@@ -265,7 +265,7 @@ export default function AddSkillModal({ onClose, onSaved }: Props) {
 
 function installLabel(preview: ImportPreview | null): string {
   if (!preview) return 'Install';
-  if (preview.kind === 'single') return 'Install Skill';
+  if (preview.kind === 'single') return 'Install skill';
   return `Install ${preview.components.length} skills`;
 }
 

--- a/ui/desktop/src/components/skills/CustomSkillModal.test.tsx
+++ b/ui/desktop/src/components/skills/CustomSkillModal.test.tsx
@@ -20,7 +20,7 @@ describe('CustomSkillModal', () => {
     };
 
     render(<CustomSkillModal onClose={onClose} onSaved={() => {}} />);
-    await user.click(screen.getByRole('button', { name: 'Save Skill' }));
+    await user.click(screen.getByRole('button', { name: 'Save skill' }));
 
     expect(await screen.findByRole('button', { name: 'Saving…' })).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
@@ -29,6 +29,6 @@ describe('CustomSkillModal', () => {
     expect(onClose).not.toHaveBeenCalled();
 
     finishWrite(false);
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Save Skill' })).toBeEnabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save skill' })).toBeEnabled());
   });
 });

--- a/ui/desktop/src/components/skills/CustomSkillModal.tsx
+++ b/ui/desktop/src/components/skills/CustomSkillModal.tsx
@@ -80,7 +80,7 @@ export default function CustomSkillModal({ onClose, onSaved }: Props) {
         className={`flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0 ${MODAL_SIZE.lg}`}
       >
         <div className="px-6 pt-5 pb-4 pr-14 border-b border-border-subtle">
-          <DialogTitle>Add Custom Skill</DialogTitle>
+          <DialogTitle>Add custom skill</DialogTitle>
         </div>
 
         <div className="p-6 flex flex-col gap-3 flex-1 overflow-hidden">
@@ -107,7 +107,7 @@ export default function CustomSkillModal({ onClose, onSaved }: Props) {
             Cancel
           </Button>
           <Button variant="default" onClick={handleSave} disabled={isSaving}>
-            {isSaving ? 'Saving…' : 'Save Skill'}
+            {isSaving ? 'Saving…' : 'Save skill'}
           </Button>
         </div>
       </DialogContent>

--- a/ui/desktop/src/components/skills/SkillsView.test.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.test.tsx
@@ -291,7 +291,7 @@ describe('SkillsView', () => {
     render(<SkillsView />);
 
     fireEvent.click(await screen.findByLabelText('Delete skill package pack'));
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete Package' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete package' }));
 
     await waitFor(() => expect(mocks.removeSkillPackage).toHaveBeenCalledTimes(1));
     expect(mocks.removeSkillPackage.mock.calls[0][0].body).toEqual({
@@ -357,7 +357,7 @@ describe('SkillsView empty and loading states', () => {
     render(<SkillsView />);
 
     const empty = await screen.findByRole('region', { name: 'No skills yet' });
-    expect(within(empty).getByRole('button', { name: 'Add Skill' })).toBeInTheDocument();
+    expect(within(empty).getByRole('button', { name: 'Add skill' })).toBeInTheDocument();
   });
 
   it('says a search matched nothing without claiming the catalog is empty', async () => {

--- a/ui/desktop/src/components/skills/SkillsView.tsx
+++ b/ui/desktop/src/components/skills/SkillsView.tsx
@@ -201,15 +201,15 @@ export default function SkillsView() {
             <>
               <Button variant="default" onClick={() => setIsAddModalOpen(true)}>
                 <Upload className="h-4 w-4" />
-                Add Skill
+                Add skill
               </Button>
               <Button variant="outline" onClick={() => setIsBrowseModalOpen(true)}>
                 <Globe className="h-4 w-4" />
-                Browse Skills
+                Browse skills
               </Button>
               <Button variant="outline" onClick={() => setIsCustomModalOpen(true)}>
                 <Plus className="h-4 w-4" />
-                Add Custom Skill
+                Add custom skill
               </Button>
             </>
           }
@@ -318,7 +318,7 @@ export default function SkillsView() {
                   actions={
                     <Button onClick={() => setIsAddModalOpen(true)}>
                       <Upload className="h-4 w-4" />
-                      Add Skill
+                      Add skill
                     </Button>
                   }
                 />
@@ -356,7 +356,7 @@ export default function SkillsView() {
             ? `This will permanently remove all ${pendingDelete.bundle.skills.length} skills in this package. This action cannot be undone.`
             : 'This will permanently remove the skill folder from disk. This action cannot be undone.'
         }
-        confirmLabel={pendingDelete?.kind === 'bundle' ? 'Delete Package' : 'Delete'}
+        confirmLabel={pendingDelete?.kind === 'bundle' ? 'Delete package' : 'Delete'}
         cancelLabel="Cancel"
         confirmVariant="destructive"
         isSubmitting={isDeleting}

--- a/ui/desktop/src/components/workflows/CreateEditWorkflowModal.tsx
+++ b/ui/desktop/src/components/workflows/CreateEditWorkflowModal.tsx
@@ -371,7 +371,7 @@ export default function CreateEditWorkflowModal({
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-5 pr-14 border-b border-border-subtle flex-shrink-0">
           <div>
-            <DialogTitle>{isCreateMode ? 'Create Workflow' : 'Edit Workflow'}</DialogTitle>
+            <DialogTitle>{isCreateMode ? 'Create workflow' : 'Edit workflow'}</DialogTitle>
             <DialogDescription className="text-supporting text-text-muted mt-0.5">
               {isCreateMode
                 ? 'Define agent behavior and capabilities for reusable chats.'
@@ -469,7 +469,7 @@ export default function CreateEditWorkflowModal({
               variant="outline"
             >
               <Save className="w-4 h-4" />
-              {isSaving ? 'Saving...' : 'Save Workflow'}
+              {isSaving ? 'Saving...' : 'Save workflow'}
             </Button>
             <Button
               onClick={handleSaveAndRunWorkflowClick}

--- a/ui/desktop/src/components/workflows/CreateWorkflowFromSessionModal.tsx
+++ b/ui/desktop/src/components/workflows/CreateWorkflowFromSessionModal.tsx
@@ -519,7 +519,7 @@ export default function CreateWorkflowFromSessionModal({
                 data-testid="create-workflow-button"
               >
                 <Save className="w-4 h-4" />
-                {isCreating ? 'Creating…' : 'Create Workflow'}
+                {isCreating ? 'Creating…' : 'Create workflow'}
               </Button>
               <Button
                 onClick={() => handleCreateWorkflow(form.state.values, true)}

--- a/ui/desktop/src/components/workflows/ImportWorkflowForm.tsx
+++ b/ui/desktop/src/components/workflows/ImportWorkflowForm.tsx
@@ -117,7 +117,7 @@ export default function ImportWorkflowForm({
     <Dialog open={isOpen} onOpenChange={(open) => !open && !isSubmitting && handleClose()}>
       <DialogContent dismissible={!isSubmitting} className={MODAL_SIZE.md}>
         <DialogHeader>
-          <DialogTitle>Import Workflow</DialogTitle>
+          <DialogTitle>Import workflow</DialogTitle>
           <DialogDescription>
             Drag and drop a workflow YAML or JSON file, or click to browse.
           </DialogDescription>
@@ -179,7 +179,7 @@ export function ImportWorkflowButton({ onClick }: { onClick: () => void }) {
     // (vocabulary V7).
     <Button onClick={onClick} variant="outline">
       <Upload />
-      Import Workflow
+      Import workflow
     </Button>
   );
 }

--- a/ui/desktop/src/components/workflows/WorkflowsView.test.tsx
+++ b/ui/desktop/src/components/workflows/WorkflowsView.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -112,8 +112,13 @@ describe('WorkflowsView loading transition', () => {
     expect(emptyState).toHaveAccessibleDescription(
       'Create a reusable workflow here, save one from a chat, or import an existing workflow.'
     );
-    expect(screen.getByRole('button', { name: 'Create workflow' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Import workflow' })).toBeInTheDocument();
+    // ⚠ Scoped to the empty state, not to the page. The header offers the SAME
+    // two actions, and until the casing sweep it offered them under different
+    // names ("Create Workflow"/"Import Workflow"), which is the only reason an
+    // unscoped `getByRole` ever resolved to one element here.
+    const emptyActions = within(emptyState as HTMLElement);
+    expect(emptyActions.getByRole('button', { name: 'Create workflow' })).toBeInTheDocument();
+    expect(emptyActions.getByRole('button', { name: 'Import workflow' })).toBeInTheDocument();
   });
 
   it('proves that starting a workflow came from the renderer user', async () => {
@@ -191,8 +196,12 @@ describe('WorkflowsView on the settings visual vocabulary', () => {
     // not in a hand-rolled `flex gap-3` beside the title.
     const strip = container.querySelector('.biorouter-settings-control-strip');
     expect(strip).not.toBeNull();
-    expect(strip).toContainElement(screen.getByRole('button', { name: 'Create Workflow' }));
-    expect(strip).toContainElement(screen.getByRole('button', { name: 'Import Workflow' }));
+    // Queried INSIDE the strip rather than page-wide and asserted to be
+    // contained: the empty state below offers the same two actions under the
+    // same two names, so a page-wide `getByRole` finds two of each.
+    const stripActions = within(strip as HTMLElement);
+    expect(stripActions.getByRole('button', { name: 'Create workflow' })).toBeInTheDocument();
+    expect(stripActions.getByRole('button', { name: 'Import workflow' })).toBeInTheDocument();
 
     // `page-transition` matches no CSS rule in this repo and resolves to no
     // animation in the running app. It was on this header; it does not come back.

--- a/ui/desktop/src/components/workflows/WorkflowsView.tsx
+++ b/ui/desktop/src/components/workflows/WorkflowsView.tsx
@@ -747,7 +747,7 @@ export default function WorkflowsView() {
               <>
                 <Button onClick={() => setShowCreateDialog(true)}>
                   <WorkflowIcon />
-                  Create Workflow
+                  Create workflow
                 </Button>
                 <ImportWorkflowButton onClick={() => setShowImportDialog(true)} />
               </>
@@ -841,7 +841,7 @@ export default function WorkflowsView() {
                     onClick={handleRemoveSchedule}
                     disabled={isSavingSchedule}
                   >
-                    {isSavingSchedule ? 'Working…' : 'Remove Schedule'}
+                    {isSavingSchedule ? 'Working…' : 'Remove schedule'}
                   </Button>
                 )}
                 <Button
@@ -868,7 +868,7 @@ export default function WorkflowsView() {
           {/* Same ladder, same reason as the schedule dialog above. */}
           <DialogContent dismissible={!isSavingSlashCommand} className={MODAL_SIZE.md}>
             <DialogHeader>
-              <DialogTitle>Slash Command</DialogTitle>
+              <DialogTitle>Slash command</DialogTitle>
             </DialogHeader>
             <div className="space-y-4">
               <div>

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -414,6 +414,16 @@
      that keeps keyboard focus out of it must be the SAME number, and two places
      writing 10px is how they stop being the same number. */
   --scroll-fade-top: 10px;
+  /* ⚠ The gradient does NOT start fading at 0 — its first `--scroll-fade-clear`
+     are FULLY transparent, and that pair of stops is the whole fix rather than
+     a refinement of it. A gradient anchored at 0 gives the topmost device pixel
+     the average alpha over its own span, and sub-pixel placement put the
+     clipped "Configuration guide" link at mask position 1-2 rather than 0-1:
+     MEASURED in the running app, the accent line went from a deviation of
+     (80,175,211) off the ground to (12,26,31) — six times fainter, and still
+     a visible pink rule at 4x. Two clear pixels remove it outright, and cost
+     nothing visible: at 10px those pixels were already under 20% alpha. */
+  --scroll-fade-clear: 2px;
 
   /* Rows. Two rhythms and no more: the rail (sidebar, nav, menu item, recents,
      select option) and the content list. They are separate because they answer
@@ -3040,8 +3050,18 @@
 }
 
 .biorouter-scroll-fade-top[data-scrolled='true'] > [data-radix-scroll-area-viewport] {
-  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--scroll-fade-top));
-  mask-image: linear-gradient(to bottom, transparent 0, #000 var(--scroll-fade-top));
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent var(--scroll-fade-clear),
+    #000 var(--scroll-fade-top)
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent var(--scroll-fade-clear),
+    #000 var(--scroll-fade-top)
+  );
 }
 
 .biorouter-settings-section {

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -406,6 +406,15 @@
   --dock-height: 36px;
   --tab-height: 32px; /* chat, artifact and dock tabs; pulled from 34 */
 
+  /* The height of a scroller's top scroll-edge fade (`.biorouter-scroll-fade-top`,
+     authored below). 10px is the middle of the 8-12px band: tall enough that a
+     row clipped to its last pixel is gone rather than reduced to a hairline,
+     short enough that the first fully visible row is not dimmed. It is a token
+     rather than a literal because the fade height and the `scroll-padding-top`
+     that keeps keyboard focus out of it must be the SAME number, and two places
+     writing 10px is how they stop being the same number. */
+  --scroll-fade-top: 10px;
+
   /* Rows. Two rhythms and no more: the rail (sidebar, nav, menu item, recents,
      select option) and the content list. They are separate because they answer
      different questions — a rail row is navigation, a content row is data. */
@@ -2988,6 +2997,51 @@
 .biorouter-settings-tabs {
   background: transparent;
   box-shadow: none;
+}
+
+/* A scroller whose top edge is FLUSH against another rule, faded so a clipped
+   row cannot masquerade as one.
+ *
+ * ⚠ Written for a specific defect, not as decoration. In Settings the tab
+ * strip's bottom edge and the scroll viewport's top edge are the same y — the
+ * strip carries `border-b-0` on purpose (§4.2: its own hairline landed a few
+ * pixels under the header's and read as a double rule), so there is nothing
+ * between them. Scroll the App tab to 663px at 1440x900 and the last 1px of the
+ * "Configuration guide" link survives the clip as an accent-coloured hairline
+ * sitting beside the active tab's underline, at the same y and in the same
+ * colour: a second, thinner tab indicator. A ~3px window of scroll positions
+ * produces it (660 shows 4px of the link, 666 shows none).
+ *
+ * ⚠ The mask is applied to the VIEWPORT, not the Root, and only while the
+ * scroller is actually scrolled. Masking the Root would fade the scrollbar with
+ * the content; fading unconditionally would dim the first row of a page nobody
+ * has scrolled, which is the one place a page has nothing to hide. The hook is
+ * `data-scrolled`, which `ui/scroll-area.tsx` has always written from
+ * `scrollTop > 0` and which nothing consumed until now.
+ *
+ * ⚠ Authored CSS, not a Tailwind arbitrary variant. `mask-image:
+ * linear-gradient(...)` inside a `data-[scrolled=true]:[...]` utility is a
+ * newly written class string, and a newly written class can silently fail to
+ * generate — see `styles/composerFocus.test.ts`, where three spellings were
+ * each measured in the running app with the class on the element and no rule
+ * anywhere in the stylesheet.
+ *
+ * It is a mask rather than an overlay gradient for one reason: an overlay has
+ * to be painted in the ground's colour, and the ground differs per theme
+ * family and per mode. A mask removes alpha, so it is correct in light and dark
+ * of all three families without a single colour being named.
+ *
+ * `scroll-padding-top` is the other half: without it, tabbing to a control that
+ * is scrolled just off the top lands it at y=0, inside the fade. With it the
+ * browser stops the scroll a fade's height short, so a focus ring is never the
+ * thing being faded out. */
+.biorouter-scroll-fade-top > [data-radix-scroll-area-viewport] {
+  scroll-padding-top: var(--scroll-fade-top);
+}
+
+.biorouter-scroll-fade-top[data-scrolled='true'] > [data-radix-scroll-area-viewport] {
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--scroll-fade-top));
+  mask-image: linear-gradient(to bottom, transparent 0, #000 var(--scroll-fade-top));
 }
 
 .biorouter-settings-section {

--- a/ui/desktop/src/styles/settingsScrollFade.test.ts
+++ b/ui/desktop/src/styles/settingsScrollFade.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The Settings scroller's top scroll-edge fade.
+ *
+ * **The defect it fixes.** Settings' `TabsList` carries `border-b-0` on purpose
+ * (§4.2 — its own hairline landed a few pixels under the header's and read as a
+ * double rule unique to Settings), so the tab strip's bottom edge and the scroll
+ * viewport's top edge are the SAME y with nothing between them. Measured in the
+ * running app at 1440x900, App tab, `scrollTop` 663: the last 1px of the
+ * "Configuration guide" `Button variant="link"` survives the clip and lands
+ * beside the active tab's underline — same y, same accent colour, a second and
+ * thinner tab indicator. The window is about 3px wide (660 shows 4px of the
+ * link, 666 shows none), which is why it reads as a rendering glitch rather
+ * than as content.
+ *
+ * ⚠ **Asserted at the SOURCE, and it has to be.** jsdom has no layout engine,
+ * never runs Tailwind, and computes no `mask-image`: a component test can mount
+ * Settings, set `scrollTop`, read the viewport's `maskImage`, and see `''`
+ * whether the rule exists or not. `styles/composerFocus.test.ts` and
+ * `styles/measures.test.ts` make the same argument for the same reason.
+ *
+ * ⚠ **Authored CSS, never a Tailwind arbitrary variant.** A
+ * `data-[scrolled=true]:[mask-image:...]` at the call site is a newly written
+ * class string, and a newly written class can silently fail to generate — three
+ * spellings of the composer's focus edge were each measured in the running app
+ * with the class on the element and no matching rule anywhere in the
+ * stylesheet. That is why the rule below lives in `main.css` and the call site
+ * carries only its name.
+ */
+const CSS = readFileSync(join(__dirname, 'main.css'), 'utf8');
+const SETTINGS_VIEW = readFileSync(
+  join(__dirname, '../components/settings/SettingsView.tsx'),
+  'utf8'
+);
+const SCROLL_AREA = readFileSync(join(__dirname, '../components/ui/scroll-area.tsx'), 'utf8');
+
+/** The `[data-scrolled='true']` rule body, or `undefined` if the rule is gone. */
+function scrolledRule(): string | undefined {
+  return CSS.match(
+    /\.biorouter-scroll-fade-top\[data-scrolled='true'\]\s*>\s*\[data-radix-scroll-area-viewport\]\s*\{([^}]*)\}/
+  )?.[1];
+}
+
+describe('the settings scroll-edge fade', () => {
+  it('is declared as authored CSS, not left to a Tailwind variant', () => {
+    expect(scrolledRule()).toBeTruthy();
+  });
+
+  /**
+   * A mask rather than an overlay gradient: an overlay has to be painted in the
+   * ground's colour, and the ground differs per theme family and per mode, so
+   * an overlay is three families x two modes of colour to keep in step. A mask
+   * removes alpha and names no colour at all.
+   */
+  it('fades by masking alpha, so it needs no per-theme colour', () => {
+    const rule = scrolledRule();
+    expect(rule).toContain('mask-image');
+    expect(rule).toContain('linear-gradient(to bottom, transparent');
+    // Prefixed alongside the standard property, not instead of it.
+    expect(rule).toContain('-webkit-mask-image');
+  });
+
+  /**
+   * The height is a token, not a literal, because the fade and the
+   * `scroll-padding-top` that keeps keyboard focus out of it must be the same
+   * number — and two places writing `10px` is how they stop being.
+   */
+  it('takes its height from one token, shared with the scroll padding', () => {
+    expect(CSS).toMatch(/--scroll-fade-top:\s*10px;/);
+    expect(scrolledRule()).toContain('var(--scroll-fade-top)');
+    const resting = CSS.match(
+      /\.biorouter-scroll-fade-top\s*>\s*\[data-radix-scroll-area-viewport\]\s*\{([^}]*)\}/
+    )?.[1];
+    expect(resting).toContain('scroll-padding-top: var(--scroll-fade-top)');
+  });
+
+  /**
+   * ⚠ Only while scrolled. A page nobody has moved has nothing hidden above its
+   * first row, and dimming that row is a regression rather than a fix — so the
+   * mask hangs off `data-scrolled`, and the unconditional rule beside it must
+   * carry the scroll padding and nothing else.
+   */
+  it('fades only the clipped edge, never an unscrolled page', () => {
+    const resting = CSS.match(
+      /\.biorouter-scroll-fade-top\s*>\s*\[data-radix-scroll-area-viewport\]\s*\{([^}]*)\}/
+    )?.[1];
+    expect(resting).toBeTruthy();
+    expect(resting).not.toContain('mask-image');
+  });
+
+  /**
+   * The rule masks the VIEWPORT, not the `ScrollArea` root: the root also holds
+   * the scrollbar, which would fade with the content.
+   */
+  it('masks the viewport, so the scrollbar is left alone', () => {
+    expect(CSS).not.toMatch(/\.biorouter-scroll-fade-top\[data-scrolled='true'\]\s*\{/);
+  });
+
+  /**
+   * The rule matches nothing without its hook, and the hook is on the one
+   * scroller the defect appears in — so the two are asserted together or they
+   * drift apart silently. The same pairing `composerFocus.test.ts` makes.
+   */
+  it('has its hook on the settings scroller', () => {
+    expect(SETTINGS_VIEW).toMatch(
+      /<ScrollArea className="biorouter-scroll-fade-top flex-1" paddingX=\{1\}>/
+    );
+  });
+
+  /**
+   * `data-scrolled` is the selector's other half and it lives in a component
+   * this rule does not own. It had NO consumers before this fade, which is
+   * exactly the state in which an attribute gets deleted as dead.
+   */
+  it('keeps the data-scrolled attribute the selector depends on', () => {
+    expect(SCROLL_AREA).toContain('data-scrolled={isScrolled}');
+    expect(SCROLL_AREA).toContain('setIsScrolled(scrollTop > 0)');
+  });
+});

--- a/ui/desktop/src/styles/settingsScrollFade.test.ts
+++ b/ui/desktop/src/styles/settingsScrollFade.test.ts
@@ -58,9 +58,34 @@ describe('the settings scroll-edge fade', () => {
   it('fades by masking alpha, so it needs no per-theme colour', () => {
     const rule = scrolledRule();
     expect(rule).toContain('mask-image');
-    expect(rule).toContain('linear-gradient(to bottom, transparent');
+    // Whitespace-tolerant: prettier does not touch main.css (it is in
+    // `.prettierignore`), but the stop list is long enough to be reflowed by
+    // hand and the assertion must survive that.
+    expect(rule?.replace(/\s+/g, ' ')).toContain('linear-gradient( to bottom, transparent 0,');
     // Prefixed alongside the standard property, not instead of it.
     expect(rule).toContain('-webkit-mask-image');
+  });
+
+  /**
+   * ⚠ The gradient's first `--scroll-fade-clear` are FULLY transparent, and
+   * that pair of stops is the fix rather than a refinement of it.
+   *
+   * MEASURED in the running app at the exact repro (Parchment light, App tab,
+   * `scrollTop` 663), reading the clipped link's pixel row against the page
+   * ground four pixels below:
+   *
+   *   no rule at all               (175, 80, 44) on (255,255,255) — a solid rule
+   *   gradient anchored at 0       (243,229,224) — six times fainter, still pink
+   *   2px clear then the gradient  (255,255,255) — gone, delta (0,0,0)
+   *
+   * The middle row is why: a gradient anchored at 0 gives the topmost device
+   * pixel the average alpha over its own span, and sub-pixel placement put the
+   * clipped link at mask position 1-2 rather than 0-1. Two clear pixels cost
+   * nothing visible — at a 10px fade they were already under 20% alpha.
+   */
+  it('clears the first pixels outright rather than only fading them', () => {
+    expect(CSS).toMatch(/--scroll-fade-clear:\s*2px;/);
+    expect(scrolledRule()?.replace(/\s+/g, ' ')).toContain('transparent var(--scroll-fade-clear)');
   });
 
   /**

--- a/ui/desktop/tests/e2e/app.spec.ts
+++ b/ui/desktop/tests/e2e/app.spec.ts
@@ -498,8 +498,8 @@ test.describe('Biorouter App', () => {
             // Wait for any animations to complete
             await mainWindow.waitForTimeout(1000);
 
-            // Click Add Extension button in modal footer
-            console.log('Looking for Add Extension button in modal...');
+            // Click Add extension button in modal footer
+            console.log('Looking for Add extension button in modal...');
             const modalAddButton = await mainWindow.waitForSelector('[data-testid="extension-submit-btn"]', {
               timeout: 2000,
               state: 'visible'
@@ -507,12 +507,12 @@ test.describe('Biorouter App', () => {
 
             // Verify button is visible
             const isModalAddButtonVisible = await modalAddButton.isVisible();
-            console.log('Add Extension button visible:', isModalAddButtonVisible);
+            console.log('Add extension button visible:', isModalAddButtonVisible);
 
             // Click the button
             await modalAddButton.click();
 
-            console.log('Clicked Add Extension button');
+            console.log('Clicked Add extension button');
 
             // Wait for the Running Quotes extension to appear in the list
             console.log('Waiting for Running Quotes extension to appear...');

--- a/ui/desktop/tests/e2e/bioroffice-install.spec.ts
+++ b/ui/desktop/tests/e2e/bioroffice-install.spec.ts
@@ -113,11 +113,8 @@ test.describe('BiorOffice .brxt — real install + agent usage', () => {
     await mainWindow.screenshot({ path: 'test-results/bioroffice-1-extensions.png' });
   });
 
-  test('2. Open Add Extension modal and load bioroffice.brxt', async () => {
-    await mainWindow.click(
-      'button:has-text("Add extension"), button:has-text("Add Extension")',
-      { timeout: 5000 }
-    );
+  test('2. Open Add extension modal and load bioroffice.brxt', async () => {
+    await mainWindow.click('button:has-text("Add extension")', { timeout: 5000 });
     await expect(mainWindow.locator('[role="dialog"]')).toBeVisible({ timeout: 5000 });
     // PLAYWRIGHT_BRXT_FILE hook returns our path without a native dialog
     await mainWindow.click('button:has-text("Browse file")', { timeout: 5000 });

--- a/ui/desktop/tests/e2e/brxt-spoke-install.spec.ts
+++ b/ui/desktop/tests/e2e/brxt-spoke-install.spec.ts
@@ -123,7 +123,7 @@ test.describe('SPOKEAgent .brxt install flow', () => {
 
   test('2. Click "Add extension" — modal opens', async () => {
     await mainWindow.click(
-      'button:has-text("Add extension"), button:has-text("Add Extension")',
+      'button:has-text("Add extension")',
       { timeout: 5000 }
     );
     // Verify the modal dialog is open (avoid strict-mode by targeting the dialog role)

--- a/ui/desktop/tests/e2e/brxt.spec.ts
+++ b/ui/desktop/tests/e2e/brxt.spec.ts
@@ -197,26 +197,29 @@ test.describe('BrxtInstallModal — .brxt extension bundle feature', () => {
   // ---------------------------------------------------------------------------
   // Test 1: Button layout in the Extensions tab header
   // ---------------------------------------------------------------------------
-  test('Extensions tab has correct button layout — Add Extension, Browse Extensions, Add Custom Extension', async () => {
+  test('Extensions tab has correct button layout — Add extension, Browse extensions, Add custom extension', async () => {
     await goToExtensions();
 
-    // Verify all three buttons are visible (UI uses title-case)
-    const addExtBtn = page.locator('button:has-text("Add Extension")').first();
-    const browseBtn = page.locator('button:has-text("Browse Extensions")').first();
-    const addCustomBtn = page.locator('button:has-text("Add Custom Extension")').first();
+    // Verify all three buttons are visible (UI copy is sentence case)
+    const addExtBtn = page.locator('button:has-text("Add extension")').first();
+    const browseBtn = page.locator('button:has-text("Browse extensions")').first();
+    const addCustomBtn = page.locator('button:has-text("Add custom extension")').first();
 
     await expect(addExtBtn).toBeVisible();
     await expect(browseBtn).toBeVisible();
     await expect(addCustomBtn).toBeVisible();
 
-    // Verify DOM order in the header button row (.flex.gap-3 above the scroll area)
+    // Verify DOM order in the header button row. The strip is
+    // `PageHeader`'s `.biorouter-settings-control-strip`; the `.flex.gap-3.mt-5`
+    // this used to name is the hand-rolled row that component replaced, and
+    // `styles/measures.test.ts` now bans it at the source.
     const buttonTexts: string[] = await page.$$eval(
-      '.flex.gap-3.mt-5 button',
+      '.biorouter-settings-control-strip button',
       (btns: Element[]) => btns.map((b) => b.textContent?.trim() ?? '')
     );
-    const addIdx = buttonTexts.findIndex((t) => t.includes('Add Extension'));
-    const browseIdx = buttonTexts.findIndex((t) => t.includes('Browse Extensions'));
-    const customIdx = buttonTexts.findIndex((t) => t.includes('Add Custom Extension'));
+    const addIdx = buttonTexts.findIndex((t) => t.includes('Add extension'));
+    const browseIdx = buttonTexts.findIndex((t) => t.includes('Browse extensions'));
+    const customIdx = buttonTexts.findIndex((t) => t.includes('Add custom extension'));
 
     expect(addIdx).toBeGreaterThanOrEqual(0);
     expect(browseIdx).toBeGreaterThan(addIdx);
@@ -251,7 +254,7 @@ test.describe('BrxtInstallModal — .brxt extension bundle feature', () => {
     await expect(dialog.getByText('Test Extension', { exact: true })).toBeVisible();
     await expect(dialog.locator('text=1.0.0')).toBeVisible();
 
-    // The modal title should still say "Add Extension" (step === 'drop')
+    // The modal title should still say "Add extension" (step === 'drop')
     await expect(page.locator('[role="dialog"] [data-slot="dialog-title"]')).toHaveText(
       /Add extension/i
     );

--- a/ui/desktop/tests/e2e/spokeagent-skills.spec.ts
+++ b/ui/desktop/tests/e2e/spokeagent-skills.spec.ts
@@ -156,8 +156,8 @@ test.describe('SPOKEAgent .brxt — skills integration & propagation', () => {
     await goToSkills();
     await page.screenshot({ path: 'test-results/spoke-03-skills-settings.png' });
 
-    // "Add Skill" button always present
-    await expect(page.locator('button:has-text("Add Skill")')).toBeVisible({ timeout: 5000 });
+    // "Add skill" button always present
+    await expect(page.locator('button:has-text("Add skill")')).toBeVisible({ timeout: 5000 });
 
     // Count any switch elements — each skill row should have one
     const switches = page.locator('button[role="switch"]');


### PR DESCRIPTION
Two cosmetic findings from the 2026-09-08 post-merge test drive of `main` (PRs #172–#179), both
reproduced and measured in a running dev instance before and after.

## Why

### 1 — action-label casing was inconsistent across the unified page header (#178)

`PageHeader` unified the SHAPE of the eight top-level views' headers but not the copy. Sentence
case in "New schedule", "Import chat", "Refresh" (Scheduler, Chat history) against Title Case in
"Create Workflow", "Import Workflow" (Workflows), "Add Extension", "Browse Extensions", "Add
Custom Extension" (Extensions), "Add Skill", "Browse Skills", "Add Custom Skill" (Skills).
Repro: `#/schedules`, then `#/workflows`, and compare the action rows.

Sentence case wins, everywhere in the renderer's own UI copy: it is what the newer surfaces
already use, what `design.md` names for labels ("sentence-case labels", §4.13) and what
`docs/contributing/documentation-style.md` requires of headings. Product names stay capitalised
(Biorouter, BAAM, MCP, UCSF).

**One view already disagreed with itself.** `WorkflowsView`'s empty state offered "Create
workflow" / "Import workflow" while its header offered "Create Workflow" / "Import Workflow" —
the same two actions, two casings, one screen. That is also the reason two of its assertions
needed scoping (below): an unscoped `getByRole` only ever resolved to one element *because* the
two spellings differed.

### 2 — a 1px accent sliver read as a second tab indicator in Settings

`SettingsView`'s `TabsList` carries `border-b-0` deliberately (§4.2 — its own hairline landed a
few pixels under the header's and read as a double rule unique to Settings), so the tab strip's
bottom edge and the scroll viewport's top edge are the SAME y with nothing between them.
Measured in the running app: viewport top **y = 211**, tab strip bottom **y = 211**.

At 1440x900 on the App tab with `scrollTop` **663**, the last **1px** of the "Configuration
guide" `Button variant="link"` survives the clip. Its colour is `rgb(184, 90, 50)` — the accent —
and it lands immediately to the right of the App tab's own underline, at the same visual line:
a second, thinner tab indicator. The window is ~3px wide, exactly as reported (660 shows 4px,
666 shows 0), which is why it reads as a rendering glitch rather than as content.

## What changed

### Casing — every label, before → after

| Where | Before | After |
|---|---|---|
| `WorkflowsView` header action | Create Workflow | Create workflow |
| `ImportWorkflowForm` button + `DialogTitle` | Import Workflow | Import workflow |
| `CreateEditWorkflowModal` `DialogTitle` | Create Workflow / Edit Workflow | Create workflow / Edit workflow |
| `CreateEditWorkflowModal` submit | Save Workflow | Save workflow |
| `CreateWorkflowFromSessionModal` submit | Create Workflow | Create workflow |
| `WorkflowsView` schedule dialog | Remove Schedule | Remove schedule |
| `WorkflowsView` slash-command `DialogTitle` | Slash Command | Slash command |
| `ExtensionsView` + `ExtensionsSection` actions | Add Extension | Add extension |
| ″ | Browse Extensions | Browse extensions |
| ″ | Add Custom Extension | Add custom extension |
| `ExtensionModal` submit (3 call sites) | Add Extension | Add extension |
| `ExtensionsSection` edit modal title | Update Extension | Update extension |
| `ExtensionsSection` edit modal submit | Save Changes | Save changes |
| `SkillsView` actions + empty state | Add Skill | Add skill |
| ″ | Browse Skills | Browse skills |
| ″ | Add Custom Skill | Add custom skill |
| `SkillsView` delete confirm | Delete Package | Delete package |
| `AddSkillModal` `DialogTitle` | Add Skill | Add skill |
| `AddSkillModal` install button | Install Skill | Install skill |
| `CustomSkillModal` `DialogTitle` | Add Custom Skill | Add custom skill |
| `CustomSkillModal` submit | Save Skill | Save skill |
| `BrowseExtensionsModal` `DialogTitle` | Browse Extensions | Browse extensions |
| `BrowseSkillsModal` `DialogTitle` | Browse Skills | Browse skills |

Three of these were not in the original list and are included because they sit in the same
files, beside labels that moved, and would otherwise have left a file self-inconsistent:
`Update Extension` / `Save Changes` (the extension edit modal's props, one line from the two
`Add extension` submit labels) and `Delete Package` / `Save Skill` / `Install Skill` / `Save
Workflow` / `Remove Schedule` / `Slash Command` (stray Title Case in the sweep the brief asked
for). `Save Changes` and `Update Extension` occur nowhere else in the renderer, so no new
inconsistency is created.

Every `aria-label` and `title` attribute in these views was already sentence case and already
agrees with the new copy (e.g. `SkillsView`'s `title="Delete package"` now matches its
`confirmLabel`). One modal title was *already* sentence case while its own submit button was
not — `ExtensionModal` was raised as "Add custom extension" with an "Add Extension" button; the
pair now agrees.

### The Settings scroll edge

`.biorouter-scroll-fade-top` (authored in `main.css`, applied by `SettingsView` to its
`ScrollArea`) masks the scroll **viewport's** top edge, and only while `data-scrolled` is true.
Three choices worth stating, because the obvious alternative gets each one wrong:

- **A mask, not an overlay gradient.** An overlay has to be painted in the ground's colour, and
  the ground differs per family and per mode — three families x two modes of colour to keep in
  step, with nothing enforcing it. A mask removes alpha and names no colour at all.
- **Authored CSS, not a Tailwind arbitrary variant.** A `data-[scrolled=true]:[mask-image:...]`
  at the call site is a newly written class string, and a newly written class can silently fail
  to generate — `styles/composerFocus.test.ts` records three spellings that were each measured
  in the running app with the class on the element and no rule anywhere in the stylesheet.
- **`scroll-padding-top` from the same token**, so tabbing to a control that is scrolled just
  off the top does not land its focus ring inside the fade. Verified: from a position 5px
  clipped, `scrollIntoView({block:'nearest'})` — what focus uses — stops at a gap of exactly
  **10px**, the full fade height.

The mask is on the viewport rather than the `ScrollArea` root because the root also holds the
scrollbar, which would otherwise fade with the content. `ui/scroll-area.tsx` has always written
`data-scrolled` from `scrollTop > 0`; **nothing consumed it until now**, which is the state in
which an attribute gets deleted as dead — so the guard test pins it too.

**No hairline was added under the tab strip.** `border-b-0` there is a decision and the block
comment says why; nothing in this PR contradicts it.

**The gradient's first 2px are fully transparent, and that pair of stops is the fix rather than
a refinement of it.** Measured at the exact repro, reading the clipped link's pixel row against
the page ground 4px below:

| rule | sliver row | ground | deviation |
|---|---|---|---|
| none (today's `main`) | `(175, 80, 44)` | `(255,255,255)` | `(80, 175, 211)` — a solid accent rule |
| `linear-gradient(transparent 0, #000 10px)` | `(243,229,224)` | `(255,255,255)` | `(12, 26, 31)` — 6x fainter, still a pink rule at 4x |
| **`transparent 0, transparent 2px, #000 10px`** | `(255,255,255)` | `(255,255,255)` | **`(0, 0, 0)` — gone** |

A gradient anchored at 0 gives the topmost device pixel the *average* alpha over its own span,
and sub-pixel placement put the clipped link at mask position 1–2 rather than 0–1, so it kept
~15% of its weight. Two clear pixels cost nothing visible: at a 10px fade they were already
under 20% alpha. The App tab's own underline is untouched by the mask in every measurement
(`(200, 98, 62)` before and after) — the fade reaches the scroll viewport only.

## Tests

Result lines, all from this branch after the rebase onto `origin/main` (`0b8d9050`):

```
$ npx vitest run <every touched test file>
 Test Files  7 passed (7)
      Tests  56 passed (56)

$ npx vitest run src/styles src/components/settings/settingsVocabulary.test.ts
 Test Files  18 passed (18)
      Tests  244 passed (244)

$ npm run test:run
 Test Files  423 passed (423)
      Tests  4747 passed | 1 skipped (4748)

$ npm run lint:check
OK — generated artifacts are current (3 themes)
OK — all 332 contrast assertions pass
OK — every semantic colour token used by a utility has a @theme inline mirror
exit=0

$ npx prettier --check <every changed src file, incl. main.css>
All matched files use Prettier code style!
```

**New test:** `ui/desktop/src/styles/settingsScrollFade.test.ts` (8 tests) — a source-level guard
in the shape `composerFocus.test.ts` uses, and it has to be: jsdom has no layout engine and
computes no `mask-image`, so a render test would mount Settings, set `scrollTop`, read
`maskImage`, see `''`, and pass whether the rule existed or not. It asserts the rule exists as
authored CSS, that it masks alpha (no colour named), that the clear lead-in and the fade height
both come from tokens, that the resting rule carries *no* mask, that the mask is on the viewport
and not the root, that `SettingsView` carries the hook, and that `scroll-area.tsx` still writes
`data-scrolled`.

**Test expectations changed (every one):**

- `PageHeader.test.tsx` — the fixture button and its `getByRole` name: `Add Skill` → `Add skill`.
- `WorkflowsView.test.tsx` — `Create Workflow`/`Import Workflow` → sentence case in the control-strip
  test, **and two queries scoped with `within`** (the empty-state test and the control-strip test).
  This is the only behavioural test change and it is forced: the header and the empty state now
  offer the same two labels, so a page-wide `getByRole` finds two of each. Both were already
  asserting containment in a specific region; they now query inside it.
- `ExtensionsView.test.tsx` — four names sentence-cased.
- `SkillsView.test.tsx` — `Delete Package` → `Delete package`, `Add Skill` → `Add skill`.
- `CustomSkillModal.test.tsx` — `Save Skill` → `Save skill` (two occurrences).
- `BrowseExtensionsModal.test.tsx` — `getByText('Browse Extensions')` → `Browse extensions`.
- `ExtensionModal.test.tsx` — **the copy was not being asserted.** Both call sites pass
  `submitLabel="Add Extension"` as a fixture prop and then find the button by
  `getByTestId('extension-submit-btn')`, so the test passes either way. The fixture was updated
  anyway so it mirrors the production call site.
- e2e specs (`brxt`, `brxt-spoke-install`, `bioroffice-install`, `spokeagent-skills`,
  `app`) — copy strings, test titles and comments. Playwright's `:has-text()` is a
  case-insensitive substring match so most of these would have kept passing, but
  `brxt.spec.ts` also does `buttonTexts.findIndex(t => t.includes('Add Extension'))`, which is a
  case-*sensitive* JS match and would have broken.

**One extra e2e fix, called out because it is not copy.** `brxt.spec.ts` queried
`.flex.gap-3.mt-5 button` for the header's button row — the hand-rolled row `PageHeader`
replaced, and one that `styles/measures.test.ts` now bans at the source, so it has matched
nothing since #178 and the test's DOM-order assertions were already failing. Repointed at
`.biorouter-settings-control-strip`. I could not run the Playwright suite here (it needs a
packaged app), so this is reasoned from the source rather than executed.

## Verification

Own sandboxed dev instance, worktree `header-casing`, window resized to 1440x900 via System
Events and read back. Screenshots in `~/biorouter-runs/test-drive/shots/pr-i/`.

**The eight views' header rows, Parchment light and dark** — `header-{light,dark}-{1..8}-*.png`
(workflows, scheduler, extensions, skills, chat-history, built-apps, mcp-apps, settings).

**The Settings repro, 4x zoom on the seam** (crop x 640–900, y 196–226, nearest-neighbour x4):

- `zoom4x-before-663.png` — the App tab's underline with a second, thinner accent rule to its
  right, at the same visual line. The defect.
- `zoom4x-after-663.png` — the first fix (gradient from 0): a faint pink residue.
- `zoom4x-after2-663.png` — shipped: only the App tab's underline remains.

Also `settings-{before,after,after2}-663-full.png` and the 660/666 pair either side of the
3px window, and `settings-unscrolled-not-faded.png` (App tab at `scrollTop` 0 — the mask
computes to `none` and the first section is at full weight).

**Light and dark of all three families**, at `scrollTop` 663, deviation of the sliver row from
the page ground: Parchment light `(0,0,0)`, Alma Mater dark `(0,0,0)` (the family and mode the
original report was captured in), Roche Limit light `(0,0,0)`. The earlier gradient-from-0
build was additionally checked in Parchment dark and Roche Limit dark; because the shipped
gradient is strictly more transparent over the same span, those cannot regress. Console errors
after the sweep: none.

## Out of scope

- **The native macOS application menu** (`main.ts` ~5114–5120: "Browse Extensions", "Add Custom
  Extension…") stays Title Case — that is the platform convention for menu items, not this
  app's copy. Likewise the `{ name: 'All Files' }` filter in `WorkflowsView`'s native file
  dialog.
- **`'Biorouter Skills'`** (`SkillsView`'s group title) is left capitalised: it is used as a
  proper name, and `CustomSkillModal`'s description refers to it the same way.
- **`components/settings/extensions/modal/ExtensionModal.tsx`'s own internals** (field labels
  such as "Request Headers") — a different surface from the header strip, and sweeping it is
  the `extensions/` exclusion that `settingsVocabulary.test.ts` deliberately still carries.
- **Prettier over `tests/e2e/`.** All five e2e specs I touched already failed `prettier --check`
  on `main`, and the repo's `format` / `format:check` scripts only cover `src/**`, so those
  files are outside Prettier's declared scope. Formatting them would bury a 20-line copy change
  in a whole-file reflow.
- **A hairline under the Settings tab strip.** Explicitly not added; `border-b-0` is a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
