### PR TITLE
fix(desktop): no focus fill on the chat summary's To Do list, a region with no role

### DIFF
--- a/design.md
+++ b/design.md
@@ -596,18 +596,19 @@ is added around it.
 
 ```css
 /* Controls: the fill steps past hover, and the label firms up.
-   A TAB TRIGGER and a REGION are exempt — see the two amendments below. */
+   A TAB TRIGGER and a REGION are exempt — see the three amendments below. */
 :where(:is(a, button, summary, [role='button'], [role='menuitem'],
            [role='option'], input[type='checkbox'], input[type='radio'],
            [tabindex]:not([tabindex='-1'])):not([role='tab'], [role='tabpanel'],
-           [role='application'])):focus-visible {
+           [role='application'], .biorouter-focus-region)):focus-visible {
   outline: none;
   background-color: var(--background-focus);
   color: var(--text-default);
 }
 
-/* A region draws nothing, so the UA ring has to be put back down by hand. */
-:where([role='tabpanel']):focus-visible {
+/* A region draws nothing, so the UA ring has to be put back down by hand.
+   `.biorouter-focus-region` is how a region with no role to key on opts out. */
+:where([role='tabpanel'], .biorouter-focus-region):focus-visible {
   outline: none;
 }
 
@@ -663,6 +664,23 @@ it writes `outline-none` plus a 2px inset `--border-accent` ring as utilities. A
 user who asked their OS for a stronger signal still gets the ring on the panel. `[role='tablist']` is
 not exempt: it matches, but focusing it redirects into the active trigger within the same event, so
 the rule never paints it.
+
+**Amendment, 2026-09-08 (third) — a region with NO role opts out with `.biorouter-focus-region`.**
+Both exemptions above key on a role, and a scroll container given a tab stop so a keyboard user can
+scroll it has none to key on. The chat summary's To Do list (`components/ChatSummary.tsx`) is an
+`<ol tabIndex={0}>`; measured in Parchment light on the real popover, opened with the keyboard, it
+read `rgb(224, 224, 220)` over the whole **334 × 240 px** list, with the D-15 rule named by CDP's
+`CSS.getMatchedStylesForNode`. It cannot take a role: an `<ol>`'s implicit `list` role is what makes
+its rows list items to a screen reader, so `role="region"` would silence the fill and take the rows'
+semantics with it, and an explicit `role="list"` would be a redundant attribute carried only so a
+stylesheet could see it. So the hook is a class — an authored selector in the same `:not()`, never a
+`focus-visible:bg-*` utility at the call site, for the reason `.biorouter-focus-surface` gives (a newly
+written Tailwind class can silently fail to generate; a hook that needs nothing generated cannot) — and
+the UA-ring restoration names the class beside the panel, or the grey list would have become a ringed
+one. After the change the focused list reads `rgba(0, 0, 0, 0)` with outline and box-shadow `none` in
+all three families in both modes; the next Tab lands on the summary's own "Make workflow" button, which
+shows its focus surface; and under `prefers-contrast: more` the list takes the `2px solid --ring`
+outline through the same `[tabindex]` arm. Guarded in `styles/tabFocus.test.ts` beside the other two.
 
 All three tokens are **shared** — the focus treatment was always explicitly neutral rather than accented
 (D-15), so unifying it changed its values without changing its intent.

--- a/docs/desktop-ui/summary-and-figures-qa.md
+++ b/docs/desktop-ui/summary-and-figures-qa.md
@@ -8,6 +8,9 @@ Show persisted To Do state as an ordered stepper with explicit status text and a
 completion count. Connections indicate list order, not inferred dependencies.
 Hide the section when there are no tasks. Task updates, reopening, renaming,
 replacement and chat switching must not show another chat's or an obsolete list.
+The task list is a scroll region with a tab stop so a keyboard user can scroll
+it; it takes no focus fill (D-15's third amendment, `.biorouter-focus-region`),
+and the next Tab lands on the panel's own buttons, which do.
 
 Generated figures prioritize the data: meaningful titles, units, source or
 assumption notes when relevant, restrained theme-aware colors, and large legible

--- a/ui/desktop/src/components/ChatSummary.test.tsx
+++ b/ui/desktop/src/components/ChatSummary.test.tsx
@@ -102,6 +102,17 @@ describe('compact chat summary', () => {
     rerender(<ChatSummary {...props} />);
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
+  it('keeps the To Do list a list with a tab stop, marked as a focus region not a control', () => {
+    render(<ChatSummary {...props} todos={{ ...props.todos, items }} />);
+    const list = screen.getByRole('list', { name: 'To Do tasks' });
+    // The tab stop is what lets a keyboard user scroll it; the class is what
+    // keeps D-15's focus fill off it (asserted at the source in
+    // `styles/tabFocus.test.ts`, since jsdom never evaluates `:focus-visible`).
+    expect(list).toHaveAttribute('tabindex', '0');
+    expect(list).toHaveClass('biorouter-focus-region');
+    // No `role`: `role="region"` would orphan the rows' list semantics.
+    expect(list).not.toHaveAttribute('role');
+  });
   it('contains long lists, wraps labels and never executes task markup', () => {
     const text = '検証 🧬 <img src=x onerror=alert(1)> '.repeat(20);
     render(

--- a/ui/desktop/src/components/ChatSummary.tsx
+++ b/ui/desktop/src/components/ChatSummary.tsx
@@ -98,10 +98,14 @@ export function ChatSummary({
               style={{ width: `${(completed / todos.items.length) * 100}%` }}
             />
           </div>
+          {/* A scroll container with a tab stop so a keyboard user can scroll
+              it — a region, not a control, so it opts out of D-15's focus fill
+              with `.biorouter-focus-region` (authored in main.css). It keeps
+              its implicit `list` role: `role="region"` would orphan the rows. */}
           <ol
             aria-label="To Do tasks"
             tabIndex={0}
-            className="max-h-60 overflow-y-auto overscroll-contain pr-1"
+            className="biorouter-focus-region max-h-60 overflow-y-auto overscroll-contain pr-1"
           >
             {todos.items.map((item, index) => {
               const label = TODO_STATUS_LABELS[item.status];

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -1477,7 +1477,23 @@
      roving-focus group gives the LIST `tabindex="0"` while focus is outside
      it), but focusing it was measured to redirect to the active trigger inside
      the same event, so it never holds `:focus-visible` and the rule never
-     paints it. An exemption there would be unfalsifiable. */
+     paints it. An exemption there would be unfalsifiable.
+
+     ⚠ **A region with NO role opts out with `.biorouter-focus-region`
+     (2026-09-08, third).** Both exemptions above key on a role, and a scroll
+     container given a tab stop so a keyboard user can scroll it has none to
+     key on: the chat summary's To Do list (`components/ChatSummary.tsx`) is
+     an `<ol tabIndex={0}>`, and its implicit `list` role is what makes its
+     rows list items, so it cannot take `role="region"` without orphaning
+     them. Measured on the real popover (Parchment light, opened with the
+     keyboard): `rgb(224, 224, 220)` over the whole 334 × 240 px list, with
+     this rule named by CDP's `CSS.getMatchedStylesForNode`; after the change
+     `rgba(0, 0, 0, 0)`, and the same element with the class stripped live
+     went straight back to the grey. The class is a selector hook
+     only — nothing has to be generated for it, which is why it is not a
+     `focus-visible:bg-*` utility at the call site (`.biorouter-focus-surface`
+     below records the scanner trap) — and it sits in the same `:not()`, so
+     the rule never matches the region rather than being out-ranked on it. */
   :where(
     :is(
         a,
@@ -1489,7 +1505,7 @@
         input[type='checkbox'],
         input[type='radio'],
         [tabindex]:not([tabindex='-1'])
-      ):not([role='tab'], [role='tabpanel'], [role='application'])
+      ):not([role='tab'], [role='tabpanel'], [role='application'], .biorouter-focus-region)
   ):focus-visible {
     outline: none;
     background-color: var(--background-focus);
@@ -1505,16 +1521,19 @@
      gets NO focus treatment: the next Tab lands on the first control inside,
      which has its own indicator.
 
-     Only the tabpanel needs this. `role="application"` keeps whatever it draws
-     for itself — the graph canvas writes `outline-none` plus a ring as
-     utilities, and for any future region that draws nothing the UA ring is the
-     better fallback than silence.
+     The tabpanel and every `.biorouter-focus-region` need this — the class is
+     the one way a region with no role can join the exemption, so it joins the
+     restoration in the same breath. `role="application"` keeps whatever it
+     draws for itself — the graph canvas writes `outline-none` plus a ring as
+     utilities — and for any future region that draws nothing and carries
+     neither the role nor the class, the UA ring is the better fallback than
+     silence.
 
      The `prefers-contrast: more` / `forced-colors` block below is deliberately
-     NOT narrowed by any of this: it still reaches the panel through the same
-     `[tabindex]` arm, so a user who asked their OS for a stronger signal keeps
-     the ring here as everywhere else. */
-  :where([role='tabpanel']):focus-visible {
+     NOT narrowed by any of this: it still reaches the panel and the region
+     through the same `[tabindex]` arm, so a user who asked their OS for a
+     stronger signal keeps the ring here as everywhere else. */
+  :where([role='tabpanel'], .biorouter-focus-region):focus-visible {
     outline: none;
   }
 

--- a/ui/desktop/src/styles/tabFocus.test.ts
+++ b/ui/desktop/src/styles/tabFocus.test.ts
@@ -42,6 +42,7 @@ const GRAPH = readFileSync(
   join(__dirname, '../components/knowledge/graph/ForceGraphCanvas.tsx'),
   'utf8'
 );
+const CHAT_SUMMARY = readFileSync(join(__dirname, '../components/ChatSummary.tsx'), 'utf8');
 
 /**
  * Every rule in the file that sets a background on a `:focus-visible` selector,
@@ -71,16 +72,18 @@ const d15 = focusVisibleBackgroundRules().find(
 );
 
 /**
- * The roles the D-15 rule excludes, read out of the `:not()` that closes the
- * alternation — `…):not([role='tab'], [role='tabpanel'], …)):focus-visible`.
+ * The selectors the D-15 rule excludes, read out of the `:not()` that closes
+ * the alternation — `…):not([role='tab'], [role='tabpanel'], …)):focus-visible`.
+ * Two roles and a class hook today; a role is what a Radix primitive already
+ * carries, the class is what a region with no role opts out with.
  *
  * Read as a SET rather than matched as a literal string, so the assertions do
- * not care what order the roles are written in, but still care that the
+ * not care what order the entries are written in, but still care that the
  * `:not()` sits around the whole list inside the outer `:where()` (an anchored
  * match on `):not(…)):focus-visible`) rather than inside one alternative — the
  * distinction #182 turned on, and the one a later edit is most likely to lose.
  */
-function exemptedRoles(): string[] {
+function exemptions(): string[] {
   const match = d15![0].replace(/\s+/g, '').match(/\):not\(([^)]*)\)\):focus-visible$/);
   expect(match, `the D-15 rule's trailing :not() is unrecognisable: ${d15![0]}`).toBeTruthy();
   return match![1].split(',');
