### PR TITLE
Model config: name the poison and keep every test off the shared settings the readers consult

### DIFF
--- a/crates/biorouter/src/config/base.rs
+++ b/crates/biorouter/src/config/base.rs
@@ -533,6 +533,43 @@ impl Config {
         load_init_config_from_workspace()
     }
 
+    /// A staging path for one write, unique to this call.
+    ///
+    /// ⚠ **Never a fixed name.** It was `config.tmp` — one path shared by every
+    /// writer in every process — and that is a correctness bug, not untidiness,
+    /// because `save_values` holds an **exclusive lock** on whatever it opens
+    /// there. Two concurrent writers interleave like this:
+    ///
+    /// 1. A and B both open the shared `config.tmp`; A wins the lock.
+    /// 2. A writes, closes, and renames `config.tmp` onto `config.yaml`.
+    /// 3. B's handle is still open on that same file object — which is now
+    ///    `config.yaml` — and B's `lock_exclusive` succeeds on it.
+    ///
+    /// So a writer ends up holding an exclusive lock on the live config file.
+    /// On unix `fs2` uses `flock`, which is advisory, and readers never notice.
+    /// On Windows it is `LockFileEx`, which is **mandatory**: a concurrent
+    /// `read_to_string` of that file fails with `ERROR_LOCK_VIOLATION`. That is
+    /// how a `ModelConfig::new` in an unrelated test came back `Err` and
+    /// panicked `test (windows-latest)` twice in one day — always in the first
+    /// ~100 ms of the job's first test binary, the one window in which
+    /// `config.yaml` does not exist yet and every thread races to create it.
+    /// See the long note above `validate_max_tokens` in `model.rs`.
+    ///
+    /// Per process AND per call: the pid separates the daemon, the CLI and the
+    /// Electron host (which `privacy::master_switch` already had to reason
+    /// about), and the counter separates threads inside one of them.
+    fn staging_path(&self) -> PathBuf {
+        static NEXT_STAGE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let nth = NEXT_STAGE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut name = self
+            .config_path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("config.yaml"))
+            .to_os_string();
+        name.push(format!(".{}.{nth}.tmp", std::process::id()));
+        self.config_path.with_file_name(name)
+    }
+
     fn save_values(&self, values: Mapping) -> Result<(), ConfigError> {
         // Create backup before writing new config
         self.create_backup_if_needed()?;
@@ -546,30 +583,40 @@ impl Config {
         }
 
         // Write to a temporary file first for atomic operation
-        let temp_path = self.config_path.with_extension("tmp");
+        let temp_path = self.staging_path();
 
-        {
-            let mut file = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&temp_path)?;
+        let staged = (|| -> Result<(), ConfigError> {
+            {
+                let mut file = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&temp_path)?;
 
-            // Acquire an exclusive lock
-            file.lock_exclusive()
-                .map_err(|e| ConfigError::LockError(e.to_string()))?;
+                // Acquire an exclusive lock
+                file.lock_exclusive()
+                    .map_err(|e| ConfigError::LockError(e.to_string()))?;
 
-            // Write the contents using the same file handle
-            file.write_all(yaml_value.as_bytes())?;
-            file.sync_all()?;
+                // Write the contents using the same file handle
+                file.write_all(yaml_value.as_bytes())?;
+                file.sync_all()?;
 
-            // Unlock is handled automatically when file is dropped
+                // Unlock is handled automatically when file is dropped
+            }
+
+            // Atomically replace the original file
+            std::fs::rename(&temp_path, &self.config_path)?;
+            Ok(())
+        })();
+
+        // A per-call staging path cannot be reused by the next attempt, so a
+        // failure that leaves it behind leaves litter in the user's config
+        // directory forever. Removing it is best-effort: the write already
+        // failed and that is the error worth reporting.
+        if staged.is_err() {
+            let _ = std::fs::remove_file(&temp_path);
         }
