### PR TITLE
CLI: honour the configured provider before creating a session, and resolve serve's paths through symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "console 0.16.2",
  "crossterm",
  "dotenvy",
+ "dunce",
  "env-lock",
  "etcetera 0.11.0",
  "futures",

--- a/crates/biorouter-cli/Cargo.toml
+++ b/crates/biorouter-cli/Cargo.toml
@@ -25,6 +25,10 @@ cliclack = "0.3.5"
 console = "0.16.1"
 uuid = { version = "1.11", features = ["v4"] }
 dotenvy = "0.15.7"
+# `serve` derives the interface bundle and the daemon from the real path of the
+# running executable, and on Windows `canonicalize` hands back a verbatim
+# `\\?\C:\…` path that must not reach a message or a child's environment.
+dunce = "1"
 bat = "0.25.0"
 pulldown-cmark = { version = "0.13", default-features = false }
 anyhow = { workspace = true }

--- a/crates/biorouter-cli/src/cli.rs
+++ b/crates/biorouter-cli/src/cli.rs
@@ -322,6 +322,64 @@ pub struct RunBehavior {
     pub scheduled_job_id: Option<String>,
 }
 
+/// The provider and model a NEW session row would run with.
+///
+/// `build_session` resolves four slots in order — the CLI flag, the provider
+/// saved on the session row, a workflow pin, and the global default from
+/// `config.yaml` (`session/builder.rs`). Three of them apply here: the row is
+/// the one about to be created, so its slot is empty by construction.
+///
+/// ⚠ The global default is read **here** rather than being passed in, and that
+/// placement is the fix rather than an implementation detail. Every call site
+/// forgot it — `handle_default_session` and `doctor --fix` passed literal
+/// `None`s, `session` passed the flags alone, `run` passed the flags or the
+/// workflow pin — so from v1.89.0 to v1.90.2 a fully configured install was
+/// told "No provider is configured" by every command that starts a chat.
+/// Resolving inside the guard is what makes a future call site unable to
+/// reintroduce it.
+///
+/// `Config::get_param` consults the environment before the file, so
+/// `BIOROUTER_PROVIDER=… biorouter` resolves through this same call.
+fn resolution_for_a_new_row(
+    provider: Option<&str>,
+    model: Option<&str>,
+) -> (Option<String>, Option<String>) {
+    let config = Config::global();
+    resolution_with_global_default(
+        provider,
+        model,
+        config.get_biorouter_provider().ok(),
+        config.get_biorouter_model().ok(),
+    )
+}
+
+/// The precedence itself, with the configured default handed in.
+///
+/// Separated from [`resolution_for_a_new_row`] only so the tests can drive
+/// every combination of "typed now / configured / neither" without a config
+/// file and without racing the process-global `Config`.
+fn resolution_with_global_default(
+    provider: Option<&str>,
+    model: Option<&str>,
+    default_provider: Option<String>,
+    default_model: Option<String>,
+) -> (Option<String>, Option<String>) {
+    (
+        provider.map(str::to_string).or(default_provider),
+        model.map(str::to_string).or(default_model),
+    )
+}
+
+/// The refusal text for a run that cannot name a provider or a model, or `None`
+/// when the row is safe to create.
+///
+/// The exit is in the caller so that this half — which is all of the logic —
+/// can be unit-tested rather than only observed by killing a process.
+fn refusal_for_a_new_row(provider: Option<&str>, model: Option<&str>) -> Option<String> {
+    let (provider, model) = resolution_for_a_new_row(provider, model);
+    crate::session::unconfigured_precondition(provider.as_deref(), model.as_deref())
+}
+
 /// Refuse an unconfigured run BEFORE a session row exists.
 ///
 /// `build_session` is the authority on provider and model resolution, but it
