### PR TITLE
Desktop: sentence-case the copy inside the dialogs #181 opened, plus three one-character fixes

### DIFF
--- a/crates/biorouter/src/config/declarative_providers.rs
+++ b/crates/biorouter/src/config/declarative_providers.rs
@@ -454,4 +454,64 @@ mod tests {
             );
         }
     }
+
+    /// `display_name` is what the provider catalog PRINTS, so a note-to-self
+    /// left in one ships to every user. `groq.json` carried
+    /// `"display_name": "Groq (d)"` — a leftover marker (the other four
+    /// bundled providers are clean), and the Public tab of the catalog listed
+    /// **"Groq (d)"** through at least v1.90.2.
+    ///
+    /// The shape is what is banned, not the one string: a trailing
+    /// parenthesised **single letter** is a marker, never a name. Real
+    /// parentheses in a display name are words and stay legal — `Moonshot AI
+    /// (Kimi)` is the bundled proof, and it is asserted here so a future
+    /// tightening of this rule has to notice it.
+    #[test]
+    fn no_bundled_display_name_carries_a_single_letter_marker() {
+        let providers = load_fixed_providers().expect("bundled declarative providers must parse");
+        assert!(
+            providers.len() >= 5,
+            "expected the bundled set to load; got {}",
+            providers.len()
+        );
+
+        for provider in &providers {
+            let name = provider.display_name.trim();
+            assert!(
+                !name.is_empty(),
+                "{}: display_name must not be empty",
+                provider.name
+            );
+            // `rsplit_once`, not an index: slicing a `&str` by a byte offset can
+            // split a multi-byte character, which is what `clippy::string_slice`
+            // is there to stop. A display name is user-visible text and can hold
+            // any character at all.
+            if let Some(inner) = name
+                .strip_suffix(')')
+                .and_then(|rest| rest.rsplit_once('(').map(|(_, inner)| inner))
+            {
+                assert!(
+                    inner.chars().count() != 1,
+                    "{}: display_name {name:?} ends in a parenthesised single letter — that is a \
+                     leftover marker, not a name (groq.json shipped \"Groq (d)\")",
+                    provider.name
+                );
+            }
+        }
+
+        // The two ends of the rule, pinned by name so neither can drift.
+        let groq = providers
+            .iter()
+            .find(|p| p.name == "groq")
+            .expect("groq.json is bundled");
+        assert_eq!(groq.display_name, "Groq");
+        let moonshot = providers
+            .iter()
+            .find(|p| p.name == "moonshot")
+            .expect("moonshot.json is bundled");
+        assert_eq!(
+            moonshot.display_name, "Moonshot AI (Kimi)",
+            "a multi-letter parenthetical is a name, not a marker, and stays legal"
+        );
+    }
 }

