### PR TITLE
Desktop: clear the Chat history reveal timer on unmount

### DIFF
--- a/ui/desktop/src/components/sessions/SessionListView.revealTimer.test.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.revealTimer.test.tsx
@@ -1,0 +1,94 @@
+import { act, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SessionListView from './SessionListView';
+import { clearSessionListCache } from '../../utils/sessionListCache';
+
+const mocks = vi.hoisted(() => ({
+  listSessions: vi.fn(),
+}));
+
+vi.mock('../../api', () => ({
+  listSessions: mocks.listSessions,
+  deleteSession: vi.fn(),
+  exportSession: vi.fn(),
+  importSession: vi.fn(),
+  updateSessionName: vi.fn(),
+  declassifySession: vi.fn(),
+}));
+
+vi.mock('../../toasts', () => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('../conversation/SearchView', () => ({
+  SearchView: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../ui/scroll-area', () => ({
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearSessionListCache();
+  mocks.listSessions.mockResolvedValue({ data: { sessions: [] } });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderPane() {
+  return render(
+    <MemoryRouter>
+      <SessionListView onSelectSession={vi.fn()} />
+    </MemoryRouter>
+  );
+}
+
+/** The content layer, whose opacity class is driven by `showContent`. */
+function contentLayer(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>('div.relative.transition-opacity');
+  if (!el) throw new Error('content layer not found');
+  return el;
+}
+
+describe('SessionListView reveal timer', () => {
+  it('clears the pending reveal timer when the pane unmounts before the tick', async () => {
+    const { unmount } = renderPane();
+
+    // Let the initial request settle so the skeleton-to-content effect runs and
+    // arms its 10ms reveal.
+    await act(async () => {});
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    // Navigating away (or a test file finishing) inside that 10ms window used to
+    // leave the reveal armed; it then fired `setShowContent` on an unmounted
+    // tree — on CI, after jsdom had been torn down, as `window is not defined`.
+    // Every timer this pane owns must be cancelled by its own cleanup.
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+    }).not.toThrow();
+  });
+
+  it('still reveals the content layer one tick after the skeleton hides', async () => {
+    const { container } = renderPane();
+
+    await act(async () => {});
+    expect(contentLayer(container).className).toContain('opacity-0');
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+    expect(contentLayer(container).className).toContain('opacity-100');
+  });
+});

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -828,22 +828,34 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
       });
     }, []);
 
