### PR TITLE
Desktop: no focus fill on tab triggers — the underline is the indicator

### DIFF
--- a/design.md
+++ b/design.md
@@ -595,10 +595,11 @@ The focused control instead **deepens its own fill by one step** and firms its e
 is added around it.
 
 ```css
-/* Controls: the fill steps past hover, and the label firms up. */
-:where(a, button, summary, [role='button'], [role='tab'], [role='menuitem'],
-       [role='option'], input[type='checkbox'], input[type='radio'],
-       [tabindex]:not([tabindex='-1'])):focus-visible {
+/* Controls: the fill steps past hover, and the label firms up.
+   A TAB TRIGGER is exempt — see the amendment below. */
+:where(:is(a, button, summary, [role='button'], [role='menuitem'],
+           [role='option'], input[type='checkbox'], input[type='radio'],
+           [tabindex]:not([tabindex='-1'])):not([role='tab'])):focus-visible {
   outline: none;
   background-color: var(--background-focus);
   color: var(--text-default);
@@ -621,6 +622,23 @@ is added around it.
   border-color: var(--border-focus);
 }
 ```
+
+**Amendment, 2026-09-08 — a tab trigger is exempt from the fill; its underline is the indicator.**
+Radix `TabsTrigger` activates on focus, so the focused tab is always the _active_ tab and the fill
+parked itself permanently on it: a grey box around the accent underline, reported against Settings
+("that weird shade") and equally present on the Provider catalog strip. Measured in Parchment light
+before the change: a mouse click read `rgba(0, 0, 0, 0)` (Chrome withholds `:focus-visible` from a
+mouse-clicked button) but one arrow key inside the strip read `rgb(224, 224, 220)` = `--background-focus`,
+and it then stayed for as long as the strip kept focus. D-15 forbids a ring and the fill is what was
+rejected, so what remains is the indicator the component already draws: `:focus-visible` takes the
+`after:` bar from 2px to 3px and firms the label to `--text-default`, in
+`ui/desktop/src/styles/main.css` beside the block above and guarded by `styles/tabFocus.test.ts`.
+Two things about the exclusion are load-bearing. It is a `:not([role='tab'])` around the **whole**
+list, because three arms match one trigger — it is a `<button>`, it carries `role="tab"`, and Radix's
+roving tabindex gives the active one `tabindex="0"` — so deleting the obvious arm changes nothing on
+screen. And the underline half is **unlayered**, because the bar's height and colour come from
+Tailwind utilities and a layered rule would lose to them silently. `.br-tab` (chat header, artifact
+panel, terminal dock) is untouched: it draws no underline and owns its own `::after`.
 
 All three tokens are **shared** — the focus treatment was always explicitly neutral rather than accented
 (D-15), so unifying it changed its values without changing its intent.
