### PR TITLE
fix(ui): give unknown routes a page, and stop leaking transient timers

### DIFF
--- a/ui/desktop/src/App.routing.test.tsx
+++ b/ui/desktop/src/App.routing.test.tsx
@@ -31,6 +31,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Outlet } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppInner } from './App';
+import { echoPath } from './components/NotFoundView';
 
 Object.defineProperty(window, 'history', {
   value: { replaceState: vi.fn(), state: null },
@@ -291,5 +292,28 @@ describe('the routes PR #184 retired', () => {
 
     expect(await screen.findByTestId('home-view')).toBeInTheDocument();
     expect(screen.queryByText('There is nothing at this address')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * The address is echoed back so a stale bookmark tells the user WHICH link
+ * died. It is also attacker-influenced text of unbounded length — a
+ * `biorouter://` deep link carries a whole payload in its path — and it lands
+ * in a `max-w-sm` paragraph, so it has to be trimmed before it is shown.
+ * (React escapes it; the hazard here is layout, not injection.)
+ */
+describe('the address the not-found page echoes', () => {
+  it('shows a short path exactly as it arrived', () => {
+    expect(echoPath('/zzz-nonexistent')).toBe('/zzz-nonexistent');
+  });
+
+  it('always reads as a path, even if the router hands it one without a slash', () => {
+    expect(echoPath('scheduler')).toBe('/scheduler');
+  });
+
+  it('trims a long one to something a sentence can hold', () => {
+    const echoed = echoPath(`/${'a'.repeat(500)}`);
+    expect(echoed.length).toBeLessThanOrEqual(72);
+    expect(echoed.endsWith('…')).toBe(true);
   });
 });

--- a/ui/desktop/src/App.routing.test.tsx
+++ b/ui/desktop/src/App.routing.test.tsx
@@ -1,0 +1,295 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * The route table's edges: what an address nobody wrote a route for does, and
+ * where the two routes PR #184 retired now land.
+ *
+ * ⚠ **A SEPARATE FILE from `App.test.tsx` because that one mocks
+ * `react-router-dom` away entirely** — its `Routes` renders every child and its
+ * `Route` renders its element unconditionally, so route MATCHING is not
+ * observable there at all. Adding these cases to it would produce assertions
+ * that pass no matter what the route table says. Here the real router runs
+ * inside a `MemoryRouter`.
+ *
+ * ⚠ **The app shell is stubbed, and that is what makes the sidebar assertion
+ * meaningful rather than decorative.** The real `AppLayout` mounts the sidebar,
+ * the titlebar controls, the dependency modal and the extension reporter — none
+ * of which this change touches, and all of which would need mocking anyway. The
+ * property under test is not "the sidebar renders" (it always did, on every
+ * other route); it is that the not-found page is a CHILD of the shell route, so
+ * whatever the shell mounts is still on screen beside it. The stub renders an
+ * `<Outlet />` inside a marked box, so "inside the shell" is directly
+ * assertable — and the previous behaviour, a blank document with no shell at
+ * all, fails it.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Outlet } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppInner } from './App';
+
+Object.defineProperty(window, 'history', {
+  value: { replaceState: vi.fn(), state: null },
+  writable: true,
+});
+
+vi.mock('./utils/providerUtils', () => ({
+  initializeSystem: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./utils/costDatabase', () => ({
+  initializeCostDatabase: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./api', () => ({
+  initConfig: vi.fn().mockResolvedValue(undefined),
+  readAllConfig: vi.fn().mockResolvedValue(undefined),
+  backupConfig: vi.fn().mockResolvedValue(undefined),
+  recoverConfig: vi.fn().mockResolvedValue(undefined),
+  validateConfig: vi.fn().mockResolvedValue(undefined),
+  startAgent: vi.fn().mockResolvedValue({ data: { session_id: 'test', messages: [] } }),
+  resumeAgent: vi.fn().mockResolvedValue({ data: { session_id: 'test', messages: [] } }),
+  // `KnowledgeProvider` wraps every route and hydrates the active knowledge base
+  // on mount. Without this the mock throws, the provider logs a warning per
+  // render, and the console noise buries a real failure.
+  getActive: vi.fn().mockResolvedValue({ data: {} }),
+  listBases: vi.fn().mockResolvedValue({ data: [] }),
+}));
+
+vi.mock('./sessions', () => ({
+  fetchSessionDetails: vi.fn().mockResolvedValue({ sessionId: 'test', messages: [] }),
+  generateSessionId: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+vi.mock('./utils/openRouterSetup', () => ({
+  startOpenRouterSetup: vi.fn().mockResolvedValue({ success: false, message: 'Test' }),
+}));
+
+vi.mock('./utils/ollamaDetection', () => ({
+  checkOllamaStatus: vi.fn().mockResolvedValue({ isRunning: false }),
+}));
+
+vi.mock('./components/ConfigContext', () => ({
+  useConfig: () => ({
+    read: vi.fn().mockResolvedValue(null),
+    update: vi.fn(),
+    getExtensions: vi.fn().mockReturnValue([]),
+    addExtension: vi.fn(),
+    updateExtension: vi.fn(),
+    createProviderDefaults: vi.fn(),
+  }),
+  ConfigProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./components/ErrorBoundary', () => ({
+  ErrorUI: ({ error }: { error: Error }) => <div>Error: {error.message}</div>,
+}));
+
+// Passthrough: onboarding is a different question from routing, and a guard
+// that swallowed the outlet would make every assertion below vacuous.
+vi.mock('./components/ProviderGuard', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./components/ModelAndProviderContext', () => ({
+  ModelAndProviderProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useModelAndProvider: () => ({
+    provider: null,
+    model: null,
+    getCurrentModelAndProvider: vi.fn(),
+    setCurrentModelAndProvider: vi.fn(),
+  }),
+}));
+
+vi.mock('./contexts/ChatContext', () => ({
+  ChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useChatContext: () => ({
+    chat: { id: 'test-id', name: 'Test Chat', messages: [], workflow: null },
+    setChat: vi.fn(),
+    setPairChat: vi.fn(),
+    resetChat: vi.fn(),
+    hasActiveSession: false,
+    setWorkflow: vi.fn(),
+    clearWorkflow: vi.fn(),
+    contextKey: 'hub',
+  }),
+  DEFAULT_CHAT_TITLE: 'New Chat',
+}));
+
+vi.mock('./components/ui/ConfirmationModal', () => ({ ConfirmationModal: () => null }));
+vi.mock('react-toastify', () => ({ ToastContainer: () => null }));
+vi.mock('./components/AnnouncementModal', () => ({ default: () => null }));
+vi.mock('./components/UpdateAvailableModal', () => ({ default: () => null }));
+vi.mock('./components/ExtensionInstallModal', () => ({ ExtensionInstallModal: () => null }));
+
+// The shell, reduced to the one thing this file is about: a marked box that
+// renders whatever the matched child route is.
+vi.mock('./components/Layout/AppLayout', () => ({
+  AppLayout: () => (
+    <div data-testid="app-shell">
+      <nav data-testid="app-sidebar" aria-label="Sidebar" />
+      <Outlet />
+    </div>
+  ),
+}));
+
+vi.mock('./components/Hub', () => ({ default: () => <div data-testid="home-view">Home</div> }));
+
+/**
+ * The other top-level views, stubbed. Their INTERNALS are irrelevant here — the
+ * question this file asks about `/settings`, `/sessions` and the rest is only
+ * "does the catch-all shadow them", which is answered by whether the route
+ * resolves to this stub or to the not-found page. Rendering them for real
+ * instead makes the test fail for reasons that have nothing to do with routing
+ * (they fetch, they subscribe to `window.electron` channels, they mount the
+ * search bar), which is a test that reports on the wrong thing.
+ */
+const { routeStub } = vi.hoisted(() => ({
+  routeStub: (name: string) => ({
+    default: () => <div data-testid={`route-${name}`}>{name}</div>,
+  }),
+}));
+vi.mock('./components/settings/SettingsView', () => routeStub('settings'));
+vi.mock('./components/sessions/SessionsView', () => routeStub('sessions'));
+vi.mock('./components/schedule/SchedulesView', () => routeStub('schedules'));
+vi.mock('./components/workflows/WorkflowsView', () => routeStub('workflows'));
+vi.mock('./components/skills/SkillsView', () => routeStub('skills'));
+vi.mock('./components/applications/ApplicationsView', () => routeStub('applications'));
+vi.mock('./components/knowledge/KnowledgeView', () => routeStub('knowledge'));
+vi.mock('./components/extensions/ExtensionsView', () => routeStub('extensions'));
+
+const mockElectron = {
+  getConfig: vi.fn().mockReturnValue({
+    BIOROUTER_DEFAULT_PROVIDER: 'openai',
+    BIOROUTER_DEFAULT_MODEL: 'gpt-4',
+    BIOROUTER_ALLOWLIST_WARNING: false,
+    BIOROUTER_WORKING_DIR: '/test/dir',
+  }),
+  logInfo: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  reactReady: vi.fn(),
+  getAllowedExtensions: vi.fn().mockResolvedValue([]),
+  platform: 'darwin',
+  createChatWindow: vi.fn(),
+  cliStatus: vi.fn().mockResolvedValue(null),
+};
+
+(window as any).electron = mockElectron;
+(window as any).appConfig = {
+  get: (key: string) => (key === 'BIOROUTER_WORKING_DIR' ? '/test/dir' : null),
+};
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppInner />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('an address with no route', () => {
+  /**
+   * The reported defect, in the shape it was reported: `#/zzz`, `#/scheduler`
+   * (the real route is `#/schedules`) and any other typo rendered an EMPTY
+   * document — `document.body.innerText.length === 0`, no sidebar, no header,
+   * no error boundary — with `No routes matched location` in the console as the
+   * only trace, and no way back short of reloading the app.
+   */
+  it.each(['/zzz-nonexistent', '/scheduler', '/settings/typo'])(
+    'renders the not-found page at %s',
+    async (path) => {
+      renderAt(path);
+
+      expect(await screen.findByText('There is nothing at this address')).toBeInTheDocument();
+      expect(document.body.innerText ?? document.body.textContent).not.toBe('');
+    }
+  );
+
+  /**
+   * The half of the fix that is easy to get wrong: a catch-all declared as a
+   * SIBLING of the shell route renders the message on the same bare canvas the
+   * blank page had. The way out has to still be on screen.
+   */
+  it('renders it inside the app shell, so the sidebar is still there', async () => {
+    renderAt('/zzz-nonexistent');
+
+    const shell = await screen.findByTestId('app-shell');
+    expect(screen.getByTestId('app-sidebar')).toBeInTheDocument();
+    expect(shell).toContainElement(screen.getByText('There is nothing at this address'));
+  });
+
+  it('echoes the address that missed', async () => {
+    renderAt('/zzz-nonexistent');
+
+    expect(await screen.findByText(/\/zzz-nonexistent/)).toBeInTheDocument();
+  });
+
+  it('offers a way back to Home', async () => {
+    renderAt('/zzz-nonexistent');
+
+    expect(await screen.findByRole('button', { name: /go to home/i })).toBeInTheDocument();
+  });
+
+  /**
+   * The catch-all must not have eaten the routes that exist. `*` outranks
+   * nothing, but a catch-all placed at the wrong nesting level would shadow the
+   * shell's own children, and every one of them would fail the same way.
+   */
+  it.each(['/', '/settings', '/sessions', '/schedules', '/workflows', '/skills', '/applications'])(
+    'leaves the real route %s alone',
+    async (path) => {
+      renderAt(path);
+
+      await waitFor(() => expect(screen.getByTestId('app-shell')).toBeInTheDocument());
+      expect(screen.queryByText('There is nothing at this address')).not.toBeInTheDocument();
+    }
+  );
+});
+
+describe('the routes PR #184 retired', () => {
+  /**
+   * `/apps` was the MCP-apps browser and `/standalone-app` its single-app
+   * surface. Both shipped, so both are in bookmarks and in `biorouter://` share
+   * links; after #184 they matched nothing and rendered the blank window.
+   *
+   * They go to Home rather than to the not-found page — a link to a feature
+   * that existed is not a typo — and deliberately NOT to `/applications`, which
+   * is Built apps, a different feature that merely reads alike.
+   */
+  it.each(['/apps', '/standalone-app'])('sends %s to Home', async (path) => {
+    renderAt(path);
+
+    expect(await screen.findByTestId('home-view')).toBeInTheDocument();
+    expect(screen.queryByText('There is nothing at this address')).not.toBeInTheDocument();
+  });
+});

--- a/ui/desktop/src/App.test.tsx
+++ b/ui/desktop/src/App.test.tsx
@@ -174,6 +174,13 @@ vi.mock('react-router-dom', () => ({
   },
   Routes: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Route: ({ element }: { element: React.ReactNode }) => element,
+  // The two retired routes (`/apps`, `/standalone-app`) redirect to Home. This
+  // mock's `Route` renders EVERY element unconditionally, so a `Navigate` that
+  // actually navigated would fire on every render here and break the
+  // `mockNavigate` assertions below — which are about the app's own startup
+  // redirects, not about the route table. Route MATCHING is exercised for real
+  // in `App.routing.test.tsx`; this stub only has to exist.
+  Navigate: () => null,
   useNavigate: () => mockNavigate,
   useLocation: () => ({ state: null, pathname: '/' }),
   useSearchParams: () => [mockSearchParams, mockSetSearchParams],

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useEffect, useState, useRef } from 'react';
 import { IpcRendererEvent } from 'electron';
 import {
   HashRouter,
+  Navigate,
   Routes,
   Route,
   useNavigate,
@@ -52,6 +53,7 @@ import SkillsView from './components/skills/SkillsView';
 import KnowledgeView from './components/knowledge/KnowledgeView';
 import { KnowledgeProvider } from './components/knowledge/KnowledgeContext';
 import ApplicationsView from './components/applications/ApplicationsView';
+import NotFoundView from './components/NotFoundView';
 import { View, ViewOptions } from './utils/navigationUtils';
 
 import { useNavigation } from './hooks/useNavigation';
@@ -684,6 +686,23 @@ export function AppInner() {
                 element={<WelcomeRoute onSelectProvider={() => setDidSelectProvider(true)} />}
               />
               <Route path="configure-providers" element={<ConfigureProvidersRoute />} />
+              {/* RETIRED ROUTES. `/apps` was the MCP-apps browser and
+                  `/standalone-app` its single-app surface; PR #184 removed the
+                  feature and both routes with it, which left every existing
+                  bookmark and every `biorouter://` share link pointing at a
+                  path nothing matched — i.e. at a blank white window.
+
+                  ⚠ NOT redirected to `/applications`. That is Built apps
+                  (Agent Drafter), a different feature that merely reads
+                  alike — sending an MCP-apps link there would answer a
+                  question nobody asked. Home is the honest destination.
+
+                  Declared OUTSIDE the shell so the redirect resolves without
+                  first mounting ProviderGuard and the whole layout, and
+                  `replace` so Back does not bounce the user off the dead
+                  address again. */}
+              <Route path="apps" element={<Navigate to="/" replace />} />
+              <Route path="standalone-app" element={<Navigate to="/" replace />} />
               <Route
                 path="/"
                 element={
@@ -722,6 +741,14 @@ export function AppInner() {
                   }
                 />
                 <Route path="permission" element={<PermissionRoute />} />
+                {/* THE CATCH-ALL, and it is a CHILD of the shell on purpose.
+                    Without it an unknown hash — a typo like `#/scheduler`, or a
+                    stale link — rendered an empty document: no sidebar, no
+                    header, no error boundary, and a `No routes matched
+                    location` warning in the console as the only evidence. Here
+                    the sidebar and titlebar stay mounted, so the way out is on
+                    screen whether or not the page's own button is used. */}
+                <Route path="*" element={<NotFoundView />} />
               </Route>
             </Routes>
           </KnowledgeProvider>

--- a/ui/desktop/src/components/GroupedExtensionLoadingToast.tsx
+++ b/ui/desktop/src/components/GroupedExtensionLoadingToast.tsx
@@ -8,6 +8,7 @@ import { useNavigation } from '../hooks/useNavigation';
 import { formatExtensionErrorMessage } from '../utils/extensionErrorUtils';
 import { getInitialWorkingDir } from '../utils/workingDir';
 import { formatExtensionName } from './settings/extensions/subcomponents/ExtensionList';
+import { useTransientValue } from '../hooks/useTransientFlag';
 
 export interface ExtensionLoadingStatus {
   name: string;
@@ -69,7 +70,9 @@ function ExtensionLoadReport({
   extensions: ExtensionLoadingStatus[];
   onAskBiorouter: ((hints: string) => void) | null;
 }) {
-  const [copiedExtension, setCopiedExtension] = useState<string | null>(null);
+  // The 2s "Copied!" label. `useTransientValue` owns the timer, so dismissing
+  // the report inside the window cannot leave a setter pointed at a dead tree.
+  const [copiedExtension, markCopied] = useTransientValue<string>(2000);
   const errorCount = extensions.filter((ext) => ext.status === 'error').length;
 
   return (
@@ -118,8 +121,7 @@ function ExtensionLoadReport({
                       variant="secondary"
                       onClick={() => {
                         navigator.clipboard.writeText(ext.error!);
-                        setCopiedExtension(ext.name);
-                        setTimeout(() => setCopiedExtension(null), 2000);
+                        markCopied(ext.name);
                       }}
                     >
                       {copiedExtension === ext.name ? 'Copied!' : 'Copy error'}

--- a/ui/desktop/src/components/Layout/yieldLadder.ts
+++ b/ui/desktop/src/components/Layout/yieldLadder.ts
@@ -9,8 +9,9 @@ import { GroupLayout } from '../chatGroups/chatGroupsTypes';
  *   1. the sidebar collapses to an overlay (< 1120px) — AppLayout.sidebarAutoCollapseAction
  *   2. the preview panel narrows to its 360px floor, then yields its column
  *      entirely rather than starve the transcript — previewPanelMode
- *   3. tab labels shrink to their 88px floor, then scroll, then collapse into a
- *      ▾ overflow menu, and NEVER wrap — shouldShowTabOverflowMenu
+ *   3. tab labels shrink to their TAB_MIN_WIDTH floor, then scroll, then
+ *      collapse into a ▾ overflow menu, and NEVER wrap —
+ *      shouldShowTabOverflowMenu
  *   4. a split merges back to one group rather than render two useless slivers —
  *      splitYieldAction
  *
@@ -67,8 +68,18 @@ export const PREVIEW_MIN_WIDTH = 360;
  */
 export const PREVIEW_YIELD_WIDTH = CHAT_MIN_WIDTH + PREVIEW_MIN_WIDTH;
 
-/** The tab shrink floor — a glyph, a few characters and the close control. Mirrors `.br-tab`'s min-width in main.css. */
-export const TAB_MIN_WIDTH = 88;
+/**
+ * The tab shrink floor. Mirrors `--tab-min-width` in main.css, and
+ * `styles/tabStripFloor.test.ts` asserts the two are the same number.
+ *
+ * ⚠ It was 88, described as "a glyph, a few characters and the close control",
+ * and that description was never measured: a tab spends 73px on its padding,
+ * its leading glyph and the close control before the title gets a pixel, so 88
+ * left the label 15px — one character and a clipped ellipsis. With six chats
+ * open at 1440 the strip read `R.` `R.` `R.` `R.` `B..`. The arithmetic and the
+ * trade are written out beside the token in main.css.
+ */
+export const TAB_MIN_WIDTH = 136;
 
 /** `.br-group-splitter`'s flex-basis in main.css. */
 export const GROUP_SPLITTER_WIDTH = 1;

--- a/ui/desktop/src/components/MessageCopyLink.tsx
+++ b/ui/desktop/src/components/MessageCopyLink.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Copy } from './icons/app-icons';
 import { MessageMetaAction } from './MessageMeta';
+import { useTransientFlag } from '../hooks/useTransientFlag';
 
 interface MessageCopyLinkProps {
   text: string;
@@ -8,7 +9,7 @@ interface MessageCopyLinkProps {
 }
 
 export default function MessageCopyLink({ text, contentRef }: MessageCopyLinkProps) {
-  const [copied, setCopied] = useState(false);
+  const [copied, markCopied] = useTransientFlag(2000);
 
   const handleCopy = async () => {
     try {
@@ -31,15 +32,13 @@ export default function MessageCopyLink({ text, contentRef }: MessageCopyLinkPro
         await navigator.clipboard.writeText(text);
       }
 
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000); // Reset after 2 seconds
+      markCopied();
     } catch (err) {
       console.error('Failed to copy text: ', err);
       // Fallback to plain text if HTML copy fails
       try {
         await navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        markCopied();
       } catch (fallbackErr) {
         console.error('Failed to copy text (fallback): ', fallbackErr);
       }

--- a/ui/desktop/src/components/NotFoundView.tsx
+++ b/ui/desktop/src/components/NotFoundView.tsx
@@ -1,0 +1,71 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { MainPanelLayout } from './Layout/MainPanelLayout';
+import { PageHeader } from './Layout/PageHeader';
+import { ReadableContent } from './Layout/ReadableContent';
+import { EmptyState } from './ui/empty-state';
+import { Button } from './ui/button';
+import { CircleHelp, Home } from './icons/app-icons';
+
+/**
+ * The longest a mistyped address is worth echoing back. Past this the string
+ * stops being a hint and starts being a wall of text in a `max-w-sm` paragraph,
+ * and a pasted deep link can be thousands of characters long.
+ */
+const MAX_ECHOED_PATH = 72;
+
+/** The address, trimmed to something a sentence can hold. Exported for the test. */
+export function echoPath(pathname: string): string {
+  const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return path.length > MAX_ECHOED_PATH ? `${path.slice(0, MAX_ECHOED_PATH - 1)}…` : path;
+}
+
+/**
+ * What an unknown address renders — and the reason it exists is that, until
+ * now, it rendered NOTHING.
+ *
+ * `App.tsx`'s route table had no catch-all, so `#/zzz`, `#/scheduler` (the real
+ * route is `#/schedules`) and the two routes PR #184 retired all produced a
+ * white window: `document.body.innerText.length === 0`, no sidebar, no header,
+ * no error boundary, and a console warning as the only trace. There was no way
+ * back except reloading the app.
+ *
+ * ⚠ **It is mounted INSIDE the app shell**, as the last child of the `/` route,
+ * so the sidebar and the titlebar are still there and Home is one click away
+ * whether or not the button below is used. A catch-all at the top level would
+ * render the message on the same bare canvas the blank page had, which fixes
+ * the wrong half of the defect: the missing page was never the problem, the
+ * missing *way out* was.
+ *
+ * The two retired routes do not land here — they redirect to Home, because an
+ * old bookmark or `biorouter://` link to a feature that shipped is a different
+ * thing from a typo, and it should arrive somewhere useful rather than be told
+ * off. See the route table in `App.tsx`.
+ */
+export default function NotFoundView() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <MainPanelLayout>
+      <div className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+        <PageHeader
+          title="Page not found"
+          description="This address does not name a page in Biorouter. It may be a typo, or a link to something that has since moved."
+        />
+        <ReadableContent size="chat" className="px-6 py-4">
+          <EmptyState
+            icon={CircleHelp}
+            title="There is nothing at this address"
+            description={`Nothing answers to ${echoPath(location.pathname)}. Everything Biorouter can show you is in the sidebar.`}
+            actions={
+              <Button onClick={() => navigate('/')}>
+                <Home />
+                Go to Home
+              </Button>
+            }
+          />
+        </ReadableContent>
+      </div>
+    </MainPanelLayout>
+  );
+}

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -94,6 +94,15 @@ export default function ProgressiveMessageList({
   });
   const [isLoading, setIsLoading] = useState(() => messages.length > showLoadingThreshold);
   const timeoutRef = useRef<number | null>(null);
+  // The 50ms "the DOM has settled" timer that fires `onRenderingComplete`.
+  // A SECOND ref, not `timeoutRef`: that one holds the NEXT batch's timer, and
+  // the completion timer is armed from inside the batch loop at the moment the
+  // last batch lands — so a single ref would have each one clobbering the
+  // other's handle and neither would be cancellable. Uncleared, this timer
+  // outlived the component: unmounting a long transcript inside its 50ms window
+  // (switching tab, closing a pane, a test file ending) left it holding a
+  // callback into a tree that no longer exists.
+  const completionTimeoutRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
   // Held in a ref so the batching effect below can CALL the latest callback
   // without taking its identity as a dependency. BaseChat memoises
@@ -119,8 +128,15 @@ export default function ProgressiveMessageList({
       setRenderedCount(messages.length);
       setIsLoading(false);
       // For small lists, call completion callback immediately
-      const completionTimer = window.setTimeout(() => onRenderingCompleteRef.current?.(), 50);
-      return () => window.clearTimeout(completionTimer);
+      window.clearTimeout(completionTimeoutRef.current ?? undefined);
+      completionTimeoutRef.current = window.setTimeout(() => {
+        completionTimeoutRef.current = null;
+        onRenderingCompleteRef.current?.();
+      }, 50);
+      return () => {
+        window.clearTimeout(completionTimeoutRef.current ?? undefined);
+        completionTimeoutRef.current = null;
+      };
     }
 
     // Large list - start progressive loading
@@ -130,8 +146,16 @@ export default function ProgressiveMessageList({
 
         if (nextCount >= messages.length) {
           setIsLoading(false);
-          // Call the completion callback after a brief delay to ensure DOM is updated
-          setTimeout(() => onRenderingCompleteRef.current?.(), 50);
+          // Call the completion callback after a brief delay to ensure DOM is
+          // updated. Recorded so the cleanup below can cancel it — see
+          // `completionTimeoutRef`. Cleared first because React may invoke this
+          // updater more than once for a single dispatch (StrictMode does), and
+          // an unrecorded handle is an uncancellable timer.
+          window.clearTimeout(completionTimeoutRef.current ?? undefined);
+          completionTimeoutRef.current = window.setTimeout(() => {
+            completionTimeoutRef.current = null;
+            onRenderingCompleteRef.current?.();
+          }, 50);
         } else {
           // Schedule next batch
           timeoutRef.current = window.setTimeout(loadNextBatch, batchDelay);
@@ -144,6 +168,13 @@ export default function ProgressiveMessageList({
     // Start loading after a short delay
     timeoutRef.current = window.setTimeout(loadNextBatch, batchDelay);
 
+    // ⚠ The COMPLETION timer is deliberately not cancelled here, only on
+    // unmount. This effect re-arms on every `messages.length` change, so during
+    // a stream it re-runs constantly; cancelling the completion callback on
+    // each re-run would swallow the "the transcript has settled" signal for the
+    // batch that had just finished. The batch timer below is a different
+    // object — it schedules FUTURE work this effect is about to redo, so
+    // cancelling it on a re-run is exactly right.
     return () => {
       if (timeoutRef.current) {
         window.clearTimeout(timeoutRef.current);
@@ -164,6 +195,10 @@ export default function ProgressiveMessageList({
       mountedRef.current = false;
       if (timeoutRef.current) {
         window.clearTimeout(timeoutRef.current);
+      }
+      if (completionTimeoutRef.current) {
+        window.clearTimeout(completionTimeoutRef.current);
+        completionTimeoutRef.current = null;
       }
     };
   }, []);

--- a/ui/desktop/src/components/chatGroups/ChatTabStrip.tsx
+++ b/ui/desktop/src/components/chatGroups/ChatTabStrip.tsx
@@ -273,7 +273,8 @@ export function ChatTabStrip({
   }, [activeTabId, tabs.length]);
 
   /**
-   * Rung 3 of the yield ladder (D-32): shrink to the 88px floor, then scroll,
+   * Rung 3 of the yield ladder (D-32): shrink to the TAB_MIN_WIDTH floor (the
+   * `--tab-min-width` token), then scroll,
    * then collapse into a ▾ menu — never wrap.
    *
    * The first two steps are pure CSS (`.br-tabstrip`: flex-wrap: nowrap;

--- a/ui/desktop/src/components/sessions/SessionHistoryView.tsx
+++ b/ui/desktop/src/components/sessions/SessionHistoryView.tsx
@@ -42,6 +42,7 @@ import { useNavigation } from '../../hooks/useNavigation';
 import { ReadableContent } from '../Layout/ReadableContent';
 import { MODAL_SIZE } from '../ModalShell';
 import { EmptyState } from '../ui/empty-state';
+import { useTransientFlag } from '../../hooks/useTransientFlag';
 
 const isUserMessage = (message: Message): boolean => {
   if (message.role === 'assistant') {
@@ -193,7 +194,7 @@ const SessionHistoryView: React.FC<SessionHistoryViewProps> = ({
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [shareLink, setShareLink] = useState<string>('');
   const [isSharing, setIsSharing] = useState(false);
-  const [isCopied, setIsCopied] = useState(false);
+  const [isCopied, markCopied] = useTransientFlag(2000);
   const [canShare, setCanShare] = useState(false);
   // Issue #56 §12.1's second entry point. The session page is where a user goes
   // to answer "what is in this chat?", so it is the other place the answer "no
@@ -268,8 +269,7 @@ const SessionHistoryView: React.FC<SessionHistoryViewProps> = ({
     navigator.clipboard
       .writeText(shareLink)
       .then(() => {
-        setIsCopied(true);
-        setTimeout(() => setIsCopied(false), 2000);
+        markCopied();
       })
       .catch((err) => {
         console.error('Failed to copy link:', err);

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -658,7 +658,6 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
     const [isLoading, setIsLoading] = useState(initialSessions === null);
     const [showSkeleton, setShowSkeleton] = useState(initialSessions === null);
     const [showContent, setShowContent] = useState(initialSessions !== null);
-    const [isInitialLoad, setIsInitialLoad] = useState(initialSessions === null);
     const [error, setError] = useState<string | null>(null);
     const [searchResults, setSearchResults] = useState<{
       count: number;
@@ -844,18 +843,19 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
       // the reveal is one opacity class on a layer that is already mounted —
       // `renderActualContent()` renders under the skeleton too. Deferring the
       // frame the delay exists to schedule is the opposite of what it is for.
-      const revealTimer = setTimeout(() => {
-        setShowContent(true);
-        if (isInitialLoad) {
-          setIsInitialLoad(false);
-        }
-      }, 10);
+      const revealTimer = setTimeout(() => setShowContent(true), 10);
       // Unmounting inside that 10ms window (navigating away, or a test file
       // finishing) must disarm it: the callback would otherwise setState on an
       // unmounted tree, and on CI it fired after jsdom was gone and took the
       // whole run down with `window is not defined`.
       return () => clearTimeout(revealTimer);
-    }, [isLoading, showContent, isInitialLoad]);
+      // `isInitialLoad` used to sit here and in the callback above. It was
+      // write-only: the only thing that ever READ it was the guard around its
+      // own setter, so the whole cycle — the `useState`, the branch, the
+      // dependency — decided nothing. As a dependency it also re-ran this
+      // effect one extra time on the very tick the reveal landed, which is the
+      // opposite of the stable deps the comment above depends on.
+    }, [isLoading, showContent]);
 
     // Memoize date groups calculation to prevent unnecessary recalculations
     const memoizedDateGroups = useMemo(() => {

--- a/ui/desktop/src/components/sessions/SessionsView.tsx
+++ b/ui/desktop/src/components/sessions/SessionsView.tsx
@@ -1,43 +1,31 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import SessionListView from './SessionListView';
-import SessionHistoryView from './SessionHistoryView';
 import { useLocation } from 'react-router-dom';
-import { getSession, Session } from '../../api';
 import { useNavigation } from '../../hooks/useNavigation';
-import { userActionHeaders } from '../../utils/userAction';
 
+/**
+ * Chat history: the list, and one thing you can do with a row — open it.
+ *
+ * ⚠ **This view never renders `SessionHistoryView`, and it never could.** It
+ * used to carry a second branch that showed the read-only transcript in place,
+ * gated on a `showSessionHistory` flag — and that flag was set in exactly one
+ * function, `loadSessionDetails`, which was called from exactly one place,
+ * `handleRetryLoadSession`, which returned early unless `selectedSession` was
+ * set, which only `loadSessionDetails` ever set. A closed cycle with no way in:
+ * the fetch, its loading and error states, the retry, the back button and the
+ * placeholder session object were all unreachable from every path through the
+ * app. The effect below, which looks like the way in, calls
+ * `handleSelectSession` — which navigates to `/pair`.
+ *
+ * Resuming the chat is the SHIPPED behaviour and the intended one (a row in
+ * Chat history opens the conversation, it does not show a frozen copy of it),
+ * so the branch is gone rather than being wired up. `SessionHistoryView` itself
+ * stays: it is the read-only transcript the schedule run detail and the shared
+ * session both mount, and both reach it directly.
+ */
 const SessionsView: React.FC = () => {
-  const [selectedSession, setSelectedSession] = useState<Session | null>(null);
-  const [showSessionHistory, setShowSessionHistory] = useState(false);
-  const [isLoadingSession, setIsLoadingSession] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [initialSessionId, setInitialSessionId] = useState<string | null>(null);
   const location = useLocation();
   const setView = useNavigation();
-
-  const loadSessionDetails = async (sessionId: string) => {
-    setIsLoadingSession(true);
-    setError(null);
-    setShowSessionHistory(true);
-    try {
-      const response = await getSession<true>({
-        path: { session_id: sessionId },
-        // Issue #56 Task 58: reading a private chat needs the proof-of-user.
-        headers: await userActionHeaders(),
-        throwOnError: true,
-      });
-      setSelectedSession(response.data);
-    } catch (err) {
-      console.error(`Failed to load session details for ${sessionId}:`, err);
-      setError('Could not load this chat. Try again.');
-      // Keep the selected session null if there's an error
-      setSelectedSession(null);
-      setShowSessionHistory(false);
-    } finally {
-      setIsLoadingSession(false);
-      setInitialSessionId(null);
-    }
-  };
 
   const handleSelectSession = useCallback(
     async (sessionId: string) => {
@@ -49,59 +37,24 @@ const SessionsView: React.FC = () => {
     [setView]
   );
 
-  // Check if a session ID was passed in the location state (from SessionsInsights)
+  // A session id handed over in the location state (from SessionsInsights on
+  // Home) opens that chat directly rather than leaving the user on the list.
   useEffect(() => {
     const state = location.state as { selectedSessionId?: string } | null;
     if (state?.selectedSessionId) {
-      // Set immediate loading state to prevent flash of session list
-      setIsLoadingSession(true);
-      setInitialSessionId(state.selectedSessionId);
       handleSelectSession(state.selectedSessionId);
       // Clear the state to prevent reloading on navigation
       window.history.replaceState({}, document.title);
     }
   }, [location.state, handleSelectSession]);
 
-  const handleBackToSessions = () => {
-    setShowSessionHistory(false);
-    setError(null);
-  };
-
-  const handleRetryLoadSession = () => {
-    if (selectedSession) {
-      loadSessionDetails(selectedSession.id);
-    }
-  };
-
-  // If we're loading an initial session or have a selected showSessionHistory, show the session history view
-  // Otherwise, show the sessions list view
-  return (showSessionHistory && selectedSession) || (isLoadingSession && initialSessionId) ? (
-    <SessionHistoryView
-      session={
-        selectedSession || {
-          id: initialSessionId || '',
-          conversation: [],
-          name: 'Loading...',
-          working_dir: '',
-          message_count: 0,
-          total_tokens: null,
-          created_at: '',
-          updated_at: '',
-          extension_data: {},
-          user_set_name: false,
-        }
-      }
-      isLoading={isLoadingSession}
-      error={error}
-      onBack={handleBackToSessions}
-      onRetry={handleRetryLoadSession}
-    />
-  ) : (
-    <SessionListView
-      onSelectSession={handleSelectSession}
-      selectedSessionId={selectedSession?.id ?? null}
-    />
-  );
+  // `selectedSessionId` is left unset rather than passed as `null`. It scrolls a
+  // named row into view "when returning from session history view" — the
+  // journey that no longer exists — and this view was already passing a value
+  // that could only ever be null. The prop stays on `SessionListView` because
+  // it is optional and describes something a caller may legitimately want; what
+  // is removed here is the pretence that this caller supplies it.
+  return <SessionListView onSelectSession={handleSelectSession} />;
 };
 
 export default SessionsView;

--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -20,6 +20,7 @@ import ThemeFamilySelector from '../../BioRouterSidebar/ThemeFamilySelector';
 import BlockLogoBlack from './icons/block-lockup_black.png';
 import BlockLogoWhite from './icons/block-lockup_white.png';
 import { useResolvedTheme } from '../../../contexts/ThemeContext';
+import { useTransientFlag } from '../../../hooks/useTransientFlag';
 
 interface AppSettingsSectionProps {
   scrollToSection?: string;
@@ -30,7 +31,8 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
   const [dockIconEnabled, setDockIconEnabled] = useState(true);
   const [wakelockEnabled, setWakelockEnabled] = useState(true);
   const [isMacOS, setIsMacOS] = useState(false);
-  const [isDockSwitchDisabled, setIsDockSwitchDisabled] = useState(false);
+  // The dock switch is held down for a second while the OS applies the change.
+  const [isDockSwitchDisabled, disableDockSwitch] = useTransientFlag(1000);
   const [showNotificationModal, setShowNotificationModal] = useState(false);
   const [showPricing, setShowPricing] = useState(true);
   // The app already resolves light/dark once, in `ThemeContext`. This file kept
@@ -98,10 +100,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
         setMenuBarIconEnabled(true);
       }
     }
-    setIsDockSwitchDisabled(true);
-    setTimeout(() => {
-      setIsDockSwitchDisabled(false);
-    }, 1000);
+    disableDockSwitch();
     const success = await window.electron.setDockIcon(newState);
     if (success) {
       setDockIconEnabled(newState);

--- a/ui/desktop/src/components/settings/chat/BioRouterHintsModal.tsx
+++ b/ui/desktop/src/components/settings/chat/BioRouterHintsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Button } from '../../ui/button';
 import { Check } from '../../icons/app-icons';
+import { useTransientFlag } from '../../../hooks/useTransientFlag';
 import {
   Dialog,
   DialogContent,
@@ -55,7 +56,7 @@ export const BioRouterHintsModal = ({
   const [biorouterHintsFileFound, setBioRouterHintsFileFound] = useState<boolean>(false);
   const [biorouterHintsFileReadError, setBioRouterHintsFileReadError] = useState<string>('');
   const [isSaving, setIsSaving] = useState(false);
-  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [saveSuccess, markSaved, clearSaved] = useTransientFlag(3000);
 
   useEffect(() => {
     const fetchBioRouterHintsFile = async () => {
@@ -74,12 +75,11 @@ export const BioRouterHintsModal = ({
 
   const writeFile = async () => {
     setIsSaving(true);
-    setSaveSuccess(false);
+    clearSaved();
     try {
       await window.electron.writeFile(biorouterHintsFilePath, biorouterHintsFile);
-      setSaveSuccess(true);
+      markSaved();
       setBioRouterHintsFileFound(true);
-      setTimeout(() => setSaveSuccess(false), 3000);
     } catch (error) {
       console.error('Error writing .biorouterhints file:', error);
       setBioRouterHintsFileReadError('Failed to save .biorouterhints file');

--- a/ui/desktop/src/components/settings/tunnel/TunnelSection.tsx
+++ b/ui/desktop/src/components/settings/tunnel/TunnelSection.tsx
@@ -24,6 +24,7 @@ import { errorMessage } from '../../../utils/conversionUtils';
 import { startTunnel, stopTunnel, getTunnelStatus } from '../../../api/sdk.gen';
 import type { TunnelInfo } from '../../../api/types.gen';
 import { useConfig } from '../../ConfigContext';
+import { useTransientFlag } from '../../../hooks/useTransientFlag';
 
 const STATUS_MESSAGES = {
   idle: 'Tunnel is not running',
@@ -46,8 +47,8 @@ export default function TunnelSection() {
   const [showQRModal, setShowQRModal] = useState(false);
   const [showAppStoreQRModal, setShowAppStoreQRModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [copiedUrl, setCopiedUrl] = useState(false);
-  const [copiedSecret, setCopiedSecret] = useState(false);
+  const [copiedUrl, markUrlCopied] = useTransientFlag(2000);
+  const [copiedSecret, markSecretCopied] = useTransientFlag(2000);
   const [showDetails, setShowDetails] = useState(false);
 
   const refreshConfigAfterTunnelWrite = async () => {
@@ -116,11 +117,9 @@ export default function TunnelSection() {
     try {
       await navigator.clipboard.writeText(text);
       if (type === 'url') {
-        setCopiedUrl(true);
-        setTimeout(() => setCopiedUrl(false), 2000);
+        markUrlCopied();
       } else {
-        setCopiedSecret(true);
-        setTimeout(() => setCopiedSecret(false), 2000);
+        markSecretCopied();
       }
     } catch (err) {
       console.error('Failed to copy to clipboard:', err);

--- a/ui/desktop/src/components/workflows/CreateEditWorkflowModal.tsx
+++ b/ui/desktop/src/components/workflows/CreateEditWorkflowModal.tsx
@@ -12,6 +12,7 @@ import { toastSuccess, toastError } from '../../toasts';
 import { saveWorkflow } from '../../workflow/workflow_management';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../ui/dialog';
 import { storeSubscriptionCleanup } from '../../utils/storeSubscription';
+import { useTransientFlag } from '../../hooks/useTransientFlag';
 
 interface CreateEditWorkflowModalProps {
   isOpen: boolean;
@@ -89,7 +90,7 @@ export default function CreateEditWorkflowModal({
     });
     return storeSubscriptionCleanup(subscription);
   }, [form]);
-  const [copied, setCopied] = useState(false);
+  const [copied, markCopied] = useTransientFlag(2000);
   const [isSaving, setIsSaving] = useState(false);
 
   // Extensions for the workflow (editable)
@@ -271,8 +272,7 @@ export default function CreateEditWorkflowModal({
     navigator.clipboard
       .writeText(deeplink)
       .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        markCopied();
       })
       .catch((err) => {
         console.error('Failed to copy the text:', err);

--- a/ui/desktop/src/hooks/useTransientFlag.test.tsx
+++ b/ui/desktop/src/hooks/useTransientFlag.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTransientFlag, useTransientValue } from './useTransientFlag';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useTransientFlag', () => {
+  it('starts down, raises on demand and lowers itself after the delay', () => {
+    const { result } = renderHook(() => useTransientFlag(2000));
+
+    expect(result.current[0]).toBe(false);
+
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(true);
+
+    act(() => vi.advanceTimersByTime(1999));
+    expect(result.current[0]).toBe(true);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current[0]).toBe(false);
+  });
+
+  /**
+   * The second of the two defects this hook exists to close. Every hand-rolled
+   * copy re-armed a SECOND timer and left the first one running, so a second
+   * copy inside the window was un-flagged by the first copy's countdown —
+   * "Copied!" vanished ~1s after the click that produced it.
+   */
+  it('restarts the countdown on a re-trigger instead of stacking timers', () => {
+    const { result } = renderHook(() => useTransientFlag(2000));
+
+    act(() => result.current[1]());
+    act(() => vi.advanceTimersByTime(1500));
+    act(() => result.current[1]());
+
+    // The first timer's original deadline. It must have been cancelled.
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current[0]).toBe(true);
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => vi.advanceTimersByTime(1500));
+    expect(result.current[0]).toBe(false);
+  });
+
+  /**
+   * The first defect: a modal closed, a toast dismissed or a route changed
+   * inside the window left a live callback holding a setter for a dead tree.
+   */
+  it('cancels its pending timer when the component unmounts', () => {
+    const { result, unmount } = renderHook(() => useTransientFlag(2000));
+
+    act(() => result.current[1]());
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+
+    expect(() => act(() => vi.advanceTimersByTime(5000))).not.toThrow();
+  });
+
+  it('can be lowered early, cancelling the timer with it', () => {
+    const { result } = renderHook(() => useTransientFlag(2000));
+
+    act(() => result.current[1]());
+    act(() => result.current[2]());
+
+    expect(result.current[0]).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('useTransientValue', () => {
+  it('holds the most recent value and clears it after the delay', () => {
+    const { result } = renderHook(() => useTransientValue<string>(2000));
+
+    expect(result.current[0]).toBeNull();
+
+    act(() => result.current[1]('developer'));
+    expect(result.current[0]).toBe('developer');
+
+    // A different value replaces the first one AND its countdown, so the value
+    // on screen always names the most recent action.
+    act(() => vi.advanceTimersByTime(1500));
+    act(() => result.current[1]('memory'));
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current[0]).toBe('memory');
+
+    act(() => vi.advanceTimersByTime(1500));
+    expect(result.current[0]).toBeNull();
+  });
+});

--- a/ui/desktop/src/hooks/useTransientFlag.ts
+++ b/ui/desktop/src/hooks/useTransientFlag.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * A flag that raises itself, then lowers itself again `durationMs` later —
+ * "Copied!", "Saved", a control disabled while the OS catches up.
+ *
+ * The app had ~12 hand-rolled copies of this, every one of them spelled
+ * `setCopied(true); setTimeout(() => setCopied(false), 2000)` inside a click
+ * handler, and every one of them wrong in the same two ways:
+ *
+ *  * **Nothing cancelled the timer on unmount.** A modal closed, a toast
+ *    dismissed or a route changed inside the 2s window left a callback holding a
+ *    setter for a tree that no longer exists. React logs it; under a test runner
+ *    that has already torn jsdom down it is the `window is not defined` crash
+ *    `SessionListView.revealTimer.test.tsx` was written for.
+ *  * **Nothing cancelled the PREVIOUS timer on a re-trigger.** Copy twice inside
+ *    two seconds and the first timer still fires on schedule, so "Copied!"
+ *    disappears roughly a second after the second copy rather than two seconds
+ *    after it. The visible flag is a lie about the most recent action.
+ *
+ * Both are closed here, once. A handler calls `raise()` and owns no timer.
+ *
+ * ⚠ The unmount cleanup reads a REF, and the effect has an empty dependency
+ * list on purpose. Clearing the timer in a `useEffect` keyed on the flag would
+ * cancel the countdown on the render the flag is raised in — the flag would
+ * never come down on its own — which is the plausible wrong shape of this hook.
+ */
+export function useTransientValue<T>(
+  durationMs: number
+): readonly [T | null, (value: T) => void, () => void] {
+  const [value, setValue] = useState<T | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Unmount only. See the warning above.
+  useEffect(() => clear, [clear]);
+
+  const raise = useCallback(
+    (next: T) => {
+      clear();
+      setValue(next);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        setValue(null);
+      }, durationMs);
+    },
+    [clear, durationMs]
+  );
+
+  const lower = useCallback(() => {
+    clear();
+    setValue(null);
+  }, [clear]);
+
+  return [value, raise, lower] as const;
+}
+
+/**
+ * The boolean case, which is almost every call site: `const [copied, markCopied]
+ * = useTransientFlag(2000)`.
+ *
+ * A thin wrapper over `useTransientValue` rather than a second implementation —
+ * the whole point of this module is that there is one place where the timer is
+ * cancelled, and two copies of that logic would be the drift it replaces.
+ */
+export function useTransientFlag(durationMs: number): readonly [boolean, () => void, () => void] {
+  const [value, raise, lower] = useTransientValue<true>(durationMs);
+  const mark = useCallback(() => raise(true), [raise]);
+  return [value === true, mark, lower] as const;
+}

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -405,6 +405,30 @@
      The VALUE does not move.) */
   --dock-height: 36px;
   --tab-height: 32px; /* chat, artifact and dock tabs; pulled from 34 */
+  /* THE TAB SHRINK FLOOR — rung 3 of the yield ladder (D-32): tabs shrink to
+     this, then the strip scrolls, then it collapses into a ▾ menu. Never wrap.
+
+     ⚠ **136px is a MEASUREMENT, not a preference, and the 88px it replaces was
+     the preference.** That number shipped with the claim "a glyph + a few
+     characters + the close control still read"; it does not, and here is the
+     arithmetic it was never checked against. A tab spends 22px on its own
+     padding, 24px on the leading kind/privacy glyph and its 8px gap, and 27px
+     on the close control and the 7px gap before it — 73px before a single
+     letter of the title. At 88px the label box is 15px wide, which at 13px sans
+     renders one glyph and a clipped ellipsis. Measured in the running app at
+     1440 with six chats and the artifact panel open, the strip read
+     `R.` `R.` `R.` `R.` `B..` — four different conversations, indistinguishable.
+
+     136 leaves the label ~63px, which is nine or ten characters plus the
+     ellipsis: `Research…` rather than `R.`. Fewer tabs fit before the strip
+     starts scrolling, and that is the trade being made deliberately — three
+     tabs you can tell apart plus the ▾ menu beat five you cannot.
+
+     `yieldLadder.ts` carries the same number for the ladder's own reasoning and
+     `styles/tabStripFloor.test.ts` pins the two together, because a floor that
+     disagreed with the constant would leave rung 3 measuring a strip it no
+     longer describes. */
+  --tab-min-width: 136px;
 
   /* The height of a scroller's top scroll-edge fade (`.biorouter-scroll-fade-top`,
      authored below). 10px is the middle of the 8-12px band: tall enough that a
@@ -2292,11 +2316,13 @@
      places rather than infer one from the parent. */
   height: var(--tab-height);
   align-self: center;
-  /* Shrink to a floor, then the strip scrolls. `min-width: 0` let a tab shrink
-     to nothing; 88px is the floor at which a glyph + a few characters + the
-     close control still read. */
+  /* Shrink to a floor, then the strip scrolls (`.br-tabstrip` is
+     `flex-wrap: nowrap; overflow-x: auto`). `min-width: 0` let a tab shrink to
+     nothing; the floor is `--tab-min-width`, whose own comment carries the
+     measurement behind the number. It is a token and not a literal because
+     `yieldLadder.ts` has to agree with it. */
   flex: 0 1 auto;
-  min-width: 88px;
+  min-width: var(--tab-min-width);
   max-width: 190px;
   padding: 0 11px;
   border: 0;

--- a/ui/desktop/src/styles/measures.test.ts
+++ b/ui/desktop/src/styles/measures.test.ts
@@ -91,6 +91,9 @@ const CHAT_MEASURE_VIEWS = [
   'extensions/ExtensionsView.tsx',
   'skills/SkillsView.tsx',
   'applications/ApplicationsView.tsx',
+  // The catch-all's page. It is a route view like the rest and shares the
+  // hairline with whatever the user came from, so it takes the same column.
+  'NotFoundView.tsx',
 ].map((rel) => ({
   rel,
   source: readFileSync(join(__dirname, '../components', rel), 'utf8'),
@@ -118,6 +121,7 @@ const PAGE_HEADER_VIEWS = [
   'extensions/ExtensionsView.tsx',
   'skills/SkillsView.tsx',
   'applications/ApplicationsView.tsx',
+  'NotFoundView.tsx',
 ].map((rel) => ({
   rel,
   source: readFileSync(join(__dirname, '../components', rel), 'utf8'),

--- a/ui/desktop/src/styles/tabStripFloor.test.ts
+++ b/ui/desktop/src/styles/tabStripFloor.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TAB_MIN_WIDTH } from '../components/Layout/yieldLadder';
+
+/**
+ * Rung 3 of the yield ladder, at the source: **a tab shrinks to a floor, then
+ * the strip SCROLLS. It never shrinks the label away.**
+ *
+ * The defect this guards was reported as "chat tab labels collapse to a single
+ * letter": with six chats open at 1440 and the artifact panel showing, the
+ * strip read `R.` `R.` `R.` `R.` `B..` — four different conversations wearing
+ * the same name. The floor was 88px and a tab spends 73px of that on padding,
+ * the leading kind/privacy glyph and the close control, so the title got 15px.
+ *
+ * ⚠ **jsdom can prove none of this and never could.** It has no layout engine,
+ * so a test that mounts `ChatTabStrip` with six tabs and reads
+ * `getBoundingClientRect()` sees zeroes; it never runs Tailwind; and the rules
+ * here are authored CSS the component does not name. What IS checkable — and is
+ * exactly what went wrong — is that the floor, the token and the constant the
+ * ladder reasons with all say the same thing, and that the two rules which turn
+ * a too-narrow strip into a SCROLLING one rather than a shrinking or wrapping
+ * one are still present. The pixel outcome is verified by driving the real app.
+ */
+const CSS = readFileSync(join(__dirname, 'main.css'), 'utf8');
+
+/** A declaration's value, read off the token block. */
+function token(name: string): string {
+  const match = CSS.match(new RegExp(`--${name}:\\s*([^;]+);`));
+  if (!match) throw new Error(`--${name} is not declared in main.css`);
+  return match[1].trim();
+}
+
+/** One rule's body, comments stripped so prose quoting a property cannot satisfy a rule. */
+function ruleBody(selector: string): string {
+  const withoutComments = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+  const index = withoutComments.indexOf(`\n${selector} {`);
+  if (index === -1) throw new Error(`${selector} has no rule in main.css`);
+  const open = withoutComments.indexOf('{', index);
+  const close = withoutComments.indexOf('}', open);
+  return withoutComments.slice(open + 1, close);
+}
+
+describe('the tab shrink floor', () => {
+  /**
+   * Asserted as an exact string for the same reason `--measure-chat` is: the
+   * failure being guarded against is a NARROWING, and every loose matcher
+   * (`/\d+px/`, `/^1/`) is satisfied by the 88px being ruled out.
+   */
+  it('is 136px, not the 15px-of-label 88 it replaced', () => {
+    expect(token('tab-min-width')).toBe('136px');
+  });
+
+  /**
+   * ONE number, in two languages. `yieldLadder.ts` reasons about the floor in
+   * TypeScript (`shouldShowTabOverflowMenu` is the rung that fires once tabs
+   * stop fitting) while the stylesheet enforces it; a copy that drifted would
+   * leave the ladder measuring a strip it no longer describes, and nothing on
+   * screen would look wrong until the ▾ menu appeared at the wrong width.
+   */
+  it('is the same number the ladder reasons with', () => {
+    expect(`${TAB_MIN_WIDTH}px`).toBe(token('tab-min-width'));
+  });
+
+  /**
+   * The floor has to be READ, not restated. `.br-tab` carrying its own literal
+   * is how the 88 above outlived the reasoning that produced it.
+   */
+  it('is read from the token by the tab itself', () => {
+    expect(ruleBody('.br-tab')).toMatch(/min-width:\s*var\(--tab-min-width\)/);
+  });
+
+  /** A floor above the ceiling would make every tab exactly one width. */
+  it('leaves room between the floor and the tab’s maximum width', () => {
+    const max = ruleBody('.br-tab').match(/max-width:\s*(\d+)px/);
+    if (!max) throw new Error('.br-tab declares no max-width');
+    expect(TAB_MIN_WIDTH).toBeLessThan(Number(max[1]));
+  });
+});
+
+describe('the strip that the floor hands over to', () => {
+  /**
+   * Raising the floor is only half the fix: a floor with nowhere to overflow to
+   * is a clipped strip. These two declarations are what make a too-narrow strip
+   * scroll — and `flex-wrap: nowrap` is the one that must never become `wrap`,
+   * because a wrapped second row moves every tab under the cursor.
+   */
+  it('scrolls rather than wrapping or clipping', () => {
+    const strip = ruleBody('.br-tabstrip');
+    expect(strip).toMatch(/flex-wrap:\s*nowrap/);
+    expect(strip).toMatch(/overflow-x:\s*auto/);
+  });
+
+  /**
+   * The preview panel nests its tablist inside the strip, so the scroll box is
+   * a different element there. It was `overflow-hidden` once — its tabs did not
+   * scroll at all, they were simply unreachable — and the same floor now
+   * applies to it, which makes the scroll it hands over to load-bearing.
+   */
+  it('applies the same rule to the panel’s nested tablist', () => {
+    expect(ruleBody('.br-tabstrip__scroll')).toMatch(/flex-wrap:\s*nowrap/);
+  });
+
+  /**
+   * The label truncates from the END. `text-overflow: ellipsis` on an
+   * `ltr` box keeps the LEADING characters, which is the half of the reported
+   * defect that was already right: the fix is that there are now enough of them
+   * to read (`Research…`), not that the ellipsis moved.
+   */
+  it('truncates the label from the end, keeping its opening characters', () => {
+    const label = ruleBody('.br-tab__label');
+    expect(label).toMatch(/text-overflow:\s*ellipsis/);
+    expect(label).toMatch(/white-space:\s*nowrap/);
+    expect(label).toMatch(/overflow:\s*hidden/);
+    // `min-width: 0` is what lets the flex item shrink to the ellipsis at all;
+    // without it the label refuses to shrink and pushes the close control out.
+    expect(label).toMatch(/min-width:\s*0/);
+  });
+});


### PR DESCRIPTION
## Why

Four findings from the round-2 runtime walkthrough, all in one class: something the app
does that leaves no way back, and code that decides nothing.

**F3 (MEDIUM) — removed and unknown hash routes render a blank window.** Verbatim repro:
open `#/apps`, `#/standalone-app` (both retired by #184), `#/zzz-nonexistent` or `#/scheduler`
(the real route is `#/schedules`). Every one produced a completely white page —
`document.body.innerText.length === 0`, no sidebar, no header, no not-found, no error
boundary — with `No routes matched location "/apps"` in the console as the only trace, and
no way back except reloading. `App.tsx:681-725` had no catch-all `<Route path="*">`.
Pre-existing, but #184 moved two routes the app itself shipped into that class, so every
existing bookmark and `biorouter://` share link now landed on a dead window.

**Dead code — Chat history can never open its read-only view.** `SessionsView.tsx` rendered
`SessionHistoryView` only when `showSessionHistory` was true; that flag was set only inside
`loadSessionDetails`, whose only caller was `handleRetryLoadSession`, which returned early
unless `selectedSession` was set, which only `loadSessionDetails` set. A closed cycle with
no way in — the fetch, its loading and error states, the retry, the back button and the
placeholder session object were all unreachable. The `useEffect` that looks like the way in
calls `handleSelectSession`, which navigates to `/pair`.

**Timer hygiene (follow-up to #186).** `ProgressiveMessageList.tsx:134` armed a 50 ms timer
inside the batch loop that invoked `onRenderingCompleteRef.current?.()` and was never
cleared. Separately, ~12 handlers hand-rolled
`setCopied(true); setTimeout(() => setCopied(false), 2000)`, each wrong twice: nothing
cancelled the timer on unmount (a closed modal, a dismissed toast, a route change inside the
window left a callback holding a setter for a dead tree — the `window is not defined` crash
`SessionListView.revealTimer.test.tsx` exists for), and nothing cancelled the PREVIOUS timer
on a re-trigger, so a second copy inside two seconds was un-flagged by the first copy's
countdown. And `SessionListView.isInitialLoad` was write-only: its only reader was the guard
around its own setter.

**F9 (LOW) — chat tab labels collapse to a single letter.** With 5–6 chats open and the
artifact panel showing at 1440 the strip read `R.` `R.` `R.` `R.` `B..` — four different
conversations, indistinguishable. `.br-tab`'s 88px shrink floor shipped with the claim "a
glyph + a few characters + the close control still read"; the arithmetic it was never checked
against is that a tab spends 22px on padding, 24px on the leading kind/privacy glyph and its
gap, and 27px on the close control and its gap — 73px before a single letter of the title —
so at 88px the label box is 15px, which at 13px sans renders one glyph and a clipped ellipsis.

## What changed

**F3**
- `components/NotFoundView.tsx` (new) — `PageHeader` "Page not found" + `EmptyState` "There
  is nothing at this address", the address echoed back (truncated at 72 chars), and a
  **Go to Home** button, on the chat measure like every other view.
- `App.tsx:751` — `<Route path="*" element={<NotFoundView />} />` as the **last child of
  the `/` shell route**, so the sidebar and titlebar stay mounted. A catch-all declared as a
  sibling would put the message on the same bare canvas the blank page had, which fixes the
  wrong half: the missing page was never the problem, the missing way out was.
- `App.tsx:704-705` — `/apps` and `/standalone-app` → `<Navigate to="/" replace />`, declared
  **outside** the shell so the redirect resolves without mounting the whole layout.
  Deliberately **not** `/applications`: that is Built apps (Agent Drafter), a different
  feature that merely reads alike, so an MCP-apps link sent there would answer a question
  nobody asked. `replace` so Back does not bounce the user onto the dead address again.
- `styles/measures.test.ts` — `NotFoundView.tsx` added to `CHAT_MEASURE_VIEWS` and
  `PAGE_HEADER_VIEWS`, so the new view is held to the same column and the same header.

**Dead code**
- `components/sessions/SessionsView.tsx` — the unreachable branch and all six pieces of state
  behind it removed (107 → 53 lines). Resuming the chat is the SHIPPED behaviour and the
  intended one, so it is removed rather than wired up. `SessionHistoryView` itself stays: the
  schedule run detail (`ScheduleDetailView.tsx:405`) and the shared view mount it directly.
  `selectedSessionId` is now left unset rather than passed as a literal `null`.

**Timers**
- `hooks/useTransientFlag.ts` (new) — `useTransientFlag(ms)` / `useTransientValue<T>(ms)`,
  one place where the timer is cancelled on unmount **and** on re-trigger.
- Adopted in `MessageCopyLink`, `TunnelSection` (both flags), `SessionHistoryView`,
  `CreateEditWorkflowModal`, `BioRouterHintsModal`, `GroupedExtensionLoadingToast` (a
  transient *value*, the extension name) and `AppSettingsSection:102` (the dock switch held
  down for 1 s). In the two files another PR is editing copy in, only the flag lines are
  touched.
- `ProgressiveMessageList.tsx` — the completion timer is recorded in its own
  `completionTimeoutRef` (a second ref: `timeoutRef` holds the NEXT batch's timer, so one ref
  would have each clobbering the other's handle) and cleared on unmount. It is deliberately
  **not** cleared on the batching effect's re-run: that effect re-arms on every
  `messages.length` change, so cancelling there would swallow the "transcript settled" signal
  mid-stream.
- `SessionListView.tsx` — `isInitialLoad` removed; the reveal effect's deps are now
  `[isLoading, showContent]`, which is the stable pair its own comment depends on.

**F9**
- `styles/main.css` — new `--tab-min-width: 136px` token beside `--tab-height`, with the
  arithmetic and the trade written out; `.br-tab` reads it instead of a literal.
- `components/Layout/yieldLadder.ts` — `TAB_MIN_WIDTH` 88 → 136, and rung 3's description no
  longer hardcodes the old number.
- `styles/tabStripFloor.test.ts` (new) — the token's value, `TAB_MIN_WIDTH` == the token,
  `.br-tab` reads the token, floor < max-width, and the strip rules that make a too-narrow
  strip SCROLL (`flex-wrap: nowrap`, `overflow-x: auto`, on `.br-tabstrip` and the panel's
  nested `.br-tabstrip__scroll`) rather than shrink or wrap.

Fewer tabs now fit before the strip scrolls, and that is the trade taken deliberately: three
tabs you can tell apart plus the ▾ overflow menu beat five you cannot. Rung 3 of the yield
ladder already specified exactly this behaviour; only its floor was wrong.

## Tests

```
cd ui/desktop && npm run test:run
  Test Files  426 passed (426)
       Tests  4791 passed | 1 skipped (4792)

npm run lint:check                     → exit 0
  (tsc + eslint --max-warnings 0 + check:themes + 332 contrast assertions + check:tokens)

npx prettier --check <21 changed files> → All matched files use Prettier code style!
```

New suites:
```
src/App.routing.test.tsx           18 passed   (real router in a MemoryRouter)
src/hooks/useTransientFlag.test.tsx  5 passed   (fake timers)
src/styles/tabStripFloor.test.ts     7 passed
src/styles/measures.test.ts         70 passed   (measured 64 on origin/main; +3 for each of the two source-guard lists)
```

`App.routing.test.tsx` is a separate file from `App.test.tsx` because that one mocks
`react-router-dom` away entirely — its `Routes` renders every child and its `Route` renders
its element unconditionally, so route MATCHING is not observable there and any case added to
it would pass whatever the route table said. `App.test.tsx` gains one line: a `Navigate` stub
that renders `null`, so its unconditional `Route` cannot fire a redirect and break its own
`mockNavigate` assertions.

## Runtime verification

Sandboxed dev instance from this worktree (`launch-dev-gui.sh`, CDP 9341, Parchment light,
1440×1000). Screenshots under `~/biorouter-runs/test-drive/round3/shots/fix-routing/`.

| Check | Result |
|---|---|
| `#/zzz-nonexistent`, `#/scheduler`, `#/settings/typo` | not-found page, sidebar intact, `bodyLen` 777–783 (was 0). `01-notfound-zzz.png` |
| Its title on the shared left edge | `left=508, top=80, 24px` — identical to Skills and Workflows |
| **Go to Home** button | lands on `#/` |
| `#/apps`, `#/standalone-app` | both land on `#/` (Home). `02-retired-apps-lands-on-home.png` |
| Console after all four | zero page errors; the `No routes matched location` warning is gone |
| Tab strip, 6 named chats, strip 716px (1048 window) — **88px floor** | `Bio…` `Po…` `Kno…` `P…` `Ext…`; labels 22–65px. `03-tabstrip-BEFORE-88px-floor-1048.png` |
| Same, **136px token** | `Bioroute…` `Poem a…` `Knowled…` `Prompt i…` `Extensio…`; every label 63px, ▾ menu lists all six by full name. `04-…AFTER-…png`, `05-…overflow-menu-1048.png` |
| Tab strip at 1440, 6 tabs | all six legible, no overflow needed. `06-tabstrip-AFTER-136px-1440.png` |
| `useTransientFlag` on a real Copy control | Copy → **Copied!** → Copy after 2 s |
| …and on re-trigger | second click at t=1.5 s: still **Copied!** at t=2.2 s (old code reverted there), back to Copy at t=3.7 s |
| Chat history after the dead-code removal | renders, reveal timer fine, a row resumes the chat at `#/pair?resumeSessionId=…`. `07-chat-history-still-resumes.png` |

The window was resized with `osascript` against this instance's own pid; `set_viewport` was
never called. Probe files deleted, instance stopped.

## Out of scope

- **The artifact panel could not be opened in the sandbox** — the developer extension fails
  to load there (`Problem with Attaching Developer · Tool call failed`), and the shell
  redirect the model fell back to registered no file artifact. The narrow strip was
  reproduced instead by taking the window to its 1048 floor, which yields a 716px strip —
  inside the band a 1440 window with the panel produces, and it reproduces the reported
  symptom exactly.
- `SessionListView`'s `selectedSessionId` prop and its scroll-into-view effect are kept. The
  effect exists "when returning from session history view", the journey just deleted, but the
  prop is optional and a future caller could legitimately pass it; removing it would cascade
  into the row ref registrar, which is a wider change than this finding.
- A pre-existing `MaxListenersExceededWarning: 11 extension-update-event listeners` appears
  after several route changes — `ExtensionUpdateReporter` adds an IPC listener per mount
  without removing it. Not caused by this change and not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