-
-        // Atomically replace the original file
-        std::fs::rename(&temp_path, &self.config_path)?;
-
-        Ok(())
+        staged
     }
 
     pub fn initialize_if_empty(&self, values: Mapping) -> Result<(), ConfigError> {
@@ -1722,11 +1769,132 @@ mod tests {
         let content = std::fs::read_to_string(config_file.path())?;
         assert!(serde_yaml::from_str::<serde_yaml::Value>(&content).is_ok());
 
-        // The temp file should not exist after successful write
-        let temp_path = config_file.path().with_extension("tmp");
-        assert!(!temp_path.exists(), "Temporary file should be cleaned up");
+        // No staging file should survive a successful write. Asserting on one
+        // fixed name would go vacuous the moment the staging path stopped being
+        // a fixed name — which is exactly what it had to stop being — so look
+        // for any `.tmp` sibling instead.
+        let dir = config_file.path().parent().unwrap();
+        let leftovers: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| {
+                name.ends_with(".tmp")
+                    && name.starts_with(
+                        &config_file
+                            .path()
+                            .file_name()
+                            .unwrap()
+                            .to_string_lossy()
+                            .into_owned(),
+                    )
+            })
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "staging files should be cleaned up, found {leftovers:?}"
+        );
 
         Ok(())