@@ -1266,7 +1284,7 @@ ground*, which is what the ANSI dim slot is for. See **[Decision D-11](#d-11--te
 >
 > | ID | Decision | Resolved value |
 > |---|---|---|
-> | D-15 | Focus indication | **A surface shift, not a ring.** No outline anywhere. Focused fill — as decided `#e4dcc9` / `#4d4430`, **now the shared `#e0e0dc` / `#35342f`**; the ring returns only under `prefers-contrast: more`. *Supersedes the D-03 answer.* |
+> | D-15 | Focus indication | **A surface shift, not a ring.** No outline anywhere. Focused fill — as decided `#e4dcc9` / `#4d4430`, **now the shared `#e0e0dc` / `#35342f`**; the ring returns only under `prefers-contrast: more`. *Supersedes the D-03 answer.* **Amended 2026-09-08: a `[role='tab']` trigger takes no fill** — it activates on focus, so the fill sat permanently on the active tab as a grey box; its underline firming (2px → 3px, label at `--text-default`) is its focus indicator instead. |
 > | D-16 | The user's turn | **Tinted, not accent.** `--background-medium` + hairline + `--text-default`. A solid coral block shouted. |
 > | D-17 | Tool calls | **Lines, not cards.** No outline, collapsed or expanded. Failure = colour + a 5% wash. A persistent rectangle reads as a stuck focus ring. |
 > | D-18 | Hairlines | **One value.** `border-border-subtle` at full strength. Eight alpha-diluted variants (`/35`…`/70`) made adjacent panels' edges read at different weights, so they never visually aligned. |

--- a/docs/desktop-ui/settings-visual-vocabulary.md
+++ b/docs/desktop-ui/settings-visual-vocabulary.md
@@ -226,6 +226,20 @@ at, so Settings' stays below the header. A **filter** — Chat history's "Show s
 changes what the page shows rather than doing something, so it is `PageHeader`'s `children`,
 under the strip rather than in it.
 
+**A tab in that strip takes no focus fill (2026-09-08).** D-15 makes focus a surface shift, and
+`ui/desktop/src/components/ui/tabs.tsx` renders a `<button role="tab">` that Radix activates on
+focus — so the focused tab is always the _active_ tab and `--background-focus` parked itself on it
+permanently, a grey box around the accent underline. Measured in Parchment light: a mouse click read
+`rgba(0, 0, 0, 0)`, but one arrow key inside the strip read `rgb(224, 224, 220)` and it then stayed.
+The base rule in `styles/main.css` now excludes `[role='tab']`, and a focused tab firms its
+underline instead — the `after:` bar goes 2px → 3px with the label at `--text-default`. The rule is
+on the TRIGGER, not on this page: `settings/providers/ProviderCatalog.tsx` reuses the same
+`.biorouter-settings-tabs` strip, and Knowledge's Sources/Graph strip uses the same primitive.
+`styles/tabFocus.test.ts` guards it. Two traps recorded there: the exclusion must wrap the whole
+`:where()` list (a trigger matches `button`, `[role='tab']` _and_ `[tabindex]:not([tabindex='-1'])`,
+so removing one arm changes nothing), and the underline rule must be **unlayered** or the Tailwind
+utility that sets the bar's height beats it silently.
+
 ## The two primitives
 
 ### `components/ui/note.tsx`

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -1421,18 +1421,34 @@
      `:focus-visible`, it fired on a plain mouse click too. Instead the focused
      control deepens its own fill by one step and firms its text.
 
-     `:where()` keeps specificity at 0 so any component can still opt out. */
+     `:where()` keeps specificity at 0 so any component can still opt out.
+
+     ⚠ **A tab TRIGGER is exempt (2026-09-08).** Radix `TabsTrigger` activates
+     on focus, so the focused tab is always the active tab — the fill therefore
+     sat permanently on the active tab as a grey box around its accent
+     underline, which is what was reported ("that weird shade"). A tab's focus
+     indicator is its underline firming instead; see the unlayered
+     `[role='tab']:focus-visible` rule immediately after this layer.
+
+     ⚠ **The exclusion is a `:not()` around the WHOLE list, not the removal of
+     `[role='tab']` from it** — three arms match one tab trigger and dropping
+     the obvious one changes nothing. Measured on the running app: the trigger
+     is a `<button>` (arm 1), carries `role="tab"` (arm 2), and Radix's roving
+     tabindex gives the ACTIVE one `tabindex="0"` (arm 3,
+     `[tabindex]:not([tabindex='-1'])`). The `:not()` lives INSIDE the
+     `:where()` so the rule stays at specificity 0. */
   :where(
-    a,
-    button,
-    summary,
-    [role='button'],
-    [role='tab'],
-    [role='menuitem'],
-    [role='option'],
-    input[type='checkbox'],
-    input[type='radio'],
-    [tabindex]:not([tabindex='-1'])
+    :is(
+        a,
+        button,
+        summary,
+        [role='button'],
+        [role='menuitem'],
+        [role='option'],
+        input[type='checkbox'],
+        input[type='radio'],
+        [tabindex]:not([tabindex='-1'])
+      ):not([role='tab'])
   ):focus-visible {
     outline: none;
     background-color: var(--background-focus);
@@ -1480,6 +1496,56 @@
       border-radius: inherit;
     }
   }