--- a/crates/biorouter/src/providers/declarative/groq.json
+++ b/crates/biorouter/src/providers/declarative/groq.json
@@ -1,7 +1,7 @@
 {
   "name": "groq",
   "engine": "openai",
-  "display_name": "Groq (d)",
+  "display_name": "Groq",
   "description": "Fast inference with Groq hardware",
   "api_key_env": "GROQ_API_KEY",
   "base_url": "https://api.groq.com/openai/v1/chat/completions",

--- a/ui/desktop/src/components/ModelAndProviderContext.tsx
+++ b/ui/desktop/src/components/ModelAndProviderContext.tsx
@@ -383,7 +383,7 @@ export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> =
 
         toastSuccess({
           title: CHANGE_MODEL_TOAST_TITLE,
-          msg: `${SWITCH_MODEL_SUCCESS_MSG} -- using ${model.alias ?? modelName} from ${model.subtext ?? providerName}`,
+          msg: `${SWITCH_MODEL_SUCCESS_MSG} — using ${model.alias ?? modelName} from ${model.subtext ?? providerName}`,
         });
         // Issue #56 DR-26 at the BIND surface. Binding a model covered by one
         // institution's agreements into a chat holding another institution's

--- a/ui/desktop/src/components/baam/BrowseSkillsModal.test.tsx
+++ b/ui/desktop/src/components/baam/BrowseSkillsModal.test.tsx
@@ -10,7 +10,7 @@ vi.mock('./registry', async (importOriginal) => ({
 vi.mock('./installSkill', () => ({ installRegistrySkill: vi.fn() }));
 vi.mock('../../toasts', () => ({ toastSuccess: vi.fn(), toastError: vi.fn() }));
 
-import BrowseSkillsModal from './BrowseSkillsModal';
+import BrowseSkillsModal, { installButtonLabel } from './BrowseSkillsModal';
 
 const skill = {
   id: 'scientific-research',
@@ -53,5 +53,43 @@ describe('BrowseSkillsModal — a classification phrase is prose, not a token', 
       expect(node.className ?? '').not.toMatch(/font-mono/);
       if (node.tagName === 'BODY') break;
     }
+  });
+});
+
+/// The button reads "Install  skills" — two spaces — whenever nothing is
+/// selected, which is the state the dialog OPENS in. The old template put the
+/// count between two literal spaces (`` `Install ${n > 0 ? n : ''} skill…` ``),
+/// so the empty substitution collapsed to nothing and left the pair behind.
+///
+/// Tested on the pure label rather than only through a render: the arithmetic
+/// is a function of one number, and a threshold you can exercise only by
+/// mounting a component is one nobody re-tests.
+describe('BrowseSkillsModal — the install label has one space between words', () => {
+  it.each([
+    [0, 'Install skills'],
+    [1, 'Install 1 skill'],
+    [2, 'Install 2 skills'],
+    [3, 'Install 3 skills'],
+  ])('reads correctly with %i selected', (count, expected) => {
+    expect(installButtonLabel(count)).toBe(expected);
+  });
+
+  it('never emits a double space at any count', () => {
+    for (let n = 0; n <= 12; n += 1) {
+      expect(installButtonLabel(n)).not.toMatch(/ {2}/);
+      expect(installButtonLabel(n).trim()).toBe(installButtonLabel(n));
+    }
+  });
+
+  /// The one shape the user actually hits first, asserted through the real
+  /// DOM so the helper cannot be correct while the button ignores it.
+  it('renders "Install skills" in the freshly-opened dialog', async () => {
+    render(<BrowseSkillsModal onClose={vi.fn()} onInstalled={vi.fn()} installedIds={new Set()} />);
+
+    const button = await screen.findByRole('button', { name: 'Install skills' });
+    expect(button).toBeDisabled();
+    // `textContent` rather than the accessible name, which normalises runs of
+    // whitespace and would report the bug as fixed while it was still there.
+    expect(button.textContent).toBe('Install skills');
   });
 });

--- a/ui/desktop/src/components/baam/BrowseSkillsModal.tsx
+++ b/ui/desktop/src/components/baam/BrowseSkillsModal.tsx
@@ -28,6 +28,25 @@ const CATEGORY_LABELS: Record<SkillCategory, string> = {
 
 type Filter = 'All' | SkillCategory;
 
+/**
+ * The install button's label.
+ *
+ * ⚠ The count goes INSIDE the conditional along with its trailing space, not
+ * beside it. The original wrote `` `Install ${n > 0 ? n : ''} skill…` `` — an
+ * empty substitution between two literal spaces — so the button read
+ * **"Install  skills"** with a double space in the state it spends most of its
+ * life in: nothing selected, and therefore disabled and in front of the user
+ * from the moment the dialog opens.
+ *
+ * Three shapes, all pinned in `BrowseSkillsModal.test.tsx`: 0 → "Install
+ * skills" (plural, because it is an invitation, not a count), 1 → "Install 1
+ * skill", n → "Install n skills".
+ */
+export function installButtonLabel(selectedCount: number): string {
+  const count = selectedCount > 0 ? `${selectedCount} ` : '';
+  return `Install ${count}skill${selectedCount !== 1 ? 's' : ''}`;
+}
+
 export default function BrowseSkillsModal({ onClose, onInstalled, installedIds }: Props) {
   const [registry, setRegistry] = useState<BaamRegistry | null>(null);
   const [live, setLive] = useState(false);
@@ -307,9 +326,7 @@ export default function BrowseSkillsModal({ onClose, onInstalled, installedIds }
               Cancel
             </Button>
             <Button onClick={handleInstall} disabled={selectedCount === 0 || installing}>
-              {installing
-                ? 'Installing…'
-                : `Install ${selectedCount > 0 ? selectedCount : ''} skill${selectedCount !== 1 ? 's' : ''}`}
+              {installing ? 'Installing…' : installButtonLabel(selectedCount)}
             </Button>
           </div>
         </div>

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -103,7 +103,7 @@ export default function SettingsView({
               the action strip the other views use. */}
           <PageHeader
             title="Settings"
-            description="Manage models, chat behavior, and app preferences"
+            description="Manage models, chat behavior, and app preferences."
           />
 
           <div className="flex-1 min-h-0 flex flex-col">

--- a/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
@@ -28,7 +28,7 @@ export default function ChatSettingsSection() {
 
       <div className="biorouter-settings-section">
         <div className="biorouter-settings-section-header">
-          <h2 className="text-caps text-text-muted mb-1">Response Styles</h2>
+          <h2 className="text-caps text-text-muted mb-1">Response styles</h2>
           <p className="text-supporting text-text-muted">
             Choose how Biorouter should format and style its responses
           </p>

--- a/ui/desktop/src/components/settings/config/ConfigSettings.tsx
+++ b/ui/desktop/src/components/settings/config/ConfigSettings.tsx
@@ -202,7 +202,7 @@ export default function ConfigSettings() {
           <DialogTrigger asChild>
             <Button variant="secondary">
               <Settings className="h-4 w-4" />
-              Edit Configuration
+              Edit configuration
             </Button>
           </DialogTrigger>
           {/* `MODAL_SIZE.lg`, not `max-w-4xl` — which additionally carried no
@@ -213,7 +213,7 @@ export default function ConfigSettings() {
                 {/* `text-iconStandard` is not a token: it had no definition and
                     no effect. */}
                 <FileText size={20} />
-                Configuration Editor
+                Configuration editor
               </DialogTitle>
               <DialogDescription>
                 Edit your biorouter configuration settings
@@ -296,7 +296,7 @@ export default function ConfigSettings() {
               {modifiedKeys.size > 0 && (
                 <Button onClick={handleReset} variant="ghost">
                   <RotateCcw />
-                  Reset Changes
+                  Reset changes
                 </Button>
               )}
               <Button onClick={() => setIsModalOpen(false)} variant="outline">

--- a/ui/desktop/src/components/settings/hostManagedSettings.browserSurface.test.tsx
+++ b/ui/desktop/src/components/settings/hostManagedSettings.browserSurface.test.tsx
@@ -201,7 +201,7 @@ describe('Settings > Models — Lead/Worker', () => {
 describe('Settings > Configuration editor', () => {
   async function openEditor() {
     render(<ConfigSettings />);
-    fireEvent.click(await screen.findByRole('button', { name: /Edit Configuration/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit configuration' }));
   }
 
   /**

--- a/ui/desktop/src/components/settings/providers/ProviderCatalog.test.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderCatalog.test.tsx
@@ -296,7 +296,10 @@ describe('ProviderCatalog — institutions', () => {
     clickTab('institutional');
     const note = screen.getByTestId('other-institutions-note');
     expect(note).toHaveTextContent(/recognises its endpoint as private/i);
-    expect(note).toHaveTextContent(/Add Custom Provider/i);
+    // Case-sensitive on purpose: this used to be `/Add Custom Provider/i`,
+    // which kept passing when the control was renamed to sentence case — so
+    // it was asserting the words, not that the note names the real label.
+    expect(note).toHaveTextContent('Add custom provider');
   });
 });
 

--- a/ui/desktop/src/components/settings/providers/ProviderCatalog.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderCatalog.tsx
@@ -196,7 +196,7 @@ const AddCustomProviderRow = React.memo(function AddCustomProviderRow({
       <div className="w-8 h-8 rounded-element flex items-center justify-center flex-shrink-0">
         <Plus className="w-4 h-4 text-text-muted" />
       </div>
-      <p className="text-label text-text-muted">Add Custom Provider</p>
+      <p className="text-label text-text-muted">Add custom provider</p>
     </button>
   );
 });
@@ -546,7 +546,7 @@ export default function ProviderCatalog({
           <h3 className="text-caps text-text-muted mb-1">Other institutions</h3>
           <p className="text-supporting text-text-muted">
             An institution&apos;s gateway appears here once Biorouter recognises its endpoint as
-            private. Anything else can still be added under Public → Add Custom Provider, and is
+            private. Anything else can still be added under Public → Add custom provider, and is
             treated as public: Biorouter cannot verify where that endpoint points, so it gets none
             of the private tier&apos;s protections.
           </p>
@@ -637,7 +637,7 @@ export default function ProviderCatalog({
           onModelSelected={onModelSelected}
           initialProvider={switchModelProvider}
           initialModel={switchModelInitial}
-          titleOverride="Choose Model"
+          titleOverride="Choose model"
         />
       )}
     </>

--- a/ui/desktop/src/components/settings/providers/ProviderSettingsPage.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderSettingsPage.tsx
@@ -108,7 +108,7 @@ export default function ProviderSettings({
             <BackButton onClick={onClose} />
           </div>
           <h1 className="text-title mb-1" data-testid="provider-selection-heading">
-            {isOnboarding ? 'Choose a provider' : 'Provider Configuration'}
+            {isOnboarding ? 'Choose a provider' : 'Provider configuration'}
           </h1>
           <p className="text-sm text-text-muted">
             {isOnboarding

--- a/ui/desktop/src/components/workflows/CreateEditWorkflowModal.tsx
+++ b/ui/desktop/src/components/workflows/CreateEditWorkflowModal.tsx
@@ -477,7 +477,7 @@ export default function CreateEditWorkflowModal({
               variant="default"
             >
               <Play className="w-4 h-4" />
-              {isSaving ? 'Saving...' : 'Save & Run Workflow'}
+              {isSaving ? 'Saving...' : 'Save & run workflow'}
             </Button>
           </div>
         </div>

--- a/ui/desktop/src/components/workflows/WorkflowsView.tsx
+++ b/ui/desktop/src/components/workflows/WorkflowsView.tsx
@@ -601,7 +601,7 @@ export default function WorkflowsView() {
             <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
               <DropdownMenuItem onClick={() => handleCopyDeeplink(workflowManifestResponse)}>
                 <Link />
-                Copy Deeplink
+                Copy deeplink
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => handleCopyYaml(workflowManifestResponse)}>
                 <Copy />
@@ -610,7 +610,7 @@ export default function WorkflowsView() {
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => handleExportFile(workflowManifestResponse)}>
                 <Download />
-                Export to File
+                Export to file
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -814,7 +814,7 @@ export default function WorkflowsView() {
           >
             <DialogHeader>
               <DialogTitle>
-                {scheduleWorkflowManifest.schedule_cron ? 'Edit' : 'Add'} Schedule
+                {scheduleWorkflowManifest.schedule_cron ? 'Edit' : 'Add'} schedule
               </DialogTitle>
             </DialogHeader>
             <div className="space-y-4">

--- a/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
+++ b/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
@@ -328,7 +328,7 @@ export function WorkflowFormFields({
                 size="sm"
                 className="h-7 rounded-element bg-background-medium px-2 text-supporting hover:bg-overlay-hover"
               >
-                Open Editor
+                Open editor
               </Button>
             </div>
             <textarea
@@ -371,12 +371,12 @@ export function WorkflowFormFields({
         )}
       </form.Field>
 
-      {/* Initial Prompt Field */}
+      {/* Initial prompt field */}
       <form.Field name="prompt">
         {(field: FormFieldApi<string | undefined>) => (
           <div>
             <label htmlFor="workflow-prompt" className="block text-label text-text-default mb-2">
-              Initial Prompt
+              Initial prompt
             </label>
             <p className="text-supporting text-text-muted mt-2 mb-2">
               (Optional - Instructions or Prompt are required)
@@ -407,7 +407,7 @@ export function WorkflowFormFields({
           <ChevronDown
             className={`w-4 h-4 text-text-muted transition-transform flex-shrink-0 relative top-0.5 ${advancedOpen ? 'rotate-0' : '-rotate-90'}`}
           />
-          <span className="text-label text-text-default">Advanced Options</span>
+          <span className="text-label text-text-default">Advanced options</span>
           <span className="text-supporting text-text-muted">
             Activities, parameters, model, resources
           </span>
@@ -563,7 +563,7 @@ export function WorkflowFormFields({
                     size="sm"
                     className="h-7 rounded-element bg-background-medium px-2 text-supporting hover:bg-overlay-hover"
                   >
-                    Open Editor
+                    Open editor
                   </Button>
                 </div>
 

--- a/ui/desktop/src/components/workflows/shared/__tests__/WorkflowFormFields.test.tsx
+++ b/ui/desktop/src/components/workflows/shared/__tests__/WorkflowFormFields.test.tsx
@@ -168,7 +168,7 @@ describe('WorkflowFormFields', () => {
     it('shows editor buttons for instructions and JSON schema', () => {
       render(<TestWrapper />);
 
-      const editorButtons = screen.getAllByText('Open Editor');
+      const editorButtons = screen.getAllByText('Open editor');
       expect(editorButtons.length).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
Five copy findings — **F5, F6, F7, F11, F13** — from the 2026-09-08 round-2 walkthrough of `main`.
Every one reproduced and re-measured in a sandboxed dev instance before and after.

> **This PR originally also carried the D-15 fix for ChatSummary's `<ol tabIndex={0}>`.** #187 fixed
> the same defect with a different design (a `.biorouter-focus-region` class rather than the
> element's own `role="list"`, and the UA ring silenced rather than kept) and was merged to `main` as
> `f06968ab` while this was in review. That is the decision, so commit `6b00b0c0` was dropped and the
> branch rebased onto it; nothing here touches `ChatSummary.tsx`, `styles/main.css`,
> `styles/tabFocus.test.ts`, `design.md` or `settings-visual-vocabulary.md` any more. The
> before/after measurement that was in this section is recorded in the final report instead.

## Why

### F5 — `Groq (d)` ships as a provider's display name

The Public tab of the provider catalog listed **"Groq (d)"**. Source:
`crates/biorouter/src/providers/declarative/groq.json:4`. The other four bundled declarative
providers are clean (DeepSeek, Inception, Mistral AI, Moonshot AI (Kimi)), so it is a note-to-self
in a file whose contents are *printed*. `display_name` is compiled into the daemon via
`include_dir!`, so it cannot be corrected from config.

### F6 — Title Case left inside the dialogs #181 opened

#181's stated scope was "the page-header actions **and the dialogs they open**". The dialog titles
all landed; their contents did not. Repro: `#/workflows` → **Create workflow** → the footer holds
`Save workflow` beside `Save & Run Workflow`. `#/workflows` → the row's clock button, labelled
"Add schedule" → a dialog titled **"Add Schedule"**.

### F7 — "Install&nbsp;&nbsp;skills" with a double space

`#/skills` → **Browse skills**, nothing selected: the footer button reads `Install  skills`. The
template put the count between two literal spaces, so the empty substitution collapsed and left the
pair behind — in the state the dialog *opens* in.

### F11 / F13 — one character each

`Switched models -- using …` used a typewriter double hyphen where an em dash belongs; it is the
only toast in the renderer that did. Settings' page subtitle was the one `PageHeader` description
with no full stop, so the punctuation flickers as you move between pages.

## What changed

### F5 — `crates/biorouter/src/providers/declarative/groq.json:4`

`"Groq (d)"` → `"Groq"`, plus a guard in `config/declarative_providers.rs` that bans the **shape**,
not the one string: a trailing parenthesised **single letter** is a marker, never a name. Real
parentheses stay legal, and `Moonshot AI (Kimi)` is asserted beside it so a future tightening has
to notice the case it would break. `rsplit_once`, not a byte index — `clippy::string_slice` is
right that a display name can hold any character.

### F6 — every label, before → after

| Where | Before | After |
|---|---|---|
| `CreateEditWorkflowModal.tsx:480` footer | Save & Run Workflow | Save & run workflow |
| `shared/WorkflowFormFields.tsx:331,566` | Open Editor | Open editor |
| `shared/WorkflowFormFields.tsx:379` field label | Initial Prompt | Initial prompt |
| `shared/WorkflowFormFields.tsx:410` collapsible | Advanced Options | Advanced options |
| `WorkflowsView.tsx:817` schedule dialog | Add / Edit **Schedule** | Add / Edit **schedule** |
| `WorkflowsView.tsx:604` share menu | Copy Deeplink | Copy deeplink |
| `WorkflowsView.tsx:613` share menu | Export to File | Export to file |
| `settings/providers/ProviderCatalog.tsx:199` | Add Custom Provider | Add custom provider |
| `settings/providers/ProviderCatalog.tsx:549` note | …Public → Add Custom Provider | …→ Add custom provider |
| `settings/providers/ProviderCatalog.tsx:640` | Choose Model | Choose model |
| `settings/providers/ProviderSettingsPage.tsx:111` page title | Provider Configuration | Provider configuration |
| `settings/chat/ChatSettingsSection.tsx:31` heading | Response Styles | Response styles |
| `settings/config/ConfigSettings.tsx:205` trigger | Edit Configuration | Edit configuration |
| `settings/config/ConfigSettings.tsx:216` dialog title | Configuration Editor | Configuration editor |
| `settings/config/ConfigSettings.tsx:299` footer | Reset Changes | Reset changes |

The "Other institutions" note is in the list because it **names** the control it sends the reader
to; leaving it would have made the prose cite a label that no longer exists.

**Swept and deliberately left**, with reasons:

- `Copy YAML` and `Response JSON Schema` — YAML is an acronym and JSON Schema is the name of the
  specification the field's own help text cites. Sentence case keeps proper nouns.
- `{ name: 'YAML Files' }` / `{ name: 'All Files' }` (`WorkflowsView.tsx:269-270`) — filter names
  handed to the **native macOS save panel**, where Title Case is the platform's convention rather
  than this app's copy. Same reasoning #181 used for the application menu.
- `Biorouter Skills` (`SkillsView.tsx:108`, `CustomSkillModal.tsx:56,90`, `BrowseSkillsModal.tsx:122`)
  — a consistent product-surface name across four sites, not a stray; changing one would create the
  inconsistency this rule exists to remove.
- `To Do` (`ChatSummary.tsx`, 4 sites) — the capability's own name, used consistently.

⚠ **One of these is invisible at runtime.** `Response styles` sits under `text-caps`, which
uppercases it, so the screen read "RESPONSE STYLES" before and after. What changes is the DOM text,
what a screen reader says, and the file's agreement with its three sibling headings.

### F7 — `baam/BrowseSkillsModal.tsx`

The count and its trailing space now live inside the conditional together, extracted as
`installButtonLabel(n)` and tested there rather than only through a render — the arithmetic is a
function of one number, and a threshold you can exercise only by mounting a component is one nobody
re-tests.

### F11 / F13

`ModelAndProviderContext.tsx:386` `--` → `—`; `settings/SettingsView.tsx:106` gains a full stop.

## Tests

`BrowseSkillsModal.test.tsx` grows 1 → 7. Confirmed to fail on the original template:
`Tests 3 failed | 4 passed (7)`. ⚠ One of the three is the render assertion, and it only fails
because it reads `textContent`: `getByRole('button', { name: 'Install skills' })` **normalises** runs
of whitespace, so a name-based test reports this bug as fixed while it is still on screen.

The Rust guard was confirmed to fail on the string that shipped:

```
groq: display_name "Groq (d)" ends in a parenthesised single letter — that is a
leftover marker, not a name (groq.json shipped "Groq (d)")
```

**Tests updated because they asserted the old copy** — three, and they failed first:
`WorkflowFormFields.test.tsx:171` (`getAllByText('Open Editor')`),
`hostManagedSettings.browserSurface.test.tsx:204` (`{ name: /Edit Configuration/ }`), and
`ProviderCatalog.test.tsx:302`.

⚠ **The third one kept PASSING across the rename, and that is the finding.** It matched
`/Add Custom Provider/i` — case-insensitive, so it was asserting the words and never the casing. It
is now an exact string, with a comment saying why.

**What the renderer suite does NOT assert, stated plainly rather than implied.** Of the fifteen F6
labels, exactly three had a test that named them (the three above). One more,
`WorkflowFormFields.test.tsx:10,68`, matches `/advanced options/i` — case-insensitive, so like the
`ProviderCatalog` one it never asserted the casing and kept passing; it is left as a *finder*, which
is what it is for. The remaining eleven — `Save & run workflow`, `Initial prompt`, `Add/Edit
schedule`, `Copy deeplink`, `Export to file`, `Choose model`, `Provider configuration`, `Response
styles`, `Configuration editor`, `Reset changes` — plus the em dash and the Settings full stop have
**no** test naming them, before or after. They were verified by reading the strings out of the
running DOM (table below); no string-equality tests were added for copy no reviewer would have to
keep in step. `Reset changes` is the one label with neither a test nor a screenshot: it renders only
after a config value is edited, and editing a sandbox config value to photograph a button was not
worth the state — it is a source-only change on a line beside two that were verified.

```
$ npm run test:run
 Test Files  423 passed (423)
      Tests  4766 passed | 1 skipped (4767)

$ npm run lint:check                  # tsc + eslint + themes + contrast + tokens
OK — generated artifacts are current (3 themes)
OK — all 332 contrast assertions pass
OK — every semantic colour token used by a utility has a @theme inline mirror
EXIT=0

$ <every changed src file> | xargs npx prettier --check
All matched files use Prettier code style!

$ cargo fmt --all -- --check                            # clean
$ BIOROUTER_DISABLE_KEYRING=true ./scripts/clippy-lint.sh
✅ All baseline clippy checks passed!    (exit 0)

$ BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib config::declarative_providers
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 3702 filtered out
```

No server route's response shape changed (a JSON *value*, not a schema; `openapi.json` carries no
provider display names), so no `just generate-openapi`.

`main` moved four times while this was in flight (#188, #189, #190, #187). The branch is **rebased
onto `f06968ab`** and every figure above is from that rebase, not from the original branch point.

## Runtime verification

Sandboxed dev instance on CDP 9342, Parchment light at 1440 × 1000, running a daemon built from this
branch (`--features biorouter/privacy-test-auth`, `TEST-AUTH` seam present) so the compiled-in Groq
name could be seen. `npm run cdp:viewport-check 9342` → *"viewport follows the window"*, exit 0.
Zero page errors throughout. Screenshots under
`~/biorouter-runs/test-drive/round3/shots/fix-copy/`:

| Finding | Verified | Shot |
|---|---|---|
| F5 | `GET /config/providers` → `Groq`; the Public tab renders "Groq" | `f5-f6-provider-catalog-public-groq-and-add-custom-…png` |
| F6 workflow dialog | title `Create workflow`; buttons `Open editor`, `Advanced options`, `Save workflow`, `Save & run workflow`; label `Initial prompt`; zero old strings in the dialog | `f6-create-workflow-dialog-…png` |
| F6 schedule dialog | title `Add schedule`, matching the control | `f6-add-schedule-dialog-…png` |
| F6 share menu | `Copy deeplink` · `Copy YAML` · `Export to file` | `f6-workflow-row-share-menu-…png` |
| F6 catalog | h1 `Provider configuration`; `Add custom provider` | `f5-f6-provider-catalog-…png` |
| F6 config editor | trigger `Edit configuration`, dialog `Configuration editor` | `f6-configuration-editor-dialog-…png` |
| F6 + F13 Settings | `h2`s = Mode · **Response styles** · Capabilities · Memory · Contexts · App SDK · Editor · Project, zero Title Case; subtitle ends `…app preferences.` | `f6-settings-chat-response-styles-…png` |
| F7 | `textContent` exactly `"Install skills"` (disabled), then `Install 1 skill`, `Install 3 skills` | `f7-browse-skills-install-skills-none-selected-…png`, `f7-…-install-3-skills-…png` |
| F11 | toast: `Switched models — using gpt-5.5-2026-04-24 from Versa API Azure` | `f11-model-switch-toast-em-dash-…png` |

⚠ The runtime pass was done on the pre-rebase tree; the rebase changed no line in any of these files
(the four commits replayed cleanly onto `f06968ab`), and the full suite, `lint:check`, Prettier and
the Rust gates were all re-run after it.

## Out of scope

- **F12** (Knowledge's page title at `left=320` while seven others sit at `508`) — reported only, as
  briefed. It is a deliberate full-bleed two-pane view; the title is not on the shared left edge
  because the page has no shared left edge. Left alone.
- **"behavior" (US) vs the "-ise" spellings used elsewhere**, noted alongside F13 in the walkthrough.
  The spelling axis runs through far more copy than one subtitle and is a separate decision.
- Nothing was touched in `AppSettingsSection.tsx`, `SessionsView.tsx`, `ProgressiveMessageList.tsx`,
  `chatGroups/*`, `App.tsx`, the `.br-tab*` rules, the composer, the context gauge or chat error
  rendering — concurrent work. The only overlap with another agent's files is
  `CreateEditWorkflowModal.tsx`, where this changes **one string literal** and no logic.
- The D-15 / ChatSummary work, now owned by the merged #187 (see the note at the top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
