### PR TITLE
Desktop: no focus fill on tab panels (a region is not a control)

### DIFF
--- a/design.md
+++ b/design.md
@@ -596,13 +596,19 @@ is added around it.
 
 ```css
 /* Controls: the fill steps past hover, and the label firms up.
-   A TAB TRIGGER is exempt — see the amendment below. */
+   A TAB TRIGGER and a REGION are exempt — see the two amendments below. */
 :where(:is(a, button, summary, [role='button'], [role='menuitem'],
            [role='option'], input[type='checkbox'], input[type='radio'],
-           [tabindex]:not([tabindex='-1'])):not([role='tab'])):focus-visible {
+           [tabindex]:not([tabindex='-1'])):not([role='tab'], [role='tabpanel'],
+           [role='application'])):focus-visible {
   outline: none;
   background-color: var(--background-focus);
   color: var(--text-default);
+}
+
+/* A region draws nothing, so the UA ring has to be put back down by hand. */
+:where([role='tabpanel']):focus-visible {
+  outline: none;
 }
 
 /* Text fields already own a border, so they shift fill AND firm that edge.
@@ -639,6 +645,24 @@ roving tabindex gives the active one `tabindex="0"` — so deleting the obvious 
 screen. And the underline half is **unlayered**, because the bar's height and colour come from
 Tailwind utilities and a layered rule would lose to them silently. `.br-tab` (chat header, artifact
 panel, terminal dock) is untouched: it draws no underline and owns its own `::after`.
+
+**Amendment, 2026-09-08 (second) — D-15 is written for CONTROLS, so a focusable REGION takes no fill
+either.** A control deepens its own fill because the fill is the size of the thing you are about to
+operate; a region is entered rather than operated, and its fill is the size of the page. The arm that
+reaches one is `[tabindex]:not([tabindex='-1'])`, which cannot tell an 8px checkbox from a document.
+Found while verifying the amendment above: Radix `TabsContent` carries `role="tabpanel"` with
+`tabindex="0"`, so one Tab out of the Settings strip painted `--background-focus` over the whole
+**712 × 2676 px** body — measured `rgb(224, 224, 220)` in Parchment light, with the same rule named by
+CDP's `CSS.getMatchedStylesForNode`. `role="application"` (the knowledge graph canvas, the app's one
+instance) measured the same and is exempt for the same reason. Two things are load-bearing. Dropping
+the panel from the block also drops its `outline: none`, and the UA `:focus-visible { outline: auto }`
+is underneath — so the fill would be traded for a ring around that same box unless the suppression is
+restored on its own, which is the second rule above; `role="application"` needs no such rule because
+it writes `outline-none` plus a 2px inset `--border-accent` ring as utilities. And the
+`prefers-contrast: more` / `forced-colors` block is deliberately **not** narrowed by any of this, so a
+user who asked their OS for a stronger signal still gets the ring on the panel. `[role='tablist']` is
+not exempt: it matches, but focusing it redirects into the active trigger within the same event, so
+the rule never paints it.
 
 All three tokens are **shared** — the focus treatment was always explicitly neutral rather than accented
 (D-15), so unifying it changed its values without changing its intent.

--- a/docs/desktop-ui/settings-visual-vocabulary.md
+++ b/docs/desktop-ui/settings-visual-vocabulary.md
@@ -240,6 +240,19 @@ on the TRIGGER, not on this page: `settings/providers/ProviderCatalog.tsx` reuse
 so removing one arm changes nothing), and the underline rule must be **unlayered** or the Tailwind
 utility that sets the bar's height beats it silently.
 
+**Neither does the PANEL under it (2026-09-08).** The same fill, on a bigger box, found while
+verifying the paragraph above. Radix `TabsContent` renders `role="tabpanel"` with `tabindex="0"`, so
+the `[tabindex]:not([tabindex='-1'])` arm reached it and one Tab out of the strip turned the whole
+Settings body `rgb(224, 224, 220)` — measured over **712 × 2676 px** in Parchment light, and the same
+element in the Provider catalog (712 × 1763) and in Knowledge (772 × 744). D-15 is written for
+controls: a control's fill is the size of the thing you are about to operate, a region's is the size
+of the page, so the panel is excluded from the fill and given no focus treatment at all — the next
+Tab lands on the first control inside, which has its own. The trap, guarded in
+`styles/tabFocus.test.ts`: excluding the panel also drops the block's `outline: none`, and Chrome's
+own `:focus-visible` ring is underneath it, so a second rule has to put the suppression back or the
+grey box becomes a ring around the same box. The `prefers-contrast` escape hatch still reaches the
+panel and is deliberately untouched.
+
 ## The two primitives
 
 ### `components/ui/note.tsx`

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -1455,7 +1455,29 @@
      is a `<button>` (arm 1), carries `role="tab"` (arm 2), and Radix's roving
      tabindex gives the ACTIVE one `tabindex="0"` (arm 3,
      `[tabindex]:not([tabindex='-1'])`). The `:not()` lives INSIDE the
-     `:where()` so the rule stays at specificity 0. */
+     `:where()` so the rule stays at specificity 0.
+
+     ⚠ **A REGION is exempt too (2026-09-08), and that is a different claim
+     from the tab one.** D-15 is written for CONTROLS: a control deepens its
+     own fill because the fill is the size of the thing you are about to
+     operate. A focusable region is not operated, it is entered — and the arm
+     that reaches one is `[tabindex]:not([tabindex='-1'])`, which cannot tell
+     an 8px checkbox from a page. Measured on the running app before this
+     change (Parchment light, `#/settings`, one Tab out of the tab strip):
+     Radix's `TabsContent` carries `role="tabpanel"` + `tabindex="0"`, took
+     `background-color: rgb(224, 224, 220)` = `--background-focus` (`#e0e0dc`)
+     over its whole **712 × 2676 px** box, and CDP's
+     `CSS.getMatchedStylesForNode` named this rule as the one that painted it.
+     The Knowledge view's panel is the same element (772 × 744 px).
+     `role="application"` — the knowledge graph, the app's one instance —
+     measured `rgb(224, 224, 220)` on the same probe and is exempt for the same
+     reason; it already draws its own 2px inset `--border-accent` ring.
+
+     ⚠ **`[role='tablist']` is NOT exempt, deliberately.** It matches (Radix's
+     roving-focus group gives the LIST `tabindex="0"` while focus is outside
+     it), but focusing it was measured to redirect to the active trigger inside
+     the same event, so it never holds `:focus-visible` and the rule never
+     paints it. An exemption there would be unfalsifiable. */
   :where(
     :is(
         a,
@@ -1467,11 +1489,33 @@
         input[type='checkbox'],
         input[type='radio'],
         [tabindex]:not([tabindex='-1'])
-      ):not([role='tab'])
+      ):not([role='tab'], [role='tabpanel'], [role='application'])
   ):focus-visible {
     outline: none;
     background-color: var(--background-focus);
     color: var(--text-default);
+  }
+
+  /* ⚠ **Dropping the panel from the block above drops its `outline: none` with
+     the fill, and the UA stylesheet is waiting underneath.** Chrome's own
+     `:focus-visible { outline: auto 1px -webkit-focus-ring-color }` matched the
+     panel in the same `CSS.getMatchedStylesForNode` dump; without this rule the
+     grey box is traded for a focus ring drawn around the same 712 × 2676 px
+     body, which is the louder half of what D-15 exists to prevent. A region
+     gets NO focus treatment: the next Tab lands on the first control inside,
+     which has its own indicator.
+
+     Only the tabpanel needs this. `role="application"` keeps whatever it draws
+     for itself — the graph canvas writes `outline-none` plus a ring as
+     utilities, and for any future region that draws nothing the UA ring is the
+     better fallback than silence.
+
+     The `prefers-contrast: more` / `forced-colors` block below is deliberately
+     NOT narrowed by any of this: it still reaches the panel through the same
+     `[tabindex]` arm, so a user who asked their OS for a stronger signal keeps
+     the ring here as everywhere else. */
+  :where([role='tabpanel']):focus-visible {
+    outline: none;
   }
 
   /* Text fields already own a border, so they shift their fill AND firm that

--- a/ui/desktop/src/styles/tabFocus.test.ts
+++ b/ui/desktop/src/styles/tabFocus.test.ts
@@ -38,6 +38,10 @@ import { describe, expect, it } from 'vitest';
  */
 const CSS = readFileSync(join(__dirname, 'main.css'), 'utf8');
 const TABS = readFileSync(join(__dirname, '../components/ui/tabs.tsx'), 'utf8');