@@ -90,7 +93,7 @@ describe('a tab trigger takes no focus fill', () => {
   it('still exists, and still fills everything that is not a tab', () => {
     expect(d15, 'the D-15 focus-visible fill rule is no longer recognisable').toBeTruthy();
     expect(d15![1]).toContain('var(--background-focus)');
-    expect(exemptedRoles()).toContain("[role='tab']");
+    expect(exemptions()).toContain("[role='tab']");
   });
 
   /**
@@ -105,7 +108,7 @@ describe('a tab trigger takes no focus fill', () => {
     expect(selector).toContain("[tabindex]:not([tabindex='-1'])");
     // The `:not()` closes the alternation and sits inside the outer `:where()`,
     // so it applies to every arm rather than to one alternative within it.
-    expect(exemptedRoles()).toContain("[role='tab']");
+    expect(exemptions()).toContain("[role='tab']");
   });
 
   /** Specificity 0 is D-15's contract: any component can still opt out. */
@@ -247,7 +250,7 @@ describe('a focused tab shows its underline firming instead', () => {
  */
 describe('a tab panel takes no focus fill either', () => {
   it('excludes the panel in the same :not(), around the whole list', () => {
-    expect(exemptedRoles()).toContain("[role='tabpanel']");
+    expect(exemptions()).toContain("[role='tabpanel']");
   });
 
   /**
@@ -273,7 +276,7 @@ describe('a tab panel takes no focus fill either', () => {
    */
   it('still suppresses the UA focus ring on the panel', () => {
     const match = CSS.replace(/\/\*[\s\S]*?\*\//g, '').match(
-      /:where\(\[role='tabpanel'\]\):focus-visible\s*\{([^}]*)\}/
+      /:where\(\[role='tabpanel'\][^)]*\):focus-visible\s*\{([^}]*)\}/
     );
     expect(match, 'nothing restores `outline: none` on a focused tabpanel').toBeTruthy();
     expect(match![1]).toMatch(/outline:\s*none/);
@@ -285,7 +288,7 @@ describe('a tab panel takes no focus fill either', () => {
 
   /** Specificity 0 is D-15's contract; the restoration must not out-rank a component. */
   it('keeps the restoration at specificity 0', () => {
-    expect(CSS).toContain(":where([role='tabpanel']):focus-visible");
+    expect(CSS).toMatch(/:where\(\[role='tabpanel'\][^)]*\):focus-visible/);
   });
 
   /**
@@ -314,7 +317,7 @@ describe('a tab panel takes no focus fill either', () => {
    * stays visible there without a rule here.
    */
   it('exempts the one other region role, and leaves its own ring in place', () => {
-    expect(exemptedRoles()).toContain("[role='application']");
+    expect(exemptions()).toContain("[role='application']");
     expect(GRAPH).toContain('role="application"');
     expect(GRAPH).toContain('focus-visible:ring-2');
     expect(GRAPH).toContain('focus-visible:ring-border-accent');
@@ -329,7 +332,7 @@ describe('a tab panel takes no focus fill either', () => {
    * can falsify, which is how a selector list rots.
    */
   it('does not exempt the tablist, which never holds focus', () => {
-    expect(exemptedRoles()).not.toContain("[role='tablist']");
+    expect(exemptions()).not.toContain("[role='tablist']");
   });
 
   /** The rule matches nothing without its hook, so the two are asserted together. */
@@ -348,5 +351,103 @@ describe('a tab panel takes no focus fill either', () => {
       return !/:not\([^)]*\[role='tabpanel'\][^)]*\)/.test(selector.replace(/\s+/g, ''));
     });
     expect(offenders, `these rules fill a focused panel: ${JSON.stringify(offenders)}`).toEqual([]);
+  });
+});
+
+/**
+ * The same fill, on a region that has NO role to exempt — the third instance,
+ * measured but deliberately left by #185 because its `:not()` keys on roles.
+ *
+ * The chat summary's To Do list (`components/ChatSummary.tsx`) is an `<ol>`
+ * given `tabIndex={0}` so a keyboard user can scroll it. That makes it a
+ * REGION by #185's argument — entered, not operated — and the `[tabindex]`
+ * arm reaches it exactly as it reached the panel. Measured on the real popover
+ * (Parchment light, a 15-row list opened with the keyboard so `:focus-visible`
+ * was Chrome's own verdict): `backgroundColor: rgb(224, 224, 220)` =
+ * `--background-focus` (`#e0e0dc`) over the whole 334 × 240 px list, with the
+ * D-15 rule named by CDP's `CSS.getMatchedStylesForNode`. After the change,
+ * `rgba(0, 0, 0, 0)` with outline and box-shadow `none`; stripping the class
+ * from the live element brought the grey straight back.
+ *
+ * ⚠ **It cannot take a role, and that is why the hook is a class.** An `<ol>`
+ * is a list, and its implicit `list` role is what makes its `<li>` rows list
+ * items to a screen reader; `role="region"` would orphan them, and an explicit
+ * `role="list"` would be a redundant attribute carried only so a stylesheet
+ * could see it. So the region opts out with `.biorouter-focus-region` — an
+ * authored selector hook in the same `:not()`, NOT a `focus-visible:bg-*`
+ * utility at the call site, for the reason `focusSurface.test.ts` gives: a
+ * newly written Tailwind class can silently fail to generate, and a hook that
+ * needs nothing generated cannot.
+ *
+ * ⚠ **Asserted at the SOURCE, like the two blocks above** — jsdom never
+ * evaluates `:focus-visible`.
+ */
+describe('a scroll region with no role opts out of the focus fill by class', () => {
+  const HOOK = '.biorouter-focus-region';
+
+  it('excludes the class in the same :not(), around the whole list', () => {
+    expect(exemptions()).toContain(HOOK);
+    // Still beside the roles, not in place of them.
+    expect(exemptions()).toContain("[role='tabpanel']");
+  });
+
+  /**
+   * The rule matches nothing without its hook, so the two are asserted
+   * together. The list keeps its tab stop (the whole reason it is reached), and
+   * keeps NO role — the plausible wrong fix is `role="region"`, which would
+   * silence the fill and take the rows' list semantics with it.
+   */
+  it('is carried by the To Do list, which stays a list', () => {
+    const tag = CHAT_SUMMARY.match(/<ol\s[^>]*aria-label="To Do tasks"[^>]*>/);
+    expect(tag, 'the To Do list is no longer recognisable').toBeTruthy();
+    expect(tag![0]).toContain('tabIndex={0}');
+    expect(tag![0]).toMatch(/className="[^"]*\bbiorouter-focus-region\b/);
+    expect(tag![0]).not.toMatch(/\brole=/);
+    // A selector hook, never a utility that has to be generated.
+    expect(tag![0]).not.toContain('focus-visible:');
+  });
+
+  /**
+   * ⚠ The trap #185 hit, again: leaving the D-15 block drops its
+   * `outline: none`, and Chrome's UA `:focus-visible { outline: auto }` is
+   * underneath. The restoration that covers the panel has to cover the class,
+   * or the grey list becomes a ringed list.
+   */
+  it('still suppresses the UA focus ring on the region', () => {
+    const match = CSS.replace(/\/\*[\s\S]*?\*\//g, '').match(
+      /:where\(([^)]*)\):focus-visible\s*\{([^}]*)\}/g
+    );
+    const restoring = (match ?? []).filter(
+      (rule) => rule.includes(HOOK) && /outline:\s*none/.test(rule)
+    );
+    expect(restoring, `nothing restores \`outline: none\` on ${HOOK}`).toHaveLength(1);
+    // A region gets NO treatment: no fill under another selector, no ring.
+    expect(restoring[0]).not.toContain('--background-focus');
+    expect(restoring[0]).not.toMatch(/box-shadow|background/);
+  });
+
+  /**
+   * The safety valve is not narrowed: a user who asked their OS for a stronger
+   * signal still gets the ring on the list, through the same `[tabindex]` arm.
+   */
+  it('leaves the prefers-contrast ring reaching the region', () => {
+    const block = CSS.replace(/\/\*[\s\S]*?\*\//g, '').match(
+      /@media \(prefers-contrast: more\), \(forced-colors: active\) \{([\s\S]*?)\n {2}\}/
+    );
+    expect(block, 'the prefers-contrast block is unrecognisable').toBeTruthy();
+    expect(block![1]).toContain("[tabindex]:not([tabindex='-1'])");
+    expect(block![1]).not.toContain(HOOK);
+  });
+
+  /** Stated as a property of the whole stylesheet: nothing paints a fill on the hook. */
+  it('has no rule anywhere that paints a background on the region', () => {
+    const offenders = focusVisibleBackgroundRules().filter(([selector]) => {
+      if (!selector.includes(HOOK)) return false;
+      // Mentioning the hook only in order to exclude it is fine.
+      return !new RegExp(`:not\\([^)]*\\${HOOK}[^)]*\\)`).test(selector.replace(/\s+/g, ''));
+    });
+    expect(offenders, `these rules fill a focused region: ${JSON.stringify(offenders)}`).toEqual(
+      []
+    );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #185. The D-15 focus fill (`--background-focus`) still painted the chat summary's To Do list: `ChatSummary.tsx` renders it as an `<ol tabIndex={0}>` — a scroll container given a tab stop so a keyboard user can scroll it — so the `[tabindex]:not([tabindex='-1'])` arm of the base rule reached it, and it carries no role the `:not()` from #182/#185 could name.

- **Why a class and not a role.** The `<ol>`'s implicit `list` role is what makes its rows list items to a screen reader; `role="region"` would silence the fill and orphan the rows, and an explicit `role="list"` would be a redundant attribute carried only so a stylesheet could see it. So the opt-out is `.biorouter-focus-region`: an authored selector hook added to the same `:not()` in `main.css`, never a `focus-visible:bg-*` utility at the call site (a newly written Tailwind class can silently fail to generate under `BIOROUTER_NO_HMR`; a hook that needs nothing generated cannot).
- **The #185 trap, handled.** Leaving the D-15 block drops its `outline: none`, with Chrome's UA `:focus-visible { outline: auto }` underneath. The rule that restores the suppression on the tabpanel now names the class beside it, so the grey list does not become a ringed one. The `prefers-contrast: more` / `forced-colors` block is deliberately untouched and still reaches the list.
- **What a keyboard user gets.** The region takes no treatment, on the same argument as the panel: the next Tab lands on the summary's own "Make workflow" button, which shows its focus surface.

## Verification (running app, real popover, 15-row overflowing list)

Opened with real CDP key events so `:focus-visible` was Chrome's own verdict.

| State | Before (class stripped live) | After |
| --- | --- | --- |
| Focused list background | `rgb(224, 224, 220)` (D-15 rule matched) | `rgba(0, 0, 0, 0)` |
| Focused list outline / box-shadow | none / none | none / none |
| Matching `:focus-visible` rules | UA + D-15 fill | UA + the `outline: none` restoration only |
| Next Tab lands on | — | "Make workflow", `rgb(224, 224, 220)` light / `rgb(53, 52, 47)` dark |
| Emulated `prefers-contrast: more` | — | `2px solid --ring` on the list |

Identical results in Parchment, Alma Mater and Roche Limit, light and dark.

## Tests

- `styles/tabFocus.test.ts`: a third describe block asserts the hook sits in the `:not()`, the To Do list carries it with its tab stop and no role, the restoration names it, the contrast block is not narrowed, and no rule anywhere fills it.
- `ChatSummary.test.tsx`: DOM-level twin (tab stop kept, no role, hook present).
- `npx vitest run src/styles` ✅ · `npm run test:run` ✅ (423 files, 4761 tests) · `npm run lint:check` ✅ · `format:check` on touched files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)