-    // Timing logic to prevent flicker between skeleton and content on initial load
+    // Timing logic to prevent flicker between skeleton and content on initial
+    // load. `showContent` — not `showSkeleton` — is the "already revealed"
+    // guard, and that is load-bearing: this effect WRITES `showSkeleton`, so
+    // keeping it in the deps re-runs the effect on the very next render and the
+    // cleanup below would cancel the reveal it had just armed. The two guards
+    // admit the same states, because the only writer that re-arms a cold load
+    // (`loadSessions`, on a cache miss) sets `showSkeleton` and `showContent`
+    // together; this one just leaves the deps stable across the 10ms window.
     useEffect(() => {
-      if (!isLoading && showSkeleton) {
-        setShowSkeleton(false);
-        // Use startTransition for non-blocking content show
-        startTransition(() => {
-          setTimeout(() => {
-            setShowContent(true);
-            if (isInitialLoad) {
-              setIsInitialLoad(false);
-            }
-          }, 10);
-        });
-      }
-      return () => void 0;
-    }, [isLoading, showSkeleton, isInitialLoad]);
+      if (isLoading || showContent) return undefined;
+      setShowSkeleton(false);
+      // No `startTransition`: it used to wrap the `setTimeout` call, which
+      // marked nothing (the callback returns before either setState runs), and
+      // the reveal is one opacity class on a layer that is already mounted —
+      // `renderActualContent()` renders under the skeleton too. Deferring the
+      // frame the delay exists to schedule is the opposite of what it is for.
+      const revealTimer = setTimeout(() => {
+        setShowContent(true);
+        if (isInitialLoad) {
+          setIsInitialLoad(false);
+        }
+      }, 10);
+      // Unmounting inside that 10ms window (navigating away, or a test file
+      // finishing) must disarm it: the callback would otherwise setState on an
+      // unmounted tree, and on CI it fired after jsdom was gone and took the
+      // whole run down with `window is not defined`.
+      return () => clearTimeout(revealTimer);
+    }, [isLoading, showContent, isInitialLoad]);
 
     // Memoize date groups calculation to prevent unnecessary recalculations
     const memoizedDateGroups = useMemo(() => {


### PR DESCRIPTION
## Why

On `main@628209f3`, the Frontend → "Unit tests (vitest)" job passed all 4748 tests and still **exited 1**, on one unhandled error:

```
Uncaught Exception — ReferenceError: window is not defined
 ❯ resolveUpdatePriority node_modules/react-dom/cjs/react-dom-client.development.js:1308:7
 ❯ dispatchSetState …
 ❯ Timeout._onTimeout src/components/sessions/SessionListView.tsx:838:13
    836|         startTransition(() => {
    837|           setTimeout(() => {
    838|             setShowContent(true);
This error originated in "src/components/sessions/SessionListView.test.tsx" test file.
```

The "prevent flicker between skeleton and content" effect armed a 10 ms `setTimeout` and returned `() => void 0`. The timer was never cleared, so unmounting inside that 10 ms window — a test file finishing, or a user navigating away from Chat history — left it armed to call `setShowContent` on an unmounted tree. On CI it fired after jsdom had been torn down, so the `setState` reached a React that no longer had a `window`.

It is timing-dependent (each contributing PR's own run passed; only the merge commit's run lost the race), so it will recur until the timer is cleared.

Two smaller things in the same six lines:

- `startTransition` wrapped the **`setTimeout` call**, not the state updates. The callback returns as soon as the timer is scheduled, so nothing was ever marked as a transition.
- `showSkeleton` was both written by this effect and listed in its deps, which is why a cleanup could not simply be added — see below.

## What changed

**`ui/desktop/src/components/sessions/SessionListView.tsx:831-858`** — the reveal effect:

- The timer id is kept and the cleanup is now `return () => clearTimeout(revealTimer);`.
- The "already revealed" guard moves from `showSkeleton` to `showContent`, and `showSkeleton` leaves the deps. **This is load-bearing, not cosmetic.** The effect *writes* `setShowSkeleton(false)`, so with `showSkeleton` in the deps the effect re-runs on the very next render — and the new cleanup would then cancel the reveal it had just armed, leaving the content layer at `opacity-0` forever. The two guards admit the same states: the only writer that re-arms a cold load (`loadSessions`, on a cache miss, `SessionListView.tsx:787-789`) sets `showSkeleton` and `showContent` together. The second test below is what catches the naive version.
- `startTransition` is **dropped** rather than moved inside the callback. It marked nothing where it was, and the update it would have marked does not want deferring: `renderActualContent()` is rendered unconditionally underneath the skeleton (`SessionListView.tsx:1311-1316`), so `showContent` only flips an opacity/z-index class on an already-mounted layer. Deprioritising the single frame the 10 ms delay exists to schedule is the opposite of what the delay is for. The `startTransition` import is still used at eight other sites in the file.
- `isInitialLoad` and its guard are kept exactly as they were (see Follow-ups).

User-visible behaviour is unchanged: skeleton hides, content is revealed one tick later, `isInitialLoad` clears once.

**`ui/desktop/src/components/sessions/SessionListView.revealTimer.test.tsx`** (new) — two tests under `vi.useFakeTimers()`:

1. render → let the load settle so the reveal is armed → `unmount()` **before** advancing → assert `vi.getTimerCount()` is 0 and that advancing 100 ms afterwards throws nothing.
2. the reveal still happens: the content layer is `opacity-0` after the load settles and `opacity-100` after `vi.advanceTimersByTime(10)`.

It is a sibling file rather than an addition to `SessionListView.test.tsx` so the fake-timer setup does not have to co-exist with that file's `userEvent` interaction tests.

### Sweep

Both greps from the brief were run over `ui/desktop/src`, plus a brace-matching scan of every `useEffect` body in the renderer (excluding `*.test.*`, `*.gen.*`, `src/test/`) for one that schedules `setTimeout`/`setInterval`/`requestAnimationFrame` and never calls a matching `clear*`/`cancel*`.

The whole renderer has exactly **three** such effects, and only the one fixed here calls `setState` from the timer callback:

| Site | Verdict |
|---|---|
| `SessionListView.tsx:832` | **Fixed** — the defect above. |
| `ChatInput.tsx:825` | Not the same shape. Its `setState`s are synchronous in the effect body; the uncleared `setTimeout(…, 0)` only runs `textAreaRef.current?.focus()`, which is `null` after unmount. |
| `AppSettingsSection.tsx:55` | Not the same shape. The uncleared `setTimeout(…, 100)` only runs `updateSectionRef.current?.scrollIntoView()`, likewise `null` after unmount. |

`grep -rn -E "return \(\) => void 0"` had exactly one hit in the whole renderer (this one). The `return undefined` cleanups that also schedule timers (`DependencySetupModal.tsx:285`, `CreateWorkflowFromSessionModal.tsx:246`, `BottomMenuAlertPopover.tsx:82`) all already store the handle and clear it.

## Tests

Fail-before / pass-after, same test file, only `SessionListView.tsx` differing:

```
=== FAIL-BEFORE (unmodified main source) ===
     × clears the pending reveal timer when the pane unmounts before the tick 43ms
     ✓ still reveals the content layer one tick after the skeleton hides 24ms
AssertionError: expected 1 to be +0 // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)

=== PASS-AFTER (with fix) ===
 ✓ src/components/sessions/SessionListView.revealTimer.test.tsx (2 tests) 64ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`npx vitest run src/components/sessions`, three consecutive runs — stable:

```
--- RUN 1 ---  Test Files  15 passed (15)   Tests  103 passed (103)
--- RUN 2 ---  Test Files  15 passed (15)   Tests  103 passed (103)
--- RUN 3 ---  Test Files  15 passed (15)   Tests  103 passed (103)
```

`npm run test:run` (full renderer suite):

```
 Test Files  423 passed (423)
      Tests  4755 passed | 1 skipped (4756)
   Duration  27.32s
```

**No `Errors` line appeared in the summary, and the process exited 0.** vitest prints an `Errors` line only when there are unhandled errors, so its absence — together with the exit code — is the direct counterpart of the failing CI run, which exited 1 on `Errors 1`.

`npm run lint:check` (typecheck + eslint + themes + contrast + tokens):

```
OK — all 332 contrast assertions pass
OK — every semantic colour token used by a utility has a @theme inline mirror
     (340 declared, 91 mirrored, 57 reached from a utility)
```

`npx prettier --check` on both changed files:

```
Checking formatting...
All matched files use Prettier code style!
```

## Follow-ups

Found while fixing this; deliberately **not** in this PR.

- **`isInitialLoad` in `SessionListView` is write-only state.** It is initialised, set to `false` once inside this timer, and never read anywhere else — its only reader was the `if (isInitialLoad)` self-guard around its own setter. Removing that guard makes `tsc` fail with `TS6133: 'isInitialLoad' is declared but its value is never read`, which is how it surfaced. The guard is kept here so this PR stays a timer fix; deleting the state (one `useState` and one setter call) is a separate, obvious cleanup.
- **Uncleared timers in event handlers are a wider family** — roughly a dozen `setTimeout(() => setCopied(false), 2000)`-shaped "copied!" resets (`MessageCopyLink.tsx:35,42`, `TunnelSection.tsx:120,123`, `SessionHistoryView.tsx:272`, `CreateEditWorkflowModal.tsx:275`, `BioRouterHintsModal.tsx:82`, `GroupedExtensionLoadingToast.tsx:122`), plus `AppSettingsSection.tsx:102` (`setIsDockSwitchDisabled` after 1000 ms). Each can `setState` after unmount if the pane closes inside its window. They are not the effect-cleanup shape this PR fixes and are better handled by one shared `useTimeout`-style hook than by a dozen scattered refs.
- **`ProgressiveMessageList.tsx:134`** schedules an uncleared 50 ms timer that invokes `onRenderingCompleteRef.current?.()` from inside a batch-loading loop. It does not `setState` directly, but the parent callback may; the ref is not nulled on unmount. Worth a look, but it is a different structure (a scheduled loop, not an effect body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