+const GRAPH = readFileSync(
+  join(__dirname, '../components/knowledge/graph/ForceGraphCanvas.tsx'),
+  'utf8'
+);
 
 /**
  * Every rule in the file that sets a background on a `:focus-visible` selector,
@@ -66,11 +70,27 @@ const d15 = focusVisibleBackgroundRules().find(
     !/prefers-contrast/.test(selector)
 );
 
+/**
+ * The roles the D-15 rule excludes, read out of the `:not()` that closes the
+ * alternation — `…):not([role='tab'], [role='tabpanel'], …)):focus-visible`.
+ *
+ * Read as a SET rather than matched as a literal string, so the assertions do
+ * not care what order the roles are written in, but still care that the
+ * `:not()` sits around the whole list inside the outer `:where()` (an anchored
+ * match on `):not(…)):focus-visible`) rather than inside one alternative — the
+ * distinction #182 turned on, and the one a later edit is most likely to lose.
+ */
+function exemptedRoles(): string[] {
+  const match = d15![0].replace(/\s+/g, '').match(/\):not\(([^)]*)\)\):focus-visible$/);
+  expect(match, `the D-15 rule's trailing :not() is unrecognisable: ${d15![0]}`).toBeTruthy();
+  return match![1].split(',');
+}
+
 describe('a tab trigger takes no focus fill', () => {
   it('still exists, and still fills everything that is not a tab', () => {
     expect(d15, 'the D-15 focus-visible fill rule is no longer recognisable').toBeTruthy();
     expect(d15![1]).toContain('var(--background-focus)');
-    expect(d15![0]).toContain(":not([role='tab'])");
+    expect(exemptedRoles()).toContain("[role='tab']");
   });
 
   /**
@@ -85,7 +105,7 @@ describe('a tab trigger takes no focus fill', () => {
     expect(selector).toContain("[tabindex]:not([tabindex='-1'])");
     // The `:not()` closes the alternation and sits inside the outer `:where()`,
     // so it applies to every arm rather than to one alternative within it.
-    expect(selector).toMatch(/\):not\(\[role='tab'\]\)\):focus-visible$/);
+    expect(exemptedRoles()).toContain("[role='tab']");
   });
 
   /** Specificity 0 is D-15's contract: any component can still opt out. */
@@ -103,8 +123,10 @@ describe('a tab trigger takes no focus fill', () => {
     const offenders = focusVisibleBackgroundRules().filter(([selector]) => {
       if (!/\[role=['"]tab['"]\]/.test(selector)) return false;
       if (/::(after|before)/.test(selector)) return false;
-      // A selector that mentions tabs only in order to exclude them is fine.
-      return !/:not\(\s*\[role='tab'\]\s*\)/.test(selector);
+      // A selector that mentions tabs only in order to exclude them is fine —
+      // including one that excludes a LIST of roles, which is what the D-15
+      // rule became once the panel joined the trigger.
+      return !/:not\([^)]*\[role='tab'\][^)]*\)/.test(selector.replace(/\s+/g, ''));
     });
     expect(offenders, `these rules fill a focused tab: ${JSON.stringify(offenders)}`).toEqual([]);
   });
@@ -193,5 +215,138 @@ describe('a focused tab shows its underline firming instead', () => {
     expect(TABS).toContain('TabsPrimitive.Trigger');
     expect(TABS).toContain("after:content-['']");
     expect(TABS).toContain('data-[state=active]:after:bg-accent-bar');
+  });
+});
+
+/**
+ * The same fill, on the tab PANEL — a bigger instance of the bug #182 fixed, on
+ * the same page, found while verifying it.
+ *
+ * #182 exempted the tab TRIGGER. The panel is a different element and was still
+ * matched, by the one arm that cannot tell a control from a page: Radix's
+ * `TabsContent` (`components/ui/tabs.tsx`) renders `role="tabpanel"` with
+ * `tabindex="0"`, so `[tabindex]:not([tabindex='-1'])` reached it.
+ *
+ * Measured in the running app before this change (Parchment light, `#/settings`,
+ * click a tab then one Tab so focus leaves the strip): the panel had
+ * `:focus-visible` matching and `backgroundColor: rgb(224, 224, 220)` —
+ * `--background-focus` = `#e0e0dc` — over a **712 × 2676 px** box, i.e. the
+ * whole Settings body. CDP's `CSS.getMatchedStylesForNode` named the D-15
+ * `@layer base` rule as the one that painted it. The Knowledge view's panel is
+ * the same element (772 × 744 px). After the change both read
+ * `rgba(0, 0, 0, 0)`.
+ *
+ * The principle, and the reason this is not just "one more selector": D-15 is
+ * written for CONTROLS. A control deepens its own fill because the fill is the
+ * size of the thing about to be operated. A region is entered, not operated,
+ * and its fill is the size of the page.
+ *
+ * ⚠ **Asserted at the SOURCE for the reason the block above gives** — jsdom
+ * never evaluates `:focus-visible`, so a component test that focuses a panel
+ * and reads `backgroundColor` passes whether the rule exists or not.
+ */
+describe('a tab panel takes no focus fill either', () => {
+  it('excludes the panel in the same :not(), around the whole list', () => {
+    expect(exemptedRoles()).toContain("[role='tabpanel']");
+  });
+
+  /**
+   * The plausible wrong fix, and the one that would silently un-focus half the
+   * app: the panel is reached ONLY by the `[tabindex]` arm, so deleting that arm
+   * also removes the focus surface from every custom control that earns its tab
+   * stop with `tabIndex={0}` — the mode radios, the ingest dropzone, the
+   * composer's threshold slider. The arm stays; the role is excluded.
+   */
+  it('keeps the [tabindex] arm that every custom control depends on', () => {
+    expect(d15![0].replace(/\s+/g, '')).toContain("[tabindex]:not([tabindex='-1'])");
+  });
+
+  /**
+   * ⚠ **The trap this fix has, which the trigger fix did not.** Exempting the
+   * panel drops the block's `outline: none` along with its fill, and Chrome's
+   * UA `:focus-visible { outline: auto 1px -webkit-focus-ring-color }` is
+   * underneath it — it was in the same `getMatchedStylesForNode` dump. Without
+   * a rule restoring the suppression the grey box is traded for a focus ring
+   * drawn around the same 712 × 2676 px body, which is the louder half of what
+   * D-15 exists to prevent. Nothing else in the tree sets an outline on a
+   * `TabsContent`.
+   */
+  it('still suppresses the UA focus ring on the panel', () => {
+    const match = CSS.replace(/\/\*[\s\S]*?\*\//g, '').match(
+      /:where\(\[role='tabpanel'\]\):focus-visible\s*\{([^}]*)\}/
+    );
+    expect(match, 'nothing restores `outline: none` on a focused tabpanel').toBeTruthy();
+    expect(match![1]).toMatch(/outline:\s*none/);
+    // A region gets NO treatment — a fill here would reintroduce the bug under
+    // a different selector, and a ring would violate D-15 outright.
+    expect(match![1]).not.toContain('--background-focus');
+    expect(match![1]).not.toMatch(/box-shadow|background/);
+  });
+
+  /** Specificity 0 is D-15's contract; the restoration must not out-rank a component. */
+  it('keeps the restoration at specificity 0', () => {
+    expect(CSS).toContain(":where([role='tabpanel']):focus-visible");
+  });
+
+  /**
+   * The safety valve must NOT be narrowed with the rest. A user who has asked
+   * their OS for a stronger signal keeps the ring on the panel, reached through
+   * the same `[tabindex]` arm — so the exemption costs a keyboard user nothing
+   * they did not opt out of.
+   */
+  it('leaves the prefers-contrast ring reaching the panel', () => {
+    const block = CSS.replace(/\/\*[\s\S]*?\*\//g, '').match(
+      /@media \(prefers-contrast: more\), \(forced-colors: active\) \{([\s\S]*?)\n {2}\}/
+    );
+    expect(block, 'the prefers-contrast block is unrecognisable').toBeTruthy();
+    expect(block![1]).toContain("[tabindex]:not([tabindex='-1'])");
+    expect(block![1]).not.toContain('tabpanel');
+    expect(block![1]).toMatch(/outline:\s*2px solid var\(--ring\)/);
+  });
+
+  /**
+   * The app's one `role="application"` is the knowledge graph canvas
+   * (`knowledge/graph/ForceGraphCanvas.tsx`), a region for the same reason —
+   * WAI-ARIA files `application` as a structure role, not a widget one. Measured
+   * `rgb(224, 224, 220)` on the same probe. It is exempted from the fill only:
+   * it draws its own `outline-none` plus a 2px inset `--border-accent` ring as
+   * utilities (measured `rgb(184, 90, 50) 0px 0px 0px 2px inset`), so focus
+   * stays visible there without a rule here.
+   */
+  it('exempts the one other region role, and leaves its own ring in place', () => {
+    expect(exemptedRoles()).toContain("[role='application']");
+    expect(GRAPH).toContain('role="application"');
+    expect(GRAPH).toContain('focus-visible:ring-2');
+    expect(GRAPH).toContain('focus-visible:ring-border-accent');
+  });
+
+  /**
+   * ⚠ **`[role='tablist']` is deliberately NOT here.** Radix's roving-focus
+   * group gives the LIST `tabindex="0"` while focus is outside it, so it matches
+   * the D-15 arm — but focusing it was measured to redirect into the active
+   * trigger within the same event, so it never holds `:focus-visible` and the
+   * rule never paints it. Exempting it would assert something no measurement
+   * can falsify, which is how a selector list rots.
+   */
+  it('does not exempt the tablist, which never holds focus', () => {
+    expect(exemptedRoles()).not.toContain("[role='tablist']");
+  });
+
+  /** The rule matches nothing without its hook, so the two are asserted together. */
+  it('has its hook on the TabsContent primitive', () => {
+    expect(TABS).toContain('TabsPrimitive.Content');
+  });
+
+  /**
+   * Stated as a property of the whole stylesheet rather than of one rule: no
+   * selector anywhere may paint a background on a focused panel.
+   */
+  it('has no rule anywhere that paints a background on a focused panel', () => {
+    const offenders = focusVisibleBackgroundRules().filter(([selector]) => {
+      if (!/\[role=['"]tabpanel['"]\]/.test(selector)) return false;
+      // A selector that mentions panels only in order to exclude them is fine.
+      return !/:not\([^)]*\[role='tabpanel'\][^)]*\)/.test(selector.replace(/\s+/g, ''));
+    });
+    expect(offenders, `these rules fill a focused panel: ${JSON.stringify(offenders)}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## Why

Follow-up to #182, found while verifying it. #182 exempted tab **triggers** (`[role='tab']`) from the D-15 focus fill. The **panel** under them was still matched, by the one arm that cannot tell a control from a page: Radix `TabsContent` renders `role="tabpanel"` with `tabindex="0"`, so `[tabindex]:not([tabindex='-1'])` reached it.

Measured on the running app (Parchment light, `#/settings`, click a tab then press Tab once so focus leaves the strip):

| Element | Before | After |
|---|---|---|
| Settings panel, `role="tabpanel"` `tabindex="0"`, **712 × 2676 px** | `rgb(224, 224, 220)` | `rgba(0, 0, 0, 0)` |
| Provider catalog panel (`#/configure-providers`), 712 × 1763 px | `rgb(224, 224, 220)` | `rgba(0, 0, 0, 0)` |
| Knowledge panel, 772 × 744 px | `rgb(224, 224, 220)` | `rgba(0, 0, 0, 0)` |
| Knowledge graph canvas, `role="application"` (synthetic probe, see below) | `rgb(224, 224, 220)` | `rgba(0, 0, 0, 0)` |

`rgb(224, 224, 220)` is `--background-focus` = `#e0e0dc`. `:focus-visible` matched in every case, and CDP `CSS.getMatchedStylesForNode` named the D-15 block in `@layer base` as the rule that painted it — the same rule, one element further in. The whole Settings body turned grey, a bigger "weird shade" than the one originally reported, on the same page.

**The principle, which is why this is not just one more selector.** D-15 is written for CONTROLS: a control deepens its own fill because the fill is the size of the thing you are about to operate. A region is *entered*, not operated, and its fill is the size of the page.

## What changed

`ui/desktop/src/styles/main.css`:

1. `[role='tabpanel']` and `[role='application']` join `[role='tab']` in the `:not()` that closes the alternation — still inside the outer `:where()`, so the rule stays at specificity 0 and the `[tabindex]` arm every custom control depends on is untouched.
2. **A second rule restores `outline: none` on the panel**, and this is the trap the trigger fix did not have. Exempting the panel drops the block's `outline: none` along with its fill, and Chrome's UA `:focus-visible { outline: auto 1px -webkit-focus-ring-color }` was in the same matched-styles dump — without this the grey box is traded for a focus ring drawn around the same 712 × 2676 px body, which is the louder half of what D-15 exists to prevent. The panel then gets no focus treatment at all; the next Tab lands on the first control inside, which has its own indicator (verified below).
3. `role="application"` needs no such rule: the graph canvas writes `outline-none` plus a 2px inset `--border-accent` ring as Tailwind utilities — measured `rgb(184, 90, 50) 0px 0px 0px 2px inset`, so focus stays visible there.
4. The `prefers-contrast: more` / `forced-colors` block is deliberately **not** narrowed. It still reaches the panel through the same `[tabindex]` arm, so a user who has asked their OS for a stronger signal keeps the ring here as everywhere else.

Plus one dated line each in `design.md` and `docs/desktop-ui/settings-visual-vocabulary.md`, in the same places #182 amended.

### Roles checked and deliberately left alone

The survey was run **against the live DOM** across seven routes, not by grepping source — `tabindex` is injected by Radix at runtime and a grep cannot see it. That is how `role="tablist"` turned up at all.

- **`[role='tablist']`** — matches the rule (Radix's roving-focus group gives the *list* `tabindex="0"` while focus is outside it), but focusing it was measured to redirect into the active trigger within the same event (`activeIsList: false`, `listFocusVisible: false`), so it never holds `:focus-visible` and the rule never paints it. Exempting it would assert something no measurement can falsify.
- **`[role='slider']`** (auto-compact threshold), **`[role='separator']`** (sidebar resize handle), **`[role='radio']`** (mode rows), **`[role='button']`** (ingest dropzone) — all controls. They keep the fill, by design.
- **`ChatSummary`'s `<ol tabIndex={0}>`** (`ui/desktop/src/components/ChatSummary.tsx:103`) — a scroll container given a tab stop for keyboard scrolling, so a region by the same argument, and it still measures `rgb(224, 224, 220)`. It carries **no `role` attribute**, so a role-based exemption cannot reach it; fixing it means a component-local change, which is out of scope here. Recorded rather than silently left.

## Tests

`ui/desktop/src/styles/tabFocus.test.ts` grew from 15 to 19 tests. Asserted at the source, for the reason the file already gives: jsdom never evaluates `:focus-visible`, so a component test that focuses a panel and reads `backgroundColor` passes whether the rule exists or not.

**Confirmed failing on `main` before the change** (the extended file run against `origin/main`'s `main.css`):

```
Tests  4 failed | 15 passed (19)
```

The four are the new panel assertions: `excludes the panel in the same :not(), around the whole list`, `still suppresses the UA focus ring on the panel`, `keeps the restoration at specificity 0`, and `exempts the one other region role, and leaves its own ring in place`. Two `:not()` assertions inherited from #182 were also generalised from a literal-string match to a set membership check, so they no longer care what order the excluded roles are written in.

With the change:

```
npx vitest run src/styles      →  Test Files  18 passed (18)   Tests  253 passed (253)
npm run test:run               →  Test Files 424 passed (424)  Tests  4766 passed | 1 skipped (4767)
npm run lint:check             →  exit 0 (typecheck, eslint --max-warnings 0, themes, 332 contrast assertions, tokens)
npx prettier --check src/styles/tabFocus.test.ts  →  All matched files use Prettier code style!
npx prettier --check src/styles/main.css          →  All matched files use Prettier code style!
```

Also re-run from a clean `git archive HEAD` extraction, so the result is what CI sees rather than what the working tree does: `generate-themes.mjs --check` OK, `tabFocus.test.ts` 19 passed.

## Verification

Runtime, in a sandboxed dev instance, all three theme families × light/dark on `#/settings`. In every one of the six:

- **panel focused** (`:focus-visible` true) → `backgroundColor: rgba(0, 0, 0, 0)`, `outline-style: none`, `box-shadow: none`;
- **tab trigger** still `rgba(0, 0, 0, 0)` with the `after:` bar at `3px` in the family's own `--accent-bar` (`#cf6d47` / `#e8895f` Parchment, `#16a0ac` / `#60d0da` Alma Mater, `#d95b08` / `#ee6c1a` Roche Limit) — #182 intact;
- **first control inside the panel** still shows its own surface: rest `rgba(0, 0, 0, 0)` → focused `color(srgb 0.92549 0.92549 0.913725 / 0.38)`.

Also checked on Settings → Models → **Configure providers** (panel focused by a real Tab press: `rgba(0, 0, 0, 0)`, outline `none`, 712 × 1763) and on **Knowledge** (772 × 744).

Sanity probes confirming the fix is narrow, run after the change: a bare `<button>` and a `[role='radio'][tabindex='0']` both still take `rgb(224, 224, 220)`. The rule still fills controls; it stopped filling regions.

## Out of scope / not verified

- **The `role="application"` measurement is synthetic**, and deliberately labelled as such. The knowledge graph canvas only mounts for a knowledge base with a digested graph, and this sandbox's base is empty ("Nothing digested yet"), so the element could not be reached in situ. What was measured is the real stylesheet's verdict on the exact element shape from `ForceGraphCanvas.tsx:884` (same `role`, `tabIndex` and `className`), mounted in the live page: `rgb(224, 224, 220)` before, `rgba(0, 0, 0, 0)` after. The component in place is unverified.
- `ChatSummary`'s `<ol>` region, above — measured, unfixed, no role to hang an exemption on.
- **`design.md`'s CSS fence is a pre-existing Prettier offender**, verified by running `prettier --write` against unmodified `origin/main`: it rewrites `[role='tab']` to double quotes and rebreaks the selector on `main` already. Per the brief the file was not reformatted, so the snippet keeps the file's (and `main.css`'s) single-quote style. The prose added to both docs is Prettier-clean in isolation; `docs/desktop-ui/settings-visual-vocabulary.md` gains no new offenders at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