+}
+
+/* D-15, amended 2026-09-08 — a TAB TRIGGER's focus indicator is its underline
+ * firming, never a fill.
+ *
+ * The base block above no longer paints `--background-focus` on `[role='tab']`.
+ * Measured on the running app before the change (Parchment light, Settings):
+ * mouse click on the App tab left `backgroundColor: rgba(0, 0, 0, 0)` because
+ * Chrome withholds `:focus-visible` from a mouse-clicked button, but one arrow
+ * key inside the strip gave `rgb(224, 224, 220)` = `--background-focus`
+ * (`#e0e0dc`) — a grey box that then SITS on the active tab for as long as the
+ * strip keeps focus, because Radix activates on focus. Same value measured on
+ * the Provider catalog strip (`catalog-tab-institutional`).
+ *
+ * D-15 forbids a ring and the fill is what was reported, so what is left is the
+ * indicator the component already draws: the `after:` bar goes from 2px to 3px
+ * and the label firms to `--text-default`. A tab that is focused without being
+ * active (manual activation) gets the bar painted rather than left transparent,
+ * so focus is never invisible.
+ *
+ * ⚠ **Unlayered, deliberately, and that is the whole mechanism** — same as
+ * `.biorouter-focus-surface` below. The bar's height and colour come from
+ * Tailwind utilities (`after:h-0.5`, `after:bg-transparent`,
+ * `data-[state=active]:after:bg-accent-bar`), and every layered utility beats
+ * every `@layer base` rule whatever the specificity. A copy of this rule inside
+ * `@layer base` would lose silently and the bar would stay 2px.
+ *
+ * ⚠ **`--accent-bar`, not `--border-accent`.** `--accent-bar` is the token the
+ * underline already uses in every family, and "the stronger accent" is not a
+ * property `--border-accent` has: it is darker than `--accent-bar` in Parchment
+ * and Alma Mater light but LIGHTER in Roche Limit light (`#ee6c1a` over
+ * `#d95b08`), so swapping it in would cut the bar's contrast in one family
+ * while raising it in two. Thickness firms the same colour everywhere.
+ *
+ * ⚠ **`.br-tab` is excluded from the underline half, and it has to be.** The
+ * chat/artifact/dock tab also carries `role="tab"`, draws no underline, and
+ * already owns its `::after`: `.br-tab[data-dropbefore='true']::after` is the
+ * drag insertion hairline, positioned with `top`/`bottom` and no `height`. A
+ * `height: 3px` landing on it over-constrains the box and collapses the
+ * hairline to a stub the moment a tab is both mid-drag and focused. Dropping
+ * the FILL still applies to it (harmlessly — `.br-tab` writes its own
+ * unlayered `background: transparent`, so the base fill never reached it). */
+:where([role='tab']:not(.br-tab)):focus-visible {
+  outline: none;
+  color: var(--text-default);
+}
+
+:where([role='tab']:not(.br-tab)):focus-visible::after {
+  height: 3px;
+  background-color: var(--accent-bar);
 }
 
 /* Motion is short and informative. Everything animated must null out here —

--- a/ui/desktop/src/styles/tabFocus.test.ts
+++ b/ui/desktop/src/styles/tabFocus.test.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * D-15's focus surface, on a TAB TRIGGER — where it must not appear.
+ *
+ * D-15 makes focus a surface shift: `:where(a, button, …):focus-visible` paints
+ * `--background-focus`. Radix `TabsTrigger` (`components/ui/tabs.tsx`) renders a
+ * `<button role="tab">` and activates on focus, so the focused tab is ALWAYS the
+ * active tab — the fill therefore parked itself permanently on the active tab as
+ * a grey box around its accent underline. Reported 2026-09-08 ("that weird
+ * shade") against the Settings strip, which `settings/providers/ProviderCatalog`
+ * reuses.
+ *
+ * Measured in the running app (Parchment light, `#/settings`) before the fix:
+ * a mouse click on `[data-testid="settings-app-tab"]` left
+ * `backgroundColor: rgba(0, 0, 0, 0)` (Chrome withholds `:focus-visible` from a
+ * mouse-clicked button), but one ArrowLeft inside the strip gave
+ * `backgroundColor: rgb(224, 224, 220)` — `--background-focus` = `#e0e0dc` —
+ * with `:focus-visible` matching, and the winning rule read off CDP's
+ * `CSS.getMatchedStylesForNode` was the D-15 block in `@layer base`. After the
+ * fix both paths read `rgba(0, 0, 0, 0)`.
+ *
+ * ⚠ **Asserted at the SOURCE, and it has to be** — the same reason
+ * `composerFocus.test.ts` and `focusSurface.test.ts` give. jsdom has no layout
+ * engine, never runs Tailwind, and does not evaluate `:focus-visible`; a
+ * component test that focuses a trigger and reads `backgroundColor` sees the
+ * resting value and passes whether the rule exists or not.
+ *
+ * ⚠ **Three arms of the D-15 list match one tab trigger**, which is why the
+ * exemption is a `:not([role='tab'])` around the whole list rather than the
+ * removal of `[role='tab']` from it: the trigger is a `<button>`, it carries
+ * `role="tab"`, and Radix's roving tabindex gives the ACTIVE trigger
+ * `tabindex="0"` so it also matches `[tabindex]:not([tabindex='-1'])` — all
+ * three verified on the running app. Deleting only the obvious arm is the
+ * plausible wrong fix, and it changes nothing on screen.
+ */
+const CSS = readFileSync(join(__dirname, 'main.css'), 'utf8');
+const TABS = readFileSync(join(__dirname, '../components/ui/tabs.tsx'), 'utf8');
+
+/**
+ * Every rule in the file that sets a background on a `:focus-visible` selector,
+ * as `[selector, body]`. Comments are stripped first so the prose around the
+ * rules — which quotes selectors — can neither satisfy nor trip an assertion.
+ */
+let cached: Array<[string, string]> | null = null;
+function focusVisibleBackgroundRules(): Array<[string, string]> {
+  if (cached) return cached;
+  const withoutComments = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+  const out: Array<[string, string]> = [];
+  const re = /([^{}]*:focus-visible[^{}]*)\{([^}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(withoutComments))) {
+    if (/background(-color)?\s*:/.test(m[2])) out.push([m[1].trim(), m[2].trim()]);
+  }
+  cached = out;
+  return out;
+}
+
+/** The D-15 base rule: the one that paints `--background-focus` on a plain control. */
+const d15 = focusVisibleBackgroundRules().find(
+  ([selector, body]) =>
+    body.includes('var(--background-focus)') &&
+    /\bbutton\b/.test(selector) &&
+    !/prefers-contrast/.test(selector)
+);
+
+describe('a tab trigger takes no focus fill', () => {
+  it('still exists, and still fills everything that is not a tab', () => {
+    expect(d15, 'the D-15 focus-visible fill rule is no longer recognisable').toBeTruthy();
+    expect(d15![1]).toContain('var(--background-focus)');
+    expect(d15![0]).toContain(":not([role='tab'])");
+  });
+
+  /**
+   * The exemption has to survive the two arms that are NOT `[role='tab']`.
+   * `button` and `[tabindex]:not([tabindex='-1'])` each match a Radix trigger on
+   * their own, so an exemption that merely drops `[role='tab']` from the list
+   * leaves the grey box exactly where it was.
+   */
+  it('exempts them by excluding the whole list, not by dropping one arm', () => {
+    const selector = d15![0].replace(/\s+/g, '');
+    expect(selector).toMatch(/\bbutton\b/);
+    expect(selector).toContain("[tabindex]:not([tabindex='-1'])");
+    // The `:not()` closes the alternation and sits inside the outer `:where()`,
+    // so it applies to every arm rather than to one alternative within it.
+    expect(selector).toMatch(/\):not\(\[role='tab'\]\)\):focus-visible$/);
+  });
+
+  /** Specificity 0 is D-15's contract: any component can still opt out. */
+  it('keeps the rule at specificity 0 by nesting the :not() inside :where()', () => {
+    expect(d15![0].replace(/\s+/g, '').startsWith(':where(')).toBe(true);
+  });
+
+  /**
+   * The operator's requirement, stated as a property of the whole stylesheet
+   * rather than of one rule. Pseudo-element rules are exempt: the underline
+   * indicator below paints `::after`, which is the tab's own bar, not a box
+   * around the label.
+   */
+  it('has no rule anywhere that paints a background on a focused tab', () => {
+    const offenders = focusVisibleBackgroundRules().filter(([selector]) => {
+      if (!/\[role=['"]tab['"]\]/.test(selector)) return false;
+      if (/::(after|before)/.test(selector)) return false;
+      // A selector that mentions tabs only in order to exclude them is fine.
+      return !/:not\(\s*\[role='tab'\]\s*\)/.test(selector);
+    });
+    expect(offenders, `these rules fill a focused tab: ${JSON.stringify(offenders)}`).toEqual([]);
+  });
+
+  it('leaves the opt-in focus surface untouched for other controls', () => {
+    const filled = focusVisibleBackgroundRules().map(([selector]) => selector);
+    expect(filled.some((s) => s.includes('.biorouter-focus-surface:focus-visible'))).toBe(true);
+  });
+});
+
+describe('a focused tab shows its underline firming instead', () => {
+  const UNDERLINE_SELECTOR = ":where([role='tab']:not(.br-tab)):focus-visible::after";
+  const LABEL_SELECTOR = ":where([role='tab']:not(.br-tab)):focus-visible";
+
+  function body(selector: string): string {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = CSS.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+    expect(match, `no rule for ${selector}`).toBeTruthy();
+    return match![1];
+  }
+
+  it('thickens the accent bar and firms the label', () => {
+    const bar = body(UNDERLINE_SELECTOR);
+    expect(bar).toMatch(/height:\s*3px/);
+    expect(bar).toContain('var(--accent-bar)');
+    expect(body(LABEL_SELECTOR)).toContain('var(--text-default)');
+  });
+
+  /** D-15 forbids a ring; the ring comes back only under `prefers-contrast`. */
+  it('never draws a ring and never paints a fill', () => {
+    for (const selector of [UNDERLINE_SELECTOR, LABEL_SELECTOR]) {
+      expect(body(selector)).not.toMatch(/box-shadow|outline:\s*\d/);
+      expect(body(selector)).not.toContain('--background-focus');
+    }
+    expect(body(LABEL_SELECTOR)).toContain('outline: none');
+  });
+
+  /**
+   * ⚠ **Unlayered, and that is the whole mechanism** — the same structural check
+   * `focusSurface.test.ts` runs. The bar's height and colour come from Tailwind
+   * utilities (`after:h-0.5`, `data-[state=active]:after:bg-accent-bar`), and
+   * every layered utility beats every `@layer base` rule whatever the
+   * specificity. Inside `@layer base` this rule would lose silently, the bar
+   * would stay 2px, and nothing here would fail.
+   */
+  it('is unlayered, so it can reach past the utilities layer', () => {
+    const index = CSS.indexOf(UNDERLINE_SELECTOR + ' {');
+    expect(index).toBeGreaterThan(-1);
+    const before = CSS.slice(0, index);
+    let depth = 0;
+    const layerStarts: number[] = [];
+    for (let i = 0; i < before.length; i++) {
+      if (before[i] === '{') {
+        if (/@layer\s+[\w\s,-]*$/.test(before.slice(Math.max(0, i - 40), i))) {
+          layerStarts.push(depth);
+        }
+        depth++;
+      } else if (before[i] === '}') {
+        depth--;
+        if (layerStarts.length && layerStarts[layerStarts.length - 1] === depth) {
+          layerStarts.pop();
+        }
+      }
+    }
+    expect(layerStarts).toHaveLength(0);
+  });
+
+  /**
+   * The underline half must not reach `.br-tab` (chat header / artifact panel /
+   * dock). That component also carries `role="tab"`, draws no underline, and
+   * already owns its `::after` — `.br-tab[data-dropbefore='true']::after` is the
+   * drag insertion hairline, sized by `top`/`bottom` with no `height`, which a
+   * `height: 3px` would over-constrain into a stub.
+   */
+  it('does not reach .br-tab, which owns its ::after for the drop hairline', () => {
+    expect(UNDERLINE_SELECTOR).toContain(':not(.br-tab)');
+    expect(CSS).toContain(".br-tab[data-dropbefore='true']::after");
+  });
+
+  /**
+   * The rule matches nothing without its hook, and the hook is the `after:` bar
+   * Radix's trigger draws — so the two are asserted together or they can drift
+   * apart silently.
+   */
+  it('has its hook on the TabsTrigger primitive', () => {
+    expect(TABS).toContain('TabsPrimitive.Trigger');
+    expect(TABS).toContain("after:content-['']");
+    expect(TABS).toContain('data-[state=active]:after:bg-accent-bar');
+  });
+});


### PR DESCRIPTION
## Why

Reported 2026-09-08 with a screenshot: in Settings the active tab ("App", accent underline) sits inside a grey shaded box in Parchment light — "that weird shade".

It is D-15's focus surface landing on a control that should never wear it. `ui/desktop/src/components/ui/tabs.tsx` renders Radix's `TabsTrigger` as a `<button role="tab">` with **automatic activation** — focus *is* selection — so the focused tab is always the *active* tab, and `--background-focus` parks itself on it and stays there for as long as the strip keeps focus.

**Measured in my own dev instance (Parchment light, `#/settings`, `[data-testid="settings-app-tab"]` / `settings-chat-tab`):**

| | mouse click | keyboard (arrow key in the strip) |
|---|---|---|
| **before** | `backgroundColor: rgba(0, 0, 0, 0)`, `:focus-visible` **false** | `backgroundColor: rgb(224, 224, 220)`, `:focus-visible` **true** |
| **after** | `backgroundColor: rgba(0, 0, 0, 0)` | `backgroundColor: rgba(0, 0, 0, 0)`, `::after` height `2px → 3px` |

`rgb(224, 224, 220)` is `--background-focus` = `#e0e0dc`. A plain mouse click never showed it because Chrome withholds `:focus-visible` from a mouse-clicked button — **one arrow key is enough**, and the box then stays. The same value was measured on the Provider catalog strip (`catalog-tab-institutional`).

**Winning rule**, read off CDP `CSS.getMatchedStylesForNode` on the focused node — the D-15 block in `@layer base`, with no Tailwind `bg-*` utility competing (the trigger paints no fill of its own):

```
layer: base
:where(a, button, summary, [role="button"], [role="tab"], [role="menuitem"],
       [role="option"], input[type="checkbox"], input[type="radio"],
       [tabindex]:not([tabindex="-1"])):focus-visible
  → background-color: var(--background-focus)
```

Screenshots (this machine): `~/biorouter-runs/test-drive/shots/pr-j/before-parchment-light-keyboard-focus.png` and `before-parchment-light-strip-crop.png` vs `after-parchment-light-keyboard-focus.png` and `after-settings-parchment-light.png`.

## What changed

`ui/desktop/src/styles/main.css`, entirely inside the D-15 block region (~L1418–1550):

1. **The base fill now excludes tab triggers** — `:not([role='tab'])` wrapped around the **whole** `:where()` list.

   ⚠ **Not** the removal of `[role='tab']` from the list, which is the obvious fix and changes nothing on screen: **three arms match one trigger**, all verified on the running app — it is a `<button>` (arm 1), it carries `role="tab"` (arm 2), and Radix's roving tabindex gives the **active** trigger `tabindex="0"` so it also matches `[tabindex]:not([tabindex='-1'])` (arm 3). The `:not()` sits *inside* the `:where()` so the rule keeps specificity 0 and any component can still opt out, as D-15 promises.

2. **A focused tab firms its underline instead.** D-15 forbids a ring and the fill is what was rejected, so what is left is the indicator the component already draws: on `:focus-visible` the `after:` bar goes 2px → 3px and the label goes to `--text-default`. A tab focused *without* being active (manual activation) gets the bar painted rather than left transparent, so focus is never invisible.

   ⚠ **That rule is unlayered, and that is the whole mechanism.** The bar's height and colour come from Tailwind utilities (`after:h-0.5`, `data-[state=active]:after:bg-accent-bar`) and every layered utility beats every `@layer base` rule whatever the specificity — inside `@layer base` this rule would lose silently and the bar would stay 2px. Authored CSS, not a variant at the call site (the class-scanning trap `composerFocus.test.ts` documents).

   ⚠ **`--accent-bar`, not `--border-accent`.** "The stronger accent" is not a property `--border-accent` has: it is darker than `--accent-bar` in Parchment and Alma Mater light but *lighter* in Roche Limit light (`#ee6c1a` over `#d95b08`), so swapping it in would cut the bar's contrast in one family while raising it in two. Thickening the same token firms it everywhere.

3. **`.br-tab` is excluded from the underline half.** The chat header / artifact panel / dock tab also carries `role="tab"`, draws no underline, and already owns its `::after` — `.br-tab[data-dropbefore='true']::after` is the drag insertion hairline, sized by `top`/`bottom` with no `height`, which a `height: 3px` would over-constrain into a stub. Dropping the *fill* still reaches it and is a no-op there: `.br-tab` writes its own unlayered `background: transparent`, so the base fill never applied.

The fix is on the **trigger**, so it covers every strip built from the primitive: Settings (Models / Chat / App), `settings/providers/ProviderCatalog.tsx` (Local / Institutional / Public) and Knowledge's Sources / Graph. No component file was touched.

Also: `design.md` (the D-15 prose, its CSS snippet and the D-15 decision-table row) and `docs/desktop-ui/settings-visual-vocabulary.md` carry a dated one-line amendment.

## Tests

New source-level guard, `ui/desktop/src/styles/tabFocus.test.ts` (10 tests), in the spirit of `composerFocus.test.ts` / `focusSurface.test.ts` — jsdom has no layout engine, never runs Tailwind and does not evaluate `:focus-visible`, so a render test passes whether the rule exists or not. It asserts the exemption, that it wraps the whole list rather than dropping one arm, that specificity stays 0, that **no rule anywhere paints a background on a `[role='tab']:focus-visible`** element, that the underline rule is unlayered, and that `.br-tab` is out of its reach.

**Both plausible wrong implementations were checked to fail it**, by patching `main.css` and re-running:

- naive "just drop `[role='tab']` from the list" → `Tests 2 failed | 8 passed (10)`
- underline rule moved inside `@layer base` → `Tests 1 failed | 9 passed (10)`

```
$ npx vitest run src/styles
 ✓ src/styles/tabFocus.test.ts (10 tests) 5ms
 Test Files  17 passed (17)
      Tests  236 passed (236)

$ npm run test:run
 Test Files  423 passed (423)
      Tests  4749 passed | 1 skipped (4750)

$ npm run lint:check          # tsc + eslint + check:themes + check:contrast + check:tokens
OK — generated artifacts are current (3 themes)
OK — all 332 contrast assertions pass
OK — every semantic colour token used by a utility has a @theme inline mirror
EXIT=0

$ npx prettier --check src/styles/tabFocus.test.ts     # clean
```

`src/styles/main.css` is in `.prettierignore` (the theme generator owns its formatting). `design.md` and `docs/desktop-ui/settings-visual-vocabulary.md` **already fail `prettier --check` on `origin/main`** — verified by checking the pristine files out and running Prettier on them — so they are left alone rather than whole-file reformatted; the paragraphs added here were checked to be Prettier-clean on their own.

## Verification

Driven in a sandboxed dev instance (`launch-dev-gui.sh`, CDP 9337), real mouse clicks and real key presses, `#/settings` and `#/configure-providers`, **all three theme families × light/dark**. Every keyboard-focused tab: `backgroundColor: rgba(0, 0, 0, 0)`, `outline: none`, `boxShadow: none`, `::after` height `3px`, `::after` background = that family's `--accent-bar`, label = `--text-default`. No page errors.

| Family / mode | focused tab background | `::after` | `--background-focus` (what it would have been) |
|---|---|---|---|
| parchment light | `rgba(0, 0, 0, 0)` | 3px `rgb(207, 109, 71)` | `#e0e0dc` |
| parchment dark | `rgba(0, 0, 0, 0)` | 3px `rgb(232, 137, 95)` | `#35342f` |
| alma-mater light | `rgba(0, 0, 0, 0)` | 3px `rgb(22, 160, 172)` | `#e0e0dc` |
| alma-mater dark | `rgba(0, 0, 0, 0)` | 3px `rgb(96, 208, 218)` | `#35342f` |
| roche-limit light | `rgba(0, 0, 0, 0)` | 3px `rgb(217, 91, 8)` | `#e0e0dc` |
| roche-limit dark | `rgba(0, 0, 0, 0)` | 3px `rgb(238, 108, 26)` | `#35342f` |

Provider catalog strip checked the same way in parchment light, alma-mater light and roche-limit dark. Screenshots in `~/biorouter-runs/test-drive/shots/pr-j/`.

## Out of scope

- **The tab PANEL still takes the fill, and this PR does not change that.** Tabbing out of the strip lands on Radix's `role="tabpanel"` `[tabindex="0"]`, which matches the same `[tabindex]:not([tabindex='-1'])` arm; measured on this branch **after** the change: `fv: true`, `backgroundColor: rgb(224, 224, 220)` — the whole Settings panel greys. Arguably a bigger "weird shade" than the one reported, but it is a different control and a different decision (a focusable scroll region legitimately wants *some* focus indication), so it is recorded here rather than fixed silently.
- `.br-tab` keeps its own `[data-active]` vocabulary. It never had the fill (its unlayered `background: transparent` outranked the base rule) and the underline half deliberately does not reach it.
- No component file changed; `SettingsView.tsx` was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