@@ -330,16 +388,16 @@ pub struct RunBehavior {
 /// every attempt the user made before configuring. Every `create_session` call
 /// below is preceded by this check.
 ///
-/// ⚠ The provider saved on the session row is absent from the resolution the
-/// caller passes in, and that is not an oversight: the row this is guarding is
-/// the one about to be created, so that slot is empty by construction. The
-/// paths here that return an EXISTING id do not call this, because such a row
-/// can legitimately carry the only provider a resumed chat has.
+/// ⚠ The provider saved on the session row is absent from the resolution, and
+/// that is not an oversight: the row this is guarding is the one about to be
+/// created, so that slot is empty by construction. The paths here that return
+/// an EXISTING id do not call this, because such a row can legitimately carry
+/// the only provider a resumed chat has.
 fn refuse_unconfigured_before_creating_a_row(
     provider: Option<&str>,
     model: Option<&str>,
 ) -> Result<()> {
-    if let Some(text) = crate::session::unconfigured_precondition(provider, model) {
+    if let Some(text) = refusal_for_a_new_row(provider, model) {
         crate::session::output::render_error(&text);
         std::process::exit(1);
     }
@@ -2867,6 +2925,134 @@ mod cli_tests {
                 "a create_session call at byte {create_at} has no precondition check above it"
             );
         }
+
+        // The guard runs; the question this test could not answer is what it is
+        // HANDED. Every call site passed the flags alone, so the configured
+        // default never reached the precondition and a working install was
+        // refused. The resolution now lives inside the guard, and this pins it
+        // there: moving it back out to the call sites is exactly the change
+        // that regresses.
+        let (_, resolution) = src
+            .split_once("fn resolution_for_a_new_row(")
+            .expect("the guard no longer resolves anything");
+        let (resolution, _) = resolution
+            .split_once("\nfn refusal_for_a_new_row(")
+            .expect("could not find the end of resolution_for_a_new_row");
+        for accessor in ["get_biorouter_provider", "get_biorouter_model"] {
+            assert!(
+                resolution.contains(accessor),
+                "a new session row must fall back to the configured default; \
+                 `{accessor}` is not read where the row is guarded"
+            );
+        }
+    }
+
+    /// The reported bug: a configured install answered every session-creating
+    /// command with "No provider is configured".
+    ///
+    /// Driven through the real `Config`, because the wiring between the guard
+    /// and the configuration is the thing that was missing — a test of the
+    /// precedence alone would have passed on the broken build too.
+    /// `Config::get_param` reads the environment before the file, so this is
+    /// deterministic wherever it runs.
+    #[test]
+    fn a_configured_default_satisfies_the_precondition_for_a_new_row() {
+        let _env = env_lock::lock_env([
+            ("BIOROUTER_PROVIDER", Some("claude_code".to_string())),
+            ("BIOROUTER_MODEL", Some("claude-opus-5".to_string())),
+        ]);
+
+        assert_eq!(
+            resolution_for_a_new_row(None, None),
+            (
+                Some("claude_code".to_string()),
+                Some("claude-opus-5".to_string())
+            ),
+            "a bare `biorouter` names no provider, so the configured one is the answer"
+        );
+        assert_eq!(
+            refusal_for_a_new_row(None, None),
+            None,
+            "a configured install must get past the guard with no flags at all"
+        );
+    }
+
+    /// What the user typed now still wins over what they configured earlier.
+    #[test]
+    fn an_explicit_flag_still_outranks_the_configured_default() {
+        let _env = env_lock::lock_env([
+            ("BIOROUTER_PROVIDER", Some("claude_code".to_string())),
+            ("BIOROUTER_MODEL", Some("claude-opus-5".to_string())),
+        ]);
+        assert_eq!(
+            resolution_for_a_new_row(Some("anthropic"), Some("opus")),
+            (Some("anthropic".to_string()), Some("opus".to_string()))
+        );
+    }
+
+    /// The model has the same four slots as the provider, and shipped with the
+    /// same gap: `biorouter run --provider claude_code` got past the provider
+    /// half and was refused with "No model is configured".
+    #[test]
+    fn the_model_slot_falls_back_too() {
+        assert_eq!(
+            resolution_with_global_default(
+                Some("claude_code"),
+                None,
+                Some("versa_azure".to_string()),
+                Some("claude-opus-5".to_string()),
+            ),
+            (
+                Some("claude_code".to_string()),
+                Some("claude-opus-5".to_string())
+            ),
+            "naming a provider must not cost the configured model"
+        );
+    }
+
+    /// The behaviour `5dc1eee1` added, which this fix must not undo: an install
+    /// with nothing configured anywhere is still refused, and the refusal names
+    /// the provider first.
+    #[test]
+    fn an_install_with_nothing_configured_is_still_refused() {
+        assert_eq!(
+            resolution_with_global_default(None, None, None, None),
+            (None, None)
+        );
+        let text = crate::session::unconfigured_precondition(None, None)
+            .expect("nothing configured anywhere must still be refused");
+        assert!(text.contains("No provider is configured"), "{text}");
+
+        // A workflow pin alone is enough — that is the whole reason `run`
+        // resolves one before asking.
+        assert_eq!(
+            resolution_with_global_default(Some("claude_code"), Some("claude-opus-5"), None, None),
+            (
+                Some("claude_code".to_string()),
+                Some("claude-opus-5".to_string())
+            )
+        );
+    }
+
+    /// The refusal tells the reader to do something they can actually do.
+    ///
+    /// `biorouter` with no subcommand has no `--provider` flag (`struct Cli`
+    /// carries only the subcommand), and it is the command the operator's
+    /// report was typed against — so the old "pass --provider <name> for this
+    /// run" named a flag that does not exist on the path printing it.
+    #[test]
+    fn the_refusal_names_a_command_that_takes_the_flag() {
+        let text = crate::session::unconfigured_precondition(None, None).expect("refused");
+        for command in ["biorouter session", "biorouter run"] {
+            assert!(
+                text.contains(command),
+                "the refusal must name a command that accepts --provider: {text}"
+            );
+        }
+        assert!(
+            Cli::try_parse_from(["biorouter", "--provider", "claude_code"]).is_err(),
+            "if a global --provider is ever added, this refusal should name it instead"
+        );
     }
 
     /// BR-71 / issue #56: `biorouter sessions <verb>` really is a command.

--- a/crates/biorouter-cli/src/commands/apps.rs
+++ b/crates/biorouter-cli/src/commands/apps.rs
@@ -241,13 +241,19 @@ pub(crate) async fn daemon_ok(host: &str, port: u16) -> bool {
 /// Locate the `biorouterd` binary: prefer the sibling of the running `biorouter`
 /// executable (dev tree and installed app both colocate them), else fall back to
 /// the bare name so the OS resolves it on `PATH`.
+///
+/// The path is resolved through symlinks first
+/// ([`crate::commands::exe_path::current_exe_resolved`]): on macOS
+/// `current_exe()` reports the link the user typed, and the CLI is installed as
+/// a symlink, so "the sibling" would otherwise be a sibling of
+/// `~/.local/bin/biorouter`.
 fn biorouterd_path() -> PathBuf {
     let bin = if cfg!(windows) {
         "biorouterd.exe"
     } else {
         "biorouterd"
     };
-    if let Ok(exe) = std::env::current_exe() {
+    if let Some(exe) = crate::commands::exe_path::current_exe_resolved() {
         if let Some(sibling) = exe.parent().map(|d| d.join(bin)) {
             if sibling.exists() {
                 return sibling;

--- a/crates/biorouter-cli/src/commands/exe_path.rs
+++ b/crates/biorouter-cli/src/commands/exe_path.rs
@@ -1,0 +1,123 @@
+//! Where this executable really lives, as opposed to how it was invoked.
+//!
+//! `std::env::current_exe()` answers a different question on each platform, and
+//! the difference is not cosmetic — it decides whether a command can find the
+//! files that were installed *next to* the binary.
+//!
+//! - **macOS** returns the path the process was launched through
+//!   (`_NSGetExecutablePath`). The in-app "Biorouter CLI Update" card and
+//!   `biorouter setup-path` both install the CLI as a **symlink**
+//!   (`crates/biorouter/src/system.rs`, `#[cfg(unix)]`), so a user who types
+//!   `biorouter` gets `~/.local/bin/biorouter` — and every sibling derived from
+//!   it (`../web`, `./biorouterd`) lands in their home directory instead of
+//!   inside the application bundle.
+//! - **Linux** reads `/proc/self/exe`, which the kernel has already resolved.
+//! - **Windows** returns the real module path from `GetModuleFileNameW`, and the
+//!   installer copies rather than symlinks, so there is no link to follow.
+//!
+//! So the resolution is a no-op on two of the three platforms — which is
+//! precisely why it is unconditional rather than `#[cfg(target_os = "macos")]`.
+//! A `cfg` here would mean the fix is only exercised on the one platform that
+//! happens to need it today, and a Linux container with a hand-made symlink, or
+//! a future Windows shim, would quietly regress.
+//!
+//! ⚠ `canonicalize` on Windows returns a **verbatim** path (`\\?\C:\…`). That
+//! string is not universally accepted: it reaches an error message the user
+//! reads and the `BIOROUTER_SERVE_UI` environment variable a child process
+//! parses. `dunce::simplified` strips the prefix whenever the plain form means
+//! the same thing, and is the identity function everywhere else.
+
+use std::path::{Path, PathBuf};
+
+/// The real path of `exe`, with symlinks followed and Windows' verbatim prefix
+/// stripped.
+///
+/// Falls back to the path as given when it cannot be resolved — a binary that
+/// has been deleted out from under a running process, or a relative path with
+/// no matching working directory, is a worse thing to fail on than to guess at,
+/// because every caller here treats the result as a *hint* and checks the file
+/// it derives before using it.
+pub fn resolve_exe_path(exe: &Path) -> PathBuf {
+    std::fs::canonicalize(exe)
+        .map(|p| dunce::simplified(&p).to_path_buf())
+        .unwrap_or_else(|_| exe.to_path_buf())
+}
+
+/// [`resolve_exe_path`] applied to the running executable.
+///
+/// `None` only when the platform cannot report it at all; callers fall back to
+/// a `PATH` lookup or to a packaged location rather than failing.
+pub fn current_exe_resolved() -> Option<PathBuf> {
+    std::env::current_exe().ok().map(|e| resolve_exe_path(&e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug this module exists for: through the symlink `setup-path`
+    /// creates, the siblings of the executable are the siblings of the *link*.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_resolves_to_the_binary_it_points_at() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real_dir = tmp.path().join("Resources").join("bin");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        let real = real_dir.join("biorouter");
+        std::fs::write(&real, b"#!/bin/sh\n").unwrap();
+
+        let link_dir = tmp.path().join("local").join("bin");
+        std::fs::create_dir_all(&link_dir).unwrap();
+        let link = link_dir.join("biorouter");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert_eq!(
+            resolve_exe_path(&link),
+            std::fs::canonicalize(&real).unwrap(),
+            "the link must resolve to the installed binary, not to its own directory"
+        );
+        assert_ne!(
+            resolve_exe_path(&link).parent(),
+            Some(link_dir.as_path()),
+            "resolving must move the parent directory too — that is the whole point"
+        );
+    }
+
+    /// Runs on every platform, and is only capable of failing on one of them:
+    /// on Windows `canonicalize` returns `\\?\C:\…`, which would then be
+    /// printed at the user and handed to a child process in an environment
+    /// variable. Dropping `dunce::simplified` turns this red.
+    #[test]
+    fn the_resolved_path_is_never_a_windows_verbatim_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp.path().join("biorouter");
+        std::fs::write(&exe, b"x").unwrap();
+
+        let resolved = resolve_exe_path(&exe);
+        assert!(
+            !resolved.to_string_lossy().starts_with(r"\\?\"),
+            "a verbatim path leaks into the serve error text and into \
+             BIOROUTER_SERVE_UI: {}",
+            resolved.display()
+        );
+        assert!(resolved.is_absolute());
+    }
+
+    /// The string-level half of the same rule, where the prefix actually exists.
+    #[cfg(windows)]
+    #[test]
+    fn a_verbatim_prefix_is_stripped_at_the_string_level() {
+        assert_eq!(
+            dunce::simplified(Path::new(r"\\?\C:\Program Files\Biorouter\biorouter.exe")),
+            Path::new(r"C:\Program Files\Biorouter\biorouter.exe")
+        );
+    }
+
+    /// A path that cannot be resolved is passed through rather than swallowed,
+    /// so the caller's own "is this file here?" check is what decides.
+    #[test]
+    fn an_unresolvable_path_is_returned_unchanged() {
+        let missing = Path::new("/definitely/not/here/biorouter");
+        assert_eq!(resolve_exe_path(missing), missing.to_path_buf());
+    }
+}

--- a/crates/biorouter-cli/src/commands/mod.rs
+++ b/crates/biorouter-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod apps;
 pub mod bench;
 pub mod configure;
 pub mod doctor;
+pub mod exe_path;
 pub mod extension;
 pub mod info;
 pub mod knowledge;

--- a/crates/biorouter-cli/src/commands/serve.rs
+++ b/crates/biorouter-cli/src/commands/serve.rs
@@ -26,6 +26,7 @@
 //! session talks to is less capable than the one the desktop application
 //! starts, and anything assuming otherwise is wrong.
 
+use crate::commands::exe_path::current_exe_resolved;
 use anyhow::{bail, Context, Result};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
@@ -271,17 +272,24 @@ fn wait_until_ready(host: &str, port: u16, child: &mut std::process::Child) -> R
 /// tree both pair the two binaries that were built together, rather than
 /// whichever one is earliest on `PATH`.
 fn resolve_biorouterd() -> Result<PathBuf> {
-    let name = format!("biorouterd{}", std::env::consts::EXE_SUFFIX);
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let beside = dir.join(&name);
-            if beside.is_file() {
-                return Ok(beside);
-            }
-        }
+    if let Some(found) = current_exe_resolved().and_then(|exe| biorouterd_beside(&exe)) {
+        return Ok(found);
     }
     // Fall back to PATH, and let the spawn report a missing binary.
-    Ok(PathBuf::from(name))
+    Ok(PathBuf::from(format!(
+        "biorouterd{}",
+        std::env::consts::EXE_SUFFIX
+    )))
+}
+
+/// The daemon installed alongside `exe`, if it is there.
+///
+/// Split out from [`resolve_biorouterd`] so a test can hand it a path instead
+/// of being at the mercy of wherever the test binary itself happens to live.
+fn biorouterd_beside(exe: &Path) -> Option<PathBuf> {
+    let name = format!("biorouterd{}", std::env::consts::EXE_SUFFIX);
+    let beside = exe.parent()?.join(name);
+    beside.is_file().then_some(beside)
 }
 
 /// Candidate locations for the built interface, in order.
@@ -290,26 +298,36 @@ fn resolve_biorouterd() -> Result<PathBuf> {
 /// says only "not found" leaves the reader guessing which of four layouts the
 /// installation is in.
 fn web_dir_candidates() -> Vec<PathBuf> {
+    web_dir_candidates_for(current_exe_resolved().as_deref())
+}
+
+/// The candidate list for a given executable path.
+///
+/// ⚠ `exe` must be the **resolved** path, not `current_exe()` — see
+/// [`crate::commands::exe_path`]. Everything below is a sibling of the binary,
+/// so a symlink one directory up from the installation moves every candidate
+/// with it: through `~/.local/bin/biorouter` the two exe-relative entries
+/// became `~/.local/web` and `~/ui/desktop/src/web`, and `serve` reported that
+/// the interface was missing on an installation that ships it.
+fn web_dir_candidates_for(exe: Option<&Path>) -> Vec<PathBuf> {
     let mut out = Vec::new();
     if let Ok(dir) = std::env::var("BIOROUTER_SERVE_UI") {
         out.push(PathBuf::from(dir));
     }
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            // Packaged: the binaries sit in `Resources/bin`, the bundle beside
-            // them in `Resources/web`.
-            out.push(dir.join("..").join("web"));
-            // A development tree: target/<profile>/biorouter, with the bundle
-            // where `npm run build:web` writes it.
-            out.push(
-                dir.join("..")
-                    .join("..")
-                    .join("ui")
-                    .join("desktop")
-                    .join("src")
-                    .join("web"),
-            );
-        }
+    if let Some(dir) = exe.and_then(Path::parent) {
+        // Packaged: the binaries sit in `Resources/bin`, the bundle beside
+        // them in `Resources/web`.
+        out.push(dir.join("..").join("web"));
+        // A development tree: target/<profile>/biorouter, with the bundle
+        // where `npm run build:web` writes it.
+        out.push(
+            dir.join("..")
+                .join("..")
+                .join("ui")
+                .join("desktop")
+                .join("src")
+                .join("web"),
+        );
     }
     // The Linux packages, where the exe-relative rule does not survive: from
     // /usr/bin, `../web` is /usr/web.
@@ -418,6 +436,9 @@ mod tests {
     /// installation layouts they are in.
     #[test]
     fn a_missing_interface_names_every_path_it_tried() {
+        // Held because the sibling tests below set this variable, and
+        // `web_dir_candidates` reads it.
+        let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
         let candidates = web_dir_candidates();
         assert!(
             candidates.len() >= 2,
@@ -429,19 +450,130 @@ mod tests {
         );
     }
 
+    /// Restated against `web_dir_candidates_for`, which takes the executable as
+    /// an argument: the previous version scanned this file's own source for the
+    /// order two string literals appear in, and would have passed against a
+    /// build that never read the variable at all.
     #[test]
     fn an_explicit_setting_is_looked_at_before_anything_else() {
-        // Not `set_var` on a shared process: assert the ordering property that
-        // matters instead, which is that the env candidate is first when set.
-        // `web_dir_candidates` reads it at position 0 by construction; this
-        // pins that construction against a reordering.
-        let src = include_str!("serve.rs");
-        let env_at = src.find("BIOROUTER_SERVE_UI").expect("env var read");
-        let usr_at = src.find("/usr/share/biorouter/web").expect("fhs path");
-        assert!(
-            env_at < usr_at,
-            "the explicit setting must be consulted before the packaged locations"
+        let _env = env_lock::lock_env([(
+            "BIOROUTER_SERVE_UI",
+            Some("/somewhere/explicit/web".to_string()),
+        )]);
+        let candidates =
+            web_dir_candidates_for(Some(Path::new("/opt/Biorouter/resources/bin/biorouter")));
+        assert_eq!(
+            candidates.first(),
+            Some(&PathBuf::from("/somewhere/explicit/web")),
+            "the explicit setting must be consulted before the packaged locations: \
+             {candidates:?}"
         );
+    }
+
+    /// The operator's report, reduced to a fixture: a macOS install reached
+    /// through the symlink `biorouter setup-path` creates.
+    ///
+    /// Before the fix, `current_exe()` on macOS returned the link and every
+    /// candidate below was derived from *its* directory — so the packaged
+    /// bundle two directories away from the link was never looked at, and the
+    /// error named `~/.local/web` and `~/ui/desktop/src/web`.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_executable_resolves_to_the_real_installation() {
+        let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
+        let tmp = tempfile::tempdir().unwrap();
+
+        let bin = tmp.path().join("Resources").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let real = bin.join("biorouter");
+        std::fs::write(&real, b"#!/bin/sh\n").unwrap();
+        let web = tmp.path().join("Resources").join("web");
+        std::fs::create_dir_all(&web).unwrap();
+        std::fs::write(web.join("index.html"), b"<!doctype html>").unwrap();
+
+        let link_dir = tmp.path().join("local").join("bin");
+        std::fs::create_dir_all(&link_dir).unwrap();
+        let link = link_dir.join("biorouter");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let resolved = crate::commands::exe_path::resolve_exe_path(&link);
+        let candidates = web_dir_candidates_for(Some(&resolved));
+        let found = candidates
+            .iter()
+            .find(|c| c.join("index.html").is_file())
+            .unwrap_or_else(|| {
+                panic!("no candidate held the bundle that is on disk: {candidates:?}")
+            });
+        assert_eq!(
+            normalise(found),
+            std::fs::canonicalize(&web).unwrap(),
+            "the packaged bundle must be found through the symlink"
+        );
+
+        // And the unresolved path is what the bug looked like, so pin that the
+        // two really do differ — otherwise this test would pass on a platform
+        // where it proves nothing.
+        let unresolved = web_dir_candidates_for(Some(&link));
+        assert!(
+            !unresolved.iter().any(|c| c.join("index.html").is_file()),
+            "fixture is wrong: the bundle must be unreachable from the link's \
+             own directory, or this test cannot fail"
+        );
+    }
+
+    /// The other half of the same defect: `serve` could not start the daemon
+    /// either, because it looked for it beside the link.
+    #[cfg(unix)]
+    #[test]
+    fn the_daemon_is_found_beside_the_real_executable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("Resources").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let real = bin.join("biorouter");
+        std::fs::write(&real, b"#!/bin/sh\n").unwrap();
+        let daemon = bin.join(format!("biorouterd{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&daemon, b"#!/bin/sh\n").unwrap();
+
+        let link_dir = tmp.path().join("local").join("bin");
+        std::fs::create_dir_all(&link_dir).unwrap();
+        let link = link_dir.join("biorouter");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert!(
+            biorouterd_beside(&link).is_none(),
+            "fixture is wrong: the daemon must not be beside the link"
+        );
+        // Compared after canonicalising both: on macOS the temp directory is
+        // itself reached through `/var -> /private/var`, so the resolved path
+        // is spelled differently while naming the same file.
+        assert_eq!(
+            biorouterd_beside(&crate::commands::exe_path::resolve_exe_path(&link))
+                .map(|p| std::fs::canonicalize(p).unwrap()),
+            Some(std::fs::canonicalize(&daemon).unwrap()),
+            "the daemon must be found beside the binary the link points at"
+        );
+    }
+
+    /// A candidate list derived from a verbatim Windows path would be printed
+    /// at the user and handed to the daemon in `BIOROUTER_SERVE_UI`. Runs
+    /// everywhere; only Windows can fail it.
+    #[test]
+    fn the_resolved_candidates_are_never_windows_verbatim_paths() {
+        let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp
+            .path()
+            .join(format!("biorouter{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&exe, b"x").unwrap();
+
+        let resolved = crate::commands::exe_path::resolve_exe_path(&exe);
+        for candidate in web_dir_candidates_for(Some(&resolved)) {
+            assert!(
+                !normalise(&candidate).to_string_lossy().starts_with(r"\\?\"),
+                "verbatim path in a candidate: {}",
+                candidate.display()
+            );
+        }
     }
 
     #[test]

--- a/crates/biorouter-cli/src/session/builder.rs
+++ b/crates/biorouter-cli/src/session/builder.rs
@@ -610,26 +610,39 @@ fn close_ephemeral_store_blocking(ephemeral_store_dir: Option<tempfile::TempDir>
 /// Takes the already-resolved values rather than reading config itself, so the
 /// two callers keep their own precedence and this stays a pure function a test
 /// can drive directly. `build_session` resolves four slots (CLI flag, the
-/// provider saved on the session row, a workflow pin, the global default);
-/// [`crate::cli::get_or_create_session_id`] resolves the same list minus the
-/// saved one, which is empty by construction at the point it asks, because it
-/// is about to create that row.
+/// provider saved on the session row, a workflow pin, the global default); the
+/// pre-session guard `cli::refuse_unconfigured_before_creating_a_row` resolves
+/// the same list minus the saved one, which is empty by construction at the
+/// point it asks, because it is about to create that row.
+///
+/// ⚠ This doc comment described that guard correctly while the guard did not:
+/// the *callers* passed only the flags, so the global default never reached
+/// here and a configured install was refused (v1.89.0 … v1.90.2). The
+/// resolution now happens inside the guard, where a call site cannot omit it —
+/// `cli::resolution_for_a_new_row`.
 ///
 /// The provider is reported first when both are missing: `biorouter configure`
 /// walks the user through provider and model together, so naming two problems
 /// would describe one fix twice.
+///
+/// The flag is named against the commands that actually accept it. `biorouter`
+/// with no subcommand takes no `--provider`, so "pass --provider for this run"
+/// was an instruction that could not be followed on the one path a new user is
+/// most likely to be reading it from.
 pub fn unconfigured_precondition(provider: Option<&str>, model: Option<&str>) -> Option<String> {
     if provider.is_none() {
         return Some(
             "No provider is configured.\n\
-             Run `biorouter configure` to set one up, or pass --provider <name> for this run."
+             Run `biorouter configure` to set one up, or pass --provider <name> to \
+             `biorouter session` or `biorouter run`."
                 .to_string(),
         );
     }
     if model.is_none() {
         return Some(
             "No model is configured.\n\
-             Run `biorouter configure` to set one up, or pass --model <name> for this run."
+             Run `biorouter configure` to set one up, or pass --model <name> to \
+             `biorouter session` or `biorouter run`."
                 .to_string(),
         );
     }

--- a/docs/deployment/browser-access.md
+++ b/docs/deployment/browser-access.md
@@ -227,6 +227,11 @@ finds none:
 3. `ui/desktop/src/web/` in a development tree.
 4. `/usr/share/biorouter/web` (where the Linux packages put it).
 
+"Beside" means beside the **real** binary. The CLI is installed on `PATH` as a symlink
+(`~/.local/bin/biorouter` → the application bundle), and steps 2 and 3 follow that link before
+deriving anything from it — otherwise they would name directories in your home folder, which is
+what they did in v1.89.5 through v1.90.2.
+
 In a development tree, build it first:
 
 ```bash


### PR DESCRIPTION
Two independent defects in the terminal CLI, both reported by an operator on macOS running the
installed 1.89.10 CLI through the `~/.local/bin/biorouter` symlink. Neither is a configuration
mistake and neither is fixed by updating the app.

## Why

**A configured install could not start a chat.**

```
$ biorouter
  error: No provider is configured.
Run `biorouter configure` to set one up, or pass --provider <name> for this run.

$ biorouter configure     # → Claude Code, CLAUDE_CODE_COMMAND=claude, model claude-opus-5; "saved successfully"
$ biorouter
  error: No provider is configured.     # unchanged
```

**`serve` could not find the interface it ships with.**

```
$ biorouter serve
Error: could not find the Biorouter web interface. Tried:
  /Users/wgu/.local/web
  /Users/wgu/ui/desktop/src/web
  /usr/share/biorouter/web
```

Both reproduced verbatim against the installed 1.89.10 binary before touching anything — see
[Manual verification](#manual-verification).

## Root causes

### 1. The pre-session guard never saw the configured default

`crates/biorouter-cli/src/cli.rs:338` — `refuse_unconfigured_before_creating_a_row(provider, model)`
passed its two arguments straight to `session::unconfigured_precondition`
(`crates/biorouter-cli/src/session/builder.rs:621`), which refuses whenever `provider.is_none()`.
The arguments were only ever what each call site chose to hand it:

| Call site | What it passed |
|---|---|
| `handle_default_session` (bare `biorouter`), `cli.rs:2523` | literal `None, None` |
| `handle_doctor_fix` (`doctor --fix`), `cli.rs:2494` | literal `None, None` |
| the `session` command, `cli.rs:1948` | `--provider` / `--model` only |
| the `run` command, `cli.rs:2165` | the flags `.or_else(`workflow pin`)` |

`build_session` resolves **four** slots (`builder.rs:699-714`): CLI flag → the provider saved on the
session row → a workflow pin → `config.get_biorouter_provider().ok()`. The fourth never reached the
guard, so `config.yaml` was invisible to it — and so was `BIOROUTER_PROVIDER` in the environment,
because `Config::get_param` reads the environment on the way to the file (`config/base.rs:800-803`).

Affected: bare `biorouter`, `biorouter session`, `biorouter run`, `session --resume` with no prior
row, `doctor --fix`, and — through the identical gap in the model slot — `run --provider <name>`
("No model is configured"). Only `--no-session` (which returns before the guard) and explicit flags
worked.

Introduced by `5dc1eee1` (2026-08-09, *"fix(cli): an unconfigured install gets an error, not a panic
and an orphan row"*), so **v1.89.0 … v1.90.2 and `main`** all ship it. The doc comment on
`unconfigured_precondition` described the guard as resolving "the same list minus the saved one" —
i.e. including the global default — which is what the guard was *supposed* to do and never did.

The existing test `no_session_row_is_created_before_the_provider_precondition_is_checked` counts
`.create_session(` calls and guards; nothing asserted what the guard was **handed**, which is how
this shipped.

### 2. `serve` derived its search paths and its daemon from the symlink

`crates/biorouter-cli/src/commands/serve.rs:273-318` — `resolve_biorouterd()` and
`web_dir_candidates()` built `<exe dir>/biorouterd`, `<exe>/../web` and
`<exe>/../../ui/desktop/src/web` from a raw `std::env::current_exe()`.

On macOS `current_exe()` is `_NSGetExecutablePath` — the path the process was **invoked** through.
`biorouter setup-path` and the in-app "Biorouter CLI Update" card install the CLI as a *symlink*
(`crates/biorouter/src/system.rs:527-530`, `#[cfg(unix)]` symlink vs `#[cfg(not(unix))]` copy), so
every sibling was a sibling of `~/.local/bin/biorouter` — exactly the two paths in the operator's
error. The daemon was not found either, so even `serve --web-dir <bundle>` died with "could not
start biorouterd".

This is **not** a missing bundle: the installed 1.89.10 app ships `Resources/web/index.html`
(12 MB, landed in `8b074646`), and invoked by its real path the same binary serves fine — verified
below. `serve` itself first shipped in v1.89.5 (`a2c04df7`), so **v1.89.5 … v1.90.2 and `main`**
carry it.

Linux was never affected (`/proc/self/exe` is pre-resolved) and Windows is moot for the symlink
(the installer copies) — both **measured**, not assumed; see [Manual verification](#manual-verification).

## What changed

**Fix 1 — resolve inside the guard, where a call site cannot omit it.**
`cli::resolution_for_a_new_row(provider, model)` applies
`.or_else(|| Config::global().get_biorouter_provider().ok())` and the model equivalent, and
`refuse_unconfigured_before_creating_a_row` goes through it. All four call sites are unchanged;
placing the fallback at the call sites is what produced four chances to forget it. The saved row
stays deliberately out of the resolution — the row being guarded is the one about to be created,
so that slot is empty by construction.

The exit is split from the decision (`refusal_for_a_new_row` returns the text, the guard calls
`process::exit`) so the logic is unit-testable rather than only observable by killing a process.

The refusal text now names commands that accept the flag: `biorouter` with no subcommand has no
`--provider` (`struct Cli`, `cli.rs:44-49`, carries only the subcommand), so *"pass `--provider`
for this run"* named a flag that does not exist on the path printing it. The doc comment on
`unconfigured_precondition` now describes what the code does.

**Fix 2 — resolve the executable before deriving anything from it.**
New `crates/biorouter-cli/src/commands/exe_path.rs`:

```rust
pub fn resolve_exe_path(exe: &Path) -> PathBuf {
    std::fs::canonicalize(exe)
        .map(|p| dunce::simplified(&p).to_path_buf())
        .unwrap_or_else(|_| exe.to_path_buf())
}
```

- `dunce::simplified` strips Windows' verbatim `\\?\` prefix, which `canonicalize` produces there
  and which would otherwise land in the error text the user reads and in the `BIOROUTER_SERVE_UI`
  variable handed to the daemon. `dunce` was already in `Cargo.lock` (via `aws-lc-sys`); it is now
  a direct dependency of `biorouter-cli`.
- Applied **unconditionally**, not under `cfg(target_os = "macos")`: it is a measured no-op where
  `current_exe()` is already resolved, and a `cfg` would leave the one platform that needs it as
  the only one that exercises it.
- An unresolvable path is passed through rather than swallowed, because every caller checks the
  file it derives before using it.

`web_dir_candidates_for(exe)` and `biorouterd_beside(exe)` take the path as an argument so tests
can drive them. `commands/apps.rs:250` (`biorouterd_path()`) had the same raw `current_exe()`
pattern and now shares the helper.

One line added to `docs/deployment/browser-access.md` saying that "beside the installed binaries"
means beside the *real* binary.

## Tests

`cargo test -p biorouter-cli --lib` needs an isolated `HOME` with the real cargo/rustup homes as
**literal** paths (`CLAUDE.md`, Skills section); every command below was run that way.

```
$ HOME=<isolated> CARGO_HOME=/Users/wgu/.cargo RUSTUP_HOME=/Users/wgu/.rustup \
  BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter-cli --lib
test result: ok. 383 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 16.26s

$ … cargo test -p biorouter-cli            # every target in the crate
test result: ok. 383 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.78s
test result: ok. 0 passed; 0 failed; …     (bin, doctests)

$ … cargo test -p biorouter-cli --lib commands::serve
running 12 tests
test commands::serve::tests::a_symlinked_executable_resolves_to_the_real_installation ... ok
test commands::serve::tests::the_daemon_is_found_beside_the_real_executable ... ok
test commands::serve::tests::the_resolved_candidates_are_never_windows_verbatim_paths ... ok
test commands::serve::tests::an_explicit_setting_is_looked_at_before_anything_else ... ok
test commands::serve::tests::a_missing_interface_names_every_path_it_tried ... ok
test commands::serve::tests::a_relative_parent_is_tidied_for_display ... ok
test commands::serve::tests::a_routable_address_is_not_loopback ... ok
test commands::serve::tests::a_token_is_long_and_different_every_time ... ok
test commands::serve::tests::a_wildcard_bind_is_not_treated_as_loopback ... ok
test commands::serve::tests::loopback_spellings_are_recognised ... ok
test commands::serve::tests::the_default_port_does_not_collide_with_the_daemon_it_starts ... ok
test commands::serve::tests::the_url_carries_the_token_and_brackets_an_ipv6_literal ... ok
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 371 filtered out

$ … cargo test -p biorouter-cli --lib commands::exe_path
running 3 tests
test commands::exe_path::tests::a_symlink_resolves_to_the_binary_it_points_at ... ok
test commands::exe_path::tests::the_resolved_path_is_never_a_windows_verbatim_path ... ok
test commands::exe_path::tests::an_unresolvable_path_is_returned_unchanged ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 380 filtered out

$ … cargo test -p biorouter-cli --lib -- --exact \
    cli::cli_tests::a_configured_default_satisfies_the_precondition_for_a_new_row \
    cli::cli_tests::an_explicit_flag_still_outranks_the_configured_default \
    cli::cli_tests::the_model_slot_falls_back_too \
    cli::cli_tests::an_install_with_nothing_configured_is_still_refused \
    cli::cli_tests::the_refusal_names_a_command_that_takes_the_flag \
    cli::cli_tests::no_session_row_is_created_before_the_provider_precondition_is_checked
running 6 tests
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 377 filtered out

$ cargo fmt --all -- --check
(clean)

$ ./scripts/clippy-lint.sh
  → Checking clippy::too_many_lines
  ✅ clippy::too_many_lines: ok
✅ All baseline clippy checks passed!
🔒 Checking for banned TLS crates...
✓ No banned TLS crates found (native-tls, openssl, openssl-sys)
✅ Done
```

### The new tests fail against the old behaviour

A test that only exercises new code passes trivially, so both fixes were re-run against a
mutation restoring the shipped behaviour.

**Mutation A** — `resolution_for_a_new_row` back to "the flags and nothing else":

```
test cli::cli_tests::an_explicit_flag_still_outranks_the_configured_default ... ok
test cli::cli_tests::no_session_row_is_created_before_the_provider_precondition_is_checked ... FAILED
  a new session row must fall back to the configured default; `get_biorouter_provider` is not read where the row is guarded
test cli::cli_tests::a_configured_default_satisfies_the_precondition_for_a_new_row ... FAILED
  assertion `left == right` failed: a bare `biorouter` names no provider, so the configured one is the answer
    left: (None, None)
   right: (Some("claude_code"), Some("claude-opus-5"))
test result: FAILED. 1 passed; 2 failed
```

**Mutation B** — `resolve_exe_path` back to the identity function:

```
test commands::exe_path::tests::a_symlink_resolves_to_the_binary_it_points_at ... FAILED
test commands::serve::tests::the_daemon_is_found_beside_the_real_executable ... FAILED
test commands::serve::tests::a_symlinked_executable_resolves_to_the_real_installation ... FAILED
  no candidate held the bundle that is on disk: [".../local/bin/../web", ".../local/bin/../../ui/desktop/src/web", "/usr/share/biorouter/web"]
test result: FAILED. 2 passed; 3 failed
```

The failing candidate list is the operator's error, reproduced in a unit test.

## Manual verification

Run against a **copy** of the operator's `config.yaml` (`BIOROUTER_PROVIDER: claude_code`,
`BIOROUTER_MODEL: claude-opus-5`, `CLAUDE_CODE_COMMAND: claude`) under
`XDG_CONFIG_HOME` / `XDG_DATA_HOME` / `XDG_STATE_HOME` scratch directories with
`BIOROUTER_DISABLE_KEYRING=true`. The real `~/.config/biorouter` was never touched.

### macOS — before (installed 1.89.10, through `~/.local/bin/biorouter`)

```
$ ~/.local/bin/biorouter --version
 1.89.10

$ ~/.local/bin/biorouter < /dev/null
  error: No provider is configured.
Run `biorouter configure` to set one up, or pass --provider <name> for this run.

$ ~/.local/bin/biorouter doctor --fix rust < /dev/null
Rust toolchain (rustc) is already detected (rustc 1.92.0 (ded5c06cf 2025-12-08)). Starting a session anyway so you can describe what is going wrong.
  error: No provider is configured.

$ ~/.local/bin/biorouter run --provider claude_code -t "hi" < /dev/null
  error: No model is configured.
Run `biorouter configure` to set one up, or pass --model <name> for this run.

$ BIOROUTER_PROVIDER=claude_code BIOROUTER_MODEL=claude-opus-5 ~/.local/bin/biorouter < /dev/null
  error: No provider is configured.

$ ~/.local/bin/biorouter serve --port 1 < /dev/null
Error: could not find the Biorouter web interface. Tried:
  /Users/wgu/.local/web
  /Users/wgu/ui/desktop/src/web
  /usr/share/biorouter/web

$ /Applications/BioRouter.app/Contents/Resources/bin/biorouter serve --port 1 < /dev/null
Error: cannot bind 127.0.0.1:1: Permission denied (os error 13)      # resolution passed; only the port pre-flight failed
```

### macOS — after (this branch, `target/debug/biorouter`, 1.90.2)

Past the guard, proven without spending a model turn (`CLAUDE_CODE_COMMAND=/nonexistent/claude`,
so the next observable step is the provider's own failure):

```
$ CLAUDE_CODE_COMMAND=/nonexistent/claude ./target/debug/biorouter < /dev/null
  error: Error could not find the `claude` command. Install it with:
    curl -fsSL https://claude.ai/install.sh | bash
If it is installed somewhere Biorouter does not search (nvm, volta, bun, asdf), set CLAUDE_CODE_COMMAND to its full path..

$ CLAUDE_CODE_COMMAND=/nonexistent/claude ./target/debug/biorouter doctor --fix rust < /dev/null
Rust toolchain (rustc) is already detected (rustc 1.92.0 (ded5c06cf 2025-12-08)). Starting a session anyway so you can describe what is going wrong.
  error: Error could not find the `claude` command. …

$ CLAUDE_CODE_COMMAND=/nonexistent/claude ./target/debug/biorouter session --resume < /dev/null
No previous chat to resume; starting a new chat.
  error: Error could not find the `claude` command. …
```

Real turns on the configured `claude_code` / `claude-opus-5` (the `claude` CLI on `PATH`,
2.1.235):

```
$ printf 'Reply with the single word ready.\nexit\n' | ./target/debug/biorouter
  ▌ starting chat
    provider  claude_code
    model     claude-opus-5
    session   20260908_3
    privacy   Public
Biorouter is running! Enter your instructions, or try asking what Biorouter can do.
ready
Elapsed time: 2.76s
Closing session. Session ID: 20260908_3

$ ./target/debug/biorouter run -t "Reply with the single word ready." -n manual-run < /dev/null
  ▌ starting chat
    provider  claude_code
    model     claude-opus-5
    session   20260908_2
ready

$ ./target/debug/biorouter run --provider claude_code -t "Reply with the single word ready." < /dev/null
    provider  claude_code
    model     claude-opus-5
    session   20260908_6
ready                                    # the model slot now falls back too
```

Nothing that worked before stopped working:

```
$ ./target/debug/biorouter run -t "Reply with the single word ready." --no-session < /dev/null
    provider  claude_code   model  claude-opus-5
ready

$ printf 'Reply with the single word ready.\nexit\n' | ./target/debug/biorouter session --provider claude_code
    provider  claude_code   model  claude-opus-5   session 20260908_4
ready

# BIOROUTER_PROVIDER/MODEL in the environment ONLY (config.yaml names neither) — refused before:
$ BIOROUTER_PROVIDER=claude_code BIOROUTER_MODEL=claude-opus-5 ./target/debug/biorouter run -t "Reply with the single word ready."
    provider  claude_code   model  claude-opus-5   session 20260908_1
ready
```

An install with nothing configured is still refused, and still leaves no orphan row:

```
$ cat $XDG_CONFIG_HOME/biorouter/config.yaml
BIOROUTER_MODE: auto

$ ./target/debug/biorouter session < /dev/null
  error: No provider is configured.
Run `biorouter configure` to set one up, or pass --provider <name> to `biorouter session` or `biorouter run`.

$ ./target/debug/biorouter run -t "hello" < /dev/null
  error: No provider is configured.
…

$ find $XDG_CONFIG_HOME $XDG_DATA_HOME $XDG_STATE_HOME -type f
…/biorouter/config.yaml
…/biorouter/privacy-tiers.json
…/biorouter/projects.json
…/biorouter/logs/cli/2026-09-08/20260908_155457.log
# no sessions.db at all — no row was created
```

For contrast, the working configuration's store does hold the rows:

```
$ sqlite3 .../sessions.db "select id, name, provider_name from sessions order by id;"
20260908_1|CLI Session|              # the CLAUDE_CODE_COMMAND=/nonexistent probe: past the guard, provider failed
20260908_2|manual-run|claude_code
20260908_3|CLI Session|claude_code
20260908_4|CLI Session|claude_code
```

### macOS — `serve` through a symlink (Fix 2 end to end)

```
$ ln -s <worktree>/target/debug/biorouter <tmp>/bin/biorouter
$ cd ui/desktop && npm run build:web      # node v24.10.0, npm 11.6.1 (hermit); node_modules symlinked, never installed
✓ built in 8.83s

$ <tmp>/bin/biorouter serve --port 1 < /dev/null
Error: cannot bind 127.0.0.1:1: Permission denied (os error 13)     # was the web-interface error before

$ <tmp>/bin/biorouter serve --port 8791
  INFO biorouterd::commands::agent: serving the web interface from /Users/wgu/biorouter-worktrees/cli-provider-serve/ui/desktop/src/web
  INFO biorouterd::commands::agent: listening on 127.0.0.1:8791

  Biorouter is serving at

      http://127.0.0.1:8791/?t=818c0da6f1f7914f95c7eb27b25e9895d81d155560f2916ed5a9c1d45ac75dc1

  The token above is shown once, and is new on every launch.
  The model is whichever `biorouter configure` chose; a browser cannot change it.
  Press Ctrl-C to stop.

$ ps -o command= -p <child of serve>
/Users/wgu/biorouter-worktrees/cli-provider-serve/target/debug/biorouterd agent   # the real sibling, not one beside the link
```

`curl`, per the token contract in `commands/serve.rs`:

```
$ curl -s -o /dev/null -w 'status=%{http_code}\n' http://127.0.0.1:8791/
status=401

$ curl -s -L -c cookies.txt -o index.out -w 'status=%{http_code} size=%{size_download} type=%{content_type}\n' "http://127.0.0.1:8791/?t=818c…5dc1"
status=200 size=18814 type=text/html; charset=utf-8

$ head -1 index.out; grep -o '<title>[^<]*</title>' index.out
<!doctype html>
<title>Biorouter</title>

$ diff <(fold ui/desktop/src/web/index.html) <(fold index.out)
> <script>window.__BIOROUTER_HEADLESS_CONFIG__={"headlessBaseUrl":"/headless","secretKey":"…"};…</script>
# the only difference is the daemon's own injected config

$ curl -s -b cookies.txt -o /dev/null -w 'status=%{http_code} size=%{size_download}\n' http://127.0.0.1:8791/assets/index-BG6PO5It.js
status=200 size=551697
$ ls -l ui/desktop/src/web/assets/index-BG6PO5It.js
-rw-r--r--  1 wgu  staff  551697  …                     # byte-for-byte the bundle that was just built
```

Both processes were stopped by the pids this run started; port 8791 is free again.

### Linux — measured, not assumed

`current_exe()` and the derivation were run natively in `rust:1.92-bullseye` (the image
`scripts/cross-env.sh` pins for the release, glibc 2.31 — the shipped floor), invoked **through a
symlink** in the packaged layout:

```
$ docker run --rm -v … rust:1.92-bullseye bash /run.sh
=== uname ===
aarch64
=== ldd --version ===
ldd (Debian GLIBC 2.31-13+deb11u13) 2.31
=== invoked THROUGH the symlink /probe/local/bin/biorouter ===
argv[0]                 = /probe/local/bin/biorouter
std::env::current_exe() = /probe/Resources/bin/biorouter
resolve_exe_path(it)    = /probe/Resources/bin/biorouter
current_exe is already resolved on this platform: true
resolved path is not verbatim: true
--- symlink layout on Linux ---
link                    = /probe/local/bin/biorouter
resolve_exe_path(link)  = /probe/Resources/bin/biorouter
bundle via resolved     = Some("/probe/Resources/bin/../web")
bundle via raw link     = None
daemon via resolved     = Some("/probe/Resources/bin/biorouterd")
daemon via raw link     = None
ALL LINUX ASSERTIONS PASSED
```

So: Linux never had the bug (`/proc/self/exe` hands back the target, not the link), and
`resolve_exe_path` is a **measured** no-op there — the change is behaviour-neutral on Linux while
the derivation logic itself is confirmed correct on it.

The crate also cross-checks clean for the shipped Linux triple, using the repo's own recipe:

```
$ CROSS_TARGET_MOUNT=<scratch> . scripts/cross-env.sh
$ cross_linux "cargo check -p biorouter-cli --all-targets --locked" /cross-target
    Checking biorouter-cli v1.90.2 (/usr/src/myapp/crates/biorouter-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 36s
```

### Windows — the `\\?\` handling

Tested at the string level, which is where it can be checked from any host:

- `the_resolved_path_is_never_a_windows_verbatim_path` and
  `the_resolved_candidates_are_never_windows_verbatim_paths` run on **every** platform and can only
  fail on Windows, where `canonicalize` returns the verbatim form.
- `a_verbatim_prefix_is_stripped_at_the_string_level` is `#[cfg(windows)]` and asserts
  `\\?\C:\Program Files\Biorouter\biorouter.exe` → `C:\Program Files\Biorouter\biorouter.exe`.

Cross-checked with the shipped mingw recipe, `--all-targets` so the test targets compile too:

```
$ cross_windows "cargo check -p biorouter-cli --all-targets --locked" /cross-target
    Checking biorouter-cli v1.90.2 (/usr/src/myapp/crates/biorouter-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 07s
```

That gate was itself verified rather than trusted: a deliberate type error inside the
`#[cfg(windows)]` test compiles fine on macOS (the item is `cfg`'d out) and turns the cross-check
red, confirming the Windows test really is built:

```
$ cargo check -p biorouter-cli --all-targets            # macOS
    Finished `dev` profile … in 33.30s
$ cross_windows "cargo check -p biorouter-cli --all-targets --locked" /cross-target
error[E0308]: mismatched types
112 |         let _instrument_check: u8 = "this is not a u8";
error: could not compile `biorouter-cli` (lib test) due to 1 previous error
exit=101
```

The error was reverted and the cross-check re-run green.

### Per-artifact layout

| Artifact | Binaries | Bundle | Before | After |
|---|---|---|---|---|
| macOS dmg, invoked directly | `Resources/bin` | `Resources/web` | ✅ | ✅ |
| macOS dmg, via the `setup-path` symlink | `Resources/bin` | `Resources/web` | ❌ | ✅ |
| Windows zip, invoked directly | `resources\bin` | `resources\web` | ✅ | ✅ |
| Linux GUI deb/rpm | `/opt/Biorouter/resources/bin` | `/opt/Biorouter/resources/web` | ✅ | ✅ |
| Linux CLI deb/rpm | `/usr/bin` | `/usr/share/biorouter/web` | ✅ | ✅ |
| dev tree | `target/<profile>` | `ui/desktop/src/web` | ✅ | ✅ |

## Operator note

The 1.89.10 build already ships the interface — `/Applications/BioRouter.app/Contents/Resources/web/index.html`
is present — so **updating the app does not fix `serve`**; the resolution fix in this PR does.
Until it ships, the workaround on an installed 1.89.10 is to invoke the real binary rather than the
symlink:

```
/Applications/BioRouter.app/Contents/Resources/bin/biorouter serve
```

There is no workaround for the provider refusal short of passing `--provider`/`--model` on every
`session`/`run`, or using `--no-session`.

## Out of scope (follow-ups, not fixed here)

1. **`biorouter term` creates its session row without the guard** — `commands/term.rs:137-143`
   calls `create_session` directly, so the "no orphan row on an unconfigured install" property that
   `5dc1eee1` established does not cover it. Widening the guard there is a behaviour change to a
   different command and belongs in its own PR.
2. **The Windows copy-install is incomplete** — `install_cli`
   (`crates/biorouter/src/system.rs:527-530`) copies only `biorouter.exe` on non-Unix; `biorouterd.exe`
   and the `web` bundle are not copied, so a copy-installed Windows CLI has neither beside it. That
   is a separate defect in the installer, not in the path resolution, and this PR does not change
   `install_cli`. (`handle_setup_path` passing a raw `current_exe()` is *not* a bug: `install_cli`
   canonicalizes its `source` on the way in.)
3. **`session list` showing fewer rows than the database holds** — reported by the investigator as
   "No sessions found" although a row existed. Probed here and it behaves correctly: it lists the
   4 rows that carry messages and hides the 2 that were created and then failed before any message
   was sent. In a sandbox where every attempt failed at the provider, that is legitimately empty.
   Not reproduced as a defect; recorded so the observation is not re-chased.
4. **`commands/term.rs:157`'s `current_exe()`** is left raw on purpose: it builds the command
   string a user's shell will run, where the on-`PATH` symlink is the *better* answer.

## Notes for the reviewer

- Two concurrent `docker` cross-checks (Windows + Linux at once) produced one spurious
  `error[E0463]: can't find crate for 'shlex' which 'cc' depends on` in `ring`'s build script. Run
  alone, the same command is clean. Flagging it because the failure names a build script and reads
  like a real toolchain problem.
- `dunce` is a new *direct* dependency of `biorouter-cli`; it was already in `Cargo.lock`
  transitively via `aws-lc-sys`, so `Cargo.lock` gains one line and no new package is vendored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