+    }
+
+    /// Two writers must never stage through the same path.
+    ///
+    /// It was `config_path.with_extension("tmp")` — one name for every writer
+    /// in every process — and `save_values` holds an **exclusive lock** on
+    /// whatever it opens there. Once one writer renames that shared file onto
+    /// `config.yaml`, a second writer that already had it open is holding an
+    /// exclusive lock on the live config file. Under `flock` (unix) that is
+    /// advisory and invisible; under `LockFileEx` (Windows) it is mandatory,
+    /// and a concurrent reader gets `ERROR_LOCK_VIOLATION` instead of the file.
+    /// That read is how `ModelConfig::new` came back `Err` and panicked
+    /// `test (windows-latest)` in tests that never touch the config layer.
+    ///
+    /// Asserted on the path rather than by racing threads, deliberately: the
+    /// race needs an interleaving CI produces and a laptop rarely does, and on
+    /// unix it cannot be observed at all. Uniqueness is the property, and it is
+    /// checkable everywhere.
+    #[test]
+    fn two_writes_never_share_a_staging_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.yaml");
+        let config =
+            Config::new_with_file_secrets(&config_path, dir.path().join("secrets.yaml")).unwrap();
+
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..64 {
+            let staged = config.staging_path();
+            assert_eq!(
+                staged.parent(),
+                config_path.parent(),
+                "staging must be a sibling of the config file or the rename is not atomic"
+            );
+            assert_ne!(staged, config_path, "staging must not BE the config file");
+            assert!(
+                staged.to_string_lossy().ends_with(".tmp"),
+                "staging paths stay recognisable as staging: {}",
+                staged.display()
+            );
+            assert!(
+                seen.insert(staged.clone()),
+                "two writes staged through {} — the second one can end up holding an \
+                 exclusive lock on config.yaml after the first renames it into place",
+                staged.display()
+            );
+        }
+        assert!(
+            seen.iter().all(|p| p
+                .to_string_lossy()
+                .contains(&std::process::id().to_string())),
+            "the staging name must also separate PROCESSES: the daemon, the CLI and the \
+             Electron host all write this directory"
+        );
+    }
+
+    /// A reader must never see a config-layer failure that the config layer
+    /// itself caused.
+    ///
+    /// This is the shape the flake took: many threads reach `Config::load` at
+    /// once at start-up, `config.yaml` does not exist yet, and every one of
+    /// them takes the create-and-save branch. The only answer any of them may
+    /// give for a key that is not set is `NotFound` — never an I/O or lock
+    /// error, which callers are entitled to read as "the value is broken".
+    ///
+    /// On unix this passes with or without the fix (`flock` is advisory), so it
+    /// is not the fail-before test — `two_writes_never_share_a_staging_path` is.
+    /// It is here because it is the assertion that runs on the platform where
+    /// the bug actually happens.
+    #[test]
+    fn a_startup_storm_on_a_missing_config_never_reports_anything_but_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.yaml");
+        let config = std::sync::Arc::new(
+            Config::new_with_file_secrets(&config_path, dir.path().join("secrets.yaml")).unwrap(),
+        );
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(16));
+        let workers: Vec<_> = (0..16)
+            .map(|_| {
+                let config = std::sync::Arc::clone(&config);
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    (0..8)
+                        .map(|_| config.get_param::<i32>("A_KEY_NOBODY_SET"))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        for worker in workers {
+            for outcome in worker.join().unwrap() {
+                assert!(
+                    matches!(outcome, Err(ConfigError::NotFound(_))),
+                    "an unset key must read as NotFound even while other threads are creating \
+                     the config file; got {outcome:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/biorouter/src/model.rs
+++ b/crates/biorouter/src/model.rs
@@ -528,6 +528,32 @@ impl ModelConfig {
     //
     // If that recurs, do NOT reach for a lock in the tests. It is already
     // there. Keep the rejection cases off the environment instead.
+    //
+    // ── The second route, found when it recurred anyway ─────────────────────
+    //
+    // It did recur, twice on `main` in one day, on merge commits that touched
+    // only renderer files — and the environment was innocent. `max_tokens` is
+    // the one setting here that is NOT read from the environment: it goes
+    // through `Config::global().get_param`, i.e. through `config.yaml`. That
+    // read can fail for reasons that have nothing to do with the value, and
+    // `validate_max_tokens` used to call every such failure a malformed value.
+    //
+    // The failing runs are what named it: both panicked 28-120 ms into the
+    // FIRST test binary of the job, which is the one moment `config.yaml` does
+    // not exist yet. Every thread that reaches `Config::load` then takes the
+    // create branch, and `save_values` staged all of them through one shared
+    // `config.tmp` while holding `fs2`'s `lock_exclusive`. On Windows that is
+    // `LockFileEx`, a **mandatory** byte-range lock — a concurrent
+    // `read_to_string` of the locked file fails with `ERROR_LOCK_VIOLATION`
+    // instead of returning bytes. On unix `flock` is advisory, so readers never
+    // notice: hence Windows-only, always at start-up, and always the same
+    // handful of alphabetically-first tests.
+    //
+    // Two fixes, and both matter. `config::base::save_values` now stages each
+    // write through its own path, so no writer can end up holding an exclusive
+    // lock on `config.yaml` itself. And `validate_max_tokens` below no longer
+    // reads an unreadable config layer as a bad value — which is the half that
+    // holds no matter what else learns to make that read fail.
 
     fn parse_temperature() -> Result<Option<f32>, ConfigError> {
         let raw = std::env::var("BIOROUTER_TEMPERATURE").ok();
@@ -562,11 +588,42 @@ impl ModelConfig {
     }
 
     /// Pure half of [`Self::parse_max_tokens`]: interpret whatever the config
-    /// layer returned for `BIOROUTER_MAX_TOKENS`. `NotFound` means unset;
-    /// any other lookup error is a malformed value.
+    /// layer returned for `BIOROUTER_MAX_TOKENS`.
+    ///
+    /// Three outcomes, and the middle one is the whole point of this function
+    /// existing separately from [`Self::parse_max_tokens`]:
+    ///
+    /// * a value that is there and usable — take it;
+    /// * a value that is there and **malformed** (`DeserializeError`) — that is
+    ///   a real mistake in the user's configuration, and saying so is useful;
+    /// * the config layer could not answer at all — unset (`NotFound`), or the
+    ///   file/keyring could not be READ this instant (`FileError`, `LockError`,
+    ///   `DirectoryError`, `KeyringError`, `FallbackToFileStorage`). None of
+    ///   those is a statement about the value, so none of them may fail the
+    ///   whole model config.
+    ///
+    /// ⚠ **That last group used to be an error, and it is what made
+    /// `test (windows-latest)` flake.** `ModelConfig::new` calls this on every
+    /// construction, and `new_or_fail` turns any `Err` into a panic — so a
+    /// transient, value-independent I/O failure in the config layer killed a
+    /// test that has nothing to do with max tokens. It happened at the one
+    /// moment `config.yaml` does not exist yet: every thread that reaches
+    /// `Config::load` races to create it, and on Windows `fs2`'s
+    /// `lock_exclusive` is a **mandatory** `LockFileEx` byte-range lock, so a
+    /// concurrent reader gets `ERROR_LOCK_VIOLATION` rather than the file. The
+    /// writers' side of that is fixed in `config::base::save_values` (each
+    /// write now stages through its own path); this half is the reader
+    /// refusing to read an outage as a bad value in the first place, which
+    /// holds however the outage arises.
+    ///
+    /// Degrading to "unset" is also what every other consumer of the config
+    /// layer already does — they reach for `.ok()` or `unwrap_or(default)`.
+    /// A session that runs with the default token budget is strictly better
+    /// than a session that panics.
     fn validate_max_tokens(
         looked_up: Result<i32, crate::config::ConfigError>,
     ) -> Result<Option<i32>, ConfigError> {
+        use crate::config::ConfigError as LookupError;
         match looked_up {
             Ok(tokens) => {
                 if tokens <= 0 {
@@ -577,12 +634,22 @@ impl ModelConfig {
                 }
                 Ok(Some(tokens))
             }
-            Err(crate::config::ConfigError::NotFound(_)) => Ok(None),
-            Err(e) => Err(ConfigError::InvalidValue(
+            // The value is present and cannot be understood — the one case
+            // that is genuinely about the value.
+            Err(LookupError::DeserializeError(detail)) => Err(ConfigError::InvalidValue(
                 "biorouter_max_tokens".to_string(),
                 String::new(),
-                e.to_string(),
+                detail,
             )),
+            Err(LookupError::NotFound(_)) => Ok(None),
+            // Unreadable, not invalid. Report it and carry on unset.
+            Err(unavailable) => {
+                tracing::warn!(
+                    "could not read biorouter_max_tokens from the config layer ({unavailable}); \
+                     treating it as unset"
+                );
+                Ok(None)
+            }
         }
     }
 
@@ -781,9 +848,18 @@ impl ModelConfig {
         Self::context_window_for(&self.model_name)
     }
 
+    /// [`Self::new`], panicking on failure.
+    ///
+    /// ⚠ **The panic must carry the error.** It did not, and that cost two CI
+    /// investigations: `test (windows-latest)` failed twice with
+    /// `Failed to create model config for gpt-5.6-codex` and nothing else, so
+    /// the one fact that identifies the cause — which setting, and what was
+    /// wrong with it — was thrown away at the moment it was known. There are
+    /// 170-odd call sites; the next one to fail should diagnose itself.
     pub fn new_or_fail(model_name: &str) -> ModelConfig {
-        ModelConfig::new(model_name)
-            .unwrap_or_else(|_| panic!("Failed to create model config for {}", model_name))
+        ModelConfig::new(model_name).unwrap_or_else(|e| {
+            panic!("Failed to create model config for {model_name}: {e}");
+        })
     }
 }
 
@@ -962,6 +1038,106 @@ mod tests {
         }
     }
 
+    /// The guard that actually covers the failure, on every route into it.
+    ///
+    /// [`no_test_poisons_a_shared_setting`] below watches the four settings
+    /// `ModelConfig::new` reads out of the **environment**. It cannot watch the
+    /// fifth, because max tokens is not an environment variable — it comes from
+    /// `Config::global().get_param`, and so it can fail for reasons no source
+    /// scan can enumerate: the file is missing, unreadable, locked by another
+    /// thread, on a directory that cannot be created, in a keyring that will
+    /// not answer. That is the hole the Windows flake went through, and closing
+    /// it by listing more writers is hopeless: the writer was the config layer
+    /// itself.
+    ///
+    /// So this guard asserts the *reader's* half instead, which is finite:
+    /// **only a value that is present and malformed may fail a model config.**
+    /// Anything else the config layer can say means "no answer", and no answer
+    /// means unset. That property is what makes `ModelConfig::new` immune to
+    /// whatever the config layer does next, rather than to the one mechanism
+    /// that has bitten so far.
+    ///
+    /// Every variant of `crate::config::ConfigError` is listed on purpose. If
+    /// one is added, this stops compiling and someone has to decide which of
+    /// the two groups it belongs to — which is the decision that was got wrong.
+    #[test]
+    fn a_config_layer_outage_is_never_read_as_a_malformed_value() {
+        use crate::config::ConfigError as LookupError;
+
+        // "The value is there and I cannot understand it" — the only lookup
+        // failure that is about the value, and so the only one that may fail.
+        let malformed = ModelConfig::validate_max_tokens(Err(LookupError::DeserializeError(
+            "invalid type: string \"nope\", expected i32".to_string(),
+        )));
+        assert!(
+            matches!(malformed, Err(ConfigError::InvalidValue(..))),
+            "a malformed configured value must still be reported, got {malformed:?}"
+        );
+
+        // Everything else says nothing about the value. `FileError` is the one
+        // the flake travelled on: on Windows, reading a file another thread has
+        // exclusively locked returns ERROR_LOCK_VIOLATION, not bytes.
+        let outages: Vec<(&str, LookupError)> = vec![
+            (
+                "unset",
+                LookupError::NotFound("BIOROUTER_MAX_TOKENS".into()),
+            ),
+            (
+                // 33 is ERROR_LOCK_VIOLATION on Windows — the code the flake
+                // actually arrived as. It renders under the host's own error
+                // table, so do not assert on its text.
+                "unreadable config file (os error 33: the Windows lock violation)",
+                LookupError::FileError(std::io::Error::from_raw_os_error(33)),
+            ),
+            (
+                "missing config file",
+                LookupError::FileError(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "no such file",
+                )),
+            ),
+            (
+                "unusable config directory",
+                LookupError::DirectoryError("permission denied".into()),
+            ),
+            (
+                "config file locked",
+                LookupError::LockError("would block".into()),
+            ),
+            (
+                "keyring will not answer",
+                LookupError::KeyringError("no backend".into()),
+            ),
+            (
+                "secrets fell back to file",
+                LookupError::FallbackToFileStorage,
+            ),
+        ];
+
+        for (what, outage) in outages {
+            let rendered = outage.to_string();
+            let verdict = ModelConfig::validate_max_tokens(Err(outage));
+            assert_eq!(
+                verdict.as_ref().ok(),
+                Some(&None),
+                "{what}: the config layer could not answer ({rendered}), which is not a claim \
+                 about the value. Failing here fails ModelConfig::new, and new_or_fail turns \
+                 that into a panic in whatever unrelated test happens to be running. Got \
+                 {verdict:?}"
+            );
+        }
+
+        // And the value cases still behave.
+        assert_eq!(
+            ModelConfig::validate_max_tokens(Ok(4096)).unwrap(),
+            Some(4096)
+        );
+        assert!(matches!(
+            ModelConfig::validate_max_tokens(Ok(0)),
+            Err(ConfigError::InvalidRange(..))
+        ));
+    }
+
     /// The standing guard against the race the split above fixed.
     ///
     /// These five variables are read process-wide by `ModelConfig::new`, which
@@ -978,9 +1154,19 @@ mod tests {
     ///
     /// It reads literal values in the two shapes these are actually written in
     /// — `env_lock::lock_env([("KEY", Some("value"))])` and
-    /// `set_var("KEY", "value")`. A value passed through a variable
-    /// (`("KEY", worker_limit)`) is invisible to it; if you need one of those,
-    /// make sure it can only ever hold values these validators accept.
+    /// `set_var("KEY", "value")`. The first also covers `temp_env::with_vars`
+    /// (the same tuple) and `temp_env::with_var("KEY", Some("value"), …)`,
+    /// where the call's own paren plays the part of the tuple's. A value passed
+    /// through a variable (`("KEY", worker_limit)`) is invisible to it; if you
+    /// need one of those, make sure it can only ever hold values these
+    /// validators accept.
+    ///
+    /// ⚠ **Being green here does not mean `ModelConfig::new` is safe.** It
+    /// watches four of the five settings, and the fifth — max tokens — is read
+    /// from the config layer, which no source scan can cover. That is where the
+    /// flake this guard was written for actually came back from;
+    /// [`a_config_layer_outage_is_never_read_as_a_malformed_value`] above is
+    /// the half that covers it.
     #[test]
     fn no_test_poisons_a_shared_setting() {
         fn rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
@@ -1020,7 +1206,15 @@ mod tests {
         // `BIOROUTER_TOOLSHIM_OLLAMA_MODEL`.
         let keys = "BIOROUTER_MAX_TOKENS|BIOROUTER_TEMPERATURE|BIOROUTER_CONTEXT_LIMIT\
                     |BIOROUTER_TOOLSHIM|BIOROUTER_TOOLSHIM_OLLAMA_MODEL";
-        // `("KEY", Some("value"))` — the `env_lock::lock_env` shape.
+        // `("KEY", Some("value"))` — the `env_lock::lock_env` / `temp_env::
+        // with_vars` shape.
+        //
+        // ⚠ This also covers `temp_env::with_var("KEY", Some("value"), …)`,
+        // which reads like a different shape and is not one: the CALL's own
+        // opening paren plays the part of the tuple's. That was measured, not
+        // assumed — a dedicated `with_var\(…` pattern was written, and the only
+        // thing it achieved was reporting every offender twice. Do not add it
+        // back without first checking that this one really misses the shape.
         let tuple = regex::Regex::new(&format!(r#"\(\s*"({keys})"\s*,\s*Some\(\s*"([^"]*)"\s*\)"#))
             .unwrap();
         // `set_var("KEY", "value")`.


### PR DESCRIPTION
## Why

`test (windows-latest)` failed twice on `main` in one day, both times with the same test, on merge
commits whose PRs touched only renderer files:

| Run | Job | Commit | Failure |
|---|---|---|---|
| [34287731182](https://github.com/BaranziniLab/biorouter/actions/runs/34287731182) (attempt 1) | `test (windows-latest)` | PR #182 (CSS + docs) | `test result: FAILED. 3624 passed; 1 failed` |
| [34296367641](https://github.com/BaranziniLab/biorouter/actions/runs/34296367641) (attempt 1) | `test (windows-latest)` | `main@b9271ceb` (the #186 merge) | `test result: FAILED. 3623 passed; 1 failed` |

Both:

```
test agents::agent::gate_a_bind_tests::a_new_same_name_composite_bind_wins_while_the_old_snapshot_is_parked ... FAILED
thread '…' panicked at crates\biorouter\src\model.rs:786:33:
Failed to create model config for gpt-5.6-codex
```

`new_or_fail` was `ModelConfig::new(m).unwrap_or_else(|_| panic!(…))` — the error was **discarded**,
so no log has ever named the setting or the value.

The environment half of this race was diagnosed and fixed earlier (the `parse_*` / `validate_*`
split, plus the source-scan guard `no_test_poisons_a_shared_setting`), and the comment at
`model.rs` even names this test as the victim. That guard is correct and stays. It simply cannot see
this route — because the setting involved is **not read from the environment**.

## Root cause

`max_tokens` is the one setting `ModelConfig::new` resolves through the **config layer** rather than
`std::env::var`: `parse_max_tokens` → `Config::global().get_param::<i32>("BIOROUTER_MAX_TOKENS")` →
`Config::load` → `config.yaml`.

The failing runs name the window themselves. Both panics landed **28–120 ms into the job's first
test binary** (`biorouter` lib, the first binary cargo runs), while only the alphabetically-first
handful of tests were in flight — which is why it was the same test twice rather than a random one.
That is the one moment `config.yaml` does not exist yet.

The interleaving:

1. Many threads call `get_param`; `BIOROUTER_MAX_TOKENS` is unset in the environment, so each falls
   through to `Config::load` (`config/base.rs:380`). The file does not exist, so **every one of them**
   takes the create branch → `create_and_save_default_config` → `save_values`.
2. `save_values` staged every write through one shared path — `self.config_path.with_extension("tmp")`
   → `config.tmp` — and held `fs2`'s `lock_exclusive()` on it while writing
   (`config/base.rs:549-566`, pre-fix).
3. Writer A opens `config.tmp`, wins the lock, writes, closes, and `rename`s it onto `config.yaml`.
   Writer B already had the *same* `config.tmp` open, so B's handle now refers to the file that has
   become `config.yaml` — and B's `lock_exclusive()` then succeeds **on the live config file**.
4. A third thread does `read_to_string(config.yaml)` in `load_values_with_recovery`
   (`config/base.rs:439`).

On unix, `fs2::lock_exclusive` is `flock(LOCK_EX)` — advisory; the reader never notices. **On Windows
it is `LockFileEx(…, LOCKFILE_EXCLUSIVE_LOCK, 0, !0, !0)` — a mandatory whole-file byte-range lock,
and a read of a locked range fails with `ERROR_LOCK_VIOLATION`** (`fs2-0.4.3/src/windows.rs:84-112`).
So the read returns `Err(io)` → `ConfigError::FileError`.

5. `validate_max_tokens` (`model.rs`, pre-fix) mapped **every** non-`NotFound` lookup error to
   `ConfigError::InvalidValue` — i.e. it read "I could not read the config file this instant" as
   "the configured value is malformed".
6. `ModelConfig::new` returns `Err`; `new_or_fail` panics and throws the reason away.

`load()` can only return `Err` through that one `read_to_string` — the create branch swallows its own
write errors — which is what makes the diagnosis tight rather than a guess.

The shared staging path was already a known hazard in this repo: `privacy/master_switch.rs:271` and
`:461` both warn about writing "through a staging path (`config.tmp`) that is not per process". That
call site was changed to avoid triggering it; the staging path itself was never fixed.

Windows-only, start-up-only, independent of the diff, and invisible to a source scan — which is
every property the two failures had.

## What changed

Three changes, in decreasing order of how much they matter:

1. **`ModelConfig::validate_max_tokens` (`crates/biorouter/src/model.rs`)** — the fix that holds
   however the read comes to fail. It now separates:
   - the value is present and **malformed** (`DeserializeError`) → still an error, as before;
   - the config layer **cannot answer** — `NotFound`, `FileError`, `LockError`, `DirectoryError`,
     `KeyringError`, `FallbackToFileStorage` → unset (`Ok(None)`), with a `tracing::warn!`.

   None of that second group is a claim about the value, and a session that runs on the default
   token budget is strictly better than one that panics. It is also what every other consumer of the
   config layer already does (`.ok()` / `unwrap_or(default)`).

2. **`Config::save_values` (`crates/biorouter/src/config/base.rs`)** — the writer's half. Each write
   now stages through its own path (`config.yaml.<pid>.<n>.tmp`) via a new `Config::staging_path`,
   so no writer can end up holding an exclusive lock on the live config file. A per-call path cannot
   be reused by the next attempt, so a failed write now removes its staging file instead of leaving
   litter in the user's config directory.

3. **`ModelConfig::new_or_fail`** — the panic carries the error (`{e}`). There are ~170 call sites;
   the next one to fail should diagnose itself instead of costing another CI investigation.

No lock was added anywhere, in tests or in production — as the existing comment insists, a lock in
the tests cannot help, because the readers never ask for it.

## Tests

**Guards (both fail on the pre-fix tree).** Verified by reverting only the two production halves and
keeping the new tests:

```
test model::tests::a_config_layer_outage_is_never_read_as_a_malformed_value ... FAILED
test config::base::tests::two_writes_never_share_a_staging_path ... FAILED
test config::base::tests::a_startup_storm_on_a_missing_config_never_reports_anything_but_not_found ... ok
test config::base::tests::test_atomic_write_prevents_corruption ... ok

---- model::tests::a_config_layer_outage_is_never_read_as_a_malformed_value stdout ----
assertion `left == right` failed: unreadable config file (os error 33: the Windows lock violation):
the config layer could not answer (Failed to read config file: … (os error 33)), which is not a claim
about the value. Failing here fails ModelConfig::new, and new_or_fail turns that into a panic in
whatever unrelated test happens to be running.
Got Err(InvalidValue("biorouter_max_tokens", "", "Failed to read config file: … (os error 33)"))
  left: None
 right: Some(None)

---- config::base::tests::two_writes_never_share_a_staging_path stdout ----
two writes staged through …/config.tmp — the second one can end up holding an exclusive lock on
config.yaml after the first renames it into place

test result: FAILED. 2 passed; 2 failed; 0 ignored; 3703 filtered out
```

After the fix, the same four pass:

```
test result: ok. 63 passed; 0 failed; 0 ignored; 0 measured; 3644 filtered out   (model:: config::base::)
```

`a_config_layer_outage_is_never_read_as_a_malformed_value` enumerates every `ConfigError` variant by
name, so adding one stops compiling until someone decides which group it is in — the decision that
was got wrong. `no_test_poisons_a_shared_setting` is kept, with a note that being green there does not make
`ModelConfig::new` safe: it covers four of the five settings and not the config-layer one.

Its patterns were checked rather than assumed, and the check is worth recording. A dedicated
`with_var\(…` pattern was added on the theory that `temp_env::with_var("KEY", Some("v"), …)` is a
different shape from the tuple the guard already reads. It is not — the call's own opening paren
plays the part of the tuple's — and the only thing the second pattern achieved was reporting every
offender twice. Proven by dropping a poisoned `with_var("BIOROUTER_TEMPERATURE", Some("-5"), …)`
into the tree: two reports with the extra pattern, one without it, and the guard fails either way.
The pattern is gone and the reason is in the comment, so it does not get re-added.

**Stress — 20 runs, `--test-threads=32`, `BIOROUTER_DISABLE_KEYRING=true`:**

```
cargo test -p biorouter --lib -- agents::agent::gate_a_bind_tests model:: providers:: --test-threads=32
runs  1-20: test result: ok. 788 passed; 0 failed; 0 ignored; 0 measured; 2919 filtered out
TALLY: 20 pass / 0 fail out of 20
```

**Full lib suite:**

```
cargo test -p biorouter --lib
test result: ok. 3706 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 24.53s
```

**Style / lint:**

```
cargo fmt --all -- --check     clean
./scripts/clippy-lint.sh       ✅ All baseline clippy checks passed!  (incl. too_many_lines)
```

**Windows cross-check** — `cargo check -p biorouter --all-targets --locked --target x86_64-pc-windows-gnu`
through the CI's own `scripts/cross-env.sh` docker recipe: `Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 43s`, no errors (only the 9 dead-code warnings already on `main`).

**CI on this branch** — every check green, including the job that flaked:

```
test (windows-latest)                   pass  16m10s
test (macos-latest)                     pass  13m22s
test (ubuntu-latest)                    pass  18m38s
cross-check (x86_64-pc-windows-gnu)     pass   8m49s
cross-check (x86_64-unknown-linux-gnu)  pass   6m47s
guards / serve / no-ai-coauthor         pass
```

One green Windows run is of course not proof against a race — it never was, on either side of this
fix. The deterministic evidence is the two guards above, which fail on the pre-fix tree on every
platform.

## Follow-ups

- The 20-run stress and the full suite are **macOS** runs. They cannot reproduce the original
  failure and never could: `flock` is advisory, so the poisoned read does not exist on unix. The
  evidence for the mechanism is the two CI logs plus the code
  (`fs2-0.4.3/src/windows.rs`, `config/base.rs`), not a local repro — the pre-fix guard failures are
  what pin the two defects deterministically on every platform.
- `Config::load` re-reads `config.yaml` on **every** `get_param` call, with no caching. That is a lot
  of I/O on a hot path, and it is what makes the start-up storm as wide as it is. Out of scope here.
- `create_and_save_default_config` swallows every write error and returns `Ok`, so a config directory
  that cannot be written is silent. Left alone deliberately — changing it would turn a new class of
  environment problem into hard failures in the same code path this PR is calming down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


