### PR TITLE
fix(privacy): the composer states the model a private chat actually runs on

### DIFF
--- a/crates/biorouter-cli/src/commands/web.rs
+++ b/crates/biorouter-cli/src/commands/web.rs
@@ -626,6 +626,16 @@ async fn process_message_streaming(
                     Ok(AgentEvent::ModelChange { model, mode }) => {
                         tracing::info!("Model changed to {} in {} mode", model, mode);
                     }
+                    // Issue #56 Gate B's repair arm: this turn ran on the
+                    // provider the session row names. Logged rather than sent:
+                    // the web bridge's frame vocabulary is the transcript, and a
+                    // browser session cannot change its model anyway (SD-1), so
+                    // there is no wrong choice on screen for it to correct.
+                    Ok(AgentEvent::PrivacyProviderPinned { provider, model }) => {
+                        tracing::info!(
+                            "Private chat pinned to its own binding: {provider} / {model}"
+                        );
+                    }
                     // BR-52: the web bridge reads token counts from the session
                     // row when it needs them, so the carried snapshot is a no-op here.
                     Ok(AgentEvent::TokenUsage(_)) => {}

--- a/crates/biorouter-cli/src/session/builder.rs
+++ b/crates/biorouter-cli/src/session/builder.rs
@@ -805,11 +805,8 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
         Ok(provider) => provider,
         Err(e) => {
             output::render_error(&format!(
-                "Error {}.\n\
-                Please check your system keychain and run 'biorouter configure' again.\n\
-                If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
-                For more info, see: https://BaranziniLab.github.io/biorouter/docs/troubleshooting/#keychainkeyring-errors",
-                e
+                "Error {e}.{}",
+                keyring_advice(&provider_name).await
             ));
             close_ephemeral_store_with_manager(&session_manager, ephemeral_store_dir).await;
             process::exit(1);
@@ -1112,9 +1109,71 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
     session
 }
 
+/// The keychain paragraph, or nothing.
+///
+/// Provider construction fails for a credential reason often enough that the
+/// advice earned its place — but it is advice about SECRETS, and not every
+/// provider has any. `claude_code` and `codex` drive a CLI the user signed in
+/// to; Biorouter never sees a credential for either and stores nothing for
+/// them, so telling a user whose `claude` binary is simply not on PATH to
+/// "check your system keychain and run 'biorouter configure' again" sends them
+/// to a place with nothing in it, and buries the error that named the real
+/// problem underneath three lines of it.
+///
+/// The question is asked of the provider's own declared config keys rather than
+/// of a list of names kept here, so a provider added later is classified by
+/// what it declares. A provider the registry cannot describe — including one it
+/// has never heard of, which is one of the ways `create` fails — keeps the
+/// advice: it may well have secrets, and an unnecessary paragraph is a much
+/// smaller failure than withholding the one that would have helped.
+async fn keyring_advice(provider_name: &str) -> &'static str {
+    const ADVICE: &str = "\n\
+        Please check your system keychain and run 'biorouter configure' again.\n\
+        If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
+        For more info, see: https://BaranziniLab.github.io/biorouter/docs/troubleshooting/#keychainkeyring-errors";
+    let has_secrets = biorouter::providers::providers()
+        .await
+        .into_iter()
+        .find(|(metadata, _)| metadata.name == provider_name)
+        .map(|(metadata, _)| metadata.config_keys.iter().any(|key| key.secret));
+    match has_secrets {
+        Some(false) => "",
+        _ => ADVICE,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two coding-agent providers declare no config keys at all: they drive
+    /// a CLI the user signed in to, and Biorouter holds no credential for
+    /// either. A `could not find the 'claude' command` failure followed by
+    /// three lines about the system keychain sends the reader somewhere with
+    /// nothing in it.
+    #[tokio::test]
+    async fn a_provider_with_no_secrets_is_not_told_to_check_its_keychain() {
+        for provider in ["claude_code", "codex"] {
+            assert_eq!(
+                keyring_advice(provider).await,
+                "",
+                "{provider} stores no secret"
+            );
+        }
+    }
+
+    /// …and the advice is kept for everything that does hold one, including a
+    /// provider the registry cannot describe: an unnecessary paragraph is a far
+    /// smaller failure than withholding the one that would have helped.
+    #[tokio::test]
+    async fn a_provider_with_secrets_still_gets_the_keychain_advice() {
+        for provider in ["anthropic", "openai", "no_such_provider_exists"] {
+            assert!(
+                keyring_advice(provider).await.contains("system keychain"),
+                "{provider} must keep the advice"
+            );
+        }
+    }
 
     /// #31: the `--no-session` store must be a private per-run directory —
     /// never the shared `<data_dir>/sessions/sessions.db` — and it must be a

--- a/crates/biorouter-cli/src/session/mod.rs
+++ b/crates/biorouter-cli/src/session/mod.rs
@@ -1546,6 +1546,22 @@ impl CliSession {
                                 eprintln!("Model changed to {} in {} mode", model, mode);
                             }
                         }
+                        // Issue #56 Gate B's repair arm: the turn ran on the
+                        // provider the session row names rather than on the
+                        // configured one. Its audience is the desktop composer,
+                        // whose model chip is the thing that was saying something
+                        // false; a terminal prints its binding at start-up and
+                        // `builder.rs` refuses, before creating any provider, the
+                        // chats this arm would have had to repair. Reported under
+                        // `--debug` rather than added to `StreamEvent`, whose shape
+                        // is a public contract.
+                        Some(Ok(AgentEvent::PrivacyProviderPinned { provider, model })) => {
+                            if self.debug {
+                                eprintln!(
+                                    "This chat is private, so the turn ran on {provider} / {model}"
+                                );
+                            }
+                        }
                         // BR-52: token accounting is rendered from the session row
                         // in the CLI; the carried snapshot is informational here.
                         Some(Ok(AgentEvent::TokenUsage(_))) => {}

--- a/crates/biorouter-cli/src/session/tui/mod.rs
+++ b/crates/biorouter-cli/src/session/tui/mod.rs
@@ -633,6 +633,11 @@ async fn drive_response(
                     Some(Ok(AgentEvent::McpNotification(_))) => {}
                     Some(Ok(AgentEvent::HistoryReplaced(c))) => { session.messages = c; }
                     Some(Ok(AgentEvent::ModelChange { .. })) => {}
+                    // Issue #56 Gate B's repair arm. The TUI shows its binding in
+                    // the status line and reads it from the same session the
+                    // agent does, so it is already displaying the pinned model;
+                    // the arm this frame exists for is the desktop composer's.
+                    Some(Ok(AgentEvent::PrivacyProviderPinned { .. })) => {}
                     // BR-52: the TUI reads token counts from the session row.
                     Some(Ok(AgentEvent::TokenUsage(_))) => {}
                     // Advisory pending tool-call hint; TUI renders authoritative

--- a/crates/biorouter-server/src/routes/reply.rs
+++ b/crates/biorouter-server/src/routes/reply.rs
@@ -385,6 +385,28 @@ pub enum MessageEvent {
     MessagesPersisted {
         messages: Vec<PersistedMessage>,
     },
+    /// Issue #56 Gate B, repair arm: the provider and model that actually
+    /// served this turn, sent when the agent had to fall back to the one the
+    /// SESSION ROW names because the chat's classification does not admit the
+    /// bound one.
+    ///
+    /// Advisory display state, exactly like `ToolCallPending`: never persisted,
+    /// never replayed, never shown to the model, and it changes nothing about
+    /// what the privacy gates permit or refuse. Its whole job is that a user who
+    /// switched the app to a public model and then sent into a private chat can
+    /// see that the turn went elsewhere — and that the composer's model chip and
+    /// context gauge can be sized to the window that was really used.
+    ///
+    /// ⚠ It does NOT carry the selection it displaced, so a client must not
+    /// treat receiving it as "the user's choice was overridden". The frame
+    /// arrives on every repaired bind, including the ordinary ones (a
+    /// rehydrated agent, a legacy row) where it names exactly what the client is
+    /// already showing. Compare it against what you display, and say nothing
+    /// when they agree.
+    PrivacyProviderPinned {
+        provider: String,
+        model: String,
+    },
     Ping,
 }
 

--- a/crates/biorouter-server/src/routes/session_events.rs
+++ b/crates/biorouter-server/src/routes/session_events.rs
@@ -128,6 +128,12 @@ fn map_bus_event_for_turn(
             AgentEvent::MessagesPersisted(messages) => {
                 Some(MessageEvent::MessagesPersisted { messages })
             }
+            // Issue #56 Gate B's repair arm, said out loud. A pass-through: the
+            // frame is advisory display state and the wire enum carries the
+            // identically-shaped variant.
+            AgentEvent::PrivacyProviderPinned { provider, model } => {
+                Some(MessageEvent::PrivacyProviderPinned { provider, model })
+            }
             // FALLBACK ONLY. The turn runner never publishes a raw
             // `TurnAborted` — it classifies it and publishes `TurnError`
             // instead, precisely so no consumer renders two terminal Error

--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -3522,6 +3522,33 @@ pub enum AgentEvent {
     /// after the rows are durable, so a consumer that stops reading mid-turn
     /// never holds an id for a row that was not written.
     MessagesPersisted(Vec<PersistedMessage>),
+    /// Issue #56 Gate B, repair arm: this turn ran on the provider the SESSION
+    /// ROW names, not on whatever the agent was holding when the turn began,
+    /// because the chat's classification does not admit the bound one.
+    ///
+    /// The repair itself is old and correct — a private chat must never reach a
+    /// public model, and asking the user to downgrade the chat instead would be
+    /// worse. What was missing is that it happened at all: a user who switches
+    /// the app to a public model, watches the composer's chip change, and then
+    /// sends into a private chat gets an answer from a different model than the
+    /// one on screen, with the context gauge sized to the wrong window.
+    ///
+    /// ⚠ Purely advisory, exactly like [`AgentEvent::ToolCallPending`]. It is
+    /// not a `Message`, so it is never persisted, replayed, or shown to the
+    /// model; it changes nothing about what any gate permits or refuses.
+    ///
+    /// ⚠ It carries no "requested" binding, and adding one would be a mistake.
+    /// The agent's own view of what was displaced is incomplete — an LRU-
+    /// rehydrated agent holds nothing at all — while the client rendering this
+    /// already knows exactly what it is showing the user. See
+    /// [`Agent::pinned_provider_event`].
+    PrivacyProviderPinned {
+        /// The provider that served the turn (`versa_azure`, …), as the
+        /// registry names it.
+        provider: String,
+        /// Its model.
+        model: String,
+    },
 }
 
 impl Default for Agent {
@@ -6389,6 +6416,28 @@ impl Agent {
         Ok(true)
     }
 
+    /// The binding Gate B's repair arm just installed, as the event that tells
+    /// the turn's readers where it actually went.
+    ///
+    /// ⚠ It states a FACT and judges nothing: "this turn ran on `provider` /
+    /// `model`". It deliberately does not carry the selection it displaced, and
+    /// it is not the place to decide whether the displacement is news. The
+    /// caller that renders it already holds the selection it is showing the
+    /// user, and only that caller can tell "the chip is wrong" from "the chip
+    /// was right all along and a rehydrated agent was quietly repaired to
+    /// match" — the common case (LRU rehydration, a legacy row, any ratchet
+    /// that commits after a legal bind) that must NOT produce a note.
+    ///
+    /// `None` if the binding vanished between the swap and this read, which is
+    /// a race no message can usefully describe.
+    async fn pinned_provider_event(&self) -> Option<AgentEvent> {
+        let provider = self.bound_provider_unchecked().await?;
+        Some(AgentEvent::PrivacyProviderPinned {
+            provider: provider.get_name().to_string(),
+            model: provider.get_model_config().model_name,
+        })
+    }
+
     /// BR-63: set the session's sticky reasoning effort (`/effort <level>`).
     pub async fn set_reasoning_effort(&self, session_id: &str, effort: ReasoningEffort) {
         self.efforts.set(session_id, effort).await;
@@ -8174,6 +8223,11 @@ impl Agent {
             .await
             .ok();
         let mut privacy_refusal: Option<String> = None;
+        // Set by Gate B's repair arm below, yielded as the turn's own account of
+        // which model actually served it. `None` on every other path, including
+        // the overwhelmingly common one where the bound provider was already
+        // admissible and nothing was repaired.
+        let mut privacy_pinned: Option<AgentEvent> = None;
         // DR-15's master opt-out. ONE read for this seam, used by both halves —
         // the turn barrier below and DR-4's turn ratchet under it — so the two
         // cannot be observed at different instants and a turn cannot be refused
@@ -8198,8 +8252,18 @@ impl Agent {
             if privacy_enforced && !crate::privacy::bind_allowed(bound_tier, row.privacy_tier) {
                 match self.rebind_from_row(row).await {
                     // 2. The row still names a provider whose tier satisfies
-                    //    the classification: rebind and continue silently.
-                    Ok(true) => {}
+                    //    the classification: rebind and continue.
+                    //
+                    // ⚠ Silent REPAIR is right; silent and INVISIBLE was the
+                    // defect. The user had deliberately switched the app to a
+                    // public model, watched the composer's chip change, and
+                    // their turn ran somewhere else — with the context gauge
+                    // then measuring the usage against the wrong model's
+                    // window. Nothing about what the gate PERMITS changes here;
+                    // the turn is simply made to say where it went.
+                    Ok(true) => {
+                        privacy_pinned = self.pinned_provider_event().await;
+                    }
                     // 3. Otherwise refuse THIS TURN. The row is untouched, so
                     //    the repair card can still offer the one-click fix.
                     _ => privacy_refusal = Some(crate::privacy::refusal::turn_refusal(row)),
@@ -8555,6 +8619,19 @@ impl Agent {
         Ok(Box::pin(async_stream::try_stream! {
             if let Some(published) = prestream_published {
                 yield published;
+            }
+            // Gate B's repair, said out loud. Its position is unconstrained by
+            // #59/#66: the frame names no stored row and carries no message
+            // body, so it can neither arrive ahead of its own content nor claim
+            // an id whose body is still buffered. It goes near the front so a
+            // client that loses the stream mid-turn still learns which model
+            // the turn it half-watched was running on.
+            //
+            // ⚠ Only the ordinary turn path carries it. The slash-command
+            // early-returns above never reach a provider, so "which model
+            // served this turn" has no answer there to report.
+            if let Some(pinned) = privacy_pinned {
+                yield pinned;
             }
             let final_conversation = if !needs_auto_compact {
                 stored_conversation
@@ -19897,6 +19974,19 @@ mod gate_b_turn_tests {
         }
     }
 
+    /// Every `PrivacyProviderPinned` the turn reported, as `(provider, model)`.
+    fn pinned(events: &[Result<AgentEvent>]) -> Vec<(String, String)> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                Ok(AgentEvent::PrivacyProviderPinned { provider, model }) => {
+                    Some((provider.clone(), model.clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     fn rendered(events: &[Result<AgentEvent>]) -> String {
         events
             .iter()
@@ -19942,6 +20032,102 @@ mod gate_b_turn_tests {
             rendered(&events)
         );
         assert_eq!(agent.provider().await.unwrap().get_name(), "versa_azure");
+    }
+
+    #[tokio::test]
+    async fn a_repaired_bind_reports_the_provider_that_actually_served_the_turn() {
+        // Silent REPAIR is right — a private chat must never reach a public
+        // model, and asking the user to downgrade the chat instead would be
+        // worse. Silent and INVISIBLE was the defect: the user had switched the
+        // app to a public model, watched the composer's chip change, and their
+        // turn ran somewhere else, with the context gauge then sized to the
+        // wrong model's window.
+        //
+        // The turn now says where it went. Note what this does NOT assert:
+        // nothing about refusing, permitting, or the row — the frame is
+        // advisory, and a test that made it look like part of the barrier would
+        // invite someone to gate on it.
+        let (_dir, agent, s) = agent_on(public_provider()).await;
+        let sm = manager(&agent);
+        let row_provider = private_provider();
+        point_row_at(&sm, &s.id, &row_provider).await;
+        ratchet_to_private(&sm, &s.id).await;
+        seams::override_rebind_provider(
+            sm.as_ref(),
+            &s.id,
+            "versa_azure",
+            Arc::clone(&row_provider),
+        );
+
+        let events = drain(
+            agent
+                .reply(Message::user().with_text("hi"), cfg(&s), None)
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            pinned(&events),
+            vec![("versa_azure".to_string(), "gpt-5.5".to_string())],
+            "a repaired bind must report the binding it repaired TO, exactly once:\n{}",
+            rendered(&events)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_turn_that_needed_no_repair_reports_nothing() {
+        // The frame must be evidence, not decoration. A private chat already on
+        // its own private provider is the overwhelmingly common turn, and a
+        // client that saw this frame on every one of them would either paint a
+        // permanent note or learn to ignore the frame.
+        let (_dir, agent, s) = agent_on(private_provider()).await;
+        let sm = manager(&agent);
+        let row_provider = private_provider();
+        point_row_at(&sm, &s.id, &row_provider).await;
+        ratchet_to_private(&sm, &s.id).await;
+
+        let events = drain(
+            agent
+                .reply(Message::user().with_text("hi"), cfg(&s), None)
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(
+            pinned(&events).is_empty(),
+            "nothing was repaired, so there is nothing to report:\n{}",
+            rendered(&events)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_turn_reports_no_pinned_provider() {
+        // Arm 3, not arm 2. The refusal is the message; a pin frame here would
+        // claim a turn ran on a provider when no turn ran at all.
+        let (_dir, agent, s) = agent_on(public_provider()).await;
+        let sm = manager(&agent);
+        let row_provider = public_provider();
+        point_row_at(&sm, &s.id, &row_provider).await;
+        ratchet_to_private(&sm, &s.id).await;
+        seams::override_rebind_provider(sm.as_ref(), &s.id, "anthropic", Arc::clone(&row_provider));
+
+        let events = drain(
+            agent
+                .reply(Message::user().with_text("hi"), cfg(&s), None)
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(
+            events.iter().any(is_refusal),
+            "fixture check: this turn must be refused:\n{}",
+            rendered(&events)
+        );
+        assert!(
+            pinned(&events).is_empty(),
+            "a refused turn ran on nothing, so it must name nothing:\n{}",
+            rendered(&events)
+        );
     }
 
     #[tokio::test]

--- a/crates/biorouter/src/agents/mistakes.rs
+++ b/crates/biorouter/src/agents/mistakes.rs
@@ -431,9 +431,34 @@ fn stop_notice(error: &ProviderError, retried: u32) -> String {
         n => format!(" Biorouter already retried it {n} times."),
     };
     format!(
-        "Ran into this error: {error}.\n\nPlease retry if you think this is a transient or \
-         recoverable error.{retried_clause}"
+        "Ran into this error: {}\n\nPlease retry if you think this is a transient or \
+         recoverable error.{retried_clause}",
+        end_sentence(&error.to_string())
     )
+}
+
+/// One full stop, not two.
+///
+/// Vendor error text usually ends in punctuation of its own, and appending a
+/// period to it produced `…then try again..` in the chat — the sort of detail
+/// that makes a real message look machine-assembled. The frame still supplies
+/// the stop when the text has none, which is the common case for a bare
+/// `Server error: 502`.
+///
+/// Deliberately conservative: only `.`, `!`, `?` and a closing quote or bracket
+/// after one of them count as an ending. Anything else gets the period it needs.
+fn end_sentence(text: &str) -> String {
+    let trimmed = text.trim_end();
+    let ends = trimmed
+        .chars()
+        .rev()
+        .find(|c| !matches!(c, '"' | '\'' | ')' | ']' | '}' | '\u{201d}' | '\u{2019}'))
+        .is_some_and(|c| matches!(c, '.' | '!' | '?'));
+    if trimmed.is_empty() || ends {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}.")
+    }
 }
 
 #[cfg(test)]
@@ -734,6 +759,49 @@ mod tests {
              transient or recoverable error.",
             "the pre-BR-66 text, byte for byte"
         );
+    }
+
+    /// Vendor text already ends in a full stop, so the frame must not add a
+    /// second one. Measured in the desktop app on a Claude Code turn against an
+    /// unsupported model: `…then try again..`.
+    #[test]
+    fn vendor_text_that_already_ends_in_a_stop_does_not_get_a_second_one() {
+        let config = MistakeConfig {
+            provider_error_retries: 0,
+            ..MistakeConfig::default()
+        };
+        let mut tracker = MistakeTracker::default();
+        let error = ProviderError::RequestFailed(
+            "API Error: 400 Claude Code 2.1.235 does not support this model; version 2.1.251 or \
+             newer is required. Run 'claude update', or update the Claude desktop app, then try \
+             again."
+                .to_string(),
+        );
+
+        let ProviderErrorAction::Stop { notice } = tracker.observe_provider_error(&config, &error)
+        else {
+            panic!("retries are off");
+        };
+        assert!(
+            notice.contains("then try again.\n\n"),
+            "one stop, not two: {notice}"
+        );
+        assert!(!notice.contains(".."), "{notice}");
+    }
+
+    #[test]
+    fn end_sentence_only_supplies_a_stop_that_is_missing() {
+        assert_eq!(end_sentence("Server error: 502"), "Server error: 502.");
+        assert_eq!(end_sentence("try again."), "try again.");
+        assert_eq!(end_sentence("what now?"), "what now?");
+        assert_eq!(end_sentence("stop!"), "stop!");
+        // Trailing whitespace is not an ending, and a stop inside a closing
+        // quote or bracket still counts as one.
+        assert_eq!(end_sentence("done.  "), "done.");
+        assert_eq!(end_sentence("(see the log.)"), "(see the log.)");
+        assert_eq!(end_sentence("he said \"no.\""), "he said \"no.\"");
+        assert_eq!(end_sentence("a bare clause"), "a bare clause.");
+        assert_eq!(end_sentence(""), "");
     }
 
     // ── BR-51: the streak now knows what kind of failures it is counting ──

--- a/crates/biorouter/src/agents/subagent_handler.rs
+++ b/crates/biorouter/src/agents/subagent_handler.rs
@@ -1030,14 +1030,20 @@ fn get_agent_messages(
                         &session_id,
                         crate::session_events::SessionBusEvent::Agent(event.clone()),
                     );
-                    // EIGHT arms, no wildcard: a `_ => {}` here would silently
-                    // swallow a ninth `AgentEvent` variant instead of failing
+                    // NINE arms, no wildcard: a `_ => {}` here would silently
+                    // swallow a tenth `AgentEvent` variant instead of failing
                     // the build.
                     match event {
                         AgentEvent::Message(msg) => conversation.push(msg),
                         AgentEvent::McpNotification(_)
                         | AgentEvent::ModelChange { .. }
                         | AgentEvent::ToolCallPending(_)
+                        // Issue #56 Gate B's repair, addressed to a HUMAN
+                        // reading a composer. A subagent has no composer and its
+                        // parent is not the user, so the parent accumulates
+                        // nothing from it; the tee above still publishes it for
+                        // an observer tab watching the child.
+                        | AgentEvent::PrivacyProviderPinned { .. }
                         // #59: the subagent's own rows are already carried by
                         // the `Message` events above (which now name
                         // themselves); the parent has no `expectedMessageIds`

--- a/crates/biorouter/src/providers/claude_code.rs
+++ b/crates/biorouter/src/providers/claude_code.rs
@@ -595,10 +595,17 @@ impl ClaudeCodeProvider {
         };
 
         if result.get("is_error").and_then(Value::as_bool) == Some(true) {
+            // Through `unwrap_json_error`, exactly as `claude_stream`'s terminal
+            // frame is: `result` carries the vendor's own text, usually a
+            // sentence but sometimes the upstream API's JSON body verbatim.
+            // Unwrapping is a no-op on the sentence and is what keeps the
+            // envelope out of the chat. Both surfaces read it the same way, so
+            // a streamed turn and a blocking one cannot say different things
+            // about the same failure.
             let detail = result
                 .get("result")
                 .and_then(Value::as_str)
-                .map(str::to_string)
+                .map(super::coding_agent::unwrap_json_error)
                 .or_else(|| Some(stderr.trim().to_string()))
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "`claude` reported an error".into());

--- a/crates/biorouter/src/providers/codex.rs
+++ b/crates/biorouter/src/providers/codex.rs
@@ -763,12 +763,14 @@ impl CodexProvider {
                 true
             }
             "turn/failed" => {
+                // #180/F8: through `codex_stream::error_message`, which also
+                // unwraps a vendor payload that arrives as a JSON envelope
+                // rather than a sentence. One reader for both surfaces, so the
+                // streaming and non-streaming paths cannot disagree about what
+                // a Codex failure says.
                 outcome.failure = Some(
-                    params
-                        .get("error")
-                        .and_then(|e| e.get("message").and_then(Value::as_str))
-                        .unwrap_or("the Codex turn failed")
-                        .to_string(),
+                    codex_stream::error_message(params.get("error"))
+                        .unwrap_or_else(|| "the Codex turn failed".to_string()),
                 );
                 true
             }
@@ -790,18 +792,20 @@ impl CodexProvider {
                 //
                 // The `turn/failed` arm above already reads the nested spelling,
                 // so this file handled both shapes — just not in this arm.
+                //
+                // Both spellings now come from `codex_stream::error_message`,
+                // the one reader the streaming decoder already used — which is
+                // also what makes the JSON-envelope unwrapping (#180/F8) apply
+                // here without a second copy of it.
                 outcome.failure = Some(
-                    params
-                        .get("error")
-                        .and_then(|error| {
-                            error
-                                .as_str()
-                                .filter(|s| !s.is_empty())
-                                .or_else(|| error.get("message").and_then(Value::as_str))
+                    codex_stream::error_message(params.get("error"))
+                        .or_else(|| {
+                            params
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .map(coding_agent::unwrap_json_error)
                         })
-                        .or_else(|| params.get("message").and_then(Value::as_str))
-                        .unwrap_or("the Codex app server reported an error")
-                        .to_string(),
+                        .unwrap_or_else(|| "the Codex app server reported an error".to_string()),
                 );
                 // Advisory errors can precede `turn.started` and are not fatal, so
                 // this does not end the turn; `turn/failed` or `turn/completed`

--- a/crates/biorouter/src/providers/coding_agent/claude_stream.rs
+++ b/crates/biorouter/src/providers/coding_agent/claude_stream.rs
@@ -748,13 +748,18 @@ fn classify_result(frame: &Value, retry_category: Option<&str>) -> Option<Termin
         .or(retry_category)
         .map(str::to_string);
 
+    // Through `unwrap_json_error`: `result` carries the vendor's own text, which
+    // is usually a sentence (`API Error: 400 Claude Code 2.1.235 does not
+    // support this model…`) but is sometimes the upstream API's JSON body
+    // verbatim. Unwrapping is a no-op on the sentence and is what keeps the
+    // envelope out of the transcript.
     let detail = frame
         .get("result")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .unwrap_or("`claude` reported an error")
-        .to_string();
+        .map(super::unwrap_json_error)
+        .unwrap_or_else(|| "`claude` reported an error".to_string());
 
     Some(TerminalError { category, detail })
 }

--- a/crates/biorouter/src/providers/coding_agent/codex_stream.rs
+++ b/crates/biorouter/src/providers/coding_agent/codex_stream.rs
@@ -837,17 +837,38 @@ fn i64_at(value: &Value, path: &[&str]) -> Option<i64> {
     cursor.as_i64()
 }
 
-/// Pull a human-readable message out of an error object, accepting both the
-/// `{message}` object the schema defines and a bare string.
-fn error_message(error: Option<&Value>) -> Option<String> {
+/// Pull a human-readable message out of an error object, accepting the
+/// `{message}` object the schema defines, a bare string, and a string that is
+/// itself a JSON error envelope.
+///
+/// ⚠ **The third shape is not hypothetical and it is the one users see.** Codex
+/// relays the upstream API's body verbatim as a *string*, so `params.error` came
+/// through here as `as_str()` and the whole envelope was rendered in the
+/// transcript:
+///
+/// ```text
+/// Ran into this error: Request failed: {"type":"error","status":400,"error":
+/// {"type":"invalid_request_error","message":"The 'gpt-6-astra' model requires a
+/// newer version of Codex. Please upgrade to the latest app or CLI and try
+/// again."}}.
+/// ```
+///
+/// The only actionable sentence in that is buried in the middle of JSON the
+/// reader cannot act on. [`unwrap_json_error`] takes it out.
+///
+/// ⚠ **Unwrapping is best-effort and must stay that way** — see
+/// [`super::unwrap_json_error`], which both vendors' decoders share so no two
+/// surfaces can disagree about what a failure says. `providers/codex.rs` reads
+/// its non-streaming failures through THIS function for the same reason.
+pub(crate) fn error_message(error: Option<&Value>) -> Option<String> {
     let error = error?;
     if let Some(s) = error.as_str() {
-        return (!s.is_empty()).then(|| explain_disabled_native_tool(s));
+        return (!s.is_empty()).then(|| explain_disabled_native_tool(&super::unwrap_json_error(s)));
     }
     error
         .get("message")
         .and_then(Value::as_str)
-        .map(explain_disabled_native_tool)
+        .map(|s| explain_disabled_native_tool(&super::unwrap_json_error(s)))
 }
 
 /// Turn the vendor's internal failure for a tool Biorouter disabled into
@@ -1402,6 +1423,39 @@ mod tests {
                 message: "something broke".to_string(),
                 will_retry: false,
             }]
+        );
+    }
+
+    /// The vendor relays the upstream API's body verbatim, as a STRING, so
+    /// `error.as_str()` used to yield the whole envelope and the transcript read
+    /// `Ran into this error: Request failed: {"type":"error","status":400,…}.`
+    /// This is the real 0.147.0 payload for an unsupported model.
+    #[test]
+    fn a_json_envelope_relayed_as_a_string_is_unwrapped_to_its_sentence() {
+        const ENVELOPE: &str = r#"{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}}"#;
+        let expected = "The 'gpt-6-astra' model requires a newer version of Codex. Please \
+                        upgrade to the latest app or CLI and try again.";
+
+        let mut d = CodexDecoder::new();
+        assert_eq!(
+            d.push("error", &json!({ "error": ENVELOPE })),
+            vec![CodexEvent::Notice {
+                message: expected.to_string(),
+                will_retry: false,
+            }]
+        );
+        assert_eq!(d.pending_failure(), Some(expected));
+
+        // …and on the terminal frame, which is the one the provider turns into
+        // the `ProviderError` the user reads.
+        let mut d = CodexDecoder::new();
+        assert_eq!(
+            d.push("turn/failed", &json!({ "error": { "message": ENVELOPE } })),
+            vec![CodexEvent::Terminal(CodexTerminal {
+                status: CodexTurnStatus::Failed,
+                error: Some(expected.to_string()),
+                turn_id: None,
+            })]
         );
     }
 

--- a/crates/biorouter/src/providers/coding_agent/mod.rs
+++ b/crates/biorouter/src/providers/coding_agent/mod.rs
@@ -186,6 +186,50 @@ impl Drop for AbortOnDrop {
     }
 }
 
+/// A vendor payload that arrived as a JSON envelope, reduced to the sentence
+/// inside it.
+///
+/// ⚠ **This is not hypothetical, and it is what the user sees.** Both CLIs relay
+/// the upstream API's response body verbatim, sometimes as a *string* rather
+/// than as prose, and the transcript then reads:
+///
+/// ```text
+/// Ran into this error: Request failed: {"type":"error","status":400,"error":
+/// {"type":"invalid_request_error","message":"The 'gpt-6-astra' model requires a
+/// newer version of Codex. Please upgrade to the latest app or CLI and try
+/// again."}}.
+/// ```
+///
+/// The one actionable sentence there is buried in JSON the reader cannot act on.
+///
+/// ⚠ **Best-effort, and it must stay that way.** A payload that is not JSON, an
+/// object with no message, or an empty message is returned UNCHANGED: printing
+/// an ugly error is a much smaller failure than losing an unrecognised one.
+/// `error.message` is read before a top-level `message` because that is the
+/// shape both vendors send; neither is a guess this function is entitled to
+/// improve on.
+///
+/// Lives here rather than in either decoder because it is about the upstream
+/// API's envelope, which is the one thing the two vendors have in common.
+pub fn unwrap_json_error(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if !trimmed.starts_with('{') {
+        return raw.to_string();
+    }
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+        return raw.to_string();
+    };
+    parsed
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| parsed.get("message").and_then(serde_json::Value::as_str))
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| raw.to_string())
+}
+
 /// Turn a missing-or-unusable CLI into the error the user should act on.
 ///
 /// Separate from the generic error mapper because these are *setup* failures, and
@@ -246,6 +290,58 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+
+    /// The real payload, from a Codex turn on `gpt-6-astra` against codex-cli
+    /// 0.147.0 (PR #180's live verification). Before this, the whole envelope
+    /// was rendered in the chat and the only actionable sentence in it was
+    /// buried in the middle.
+    const CODEX_400: &str = r#"{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}}"#;
+
+    #[test]
+    fn a_json_envelope_is_reduced_to_the_sentence_inside_it() {
+        assert_eq!(
+            unwrap_json_error(CODEX_400),
+            "The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the \
+             latest app or CLI and try again."
+        );
+    }
+
+    #[test]
+    fn a_top_level_message_is_read_when_there_is_no_error_object() {
+        assert_eq!(
+            unwrap_json_error(r#"{"message":"You've hit your usage limit."}"#),
+            "You've hit your usage limit."
+        );
+    }
+
+    /// The other vendor's text is already a sentence, so unwrapping it must be a
+    /// no-op. Verbatim from the same PR's Claude Code run on claude 2.1.235.
+    #[test]
+    fn prose_is_returned_unchanged() {
+        const CLAUDE_400: &str = "API Error: 400 Claude Code 2.1.235 does not support this model; \
+                                  version 2.1.251 or newer is required. Run 'claude update', or \
+                                  update the Claude desktop app, then try again.";
+        assert_eq!(unwrap_json_error(CLAUDE_400), CLAUDE_400);
+    }
+
+    /// Losing an unrecognised failure would be far worse than printing an ugly
+    /// one, so every shape this function cannot improve on is passed through.
+    #[test]
+    fn anything_it_cannot_improve_on_survives_verbatim() {
+        for raw in [
+            // Not JSON at all, but starts with a brace.
+            "{not json",
+            // JSON, but nothing to pull out.
+            r#"{"status":500}"#,
+            // A message that is present and empty is not an improvement.
+            r#"{"error":{"message":"   "}}"#,
+            // A JSON array is not an envelope.
+            r#"["a"]"#,
+            "",
+        ] {
+            assert_eq!(unwrap_json_error(raw), raw, "mangled: {raw}");
+        }
+    }
 
     fn availability(kind: CodingAgentKind, auth: AuthState) -> AgentAvailability {
         AgentAvailability {

--- a/crates/biorouter/tests/agent.rs
+++ b/crates/biorouter/tests/agent.rs
@@ -600,6 +600,7 @@ mod tests {
                     Ok(AgentEvent::ToolCallPending(_)) => {}
                     Ok(AgentEvent::MessagesPersisted(_)) => {}
                     Ok(AgentEvent::ModelChange { .. }) => {}
+                    Ok(AgentEvent::PrivacyProviderPinned { .. }) => {}
                     Ok(AgentEvent::HistoryReplaced(_updated_conversation)) => {
                         // We should update the conversation here, but we're not reading it
                     }
@@ -790,6 +791,7 @@ mod tests {
                     Ok(AgentEvent::ToolCallPending(_)) => {}
                     Ok(AgentEvent::MessagesPersisted(_)) => {}
                     Ok(AgentEvent::ModelChange { .. }) => {}
+                    Ok(AgentEvent::PrivacyProviderPinned { .. }) => {}
                     Ok(AgentEvent::HistoryReplaced(_)) => {}
                     Ok(AgentEvent::TokenUsage(_)) => {}
                     Ok(AgentEvent::TurnAborted { code, message }) => {
@@ -932,6 +934,7 @@ mod tests {
                     | AgentEvent::ToolCallPending(_)
                     | AgentEvent::MessagesPersisted(_)
                     | AgentEvent::ModelChange { .. }
+                    | AgentEvent::PrivacyProviderPinned { .. }
                     | AgentEvent::HistoryReplaced(_) => {}
                     AgentEvent::TurnAborted { code, message } => {
                         return Err(anyhow::anyhow!(

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -9914,6 +9914,29 @@
           },
           {
             "type": "object",
+            "description": "Issue #56 Gate B, repair arm: the provider and model that actually\nserved this turn, sent when the agent had to fall back to the one the\nSESSION ROW names because the chat's classification does not admit the\nbound one.\n\nAdvisory display state, exactly like `ToolCallPending`: never persisted,\nnever replayed, never shown to the model, and it changes nothing about\nwhat the privacy gates permit or refuse. Its whole job is that a user who\nswitched the app to a public model and then sent into a private chat can\nsee that the turn went elsewhere — and that the composer's model chip and\ncontext gauge can be sized to the window that was really used.\n\n⚠ It does NOT carry the selection it displaced, so a client must not\ntreat receiving it as \"the user's choice was overridden\". The frame\narrives on every repaired bind, including the ordinary ones (a\nrehydrated agent, a legacy row) where it names exactly what the client is\nalready showing. Compare it against what you display, and say nothing\nwhen they agree.",
+            "required": [
+              "provider",
+              "model",
+              "type"
+            ],
+            "properties": {
+              "model": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "PrivacyProviderPinned"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "type"
             ],

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -2145,6 +2145,10 @@ export type MessageEvent = {
     messages: Array<PersistedMessage>;
     type: 'MessagesPersisted';
 } | {
+    model: string;
+    provider: string;
+    type: 'PrivacyProviderPinned';
+} | {
     type: 'Ping';
 };
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -42,6 +42,7 @@ import { WorkflowHeader } from './WorkflowHeader';
 import { WorkflowWarningModal } from './ui/WorkflowWarningModal';
 import { NonPrivateModelDisclosureGate } from './privacy/NonPrivateModelDisclosureGate';
 import { PinnedModelNote } from './privacy/PinnedModelNote';
+import { chatBinding } from './privacy/pinnedModel';
 import { scanWorkflow } from '../workflow';
 import { useCostTracking } from '../hooks/useCostTracking';
 import { useDiverge } from '../hooks/useDiverge';
@@ -2030,6 +2031,18 @@ function BaseChatContent({
     return () => animation.cancel();
   }, [isCleanConversation]);
 
+  /**
+   * Issue #56 / F2 — what THIS chat runs on, which is not what the app-wide
+   * selection says. `restore_provider_from_session` binds the session row's own
+   * provider, so the composer's model chip and context gauge were naming a
+   * model that never served the turn and sizing the gauge to its window.
+   *
+   * Free: both facts already ride the `/agent/resume` payload the chat stream
+   * holds. A turn that repaired its own binding outranks the row — see
+   * `privacy/pinnedModel.ts`.
+   */
+  const effectiveModel = chatBinding(session, pinnedModel);
+
   const renderChatInput = () => (
     <div
       ref={composerMotionRef}
@@ -2100,10 +2113,14 @@ function BaseChatContent({
         Mounted unconditionally — it renders nothing when there is nothing to
         say, which is almost always.
       */}
-      <PinnedModelNote pinnedModel={pinnedModel} className="mx-3 mb-2" />
+      <PinnedModelNote
+        binding={effectiveModel}
+        chatTier={session?.privacy_tier}
+        className="mx-3 mb-2"
+      />
       <ChatInput
         sessionId={sessionId}
-        pinnedModel={pinnedModel}
+        effectiveModel={effectiveModel}
         handleSubmit={handleFormSubmit}
         chatState={chatState}
         setChatState={setChatState}

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -42,7 +42,7 @@ import { WorkflowHeader } from './WorkflowHeader';
 import { WorkflowWarningModal } from './ui/WorkflowWarningModal';
 import { NonPrivateModelDisclosureGate } from './privacy/NonPrivateModelDisclosureGate';
 import { PinnedModelNote } from './privacy/PinnedModelNote';
-import { chatBinding } from './privacy/pinnedModel';
+import { usePinnedModel } from './privacy/usePinnedModel';
 import { scanWorkflow } from '../workflow';
 import { useCostTracking } from '../hooks/useCostTracking';
 import { useDiverge } from '../hooks/useDiverge';
@@ -2032,16 +2032,16 @@ function BaseChatContent({
   }, [isCleanConversation]);
 
   /**
-   * Issue #56 / F2 — what THIS chat runs on, which is not what the app-wide
-   * selection says. `restore_provider_from_session` binds the session row's own
-   * provider, so the composer's model chip and context gauge were naming a
-   * model that never served the turn and sizing the gauge to its window.
+   * Issue #56 / F2 — what THIS chat runs on, when the app-wide selection
+   * provably cannot. `restore_provider_from_session` binds the session row's own
+   * provider, so the composer's model chip and context gauge were naming a model
+   * that never served the turn and sizing the gauge to its window.
    *
    * Free: both facts already ride the `/agent/resume` payload the chat stream
-   * holds. A turn that repaired its own binding outranks the row — see
-   * `privacy/pinnedModel.ts`.
+   * holds. See `privacy/usePinnedModel.ts` for the one rule, and for why the
+   * override is gated rather than unconditional.
    */
-  const effectiveModel = chatBinding(session, pinnedModel);
+  const { effectiveModel } = usePinnedModel(session, pinnedModel);
 
   const renderChatInput = () => (
     <div
@@ -2113,11 +2113,7 @@ function BaseChatContent({
         Mounted unconditionally — it renders nothing when there is nothing to
         say, which is almost always.
       */}
-      <PinnedModelNote
-        binding={effectiveModel}
-        chatTier={session?.privacy_tier}
-        className="mx-3 mb-2"
-      />
+      <PinnedModelNote session={session} reportedByTurn={pinnedModel} className="mx-3 mb-2" />
       <ChatInput
         sessionId={sessionId}
         effectiveModel={effectiveModel}

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -41,6 +41,7 @@ import { useNavigation } from '../hooks/useNavigation';
 import { WorkflowHeader } from './WorkflowHeader';
 import { WorkflowWarningModal } from './ui/WorkflowWarningModal';
 import { NonPrivateModelDisclosureGate } from './privacy/NonPrivateModelDisclosureGate';
+import { PinnedModelNote } from './privacy/PinnedModelNote';
 import { scanWorkflow } from '../workflow';
 import { useCostTracking } from '../hooks/useCostTracking';
 import { useDiverge } from '../hooks/useDiverge';
@@ -1394,6 +1395,7 @@ function BaseChatContent({
     agentReady,
     notifications: toolCallNotifications,
     pendingToolCalls,
+    pinnedModel,
     onMessageUpdate,
   } = useChatStream({
     sessionId,
@@ -2084,8 +2086,24 @@ function BaseChatContent({
           </div>
         </div>
       )}
+      {/*
+        Issue #56 Gate B. Above the composer, on the composer's own rails, in
+        the same slot the Stop-and-send banner already uses — so it sits with
+        the control it is about rather than in the transcript, where it would
+        scroll away from the chip and gauge it explains.
+
+        ⚠ NOT inside `ChatInput`: that component's three rows (context · card ·
+        controls) are one visually grouped object held together by a 6px gap,
+        and a fourth block inside it would join the group and read as more
+        chrome on the input. `mb-2` puts this outside that grouping.
+
+        Mounted unconditionally — it renders nothing when there is nothing to
+        say, which is almost always.
+      */}
+      <PinnedModelNote pinnedModel={pinnedModel} className="mx-3 mb-2" />
       <ChatInput
         sessionId={sessionId}
+        pinnedModel={pinnedModel}
         handleSubmit={handleFormSubmit}
         chatState={chatState}
         setChatState={setChatState}

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -43,7 +43,7 @@ import { getPredefinedModelsFromEnv } from './settings/models/predefinedModelsUt
 import { getNavigationShortcutText, getSteerShortcutText } from '../utils/keyboardShortcuts';
 import type { UserAttachment } from '../types/message';
 import { useStopAcknowledgement } from '../hooks/useStopAcknowledgement';
-import { isRunningState } from '../hooks/chatStreamStore';
+import { isRunningState, type PinnedModelView } from '../hooks/chatStreamStore';
 import { toastWarning } from '../toasts';
 import { cn } from '../utils';
 import {
@@ -269,6 +269,18 @@ interface ModelLimit {
 interface ChatInputProps {
   sessionId: string | null;
   /**
+   * Issue #56 Gate B — the binding the privacy barrier pinned THIS chat to,
+   * when a turn had to fall back to it.
+   *
+   * ⚠ It is the composer's model chip and context gauge that this fixes, and
+   * they are the reason it is a prop rather than something the note alone
+   * carries: both used to state the app's GLOBAL selection, so a private chat
+   * running on Versa showed `claude-opus-5` and measured its usage against
+   * Claude's 1M window. Preferring this binding is a no-op whenever it names
+   * what was already selected, which is the common case.
+   */
+  pinnedModel?: PinnedModelView;
+  /**
    * Send the composed message. Resolving FALSE means the submit was REFUSED
    * silently and the composer still owns the text (see
    * `ChatStreamController.handleSubmit`); the composer must then put the text
@@ -337,6 +349,7 @@ interface ChatInputProps {
 
 export default function ChatInput({
   sessionId,
+  pinnedModel,
   handleSubmit,
   chatState = ChatState.Idle,
   setChatState,
@@ -1075,10 +1088,25 @@ export default function ChatInput({
       setIsTokenLimitLoaded(false);
 
       // Get current model and provider first to avoid unnecessary provider fetches
-      const { model, provider } = await getCurrentModelAndProvider();
+      //
+      // Issue #56 Gate B: THIS CHAT's binding wins over the app's global
+      // selection. A private chat pinned to Versa was measuring its usage
+      // against whatever public model the app happened to be pointed at —
+      // measured at "969.9k of 1M" for a turn that ran on a different model
+      // entirely. When nothing is pinned, or the pin names what is already
+      // selected, this resolves to exactly what it always did.
+      const selected = await getCurrentModelAndProvider();
+      const model = pinnedModel?.model ?? selected.model;
+      const provider = pinnedModel?.provider ?? selected.provider;
       if (!model || !provider) {
-        console.log('No model or provider found');
-        setIsTokenLimitLoaded(true);
+        // No model is bound, so there is no context window to report. Leaving
+        // the 128k default in place while announcing it as LOADED is what made
+        // the onboarding gauge read "128k of 128k tokens remaining" beside a
+        // chip correctly saying no model was chosen — a precise figure for a
+        // model that does not exist. Zero is what the gauge renders its empty
+        // state from.
+        setTokenLimit(0);
+        setIsTokenLimitLoaded(false);
         return;
       }
 
@@ -1144,11 +1172,12 @@ export default function ChatInput({
     }
   };
 
-  // Initial load and refresh when model changes
+  // Initial load and refresh when model changes — including when a turn reports
+  // that this chat is pinned to a different one (issue #56 Gate B).
   useEffect(() => {
     loadProviderDetails();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentModel, currentProvider]);
+  }, [currentModel, currentProvider, pinnedModel?.provider, pinnedModel?.model]);
 
   // Handle tool count alerts and token usage
   useEffect(() => {
@@ -2293,6 +2322,7 @@ export default function ChatInput({
     <div className="min-w-0">
       <ModelsBottomBar
         sessionId={sessionId}
+        pinnedModel={pinnedModel}
         privacyTier={sessionPrivacyTier}
         dropdownRef={dropdownRef}
         setView={setView}

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -269,17 +269,18 @@ interface ModelLimit {
 interface ChatInputProps {
   sessionId: string | null;
   /**
-   * Issue #56 Gate B — the binding the privacy barrier pinned THIS chat to,
-   * when a turn had to fall back to it.
+   * Issue #56 / F2 — what THIS chat actually runs on (`BaseChat.chatBinding`):
+   * the session row's own provider and model, or the one a turn reported when
+   * the privacy barrier had to repair the binding mid-turn.
    *
-   * ⚠ It is the composer's model chip and context gauge that this fixes, and
-   * they are the reason it is a prop rather than something the note alone
-   * carries: both used to state the app's GLOBAL selection, so a private chat
-   * running on Versa showed `claude-opus-5` and measured its usage against
-   * Claude's 1M window. Preferring this binding is a no-op whenever it names
-   * what was already selected, which is the common case.
+   * ⚠ It is the composer's model chip and context gauge that this fixes. Both
+   * stated the app's GLOBAL selection, while `restore_provider_from_session`
+   * binds the row's — so a private chat running on Versa showed
+   * `claude-opus-5` and measured its usage against Claude's 1M window instead
+   * of the 400k one really in play. Preferring this binding is a no-op whenever
+   * it names what was already selected, which is the common case.
    */
-  pinnedModel?: PinnedModelView;
+  effectiveModel?: PinnedModelView;
   /**
    * Send the composed message. Resolving FALSE means the submit was REFUSED
    * silently and the composer still owns the text (see
@@ -349,7 +350,7 @@ interface ChatInputProps {
 
 export default function ChatInput({
   sessionId,
-  pinnedModel,
+  effectiveModel,
   handleSubmit,
   chatState = ChatState.Idle,
   setChatState,
@@ -1096,8 +1097,8 @@ export default function ChatInput({
       // entirely. When nothing is pinned, or the pin names what is already
       // selected, this resolves to exactly what it always did.
       const selected = await getCurrentModelAndProvider();
-      const model = pinnedModel?.model ?? selected.model;
-      const provider = pinnedModel?.provider ?? selected.provider;
+      const model = effectiveModel?.model ?? selected.model;
+      const provider = effectiveModel?.provider ?? selected.provider;
       if (!model || !provider) {
         // No model is bound, so there is no context window to report. Leaving
         // the 128k default in place while announcing it as LOADED is what made
@@ -1177,7 +1178,7 @@ export default function ChatInput({
   useEffect(() => {
     loadProviderDetails();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentModel, currentProvider, pinnedModel?.provider, pinnedModel?.model]);
+  }, [currentModel, currentProvider, effectiveModel?.provider, effectiveModel?.model]);
 
   // Handle tool count alerts and token usage
   useEffect(() => {
@@ -2322,7 +2323,7 @@ export default function ChatInput({
     <div className="min-w-0">
       <ModelsBottomBar
         sessionId={sessionId}
-        pinnedModel={pinnedModel}
+        effectiveModel={effectiveModel}
         privacyTier={sessionPrivacyTier}
         dropdownRef={dropdownRef}
         setView={setView}

--- a/ui/desktop/src/components/ContextWindowIndicator.test.tsx
+++ b/ui/desktop/src/components/ContextWindowIndicator.test.tsx
@@ -120,3 +120,71 @@ describe('ContextWindowGauge compaction control', () => {
     expect(usageLine).toHaveTextContent('100% remaining, 0% used');
   });
 });
+
+/**
+ * F10. A context window is a property of a bound model; with no model there is
+ * no window, and every figure this component could print would be about a model
+ * that does not exist. Measured in onboarding: the composer's chip correctly
+ * read "No model yet — choose a provider" while the gauge beside it read
+ * "Context window usage. 128k of 128k tokens remaining".
+ */
+describe('with no model bound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.read.mockResolvedValue(null);
+    mocks.upsert.mockResolvedValue(undefined);
+  });
+
+  it('renders nothing rather than a window for a model that does not exist', () => {
+    const { container } = render(
+      <ContextWindowIndicator
+        totalTokens={0}
+        tokenLimit={0}
+        isTokenLimitLoaded
+        onCompact={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/tokens remaining/)).toBeNull();
+  });
+
+  it('renders nothing in the popover-body gauge either', () => {
+    const { container } = render(
+      <ContextWindowGauge totalTokens={0} tokenLimit={0} isTokenLimitLoaded onCompact={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  /**
+   * The guard is on the LIMIT, not only on the loaded flag: a lookup that
+   * finished and found nothing is exactly the case, and usage without a window
+   * is a pair nothing can render honestly either.
+   */
+  it('stays hidden even when tokens have been counted', () => {
+    const { container } = render(
+      <ContextWindowIndicator
+        totalTokens={1766}
+        tokenLimit={0}
+        isTokenLimitLoaded
+        onCompact={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('still renders once a real window is known', () => {
+    render(
+      <ContextWindowIndicator
+        totalTokens={0}
+        tokenLimit={128_000}
+        isTokenLimitLoaded
+        onCompact={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', {
+        name: 'Context window usage. 128k of 128k tokens remaining. 100% remaining, 0% used',
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/desktop/src/components/ContextWindowIndicator.tsx
+++ b/ui/desktop/src/components/ContextWindowIndicator.tsx
@@ -176,7 +176,20 @@ export const ContextWindowGauge: React.FC<ContextWindowGaugeProps> = ({
   }, [handleDragMove, handleDragEnd]);
 
   if (!isTokenLimitLoaded && !current) return null;
-  const ratio = total > 0 ? Math.min(1, current / total) : 0;
+  // NO MODEL, NO GAUGE. A context window is a property of a bound model, so
+  // with none there is no number to report and every number this component
+  // could print would be about a model that does not exist. It read
+  // "128k of 128k tokens remaining" during onboarding — beside a chip that
+  // correctly said "No model yet — choose a provider" — because the composer's
+  // 128k fallback was announced as a loaded limit.
+  //
+  // Asserted on the LIMIT rather than only on the loaded flag: the flag says
+  // whether a lookup finished, and a finished lookup that found nothing is
+  // exactly the case being guarded. A caller with usage but no window is a
+  // state nothing can render honestly either, so it is covered by the same
+  // test.
+  if (total <= 0) return null;
+  const ratio = Math.min(1, current / total);
   const pct = Math.round(ratio * 100);
   const overThreshold = pct >= thresholdPct;
   // Three bands, not four: the old ladder spelled `warning` twice (`ratio <= 0.75`
@@ -343,10 +356,23 @@ export const ContextWindowIndicator: React.FC<ContextWindowIndicatorProps> = ({
   const current = totalTokens ?? 0;
   if (!isTokenLimitLoaded && !current) return null;
   const total = tokenLimit || 0;
-  const ratio = total > 0 ? Math.min(1, current / total) : 0;
+  // NO MODEL, NO GAUGE. A context window is a property of a bound model, so
+  // with none there is no number to report and every number this component
+  // could print would be about a model that does not exist. It read
+  // "128k of 128k tokens remaining" during onboarding — beside a chip that
+  // correctly said "No model yet — choose a provider" — because the composer's
+  // 128k fallback was announced as a loaded limit.
+  //
+  // Asserted on the LIMIT rather than only on the loaded flag: the flag says
+  // whether a lookup finished, and a finished lookup that found nothing is
+  // exactly the case being guarded. A caller with usage but no window is a
+  // state nothing can render honestly either, so it is covered by the same
+  // test.
+  if (total <= 0) return null;
+  const ratio = Math.min(1, current / total);
   const pct = Math.round(ratio * 100);
-  const remainingTokens = total > 0 ? Math.max(total - current, 0) : 0;
-  const remainingRatio = total > 0 ? Math.max(0, Math.min(1, remainingTokens / total)) : 0;
+  const remainingTokens = Math.max(total - current, 0);
+  const remainingRatio = Math.max(0, Math.min(1, remainingTokens / total));
   const remainingPct = Math.round(remainingRatio * 100);
   const radius = 8;
   const circumference = 2 * Math.PI * radius;

--- a/ui/desktop/src/components/knowledge/KnowledgeContext.tsx
+++ b/ui/desktop/src/components/knowledge/KnowledgeContext.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react';
 import { listBases, getActive, setActive } from '../../api';
+import { briefSelectionFailure } from './selectionWarning';
 import { userActionHeaders } from '../../utils/userAction';
 /**
  * `KbListEntry` is `Manifest & { tier }` — the manifest the daemon stores plus
@@ -194,7 +195,10 @@ export function KnowledgeProvider({
       } catch (err) {
         // Both the write and the recovery read failed. Keep what is on screen —
         // there is nothing better to show, and the next hydrate will settle it.
-        console.warn('getActive (recovering a failed selection write) failed:', err);
+        console.warn(
+          'Knowledge selection not re-read after a failed write:',
+          briefSelectionFailure(err)
+        );
       }
     },
     [applyHidden, applyPrimary, sessionId]
@@ -324,7 +328,7 @@ export function KnowledgeProvider({
     } catch (err) {
       // Keep the last known default: a failed read is not evidence that there
       // is none, and inventing one would offer a base nobody chose.
-      console.warn('getActive (machine-wide default) failed:', err);
+      console.warn('Machine-wide knowledge default not read:', briefSelectionFailure(err));
     }
   }, [sessionId]);
 
@@ -458,7 +462,13 @@ export function KnowledgeProvider({
         applyHidden(readHidden(res.data) ?? []);
       } catch (err) {
         if (cancelled) return;
-        console.warn('getActive (server hydrate) failed:', err);
+        // ⚠ One quiet line, deliberately. A private chat opened while a
+        // public model is bound refuses this read with a ~900-character
+        // paragraph addressed to an AI agent, and printing it here made a
+        // correct outcome — the chat opened and rendered in full — look like a
+        // crash. The person's answer is the composer's pinned-model note; see
+        // `selectionWarning.ts` for the full reasoning.
+        console.warn('Knowledge selection not hydrated:', briefSelectionFailure(err));
         setPrimaryKbIdState(local);
         setHiddenKbIdsState(localHidden);
       }

--- a/ui/desktop/src/components/knowledge/selectionWarning.test.ts
+++ b/ui/desktop/src/components/knowledge/selectionWarning.test.ts
@@ -49,10 +49,29 @@ describe('briefSelectionFailure', () => {
     expect(brief.endsWith('…')).toBe(true);
   });
 
+  /**
+   * ⚠ Measured in the running app: this route's body is `text/plain`, so the
+   * generated client throws a bare STRING. Routing that through
+   * `conversionUtils.errorMessage(err, 'unknown error')` returns the DEFAULT
+   * for a string, which printed `Knowledge selection not hydrated: unknown
+   * error` and threw away the only fact the line carries.
+   */
+  it('reads a bare string body, which is what this route actually throws', () => {
+    expect(briefSelectionFailure(AGENT_REFUSAL)).toBe(
+      'That chat is private, or there is no chat with that id.'
+    );
+  });
+
+  it('reads the JSON shapes the other routes throw', () => {
+    expect(briefSelectionFailure({ error: 'no such base' })).toBe('no such base');
+    expect(briefSelectionFailure({ error: { message: 'no such base' } })).toBe('no such base');
+    expect(briefSelectionFailure({ detail: 'no such base' })).toBe('no such base');
+  });
+
   it('never returns an empty line, whatever it is handed', () => {
     expect(briefSelectionFailure(undefined)).toBe('unknown error');
     expect(briefSelectionFailure(new Error(''))).toBe('unknown error');
-    // An object with no `message` is not a shape this can improve on either.
+    // An object with no text anywhere is not a shape this can improve on.
     expect(briefSelectionFailure({})).toBe('unknown error');
     expect(briefSelectionFailure('   ')).toBe('unknown error');
   });

--- a/ui/desktop/src/components/knowledge/selectionWarning.test.ts
+++ b/ui/desktop/src/components/knowledge/selectionWarning.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { briefSelectionFailure } from './selectionWarning';
+
+/**
+ * F14. Opening a private chat while a public model is bound refuses
+ * `GET /knowledge/active` with a paragraph addressed to an AI agent. The
+ * refusal is correct and stays exactly as it is; what was wrong is that it was
+ * printed in full in the devtools console of a desktop app, where the chat had
+ * opened and rendered correctly and the only reader is a person.
+ */
+const AGENT_REFUSAL =
+  'That chat is private, or there is no chat with that id. This request was made on a public ' +
+  'model and carried no proof it came from the person at the keyboard, and the two answers are ' +
+  'deliberately the same so that nothing about the chat is disclosed. Nothing was read and ' +
+  'nothing was changed. Do not retry as you are; the same call will be refused again, and no ' +
+  'setting, hook or permission mode changes it. A private chat is reachable from a session ' +
+  'running a private model, one the institution hosts or one that runs on this machine, or ' +
+  'from the desktop app when the person at the keyboard acts. Pointing a program that already ' +
+  'runs under such a model at this daemon is a setup decision for whoever operates it, and the ' +
+  'Biorouter documentation covers it under ‘Reaching a private chat from a script’. If ' +
+  'this task genuinely needs that chat, stop and ask the user to open it for you.';
+
+describe('briefSelectionFailure', () => {
+  it('keeps the first sentence of the agent-facing refusal and drops the rest', () => {
+    const brief = briefSelectionFailure(new Error(AGENT_REFUSAL));
+    expect(brief).toBe('That chat is private, or there is no chat with that id.');
+    // The instructions are the part that reads as a crash to a person, and the
+    // part that is addressed to somebody who is not there.
+    expect(brief).not.toContain('Do not retry as you are');
+    expect(brief).not.toContain('ask the user to open it for you');
+    expect(brief.length).toBeLessThan(AGENT_REFUSAL.length / 4);
+  });
+
+  /**
+   * Trimming to the first SENTENCE rather than to a fixed prefix is what keeps
+   * this useful for the failures that are not the refusal.
+   */
+  it('leaves a short real failure intact', () => {
+    expect(briefSelectionFailure(new TypeError('Failed to fetch'))).toBe('Failed to fetch');
+    expect(briefSelectionFailure({ message: 'Internal Server Error' })).toBe(
+      'Internal Server Error'
+    );
+  });
+
+  it('caps a first sentence that is itself a paragraph', () => {
+    const long = `${'x'.repeat(400)}. and then some`;
+    const brief = briefSelectionFailure(new Error(long));
+    expect(brief).toHaveLength(160);
+    expect(brief.endsWith('…')).toBe(true);
+  });
+
+  it('never returns an empty line, whatever it is handed', () => {
+    expect(briefSelectionFailure(undefined)).toBe('unknown error');
+    expect(briefSelectionFailure(new Error(''))).toBe('unknown error');
+    // An object with no `message` is not a shape this can improve on either.
+    expect(briefSelectionFailure({})).toBe('unknown error');
+    expect(briefSelectionFailure('   ')).toBe('unknown error');
+  });
+
+  it('collapses newlines so one warning stays one line', () => {
+    expect(briefSelectionFailure(new Error('refused\n\n  because of reasons'))).toBe(
+      'refused because of reasons'
+    );
+  });
+});

--- a/ui/desktop/src/components/knowledge/selectionWarning.ts
+++ b/ui/desktop/src/components/knowledge/selectionWarning.ts
@@ -1,5 +1,3 @@
-import { errorMessage } from '../../utils/conversionUtils';
-
 /**
  * How long a console warning is allowed to be before it stops being a warning.
  *
@@ -35,11 +33,43 @@ const MAX_REASON_CHARS = 160;
  * a 500 both survive intact.
  */
 export function briefSelectionFailure(err: unknown): string {
-  const raw = errorMessage(err, 'unknown error').trim().replace(/\s+/g, ' ');
+  const raw = rawText(err).trim().replace(/\s+/g, ' ');
   if (!raw) return 'unknown error';
   // The first sentence, keeping its full stop. `. ` rather than `.` so a
   // version number or a file name is not mistaken for the end of one.
   const stop = raw.indexOf('. ');
   const first = stop === -1 ? raw : raw.slice(0, stop + 1);
   return first.length > MAX_REASON_CHARS ? `${first.slice(0, MAX_REASON_CHARS - 1)}…` : first;
+}
+
+/**
+ * Whatever text the thrown value carries.
+ *
+ * ⚠ **Not `utils/conversionUtils.errorMessage`, and the difference was measured
+ * in the running app.** The generated API client with `throwOnError` throws the
+ * *response body*, and this route's body is `text/plain` — so the thrown value
+ * is a bare STRING. `errorMessage(err, 'unknown error')` reaches its last arm
+ * for a string and returns the DEFAULT rather than the string, so routing
+ * through it printed `Knowledge selection not hydrated: unknown error` and
+ * threw away the one fact the line existed to carry. Quieting a warning is not
+ * the same as emptying it.
+ *
+ * The object arms cover the JSON routes and a thrown `Error`; anything with no
+ * text at all falls through to the caller's placeholder.
+ */
+function rawText(err: unknown): string {
+  if (typeof err === 'string') return err;
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'object' && err !== null) {
+    const record = err as Record<string, unknown>;
+    for (const key of ['message', 'error', 'detail']) {
+      const value = record[key];
+      if (typeof value === 'string' && value.trim()) return value;
+      if (typeof value === 'object' && value !== null) {
+        const nested = (value as Record<string, unknown>).message;
+        if (typeof nested === 'string' && nested.trim()) return nested;
+      }
+    }
+  }
+  return '';
 }

--- a/ui/desktop/src/components/knowledge/selectionWarning.ts
+++ b/ui/desktop/src/components/knowledge/selectionWarning.ts
@@ -1,0 +1,45 @@
+import { errorMessage } from '../../utils/conversionUtils';
+
+/**
+ * How long a console warning is allowed to be before it stops being a warning.
+ *
+ * Chosen to fit the first sentence of the refusals this actually sees, and to
+ * be visibly shorter than the paragraph it replaced.
+ */
+const MAX_REASON_CHARS = 160;
+
+/**
+ * A failed knowledge-selection read, reduced to one line for the console.
+ *
+ * ⚠ **The paragraph this trims is deliberate, correct, and written for somebody
+ * else.** Opening a private chat while a public model is bound refuses
+ * `GET /knowledge/active` with ~900 characters addressed to an AI AGENT — "Do
+ * not retry as you are… If this task genuinely needs that chat, stop and ask
+ * the user to open it for you." That text is privacy-critical, pinned by
+ * repo-grep tests in `crates/biorouter-server/src/routes/session_reach.rs`, and
+ * nothing here changes it or should.
+ *
+ * What was wrong is where it landed: in the devtools console of a **desktop**
+ * app, where the chat had opened correctly and rendered in full, and where the
+ * only reader is a person who has no task, is not an agent, and cannot open the
+ * chat "for" anybody. A normal, correct outcome printed as a wall of red-flag
+ * prose reads as a crash.
+ *
+ * So the console keeps a one-line record — the read did not settle, and which
+ * one — and the user-facing answer lives where a person will actually see it:
+ * the composer's own note about the model this chat is pinned to
+ * (`privacy/PinnedModelNote`).
+ *
+ * Trimming to the first sentence rather than to a fixed prefix is what keeps
+ * this useful for the failures that are NOT the refusal: "Failed to fetch" and
+ * a 500 both survive intact.
+ */
+export function briefSelectionFailure(err: unknown): string {
+  const raw = errorMessage(err, 'unknown error').trim().replace(/\s+/g, ' ');
+  if (!raw) return 'unknown error';
+  // The first sentence, keeping its full stop. `. ` rather than `.` so a
+  // version number or a file name is not mistaken for the end of one.
+  const stop = raw.indexOf('. ');
+  const first = stop === -1 ? raw : raw.slice(0, stop + 1);
+  return first.length > MAX_REASON_CHARS ? `${first.slice(0, MAX_REASON_CHARS - 1)}…` : first;
+}

--- a/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
+++ b/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PinnedModelNote } from './PinnedModelNote';
+import { usePinnedModel } from './usePinnedModel';
 import {
   bindingDiffersFromSelection,
   bindingLabel,
@@ -40,6 +41,15 @@ const CATALOG = [
 
 const BINDING = { provider: 'versa_azure', model: 'gpt-5.2-2025-12-11' };
 
+/** A row bound to `BINDING`, with the classification under test. */
+const chat = (privacy_tier: 'private' | 'public'): Session =>
+  ({
+    id: '20260610_28',
+    privacy_tier,
+    provider_name: BINDING.provider,
+    model_config: { model_name: BINDING.model },
+  }) as Session;
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getProviders.mockResolvedValue(CATALOG);
@@ -56,7 +66,7 @@ beforeEach(() => {
  */
 describe('PinnedModelNote', () => {
   it('names both bindings by their display names, not their ids', async () => {
-    render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    render(<PinnedModelNote session={chat('private')} />);
 
     const note = await screen.findByTestId('pinned-model-note');
     await waitFor(() =>
@@ -75,12 +85,14 @@ describe('PinnedModelNote', () => {
   it('says nothing when the chat already runs on the selected model', () => {
     mocks.currentProvider = 'versa_azure';
     mocks.currentModel = 'gpt-5.2-2025-12-11';
-    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    const { container } = render(<PinnedModelNote session={chat('private')} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it('says nothing about a chat with no binding of its own', () => {
-    const { container } = render(<PinnedModelNote binding={undefined} chatTier="private" />);
+    const { container } = render(
+      <PinnedModelNote session={{ ...chat('private'), provider_name: null } as Session} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -90,9 +102,11 @@ describe('PinnedModelNote', () => {
    * private, so…" would name a cause that does not exist.
    */
   it('says nothing about a public chat that merely differs', async () => {
-    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="public" />);
-    await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
-    expect(container).toBeEmptyDOMElement();
+    const { container } = render(<PinnedModelNote session={chat('public')} />);
+    // …and reads no catalog to decide it: only a private chat can ever refuse
+    // the selection, so a public one costs nothing.
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    expect(mocks.getProviders).not.toHaveBeenCalled();
   });
 
   /**
@@ -103,7 +117,7 @@ describe('PinnedModelNote', () => {
     mocks.currentProvider = 'ollama';
     mocks.currentModel = 'qwen3.6';
     mocks.getProviders.mockResolvedValue([...CATALOG, providerRow('ollama', 'Ollama', 'private')]);
-    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    const { container } = render(<PinnedModelNote session={chat('private')} />);
     await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
   });
@@ -116,7 +130,7 @@ describe('PinnedModelNote', () => {
   it('says nothing while the selection is still unresolved', () => {
     mocks.currentProvider = null;
     mocks.currentModel = null;
-    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    const { container } = render(<PinnedModelNote session={chat('private')} />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -126,7 +140,7 @@ describe('PinnedModelNote', () => {
    */
   it('says nothing when the catalog cannot be read', async () => {
     mocks.getProviders.mockRejectedValue(new Error('offline'));
-    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    const { container } = render(<PinnedModelNote session={chat('private')} />);
     await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
   });
@@ -140,7 +154,7 @@ describe('PinnedModelNote', () => {
       { name: 'versa_azure', metadata: { tier: 'private' }, resolved_tier: 'private' },
       { name: 'claude_code', metadata: { tier: 'public' }, resolved_tier: 'public' },
     ]);
-    render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    render(<PinnedModelNote session={chat('private')} />);
     const note = await screen.findByTestId('pinned-model-note');
     expect(note).toHaveTextContent(
       'This chat is marked private, so it stays on gpt-5.2-2025-12-11. ' +
@@ -149,12 +163,51 @@ describe('PinnedModelNote', () => {
   });
 
   it('is a neutral note, not a warning: nothing has gone wrong', async () => {
-    render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    render(<PinnedModelNote session={chat('private')} />);
     const note = await screen.findByTestId('pinned-model-note');
     expect(note).toHaveAttribute('role', 'status');
     expect(note.className).toContain('bg-background-muted');
     expect(note.className).not.toContain('wash-warning');
     expect(note.className).not.toContain('wash-danger');
+  });
+});
+
+/**
+ * ⚠ The regression this gate exists to prevent, and it is not hypothetical:
+ * `ModelAndProviderContext.changeModel` writes BOTH the session row and the
+ * global default, so right after a per-chat model switch the daemon has them in
+ * step while the client's cached `/agent/resume` copy of the row is the value
+ * from BEFORE the switch. A composer that preferred the row on every
+ * disagreement would answer the switch by showing the model the user had just
+ * switched away from.
+ */
+describe('what the chip and gauge are told to state', () => {
+  it('states the chat’s own binding when the selection is barred from it', async () => {
+    const { result } = renderHook(() => usePinnedModel(chat('private'), undefined));
+    await waitFor(() => expect(result.current.effectiveModel).toEqual(BINDING));
+  });
+
+  it('leaves the app-wide selection standing when it could run here', async () => {
+    // Both private: Gate A admits the selection, so the row may simply be this
+    // client's stale copy and the selection is the fresher fact.
+    mocks.currentProvider = 'ollama';
+    mocks.currentModel = 'qwen3.6';
+    mocks.getProviders.mockResolvedValue([...CATALOG, providerRow('ollama', 'Ollama', 'private')]);
+    const { result } = renderHook(() => usePinnedModel(chat('private'), undefined));
+    await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
+    expect(result.current.effectiveModel).toBeUndefined();
+  });
+
+  it('leaves a public chat entirely alone, and reads no catalog for it', async () => {
+    const { result } = renderHook(() => usePinnedModel(chat('public'), undefined));
+    await waitFor(() => expect(result.current.effectiveModel).toBeUndefined());
+    expect(mocks.getProviders).not.toHaveBeenCalled();
+  });
+
+  it('prefers what a turn reported over the row', async () => {
+    const reported = { provider: 'llamacpp', model: 'gemma4' };
+    const { result } = renderHook(() => usePinnedModel(chat('private'), reported));
+    await waitFor(() => expect(result.current.effectiveModel).toEqual(reported));
   });
 });
 

--- a/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
+++ b/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PinnedModelNote } from './PinnedModelNote';
+import { bindingLabel, pinContradictsSelection, pinnedModelNotice } from './pinnedModel';
+
+const mocks = vi.hoisted(() => ({
+  getProviders: vi.fn(),
+  currentModel: 'claude-opus-5' as string | null,
+  currentProvider: 'claude_code' as string | null,
+}));
+
+vi.mock('../ConfigContext', () => ({
+  useConfig: () => ({ getProviders: mocks.getProviders }),
+}));
+
+vi.mock('../ModelAndProviderContext', () => ({
+  useModelAndProvider: () => ({
+    currentModel: mocks.currentModel,
+    currentProvider: mocks.currentProvider,
+  }),
+}));
+
+const CATALOG = [
+  { name: 'versa_azure', metadata: { display_name: 'Versa API Azure' } },
+  { name: 'claude_code', metadata: { display_name: 'Claude Code' } },
+];
+
+const PINNED = { provider: 'versa_azure', model: 'gpt-5.5-2026-04-24' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getProviders.mockResolvedValue(CATALOG);
+  mocks.currentModel = 'claude-opus-5';
+  mocks.currentProvider = 'claude_code';
+});
+
+/**
+ * F2, the verbatim repro: Settings → Models → Claude Code / claude-opus-5, then
+ * send into a chat whose `privacy_tier` is `private`. The turn answers from
+ * Versa; before this note, nothing on screen said so.
+ */
+describe('PinnedModelNote', () => {
+  it('names both bindings by their display names, not their ids', async () => {
+    render(<PinnedModelNote pinnedModel={PINNED} />);
+
+    const note = await screen.findByTestId('pinned-model-note');
+    await waitFor(() =>
+      expect(note).toHaveTextContent(
+        'This chat is marked private, so it stays on Versa API Azure / gpt-5.5-2026-04-24. ' +
+          'Claude Code / claude-opus-5 is not used here.'
+      )
+    );
+    // `versa_azure` is not what that provider is called anywhere else in the
+    // app; leaking the registry id here would read as a bug in the one place
+    // the user is being told something new.
+    expect(note.textContent).not.toContain('versa_azure');
+    expect(note.textContent).not.toContain('claude_code');
+  });
+
+  /**
+   * The daemon sends the frame on EVERY repaired bind, including the ordinary
+   * ones (an LRU-rehydrated agent, a legacy row) where it names exactly what is
+   * already selected. A note there would be permanent and meaningless.
+   */
+  it('says nothing when the pin names what is already selected', () => {
+    mocks.currentProvider = 'versa_azure';
+    mocks.currentModel = 'gpt-5.5-2026-04-24';
+    const { container } = render(<PinnedModelNote pinnedModel={PINNED} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('says nothing when no turn has been pinned', () => {
+    const { container } = render(<PinnedModelNote pinnedModel={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  /**
+   * `currentProvider` / `currentModel` are `null` on the first render of every
+   * chat while the config loads. A note that flashed on and off there would be
+   * asserting something the component cannot yet know.
+   */
+  it('says nothing while the selection is still unresolved', () => {
+    mocks.currentProvider = null;
+    mocks.currentModel = null;
+    const { container } = render(<PinnedModelNote pinnedModel={PINNED} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  /**
+   * A catalog that cannot be read costs the display names and nothing else.
+   * Staying silent about the pin is the one outcome that reintroduces the
+   * defect, so the ids stand in.
+   */
+  it('falls back to ids rather than going quiet when the catalog fails', async () => {
+    mocks.getProviders.mockRejectedValue(new Error('offline'));
+    render(<PinnedModelNote pinnedModel={PINNED} />);
+
+    const note = await screen.findByTestId('pinned-model-note');
+    expect(note).toHaveTextContent(
+      'This chat is marked private, so it stays on gpt-5.5-2026-04-24. ' +
+        'claude-opus-5 is not used here.'
+    );
+  });
+
+  it('is a neutral note, not a warning: nothing has gone wrong', async () => {
+    render(<PinnedModelNote pinnedModel={PINNED} />);
+    const note = await screen.findByTestId('pinned-model-note');
+    expect(note).toHaveAttribute('role', 'status');
+    expect(note.className).toContain('bg-background-muted');
+    expect(note.className).not.toContain('wash-warning');
+    expect(note.className).not.toContain('wash-danger');
+  });
+});
+
+describe('the pure half', () => {
+  it('reports a contradiction only when both sides are known and differ', () => {
+    const selected = { provider: 'claude_code', model: 'claude-opus-5' };
+    expect(pinContradictsSelection(PINNED, selected)).toBe(true);
+    // Same provider, different model, and the reverse: both are contradictions.
+    expect(
+      pinContradictsSelection({ provider: 'claude_code', model: 'claude-sonnet-5' }, selected)
+    ).toBe(true);
+    expect(pinContradictsSelection({ ...selected }, selected)).toBe(false);
+    expect(pinContradictsSelection(undefined, selected)).toBe(false);
+    expect(pinContradictsSelection(PINNED, { provider: null, model: null })).toBe(false);
+    expect(pinContradictsSelection(PINNED, { provider: 'claude_code', model: null })).toBe(false);
+  });
+
+  it('drops the second clause when the selection cannot be named', () => {
+    expect(pinnedModelNotice('Versa API Azure / gpt-5.5')).toBe(
+      'This chat is marked private, so it stays on Versa API Azure / gpt-5.5.'
+    );
+  });
+
+  it('labels a binding by provider and model, or by model alone', () => {
+    expect(bindingLabel('Versa API Azure', 'gpt-5.5')).toBe('Versa API Azure / gpt-5.5');
+    expect(bindingLabel(undefined, 'gpt-5.5')).toBe('gpt-5.5');
+    expect(bindingLabel('   ', 'gpt-5.5')).toBe('gpt-5.5');
+  });
+});

--- a/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
+++ b/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PinnedModelNote } from './PinnedModelNote';
-import { bindingLabel, pinContradictsSelection, pinnedModelNotice } from './pinnedModel';
+import {
+  bindingDiffersFromSelection,
+  bindingLabel,
+  chatBinding,
+  pinnedModelNotice,
+  selectionBarredByPrivacy,
+} from './pinnedModel';
+import type { Session } from '../../api/types.gen';
 
 const mocks = vi.hoisted(() => ({
   getProviders: vi.fn(),
@@ -20,12 +27,18 @@ vi.mock('../ModelAndProviderContext', () => ({
   }),
 }));
 
+const providerRow = (name: string, display: string, tier: 'private' | 'public') => ({
+  name,
+  metadata: { display_name: display, tier },
+  resolved_tier: tier,
+});
+
 const CATALOG = [
-  { name: 'versa_azure', metadata: { display_name: 'Versa API Azure' } },
-  { name: 'claude_code', metadata: { display_name: 'Claude Code' } },
+  providerRow('versa_azure', 'Versa API Azure', 'private'),
+  providerRow('claude_code', 'Claude Code', 'public'),
 ];
 
-const PINNED = { provider: 'versa_azure', model: 'gpt-5.5-2026-04-24' };
+const BINDING = { provider: 'versa_azure', model: 'gpt-5.2-2025-12-11' };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -35,18 +48,20 @@ beforeEach(() => {
 });
 
 /**
- * F2, the verbatim repro: Settings → Models → Claude Code / claude-opus-5, then
- * send into a chat whose `privacy_tier` is `private`. The turn answers from
- * Versa; before this note, nothing on screen said so.
+ * F2, the verbatim repro (measured 2026-09-08): Settings → Models → Claude Code
+ * / claude-opus-5, open a chat whose `privacy_tier` is `private` and send. The
+ * turn answers from Versa — `restore_provider_from_session` binds the row's own
+ * provider — while the composer names claude-opus-5 and sizes its gauge to
+ * Claude's 1M window. Nothing on screen said so.
  */
 describe('PinnedModelNote', () => {
   it('names both bindings by their display names, not their ids', async () => {
-    render(<PinnedModelNote pinnedModel={PINNED} />);
+    render(<PinnedModelNote binding={BINDING} chatTier="private" />);
 
     const note = await screen.findByTestId('pinned-model-note');
     await waitFor(() =>
       expect(note).toHaveTextContent(
-        'This chat is marked private, so it stays on Versa API Azure / gpt-5.5-2026-04-24. ' +
+        'This chat is marked private, so it stays on Versa API Azure / gpt-5.2-2025-12-11. ' +
           'Claude Code / claude-opus-5 is not used here.'
       )
     );
@@ -57,20 +72,39 @@ describe('PinnedModelNote', () => {
     expect(note.textContent).not.toContain('claude_code');
   });
 
-  /**
-   * The daemon sends the frame on EVERY repaired bind, including the ordinary
-   * ones (an LRU-rehydrated agent, a legacy row) where it names exactly what is
-   * already selected. A note there would be permanent and meaningless.
-   */
-  it('says nothing when the pin names what is already selected', () => {
+  it('says nothing when the chat already runs on the selected model', () => {
     mocks.currentProvider = 'versa_azure';
-    mocks.currentModel = 'gpt-5.5-2026-04-24';
-    const { container } = render(<PinnedModelNote pinnedModel={PINNED} />);
+    mocks.currentModel = 'gpt-5.2-2025-12-11';
+    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('says nothing when no turn has been pinned', () => {
-    const { container } = render(<PinnedModelNote pinnedModel={undefined} />);
+  it('says nothing about a chat with no binding of its own', () => {
+    const { container } = render(<PinnedModelNote binding={undefined} chatTier="private" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  /**
+   * ⚠ The reason has to be the barrier. A PUBLIC chat bound to something other
+   * than the selection was simply switched by hand, and "this chat is marked
+   * private, so…" would name a cause that does not exist.
+   */
+  it('says nothing about a public chat that merely differs', async () => {
+    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="public" />);
+    await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  /**
+   * …and nothing when the selected model is itself private: the barrier admits
+   * it, so whatever moved this chat elsewhere, privacy did not.
+   */
+  it('says nothing when the selected model would be admitted here', async () => {
+    mocks.currentProvider = 'ollama';
+    mocks.currentModel = 'qwen3.6';
+    mocks.getProviders.mockResolvedValue([...CATALOG, providerRow('ollama', 'Ollama', 'private')]);
+    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -82,28 +116,40 @@ describe('PinnedModelNote', () => {
   it('says nothing while the selection is still unresolved', () => {
     mocks.currentProvider = null;
     mocks.currentModel = null;
-    const { container } = render(<PinnedModelNote pinnedModel={PINNED} />);
+    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
     expect(container).toBeEmptyDOMElement();
   });
 
   /**
-   * A catalog that cannot be read costs the display names and nothing else.
-   * Staying silent about the pin is the one outcome that reintroduces the
-   * defect, so the ids stand in.
+   * A catalog that cannot be read yields no tier, and the sentence claims to
+   * know WHY the user's choice is not in effect. Without the tier we do not.
    */
-  it('falls back to ids rather than going quiet when the catalog fails', async () => {
+  it('says nothing when the catalog cannot be read', async () => {
     mocks.getProviders.mockRejectedValue(new Error('offline'));
-    render(<PinnedModelNote pinnedModel={PINNED} />);
+    const { container } = render(<PinnedModelNote binding={BINDING} chatTier="private" />);
+    await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
 
+  /**
+   * …but a provider the catalog knows and cannot NAME still gets its sentence:
+   * the id is true, and an invented display name would not be.
+   */
+  it('falls back to ids when a row carries no display name', async () => {
+    mocks.getProviders.mockResolvedValue([
+      { name: 'versa_azure', metadata: { tier: 'private' }, resolved_tier: 'private' },
+      { name: 'claude_code', metadata: { tier: 'public' }, resolved_tier: 'public' },
+    ]);
+    render(<PinnedModelNote binding={BINDING} chatTier="private" />);
     const note = await screen.findByTestId('pinned-model-note');
     expect(note).toHaveTextContent(
-      'This chat is marked private, so it stays on gpt-5.5-2026-04-24. ' +
+      'This chat is marked private, so it stays on gpt-5.2-2025-12-11. ' +
         'claude-opus-5 is not used here.'
     );
   });
 
   it('is a neutral note, not a warning: nothing has gone wrong', async () => {
-    render(<PinnedModelNote pinnedModel={PINNED} />);
+    render(<PinnedModelNote binding={BINDING} chatTier="private" />);
     const note = await screen.findByTestId('pinned-model-note');
     expect(note).toHaveAttribute('role', 'status');
     expect(note.className).toContain('bg-background-muted');
@@ -113,17 +159,49 @@ describe('PinnedModelNote', () => {
 });
 
 describe('the pure half', () => {
-  it('reports a contradiction only when both sides are known and differ', () => {
-    const selected = { provider: 'claude_code', model: 'claude-opus-5' };
-    expect(pinContradictsSelection(PINNED, selected)).toBe(true);
-    // Same provider, different model, and the reverse: both are contradictions.
+  const session = (over: Partial<Session>) =>
+    ({ id: 's', provider_name: 'versa_azure', ...over }) as Session;
+
+  it('takes the binding from the session row, and a turn report outranks it', () => {
     expect(
-      pinContradictsSelection({ provider: 'claude_code', model: 'claude-sonnet-5' }, selected)
+      chatBinding(
+        session({ model_config: { model_name: 'gpt-5.2-2025-12-11' } as never }),
+        undefined
+      )
+    ).toEqual(BINDING);
+    // The frame the daemon sends when the barrier repaired the binding
+    // mid-turn: the row is not what ran.
+    expect(
+      chatBinding(session({ model_config: { model_name: 'gpt-5.2' } as never }), {
+        provider: 'llamacpp',
+        model: 'gemma4',
+      })
+    ).toEqual({ provider: 'llamacpp', model: 'gemma4' });
+    // A chat that has never run has no binding of its own.
+    expect(chatBinding(session({ provider_name: null }), undefined)).toBeUndefined();
+    expect(chatBinding(undefined, undefined)).toBeUndefined();
+  });
+
+  it('reports a difference only when both sides are known', () => {
+    const selected = { provider: 'claude_code', model: 'claude-opus-5' };
+    expect(bindingDiffersFromSelection(BINDING, selected)).toBe(true);
+    expect(
+      bindingDiffersFromSelection({ provider: 'claude_code', model: 'claude-sonnet-5' }, selected)
     ).toBe(true);
-    expect(pinContradictsSelection({ ...selected }, selected)).toBe(false);
-    expect(pinContradictsSelection(undefined, selected)).toBe(false);
-    expect(pinContradictsSelection(PINNED, { provider: null, model: null })).toBe(false);
-    expect(pinContradictsSelection(PINNED, { provider: 'claude_code', model: null })).toBe(false);
+    expect(bindingDiffersFromSelection({ ...selected }, selected)).toBe(false);
+    expect(bindingDiffersFromSelection(undefined, selected)).toBe(false);
+    expect(bindingDiffersFromSelection(BINDING, { provider: null, model: null })).toBe(false);
+    expect(bindingDiffersFromSelection(BINDING, { provider: 'claude_code', model: null })).toBe(
+      false
+    );
+  });
+
+  it('blames the barrier only for a public model on a private chat', () => {
+    expect(selectionBarredByPrivacy('private', 'public')).toBe(true);
+    expect(selectionBarredByPrivacy('private', 'private')).toBe(false);
+    expect(selectionBarredByPrivacy('public', 'public')).toBe(false);
+    expect(selectionBarredByPrivacy(undefined, 'public')).toBe(false);
+    expect(selectionBarredByPrivacy('private', undefined)).toBe(false);
   });
 
   it('drops the second clause when the selection cannot be named', () => {

--- a/ui/desktop/src/components/privacy/PinnedModelNote.tsx
+++ b/ui/desktop/src/components/privacy/PinnedModelNote.tsx
@@ -1,7 +1,7 @@
 import { Note } from '../ui/note';
 import { usePinnedModel } from './usePinnedModel';
 import type { PinnedModelView } from '../../hooks/chatStreamStore';
-import type { SessionClassification } from '../../api/types.gen';
+import type { Session } from '../../api/types.gen';
 
 /**
  * Issue #56 / F2 — the one line telling the user that this chat is running on a
@@ -26,19 +26,18 @@ import type { SessionClassification } from '../../api/types.gen';
  * this chat can use.
  */
 export function PinnedModelNote({
-  binding,
-  chatTier,
+  session,
+  reportedByTurn,
   className,
 }: {
-  /** What this chat actually runs on: the session row's binding, or the
-   *  authoritative one a turn reported. */
-  binding?: PinnedModelView;
-  /** The chat's ratcheted classification. */
-  chatTier?: SessionClassification;
+  /** The chat's own row: its classification and the binding it runs on. */
+  session?: Session;
+  /** A binding a turn reported for itself, which outranks the row. */
+  reportedByTurn?: PinnedModelView;
   /** Layout only — `mx-*`, `mb-*`. */
   className?: string;
 }) {
-  const { notice } = usePinnedModel(binding, chatTier);
+  const { notice } = usePinnedModel(session, reportedByTurn);
   if (!notice) return null;
   return (
     <Note tone="neutral" role="status" testId="pinned-model-note" className={className}>

--- a/ui/desktop/src/components/privacy/PinnedModelNote.tsx
+++ b/ui/desktop/src/components/privacy/PinnedModelNote.tsx
@@ -1,0 +1,41 @@
+import { Note } from '../ui/note';
+import { usePinnedModel } from './usePinnedModel';
+import type { PinnedModelView } from '../../hooks/chatStreamStore';
+
+/**
+ * Issue #56 Gate B — the one line telling the user that this chat is running on
+ * a model other than the one they selected, and why.
+ *
+ * ⚠ **Renders nothing unless there is something to say**, so a call site can
+ * mount it unconditionally — the same shape (and the same reason)
+ * {@link ../privacy/HostManagedModelNote.HostManagedModelNote} uses. The pin
+ * frame arrives on every repaired turn, including the ordinary ones where it
+ * names exactly what is already on screen; `usePinnedModel` is what tells those
+ * apart.
+ *
+ * ⚠ **`neutral`, not `warning`.** Nothing has gone wrong. The chat is doing
+ * precisely what being private means, the answer the user got is a real answer,
+ * and their model choice is still in force in every other chat. A warning tone
+ * here would tell them to go and fix something that is not broken.
+ *
+ * It has no dismiss control and never goes quiet, for the reason the standing
+ * disclosure note already records: the condition is standing, so the statement
+ * of it is too. It disappears on its own the moment the user selects a model
+ * this chat can use.
+ */
+export function PinnedModelNote({
+  pinnedModel,
+  className,
+}: {
+  pinnedModel?: PinnedModelView;
+  /** Layout only — `mx-*`, `mb-*`. */
+  className?: string;
+}) {
+  const { notice } = usePinnedModel(pinnedModel);
+  if (!notice) return null;
+  return (
+    <Note tone="neutral" role="status" testId="pinned-model-note" className={className}>
+      {notice}
+    </Note>
+  );
+}

--- a/ui/desktop/src/components/privacy/PinnedModelNote.tsx
+++ b/ui/desktop/src/components/privacy/PinnedModelNote.tsx
@@ -1,17 +1,19 @@
 import { Note } from '../ui/note';
 import { usePinnedModel } from './usePinnedModel';
 import type { PinnedModelView } from '../../hooks/chatStreamStore';
+import type { SessionClassification } from '../../api/types.gen';
 
 /**
- * Issue #56 Gate B — the one line telling the user that this chat is running on
- * a model other than the one they selected, and why.
+ * Issue #56 / F2 — the one line telling the user that this chat is running on a
+ * model other than the one they selected, and why.
  *
  * ⚠ **Renders nothing unless there is something to say**, so a call site can
  * mount it unconditionally — the same shape (and the same reason)
- * {@link ../privacy/HostManagedModelNote.HostManagedModelNote} uses. The pin
- * frame arrives on every repaired turn, including the ordinary ones where it
- * names exactly what is already on screen; `usePinnedModel` is what tells those
- * apart.
+ * {@link ../privacy/HostManagedModelNote.HostManagedModelNote} uses. Most chats
+ * run on exactly what is selected, and of the ones that do not, only a chat the
+ * privacy barrier is holding has earned this sentence. `usePinnedModel` is what
+ * tells those apart; see `pinnedModel.ts` for why the two questions are
+ * separate.
  *
  * ⚠ **`neutral`, not `warning`.** Nothing has gone wrong. The chat is doing
  * precisely what being private means, the answer the user got is a real answer,
@@ -24,14 +26,19 @@ import type { PinnedModelView } from '../../hooks/chatStreamStore';
  * this chat can use.
  */
 export function PinnedModelNote({
-  pinnedModel,
+  binding,
+  chatTier,
   className,
 }: {
-  pinnedModel?: PinnedModelView;
+  /** What this chat actually runs on: the session row's binding, or the
+   *  authoritative one a turn reported. */
+  binding?: PinnedModelView;
+  /** The chat's ratcheted classification. */
+  chatTier?: SessionClassification;
   /** Layout only — `mx-*`, `mb-*`. */
   className?: string;
 }) {
-  const { notice } = usePinnedModel(pinnedModel);
+  const { notice } = usePinnedModel(binding, chatTier);
   if (!notice) return null;
   return (
     <Note tone="neutral" role="status" testId="pinned-model-note" className={className}>

--- a/ui/desktop/src/components/privacy/pinnedModel.ts
+++ b/ui/desktop/src/components/privacy/pinnedModel.ts
@@ -1,35 +1,67 @@
 import type { PinnedModelView } from '../../hooks/chatStreamStore';
+import type { ProviderTier, Session, SessionClassification } from '../../api/types.gen';
 
 /**
- * Issue #56 Gate B, repair arm — what the user is told when a private chat runs
- * on a model other than the one they selected.
+ * Issue #56 / F2 — what the user is told when a chat runs on a model other than
+ * the one they selected.
  *
- * # The defect this answers
+ * # The defect
  *
- * A private chat may never reach a public model. When the app's globally
- * selected model is public and the user sends into such a chat, the agent
- * re-binds to the provider the SESSION ROW names and answers from there. That
- * repair is right: refusing the turn would strand the user, and asking them to
- * downgrade the chat would trade the guarantee away to fix a display problem.
+ * The composer's model chip and context gauge state the app's GLOBAL selection.
+ * A resumed chat does not run on the global selection: `restore_provider_from_session`
+ * binds the provider the SESSION ROW names (`routes/agent.rs`), and for a chat
+ * marked private that is the only binding the barrier will admit — Gate A
+ * refuses to attach a public provider to a private row at all.
  *
- * What was wrong is that nothing said so. The user had switched models in
- * Settings, watched a toast confirm it, watched the composer's chip change —
- * and then got an answer from a different model, with the context gauge sized
- * to the wrong window (measured: chip `claude-opus-5`, gauge "969.9k of 1M",
- * while the row still read `provider_name = versa_azure` and its token counts
- * matched Versa).
+ * So: switch the app to Claude Code / claude-opus-5, watch the toast and the
+ * chip change, open a private chat and send. The answer comes from Versa. The
+ * chip still names claude-opus-5, and the gauge measures the usage against
+ * Claude's 1M window instead of the 400k one that was really in play. Nothing on
+ * screen said any of this. Measured on 2026-09-08: chip `claude-opus-5`, gauge
+ * "998.6k of 1M", row `provider_name = versa_azure`, `privacy_tier = private`,
+ * and after the turn `input_tokens = 27833` — a Versa turn.
  *
- * # Why the daemon does not decide this
+ * # Two statements, deliberately separated
  *
- * The frame the daemon sends says only "this turn ran on `provider`/`model`",
- * because the agent's own view of what it displaced is incomplete — an
- * LRU-rehydrated agent was holding nothing at all, and a repair from "nothing"
- * to the row's own binding is not news to anybody. The client knows exactly
- * what it is showing the user, so the client is the only side that can tell a
- * silent correction from a contradiction. That comparison is
- * {@link pinContradictsSelection}, and it is a pure function so it can be
- * tested without a daemon, a socket or a render.
+ * 1. **What runs here** — the chat's own binding, which the chip and gauge must
+ *    state for EVERY chat, private or not. It says nothing about privacy and
+ *    needs no permission to be true.
+ * 2. **Why your choice is not in effect** — a sentence only the privacy barrier
+ *    earns. {@link selectionBarredByPrivacy} is the whole test, and it is the
+ *    same statement the chip's own tooltip already makes ("Private chat.
+ *    Biorouter only lets a private model open it").
+ *
+ * Folding the two together is how an earlier draft came to say "this chat is
+ * marked private, so it stays on X" about a chat that had simply been switched
+ * to a different *private* provider by hand — true about the binding, wrong
+ * about the reason.
  */
+
+/**
+ * What this chat actually runs on.
+ *
+ * The session row is the standing answer, and it needs no extra request: the
+ * `/agent/resume` payload the chat stream already holds carries `provider_name`
+ * and `model_config`, and `restore_provider_from_session` binds exactly those.
+ *
+ * A turn that reported its own binding (`PrivacyProviderPinned`) OUTRANKS the
+ * row, and the case where they disagree is the one the frame exists for: the
+ * live agent was holding something the row's classification refuses, the
+ * barrier repaired it mid-turn, and the row is not what ran.
+ *
+ * `undefined` when the row names no provider — a chat that has never run, which
+ * genuinely has no binding of its own and correctly falls back to the app's
+ * selection.
+ */
+export function chatBinding(
+  session: Session | undefined,
+  reportedByTurn: PinnedModelView | undefined
+): PinnedModelView | undefined {
+  if (reportedByTurn) return reportedByTurn;
+  const provider = session?.provider_name;
+  const model = session?.model_config?.model_name;
+  return provider && model ? { provider, model } : undefined;
+}
 
 /** The globally selected binding, as the composer knows it. */
 export interface SelectedModel {
@@ -38,22 +70,42 @@ export interface SelectedModel {
 }
 
 /**
- * Does the pin contradict what the user picked?
+ * Does this chat run on something other than the app-wide selection?
  *
  * `false` — say nothing — for every uncertain case, and the uncertainty is not
- * hypothetical: `currentProvider`/`currentModel` are `null` for the first
- * render of every chat while the config loads. A note that flashed on and off
- * there would be worse than no note, and it would be claiming something the
+ * hypothetical: `currentProvider`/`currentModel` are `null` for the first render
+ * of every chat while the config loads, and the session row lands a moment
+ * later. Anything that flashed on and off there would be claiming something the
  * component cannot yet know.
  */
-export function pinContradictsSelection(
-  pinned: PinnedModelView | undefined,
+export function bindingDiffersFromSelection(
+  binding: PinnedModelView | undefined,
   selected: SelectedModel
 ): boolean {
-  if (!pinned) return false;
+  if (!binding) return false;
   const { provider, model } = selected;
   if (!provider || !model) return false;
-  return pinned.provider !== provider || pinned.model !== model;
+  return binding.provider !== provider || binding.model !== model;
+}
+
+/**
+ * Is the app-wide selection barred from this chat by the privacy barrier?
+ *
+ * Exactly `bind_allowed(public, private) == false` — a public model may not open
+ * a private chat. It is not a second implementation of the gate: the gate
+ * decides what may RUN and lives in the daemon, and this decides only whether a
+ * sentence is warranted. Both inputs are the daemon's own answers — the row's
+ * ratcheted classification and the provider catalog's instance-resolved tier.
+ *
+ * `false` whenever either is unresolved, and `false` when both are private:
+ * a private chat on a different *private* provider is a per-chat choice, not a
+ * barrier, and telling the user otherwise would name the wrong cause.
+ */
+export function selectionBarredByPrivacy(
+  chatTier: SessionClassification | undefined,
+  selectedTier: ProviderTier | undefined
+): boolean {
+  return chatTier === 'private' && selectedTier === 'public';
 }
 
 /**
@@ -62,9 +114,8 @@ export function pinContradictsSelection(
  * Written for a person, not for an agent: it names what is true of the chat,
  * what follows from it, and which choice is not in effect here — and it stops.
  * It does not tell anyone to change a setting, because the setting is not
- * wrong; it does not apologise; and it does not describe a barrier, a gate or a
- * tier, none of which is a thing the reader has to know about to understand the
- * sentence.
+ * wrong; it does not apologise; and it does not mention a barrier, a gate or a
+ * tier, none of which the reader has to know about to understand the sentence.
  *
  * ⚠ The daemon's own refusal text (`crates/biorouter/src/privacy/refusal.rs`,
  * `routes/session_reach.rs`) is addressed to an AI agent and is pinned by

--- a/ui/desktop/src/components/privacy/pinnedModel.ts
+++ b/ui/desktop/src/components/privacy/pinnedModel.ts
@@ -1,0 +1,90 @@
+import type { PinnedModelView } from '../../hooks/chatStreamStore';
+
+/**
+ * Issue #56 Gate B, repair arm — what the user is told when a private chat runs
+ * on a model other than the one they selected.
+ *
+ * # The defect this answers
+ *
+ * A private chat may never reach a public model. When the app's globally
+ * selected model is public and the user sends into such a chat, the agent
+ * re-binds to the provider the SESSION ROW names and answers from there. That
+ * repair is right: refusing the turn would strand the user, and asking them to
+ * downgrade the chat would trade the guarantee away to fix a display problem.
+ *
+ * What was wrong is that nothing said so. The user had switched models in
+ * Settings, watched a toast confirm it, watched the composer's chip change —
+ * and then got an answer from a different model, with the context gauge sized
+ * to the wrong window (measured: chip `claude-opus-5`, gauge "969.9k of 1M",
+ * while the row still read `provider_name = versa_azure` and its token counts
+ * matched Versa).
+ *
+ * # Why the daemon does not decide this
+ *
+ * The frame the daemon sends says only "this turn ran on `provider`/`model`",
+ * because the agent's own view of what it displaced is incomplete — an
+ * LRU-rehydrated agent was holding nothing at all, and a repair from "nothing"
+ * to the row's own binding is not news to anybody. The client knows exactly
+ * what it is showing the user, so the client is the only side that can tell a
+ * silent correction from a contradiction. That comparison is
+ * {@link pinContradictsSelection}, and it is a pure function so it can be
+ * tested without a daemon, a socket or a render.
+ */
+
+/** The globally selected binding, as the composer knows it. */
+export interface SelectedModel {
+  provider?: string | null;
+  model?: string | null;
+}
+
+/**
+ * Does the pin contradict what the user picked?
+ *
+ * `false` — say nothing — for every uncertain case, and the uncertainty is not
+ * hypothetical: `currentProvider`/`currentModel` are `null` for the first
+ * render of every chat while the config loads. A note that flashed on and off
+ * there would be worse than no note, and it would be claiming something the
+ * component cannot yet know.
+ */
+export function pinContradictsSelection(
+  pinned: PinnedModelView | undefined,
+  selected: SelectedModel
+): boolean {
+  if (!pinned) return false;
+  const { provider, model } = selected;
+  if (!provider || !model) return false;
+  return pinned.provider !== provider || pinned.model !== model;
+}
+
+/**
+ * The one line the user reads, in the composer.
+ *
+ * Written for a person, not for an agent: it names what is true of the chat,
+ * what follows from it, and which choice is not in effect here — and it stops.
+ * It does not tell anyone to change a setting, because the setting is not
+ * wrong; it does not apologise; and it does not describe a barrier, a gate or a
+ * tier, none of which is a thing the reader has to know about to understand the
+ * sentence.
+ *
+ * ⚠ The daemon's own refusal text (`crates/biorouter/src/privacy/refusal.rs`,
+ * `routes/session_reach.rs`) is addressed to an AI agent and is pinned by
+ * repo-grep tests. Nothing here may be copied back into it, and none of it
+ * belongs here — the same rule `privacy/hostManagedModelCopy.ts` already
+ * records for the browser-surface case.
+ *
+ * `selectedLabel` is omitted when the selection cannot be named, which leaves a
+ * sentence that is still complete and still true.
+ */
+export function pinnedModelNotice(effectiveLabel: string, selectedLabel?: string): string {
+  const stays = `This chat is marked private, so it stays on ${effectiveLabel}.`;
+  return selectedLabel ? `${stays} ${selectedLabel} is not used here.` : stays;
+}
+
+/** `Versa API Azure / gpt-5.5-2026-04-24`, falling back to the raw id. */
+export function bindingLabel(
+  providerDisplayName: string | undefined | null,
+  model: string
+): string {
+  const provider = providerDisplayName?.trim();
+  return provider ? `${provider} / ${model}` : model;
+}

--- a/ui/desktop/src/components/privacy/usePinnedModel.ts
+++ b/ui/desktop/src/components/privacy/usePinnedModel.ts
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { useConfig } from '../ConfigContext';
+import { useModelAndProvider } from '../ModelAndProviderContext';
+import type { PinnedModelView } from '../../hooks/chatStreamStore';
+import { bindingLabel, pinContradictsSelection, pinnedModelNotice } from './pinnedModel';
+
+export interface PinnedModelPresentation {
+  /** The binding the chat is pinned to, or `undefined` when nothing is. */
+  pinned?: PinnedModelView;
+  /**
+   * The one line to show the user, or `null` when there is nothing to say —
+   * either nothing is pinned, or the pin names exactly what is already on
+   * screen, or the selection has not resolved yet.
+   */
+  notice: string | null;
+}
+
+/**
+ * Resolve the pin (issue #56 Gate B) into the sentence the composer shows, or
+ * into `null`.
+ *
+ * ⚠ The provider's **display name** is resolved through `getProviders`, which
+ * `ConfigContext` caches, rather than being derived from the id. `versa_azure`
+ * is not what that provider is called anywhere else in the app, and a note that
+ * named it that way would read as an internal leak in the one place the user is
+ * being told something they did not already know.
+ *
+ * ⚠ A provider the catalog cannot name falls back to the model alone. The
+ * sentence stays true and complete; inventing a display name from the id would
+ * not.
+ */
+export function usePinnedModel(pinned: PinnedModelView | undefined): PinnedModelPresentation {
+  const { getProviders } = useConfig();
+  const { currentModel, currentProvider } = useModelAndProvider();
+  const [displayNames, setDisplayNames] = useState<Record<string, string>>({});
+
+  const contradicts = pinContradictsSelection(pinned, {
+    provider: currentProvider,
+    model: currentModel,
+  });
+  const pinnedProvider = pinned?.provider;
+  const selectedProvider = currentProvider ?? undefined;
+
+  useEffect(() => {
+    // ⚠ Nothing is fetched unless there is a sentence to build. This hook runs
+    // in every chat, on every render of the composer, and the overwhelmingly
+    // common answer is "no note" — a catalog read there would be pure cost, and
+    // a state update behind it would churn the composer for no visible change.
+    if (!contradicts) return;
+    // Both halves of the sentence name a provider, and both are ids until this
+    // lands. Resolved in ONE pass over ONE fetch so the two names can never
+    // come from different reads of the catalog.
+    const wanted = [pinnedProvider, selectedProvider].filter((id): id is string => !!id);
+    if (wanted.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const rows = await getProviders(false);
+        if (cancelled) return;
+        const resolved: Record<string, string> = {};
+        for (const id of wanted) {
+          const name = rows.find((row) => row.name === id)?.metadata?.display_name;
+          if (name) resolved[id] = name;
+        }
+        setDisplayNames((prev) => {
+          const unchanged = wanted.every((id) => prev[id] === resolved[id]);
+          return unchanged ? prev : { ...prev, ...resolved };
+        });
+      } catch {
+        // A catalog we cannot read costs the display names and nothing else:
+        // the ids below are still true, and staying silent about the pin would
+        // be the one outcome that reintroduces the defect.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [contradicts, getProviders, pinnedProvider, selectedProvider]);
+
+  if (!contradicts) return { pinned, notice: null };
+
+  return {
+    pinned,
+    notice: pinnedModelNotice(
+      bindingLabel(displayNames[pinned!.provider], pinned!.model),
+      bindingLabel(selectedProvider ? displayNames[selectedProvider] : undefined, currentModel!)
+    ),
+  };
+}

--- a/ui/desktop/src/components/privacy/usePinnedModel.ts
+++ b/ui/desktop/src/components/privacy/usePinnedModel.ts
@@ -1,23 +1,27 @@
 import { useEffect, useState } from 'react';
 import { useConfig } from '../ConfigContext';
 import { useModelAndProvider } from '../ModelAndProviderContext';
+import { readResolvedProviderTier } from './useBoundProviderTier';
 import type { PinnedModelView } from '../../hooks/chatStreamStore';
-import { bindingLabel, pinContradictsSelection, pinnedModelNotice } from './pinnedModel';
+import type { ProviderTier, SessionClassification } from '../../api/types.gen';
+import {
+  bindingDiffersFromSelection,
+  bindingLabel,
+  pinnedModelNotice,
+  selectionBarredByPrivacy,
+} from './pinnedModel';
 
 export interface PinnedModelPresentation {
-  /** The binding the chat is pinned to, or `undefined` when nothing is. */
-  pinned?: PinnedModelView;
   /**
    * The one line to show the user, or `null` when there is nothing to say —
-   * either nothing is pinned, or the pin names exactly what is already on
-   * screen, or the selection has not resolved yet.
+   * nothing differs, the difference is not the barrier's doing, or the facts
+   * have not resolved yet.
    */
   notice: string | null;
 }
 
 /**
- * Resolve the pin (issue #56 Gate B) into the sentence the composer shows, or
- * into `null`.
+ * Resolve a chat's binding into the sentence the composer shows, or into `null`.
  *
  * ⚠ The provider's **display name** is resolved through `getProviders`, which
  * `ConfigContext` caches, rather than being derived from the id. `versa_azure`
@@ -25,32 +29,43 @@ export interface PinnedModelPresentation {
  * named it that way would read as an internal leak in the one place the user is
  * being told something they did not already know.
  *
+ * ⚠ The SELECTED provider's tier comes off the same fetch, and off the ROW
+ * rather than `row.metadata` — `metadata.tier` is the type-level claim, and
+ * `resolved_tier` is the instance-resolved one (DR-26). Reading the type-level
+ * field would mis-classify an `ollama` re-pointed off this machine, which is the
+ * exact demotion the tier exists to catch.
+ *
  * ⚠ A provider the catalog cannot name falls back to the model alone. The
  * sentence stays true and complete; inventing a display name from the id would
- * not.
+ * not. A catalog that cannot be read at all yields no tier, so no note — saying
+ * *why* a choice is not in effect requires knowing that it is not.
  */
-export function usePinnedModel(pinned: PinnedModelView | undefined): PinnedModelPresentation {
+export function usePinnedModel(
+  binding: PinnedModelView | undefined,
+  chatTier: SessionClassification | undefined
+): PinnedModelPresentation {
   const { getProviders } = useConfig();
   const { currentModel, currentProvider } = useModelAndProvider();
   const [displayNames, setDisplayNames] = useState<Record<string, string>>({});
+  const [selectedTier, setSelectedTier] = useState<ProviderTier | undefined>(undefined);
 
-  const contradicts = pinContradictsSelection(pinned, {
+  const differs = bindingDiffersFromSelection(binding, {
     provider: currentProvider,
     model: currentModel,
   });
-  const pinnedProvider = pinned?.provider;
+  const bindingProvider = binding?.provider;
   const selectedProvider = currentProvider ?? undefined;
 
   useEffect(() => {
-    // ⚠ Nothing is fetched unless there is a sentence to build. This hook runs
+    // ⚠ Nothing is fetched unless a difference exists to explain. This hook runs
     // in every chat, on every render of the composer, and the overwhelmingly
     // common answer is "no note" — a catalog read there would be pure cost, and
     // a state update behind it would churn the composer for no visible change.
-    if (!contradicts) return;
-    // Both halves of the sentence name a provider, and both are ids until this
-    // lands. Resolved in ONE pass over ONE fetch so the two names can never
-    // come from different reads of the catalog.
-    const wanted = [pinnedProvider, selectedProvider].filter((id): id is string => !!id);
+    if (!differs) return;
+    // Both halves of the sentence name a provider, and the tier decides whether
+    // there is a sentence at all. Resolved in ONE pass over ONE fetch so the
+    // three facts cannot come from different reads of the catalog.
+    const wanted = [bindingProvider, selectedProvider].filter((id): id is string => !!id);
     if (wanted.length === 0) return;
     let cancelled = false;
     (async () => {
@@ -66,23 +81,29 @@ export function usePinnedModel(pinned: PinnedModelView | undefined): PinnedModel
           const unchanged = wanted.every((id) => prev[id] === resolved[id]);
           return unchanged ? prev : { ...prev, ...resolved };
         });
+        const selectedRow = selectedProvider
+          ? rows.find((row) => row.name === selectedProvider)
+          : undefined;
+        setSelectedTier(selectedRow ? readResolvedProviderTier(selectedRow) : undefined);
       } catch {
-        // A catalog we cannot read costs the display names and nothing else:
-        // the ids below are still true, and staying silent about the pin would
-        // be the one outcome that reintroduces the defect.
+        // A catalog we cannot read leaves the tier unresolved, and an
+        // unresolved tier means no note: the sentence claims to know WHY the
+        // user's choice is not in effect, and here we do not.
+        if (!cancelled) setSelectedTier(undefined);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [contradicts, getProviders, pinnedProvider, selectedProvider]);
+  }, [differs, getProviders, bindingProvider, selectedProvider]);
 
-  if (!contradicts) return { pinned, notice: null };
+  if (!differs || !selectionBarredByPrivacy(chatTier, selectedTier)) {
+    return { notice: null };
+  }
 
   return {
-    pinned,
     notice: pinnedModelNotice(
-      bindingLabel(displayNames[pinned!.provider], pinned!.model),
+      bindingLabel(displayNames[binding!.provider], binding!.model),
       bindingLabel(selectedProvider ? displayNames[selectedProvider] : undefined, currentModel!)
     ),
   };

--- a/ui/desktop/src/components/privacy/usePinnedModel.ts
+++ b/ui/desktop/src/components/privacy/usePinnedModel.ts
@@ -3,75 +3,96 @@ import { useConfig } from '../ConfigContext';
 import { useModelAndProvider } from '../ModelAndProviderContext';
 import { readResolvedProviderTier } from './useBoundProviderTier';
 import type { PinnedModelView } from '../../hooks/chatStreamStore';
-import type { ProviderTier, SessionClassification } from '../../api/types.gen';
+import type { ProviderTier, Session } from '../../api/types.gen';
 import {
   bindingDiffersFromSelection,
   bindingLabel,
+  chatBinding,
   pinnedModelNotice,
   selectionBarredByPrivacy,
 } from './pinnedModel';
 
 export interface PinnedModelPresentation {
   /**
+   * What the composer's model chip and context gauge should state, or
+   * `undefined` to keep stating the app-wide selection.
+   */
+  effectiveModel?: PinnedModelView;
+  /**
    * The one line to show the user, or `null` when there is nothing to say —
-   * nothing differs, the difference is not the barrier's doing, or the facts
+   * nothing differs, or the difference is not the barrier's doing, or the facts
    * have not resolved yet.
    */
   notice: string | null;
 }
 
 /**
- * Resolve a chat's binding into the sentence the composer shows, or into `null`.
+ * What this chat runs on, and whether that needs explaining.
  *
- * ⚠ The provider's **display name** is resolved through `getProviders`, which
- * `ConfigContext` caches, rather than being derived from the id. `versa_azure`
- * is not what that provider is called anywhere else in the app, and a note that
- * named it that way would read as an internal leak in the one place the user is
- * being told something they did not already know.
+ * # One rule
  *
- * ⚠ The SELECTED provider's tier comes off the same fetch, and off the ROW
- * rather than `row.metadata` — `metadata.tier` is the type-level claim, and
- * `resolved_tier` is the instance-resolved one (DR-26). Reading the type-level
- * field would mis-classify an `ollama` re-pointed off this machine, which is the
- * exact demotion the tier exists to catch.
+ * **The composer states the chat's own binding exactly when the app-wide
+ * selection cannot run here.** Otherwise the selection stands.
  *
- * ⚠ A provider the catalog cannot name falls back to the model alone. The
- * sentence stays true and complete; inventing a display name from the id would
- * not. A catalog that cannot be read at all yields no tier, so no note — saying
- * *why* a choice is not in effect requires knowing that it is not.
+ * ⚠ The second half is not a hedge, it is a correctness requirement, and
+ * dropping it was a regression this hook was written twice to avoid.
+ * `ModelAndProviderContext.changeModel` writes BOTH the session row
+ * (`updateAgentProvider`) and the global default (`setConfigProvider`), so after
+ * a per-chat model switch the daemon has them in step — while the client's copy
+ * of the row, cached in the `/agent/resume` payload the chat stream holds, is
+ * the value from BEFORE the switch. A composer that preferred the row on every
+ * disagreement would answer a switch by showing the model the user had just
+ * switched away from, until the window reloaded.
+ *
+ * When the selection is barred there is no such ambiguity: Gate A refuses to
+ * bind it to this chat at all, so it provably is not what runs here, and the
+ * row is the only binding that can be.
+ *
+ * ⚠ The residual case is deliberate and unchanged from `main`: a PRIVATE chat
+ * bound to a different PRIVATE model than the selection still shows the
+ * selection. It is stale in the same narrow way it has always been, it is not
+ * what F2 reported, and fixing it needs the client's cached row to be
+ * invalidated on a switch rather than a heuristic here.
+ *
+ * ⚠ The provider **display names** are resolved through `getProviders`, which
+ * `ConfigContext` caches. `versa_azure` is not what that provider is called
+ * anywhere else in the app. The selected provider's tier comes off the same
+ * fetch, and off the ROW rather than `row.metadata` — `metadata.tier` is the
+ * type-level claim and `resolved_tier` the instance-resolved one (DR-26);
+ * reading the type-level field would mis-classify an `ollama` re-pointed off
+ * this machine, the exact demotion the tier exists to catch.
  */
 export function usePinnedModel(
-  binding: PinnedModelView | undefined,
-  chatTier: SessionClassification | undefined
+  session: Session | undefined,
+  reportedByTurn: PinnedModelView | undefined
 ): PinnedModelPresentation {
   const { getProviders } = useConfig();
   const { currentModel, currentProvider } = useModelAndProvider();
   const [displayNames, setDisplayNames] = useState<Record<string, string>>({});
   const [selectedTier, setSelectedTier] = useState<ProviderTier | undefined>(undefined);
 
-  const differs = bindingDiffersFromSelection(binding, {
-    provider: currentProvider,
-    model: currentModel,
-  });
+  const binding = chatBinding(session, reportedByTurn);
+  const chatTier = session?.privacy_tier;
   const bindingProvider = binding?.provider;
   const selectedProvider = currentProvider ?? undefined;
 
   useEffect(() => {
-    // ⚠ Nothing is fetched unless a difference exists to explain. This hook runs
-    // in every chat, on every render of the composer, and the overwhelmingly
-    // common answer is "no note" — a catalog read there would be pure cost, and
-    // a state update behind it would churn the composer for no visible change.
-    if (!differs) return;
-    // Both halves of the sentence name a provider, and the tier decides whether
-    // there is a sentence at all. Resolved in ONE pass over ONE fetch so the
-    // three facts cannot come from different reads of the catalog.
+    // ⚠ Nothing is fetched for a chat that cannot be barred. This hook runs in
+    // every chat, on every render of the composer, and only a PRIVATE one can
+    // ever refuse the selection — so a public chat costs no catalog read and no
+    // state update.
+    if (chatTier !== 'private' || !selectedProvider) {
+      setSelectedTier(undefined);
+      return;
+    }
     const wanted = [bindingProvider, selectedProvider].filter((id): id is string => !!id);
-    if (wanted.length === 0) return;
     let cancelled = false;
     (async () => {
       try {
         const rows = await getProviders(false);
         if (cancelled) return;
+        // The tier and both display names come from ONE pass over ONE fetch, so
+        // they cannot be taken from different reads of the catalog.
         const resolved: Record<string, string> = {};
         for (const id of wanted) {
           const name = rows.find((row) => row.name === id)?.metadata?.display_name;
@@ -81,30 +102,38 @@ export function usePinnedModel(
           const unchanged = wanted.every((id) => prev[id] === resolved[id]);
           return unchanged ? prev : { ...prev, ...resolved };
         });
-        const selectedRow = selectedProvider
-          ? rows.find((row) => row.name === selectedProvider)
-          : undefined;
+        const selectedRow = rows.find((row) => row.name === selectedProvider);
         setSelectedTier(selectedRow ? readResolvedProviderTier(selectedRow) : undefined);
       } catch {
-        // A catalog we cannot read leaves the tier unresolved, and an
-        // unresolved tier means no note: the sentence claims to know WHY the
-        // user's choice is not in effect, and here we do not.
+        // A catalog we cannot read leaves the tier unresolved, and unresolved
+        // means "say nothing and change nothing": both the note and the chip
+        // override claim to know that the selection is not what runs here.
         if (!cancelled) setSelectedTier(undefined);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [differs, getProviders, bindingProvider, selectedProvider]);
+  }, [chatTier, getProviders, bindingProvider, selectedProvider]);
 
-  if (!differs || !selectionBarredByPrivacy(chatTier, selectedTier)) {
+  if (!binding || !selectionBarredByPrivacy(chatTier, selectedTier)) {
     return { notice: null };
   }
 
+  // The chip and gauge state the binding whether or not it is news; the
+  // SENTENCE needs the selection to be nameable and different.
+  const differs = bindingDiffersFromSelection(binding, {
+    provider: currentProvider,
+    model: currentModel,
+  });
+
   return {
-    notice: pinnedModelNotice(
-      bindingLabel(displayNames[binding!.provider], binding!.model),
-      bindingLabel(selectedProvider ? displayNames[selectedProvider] : undefined, currentModel!)
-    ),
+    effectiveModel: binding,
+    notice: differs
+      ? pinnedModelNotice(
+          bindingLabel(displayNames[binding.provider], binding.model),
+          bindingLabel(displayNames[selectedProvider!], currentModel!)
+        )
+      : null,
   };
 }

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ModelsBottomBar from './ModelsBottomBar';
+import { __resetDisclosureStoreForTests } from '../../../privacy/disclosureCopy';
+
+/**
+ * Issue #56 Gate B / F2 — the chip states what runs in THIS chat.
+ *
+ * The measured defect: Settings → Models → Claude Code / claude-opus-5, then
+ * send into a chat whose `privacy_tier` is `private`. The turn was served by
+ * Versa (the session row was unchanged, and its token counts matched Versa),
+ * while this chip read `claude-opus-5` — the model that was not used — and the
+ * gauge beside it sized itself to Claude's 1M window.
+ */
+const mocks = vi.hoisted(() => ({
+  read: vi.fn(async () => ''),
+  getProviders: vi.fn(async () => [] as unknown[]),
+  getPrivacyDisclosure: vi.fn(),
+  ackPrivacyDisclosure: vi.fn(),
+}));
+
+vi.mock('../../../../api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getPrivacyDisclosure: mocks.getPrivacyDisclosure,
+  ackPrivacyDisclosure: mocks.ackPrivacyDisclosure,
+}));
+vi.mock('../../../../utils/userAction', () => ({
+  userActionHeaders: async () => ({ 'X-User-Action': 'test-key' }),
+}));
+
+vi.mock('../../../ConfigContext', () => ({
+  useConfig: () => ({ read: mocks.read, getProviders: mocks.getProviders }),
+  usePrivacyTiersEnabled: () => true,
+}));
+
+// The GLOBAL selection throughout this file: the public model the user picked.
+vi.mock('../../../ModelAndProviderContext', () => ({
+  useModelAndProvider: () => ({
+    currentModel: 'claude-opus-5',
+    currentProvider: 'claude_code',
+    getCurrentModelAndProviderForDisplay: async () => ({
+      model: 'claude-opus-5',
+      provider: 'Claude Code',
+    }),
+    getCurrentModelDisplayName: async () => 'claude-opus-5',
+    getCurrentProviderDisplayName: async () => 'Claude Code',
+  }),
+}));
+
+vi.mock('../../../BaseChat', () => ({ useCurrentModelInfo: () => null }));
+vi.mock('../subcomponents/SwitchModelModal', () => ({ SwitchModelModal: () => null }));
+vi.mock('../subcomponents/LeadWorkerSettings', () => ({ LeadWorkerSettings: () => null }));
+
+const dropdownRef = { current: null } as unknown as React.RefObject<HTMLDivElement>;
+
+const PINNED = { provider: 'versa_azure', model: 'gpt-5.5-2026-04-24' };
+
+const providerEntry = (name: string, display: string, tier: 'private' | 'public') => ({
+  name,
+  is_configured: true,
+  provider_type: 'Builtin',
+  metadata: { name, display_name: display, tier, runs_locally: false },
+  affiliation: null,
+  resolved_tier: tier,
+});
+
+function renderBar(pinnedModel?: { provider: string; model: string }) {
+  return render(
+    <ModelsBottomBar
+      sessionId="s1"
+      privacyTier="private"
+      pinnedModel={pinnedModel}
+      dropdownRef={dropdownRef}
+      setView={vi.fn()}
+      alerts={[]}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetDisclosureStoreForTests();
+  mocks.getProviders.mockResolvedValue([
+    providerEntry('versa_azure', 'Versa API Azure', 'private'),
+    providerEntry('claude_code', 'Claude Code', 'public'),
+  ]);
+  mocks.getPrivacyDisclosure.mockResolvedValue({
+    data: {
+      title_template: '{provider} is not hosted by your institution.',
+      long: 'LONG',
+      short: 'SHORT',
+      acknowledged: true,
+    },
+  });
+});
+
+describe('a chat pinned by the privacy barrier', () => {
+  it('names the model that actually runs here, not the app-wide selection', async () => {
+    renderBar(PINNED);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Current model: gpt-5\.5-2026-04-24/ })
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText('claude-opus-5')).toBeNull();
+  });
+
+  /**
+   * Not just the name. The padlock and the tier word are read off the bound
+   * provider's catalog row, and reading the GLOBAL provider's row would put a
+   * "Public model" label under a private model's name — the precise
+   * misattribution the chip's own comments were written against.
+   */
+  it('states the pinned provider’s tier, not the selected one’s', async () => {
+    renderBar(PINNED);
+    const trigger = await screen.findByRole('button', { name: /Current model:/ });
+    await waitFor(() => expect(trigger).toHaveAccessibleName(/Private model/));
+    expect(trigger).not.toHaveAccessibleName(/Public model/);
+  });
+
+  it('names the pinned binding in the dropdown header, by display name', async () => {
+    renderBar(PINNED);
+    await screen.findByRole('button', { name: /Current model:/ });
+    // `pointerDown`, not `click`: Radix's dropdown trigger opens on the pointer
+    // event, exactly as the sibling suite in this directory does it.
+    fireEvent.pointerDown(screen.getByLabelText(/Current model/), { button: 0, ctrlKey: false });
+    const header = await screen.findByText('Current model');
+    await waitFor(() =>
+      expect(header.parentElement).toHaveTextContent('gpt-5.5-2026-04-24 · Versa API Azure')
+    );
+  });
+
+  it('leaves an unpinned chat showing the app-wide selection', async () => {
+    renderBar(undefined);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /Current model: claude-opus-5/ })
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText('gpt-5.5-2026-04-24')).toBeNull();
+  });
+});

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
@@ -4,12 +4,12 @@ import ModelsBottomBar from './ModelsBottomBar';
 import { __resetDisclosureStoreForTests } from '../../../privacy/disclosureCopy';
 
 /**
- * Issue #56 Gate B / F2 — the chip states what runs in THIS chat.
+ * Issue #56 / F2 — the chip states what runs in THIS chat.
  *
  * The measured defect: Settings → Models → Claude Code / claude-opus-5, then
  * send into a chat whose `privacy_tier` is `private`. The turn was served by
- * Versa (the session row was unchanged, and its token counts matched Versa),
- * while this chip read `claude-opus-5` — the model that was not used — and the
+ * Versa — `restore_provider_from_session` binds the session row's own provider
+ * — while this chip read `claude-opus-5`, the model that was not used, and the
  * gauge beside it sized itself to Claude's 1M window.
  */
 const mocks = vi.hoisted(() => ({
@@ -64,12 +64,12 @@ const providerEntry = (name: string, display: string, tier: 'private' | 'public'
   resolved_tier: tier,
 });
 
-function renderBar(pinnedModel?: { provider: string; model: string }) {
+function renderBar(effectiveModel?: { provider: string; model: string }) {
   return render(
     <ModelsBottomBar
       sessionId="s1"
       privacyTier="private"
-      pinnedModel={pinnedModel}
+      effectiveModel={effectiveModel}
       dropdownRef={dropdownRef}
       setView={vi.fn()}
       alerts={[]}
@@ -94,7 +94,7 @@ beforeEach(() => {
   });
 });
 
-describe('a chat pinned by the privacy barrier', () => {
+describe('a chat bound to something other than the app-wide selection', () => {
   it('names the model that actually runs here, not the app-wide selection', async () => {
     renderBar(PINNED);
     await waitFor(() =>
@@ -106,19 +106,19 @@ describe('a chat pinned by the privacy barrier', () => {
   });
 
   /**
-   * Not just the name. The padlock and the tier word are read off the bound
-   * provider's catalog row, and reading the GLOBAL provider's row would put a
+   * Not just the name. The padlock and the tier word are read off the BOUND
+   * provider's catalog row; reading the global provider's row would put a
    * "Public model" label under a private model's name — the precise
    * misattribution the chip's own comments were written against.
    */
-  it('states the pinned provider’s tier, not the selected one’s', async () => {
+  it('states the bound provider’s tier, not the selected one’s', async () => {
     renderBar(PINNED);
     const trigger = await screen.findByRole('button', { name: /Current model:/ });
     await waitFor(() => expect(trigger).toHaveAccessibleName(/Private model/));
     expect(trigger).not.toHaveAccessibleName(/Public model/);
   });
 
-  it('names the pinned binding in the dropdown header, by display name', async () => {
+  it('names the chat’s own binding in the dropdown header, by display name', async () => {
     renderBar(PINNED);
     await screen.findByRole('button', { name: /Current model:/ });
     // `pointerDown`, not `click`: Radix's dropdown trigger opens on the pointer
@@ -130,7 +130,7 @@ describe('a chat pinned by the privacy barrier', () => {
     );
   });
 
-  it('leaves an unpinned chat showing the app-wide selection', async () => {
+  it('leaves a chat with no binding of its own showing the app-wide selection', async () => {
     renderBar(undefined);
     await waitFor(() =>
       expect(

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -57,9 +57,10 @@ interface ModelsBottomBarProps {
    */
   privacyTier?: SessionClassification;
   /**
-   * Issue #56 Gate B — the binding the privacy barrier pinned THIS chat to,
-   * when a turn had to fall back to it because the chat's classification does
-   * not admit the globally selected model.
+   * Issue #56 / F2 — what THIS chat actually runs on: the session row's own
+   * provider and model (`restore_provider_from_session` binds exactly those),
+   * or the one a turn reported when the privacy barrier repaired the binding
+   * mid-turn.
    *
    * ⚠ This chip states the app's global selection, and that is exactly what
    * made the defect invisible: a user switched to a public model, watched this
@@ -69,12 +70,12 @@ interface ModelsBottomBarProps {
    * is about the binding that actually runs here.
    *
    * ⚠ It is NOT a signal that anything is wrong, and this component must not
-   * editorialise. The daemon sends it on every repaired bind, including the
-   * ordinary ones where it names exactly what is already selected. The sentence
-   * explaining a genuine contradiction is `privacy/PinnedModelNote`, which
-   * decides for itself whether there is one.
+   * editorialise. Most chats are bound to exactly what is selected, and a chat
+   * bound to something else may simply have been switched by hand. The sentence
+   * explaining a difference the privacy barrier caused is
+   * `privacy/PinnedModelNote`, which decides for itself whether there is one.
    */
-  pinnedModel?: PinnedModelView;
+  effectiveModel?: PinnedModelView;
 }
 
 const MAX_INLINE_MODEL_LABEL_CHARS = 24;
@@ -86,7 +87,7 @@ export default function ModelsBottomBar({
   alerts,
   hideAlertPopover = false,
   privacyTier,
-  pinnedModel,
+  effectiveModel,
 }: ModelsBottomBarProps) {
   const {
     currentModel,
@@ -168,12 +169,12 @@ export default function ModelsBottomBar({
    * Issue #56 Gate B. What actually runs in THIS chat: the pin when there is
    * one, the app's global selection otherwise.
    *
-   * ⚠ The pin outranks lead/worker below. A pinned chat runs the single
-   * provider its session row names, so a lead/worker pair configured globally
-   * is not what answers here, and labelling the chip `(lead)` would name a
-   * mechanism that is not in play.
+   * ⚠ The chat's own binding outranks lead/worker below. Such a chat runs the
+   * single provider its session row names, so a lead/worker pair configured
+   * globally is not what answers here, and labelling the chip `(lead)` would
+   * name a mechanism that is not in play.
    */
-  const effectiveProvider = pinnedModel?.provider ?? currentProvider;
+  const effectiveProvider = effectiveModel?.provider ?? currentProvider;
 
   // Check if lead/worker mode is active
   useEffect(() => {
@@ -237,12 +238,12 @@ export default function ModelsBottomBar({
 
   // Determine which model to display - activeModel takes priority when lead/worker is active
   const displayModel =
-    pinnedModel?.model ??
+    effectiveModel?.model ??
     (isLeadWorkerActive && currentModelInfo?.model
       ? currentModelInfo.model
       : currentModel || providerDefaultModel || displayModelName);
   const fullModelLabel =
-    !pinnedModel && isLeadWorkerActive && modelMode
+    !effectiveModel && isLeadWorkerActive && modelMode
       ? `${displayModel} (${modelMode})`
       : displayModel;
   const inlineModelLabel =
@@ -384,9 +385,9 @@ export default function ModelsBottomBar({
    * effects race to own one state was how the earlier drafts of this went
    * wrong.
    */
-  const shownModelName = pinnedModel?.model ?? displayModelName;
-  const shownProviderName = pinnedModel
-    ? (pinnedProviderName ?? pinnedModel.provider)
+  const shownModelName = effectiveModel?.model ?? displayModelName;
+  const shownProviderName = effectiveModel
+    ? (pinnedProviderName ?? effectiveModel.provider)
     : displayProvider;
 
   // What is true of the MODEL, as one clause: its tier, then who covers it.

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -30,6 +30,7 @@ import { HostManagedModelNote } from '../../../privacy/HostManagedModelNote';
 import { HOST_MANAGED_MODEL_REASON } from '../../../privacy/hostManagedModelCopy';
 import { isBrowserSurface } from '../../../../utils/surface';
 import type { ProviderTier, SessionClassification } from '../../../../api/types.gen';
+import type { PinnedModelView } from '../../../../hooks/chatStreamStore';
 
 interface ModelsBottomBarProps {
   sessionId: string | null;
@@ -55,6 +56,25 @@ interface ModelsBottomBarProps {
    * than asserting Public, matching `SessionNamePill`.
    */
   privacyTier?: SessionClassification;
+  /**
+   * Issue #56 Gate B — the binding the privacy barrier pinned THIS chat to,
+   * when a turn had to fall back to it because the chat's classification does
+   * not admit the globally selected model.
+   *
+   * ⚠ This chip states the app's global selection, and that is exactly what
+   * made the defect invisible: a user switched to a public model, watched this
+   * chip change, sent into a private chat, and got an answer from a different
+   * model — with this chip still naming the one that was not used. When set,
+   * every fact this chip states (the name, the tier padlock, the affiliation)
+   * is about the binding that actually runs here.
+   *
+   * ⚠ It is NOT a signal that anything is wrong, and this component must not
+   * editorialise. The daemon sends it on every repaired bind, including the
+   * ordinary ones where it names exactly what is already selected. The sentence
+   * explaining a genuine contradiction is `privacy/PinnedModelNote`, which
+   * decides for itself whether there is one.
+   */
+  pinnedModel?: PinnedModelView;
 }
 
 const MAX_INLINE_MODEL_LABEL_CHARS = 24;
@@ -66,6 +86,7 @@ export default function ModelsBottomBar({
   alerts,
   hideAlertPopover = false,
   privacyTier,
+  pinnedModel,
 }: ModelsBottomBarProps) {
   const {
     currentModel,
@@ -97,6 +118,13 @@ export default function ModelsBottomBar({
    * re-rendered on every keystroke in the composer.
    */
   const [needsDisclosure, setNeedsDisclosure] = useState<boolean | null>(null);
+  /**
+   * The display name of the provider this chat is PINNED to, read off the same
+   * catalog row as the tier and affiliation below. `null` until it resolves, and
+   * for a provider the catalog cannot name — in both cases the chip falls back
+   * to the provider's id, which is true rather than invented.
+   */
+  const [pinnedProviderName, setPinnedProviderName] = useState<string | null>(null);
   /**
    * Issue #56, DR-26 — *under whose agreements?* for the model bound to this
    * chat. `null` renders nothing, which is both the "not resolved yet" answer
@@ -135,6 +163,17 @@ export default function ModelsBottomBar({
    * the two menu items are still offered.
    */
   const hostManaged = isBrowserSurface();
+
+  /**
+   * Issue #56 Gate B. What actually runs in THIS chat: the pin when there is
+   * one, the app's global selection otherwise.
+   *
+   * ⚠ The pin outranks lead/worker below. A pinned chat runs the single
+   * provider its session row names, so a lead/worker pair configured globally
+   * is not what answers here, and labelling the chip `(lead)` would name a
+   * mechanism that is not in play.
+   */
+  const effectiveProvider = pinnedModel?.provider ?? currentProvider;
 
   // Check if lead/worker mode is active
   useEffect(() => {
@@ -198,11 +237,14 @@ export default function ModelsBottomBar({
 
   // Determine which model to display - activeModel takes priority when lead/worker is active
   const displayModel =
-    isLeadWorkerActive && currentModelInfo?.model
+    pinnedModel?.model ??
+    (isLeadWorkerActive && currentModelInfo?.model
       ? currentModelInfo.model
-      : currentModel || providerDefaultModel || displayModelName;
+      : currentModel || providerDefaultModel || displayModelName);
   const fullModelLabel =
-    isLeadWorkerActive && modelMode ? `${displayModel} (${modelMode})` : displayModel;
+    !pinnedModel && isLeadWorkerActive && modelMode
+      ? `${displayModel} (${modelMode})`
+      : displayModel;
   const inlineModelLabel =
     fullModelLabel.length > MAX_INLINE_MODEL_LABEL_CHARS
       ? `${fullModelLabel.slice(0, MAX_INLINE_MODEL_LABEL_CHARS - 3)}...`
@@ -258,19 +300,24 @@ export default function ModelsBottomBar({
   // both off a single `&dyn Provider`), and two fetches here could pair one
   // provider's tier with another's institution across a model switch.
   useEffect(() => {
-    if (!currentProvider) {
+    if (!effectiveProvider) {
       setNeedsDisclosure(null);
       setAffiliation(null);
       setBoundTier(undefined);
+      setPinnedProviderName(null);
       return;
     }
     let cancelled = false;
     (async () => {
       try {
         const rows = await getProviders(false);
-        const row = rows.find((candidate) => candidate.name === currentProvider);
-        if (!row) throw new Error(`No match for provider: ${currentProvider}`);
+        const row = rows.find((candidate) => candidate.name === effectiveProvider);
+        if (!row) throw new Error(`No match for provider: ${effectiveProvider}`);
         if (cancelled) return;
+        // Off the SAME row as the tier and affiliation below. The sibling
+        // effect that fills `displayProvider` asks the global model context,
+        // which by definition cannot name a provider this chat was pinned to.
+        setPinnedProviderName(row.metadata.display_name ?? null);
         setNeedsDisclosure(disclosureRequiredForTier(row.metadata.tier));
         // Read off the ROW, never `row.metadata`: the metadata's tier is the
         // type-level claim, and affiliation is served beside it precisely
@@ -281,6 +328,7 @@ export default function ModelsBottomBar({
         // A provider Biorouter cannot classify is one it cannot vouch for.
         // Fail-safe here means fail towards telling the user.
         if (!cancelled) {
+          setPinnedProviderName(null);
           setNeedsDisclosure(true);
           // ...but NOT towards claiming an affiliation. Failing safe on the
           // disclosure means saying more; failing safe on the third axis means
@@ -296,7 +344,7 @@ export default function ModelsBottomBar({
     return () => {
       cancelled = true;
     };
-  }, [currentProvider, getProviders]);
+  }, [effectiveProvider, getProviders]);
 
   // ⚠ Unconditional on the master privacy switch — DR-15 turns off enforcement,
   // not the truth. See `privacy/disclosureCopy.ts`.
@@ -326,6 +374,20 @@ export default function ModelsBottomBar({
   // has room for a glyph and nothing more. `null` for a public model, which has
   // no affiliation, so a public chat's chip is byte-for-byte what it was.
   const affiliationWords = affiliationPresentation(affiliation);
+
+  /**
+   * The two names in the dropdown's "Current model" block, pinned binding first.
+   *
+   * Layered here rather than inside the effects that fill `displayModelName` /
+   * `displayProvider`: those two describe the app's GLOBAL selection, which is
+   * still the right answer for every chat that is not pinned, and having two
+   * effects race to own one state was how the earlier drafts of this went
+   * wrong.
+   */
+  const shownModelName = pinnedModel?.model ?? displayModelName;
+  const shownProviderName = pinnedModel
+    ? (pinnedProviderName ?? pinnedModel.provider)
+    : displayProvider;
 
   // What is true of the MODEL, as one clause: its tier, then who covers it.
   // Both axes come off one sample of one endpoint, so they can be said in one
@@ -444,8 +506,8 @@ export default function ModelsBottomBar({
           <div className="border-b border-border-subtle px-3 py-2.5">
             <div className="text-sm font-medium text-text-default">Current model</div>
             <div className="mt-0.5 text-supporting leading-4 text-text-muted">
-              {displayModelName}
-              {displayProvider && ` · ${displayProvider}`}
+              {shownModelName}
+              {shownProviderName && ` · ${shownProviderName}`}
             </div>
             {/* Under the heading "Current model", so it must be about the
                 model. It used to be `privacyLine`. */}

--- a/ui/desktop/src/hooks/chatStreamStore.pinnedModel.test.ts
+++ b/ui/desktop/src/hooks/chatStreamStore.pinnedModel.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatStreamRegistry } from './chatStreamStore';
+import type { MessageEvent, Session, TokenState } from '../api';
+import { reply, resumeAgent } from '../api';
+
+/**
+ * Issue #56 Gate B / F2 — the store's half of "which model actually served this
+ * turn".
+ *
+ * The daemon sends `PrivacyProviderPinned` when a turn had to fall back to the
+ * provider the session row names. Before this frame existed, a private chat
+ * answered from Versa while the composer's chip said `claude-opus-5` and its
+ * gauge measured against Claude's 1M window.
+ */
+vi.mock('../api', () => ({
+  cancelTurn: vi.fn(),
+  editMessage: vi.fn(),
+  getSession: vi.fn(async () => ({ data: null })),
+  interrupt: vi.fn(),
+  listSessions: vi.fn(async () => ({ data: { sessions: [] } })),
+  reply: vi.fn(),
+  resumeAgent: vi.fn(),
+  updateFromSession: vi.fn(async () => ({ data: {} })),
+  updateSessionUserWorkflowValues: vi.fn(async () => ({ data: {} })),
+}));
+
+vi.mock('../utils/continuationLease', () => ({
+  abandonContinuationLease: vi.fn(async () => undefined),
+  getContinuationOwnerId: vi.fn(() => 'test-window-owner'),
+  recoverContinuationGroup: vi.fn(),
+}));
+
+vi.mock('../utils/userAction', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/userAction')>()),
+  userActionHeaders: async () => ({ 'X-User-Action': 'test-key' }),
+}));
+
+const tokenState: TokenState = {
+  accumulatedInputTokens: 0,
+  accumulatedOutputTokens: 0,
+  accumulatedTotalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+};
+
+function session(id: string): Session {
+  return {
+    id,
+    name: `Session ${id}`,
+    working_dir: '/tmp',
+    conversation: [],
+    message_count: 0,
+    total_tokens: 0,
+    created_at: '',
+    updated_at: '',
+    extension_data: {},
+    user_set_name: false,
+  } as Session;
+}
+
+const PIN: MessageEvent = {
+  type: 'PrivacyProviderPinned',
+  provider: 'versa_azure',
+  model: 'gpt-5.5-2026-04-24',
+} as MessageEvent;
+
+function streamOf(...events: MessageEvent[]) {
+  return {
+    stream: (async function* () {
+      for (const event of events) yield event;
+    })(),
+  } as never;
+}
+
+beforeEach(() => {
+  vi.mocked(reply).mockReset();
+  vi.mocked(resumeAgent).mockReset();
+  Object.assign(window, {
+    electron: {
+      openExternal: vi.fn(async () => undefined),
+      showNotification: vi.fn(),
+      logInfo: vi.fn(),
+    },
+  });
+});
+
+describe('PrivacyProviderPinned', () => {
+  async function runTurn(sid: string, ...events: MessageEvent[]) {
+    const registry = new ChatStreamRegistry();
+    vi.mocked(resumeAgent).mockResolvedValue({ data: { session: session(sid) } } as never);
+    vi.mocked(reply).mockImplementation(async () => streamOf(...events));
+    const controller = registry.getController(sid);
+    await controller.handleSubmit('hi');
+    return controller;
+  }
+
+  it('records the binding the turn actually ran on', async () => {
+    const controller = await runTurn('pin-records', PIN, {
+      type: 'Finish',
+      reason: 'done',
+      token_state: tokenState,
+    } as MessageEvent);
+
+    expect(controller.getSnapshot().pinnedModel).toEqual({
+      provider: 'versa_azure',
+      model: 'gpt-5.5-2026-04-24',
+    });
+  });
+
+  /**
+   * ⚠ It must OUTLIVE the turn that reported it. The pin is a property of the
+   * chat, not of one turn: clearing it on `Finish` would put the wrong model
+   * back on the chip and the wrong window back on the gauge at the exact moment
+   * the answer arrived — which is the defect, one second later.
+   */
+  it('survives the end of the turn that reported it', async () => {
+    const controller = await runTurn('pin-survives', PIN, {
+      type: 'Finish',
+      reason: 'done',
+      token_state: tokenState,
+    } as MessageEvent);
+
+    expect(controller.getSnapshot().chatState).not.toBe('streaming');
+    expect(controller.getSnapshot().pinnedModel?.provider).toBe('versa_azure');
+  });
+
+  it('leaves an unpinned chat with nothing recorded', async () => {
+    const controller = await runTurn('pin-absent', {
+      type: 'Finish',
+      reason: 'done',
+      token_state: tokenState,
+    } as MessageEvent);
+
+    expect(controller.getSnapshot().pinnedModel).toBeUndefined();
+  });
+
+  /**
+   * The frame arrives on every repaired turn. A fresh object each time would
+   * re-render the composer — chip and gauge included — once per turn for no
+   * change at all, so the snapshot identity has to be stable.
+   */
+  it('does not churn the snapshot when the same binding is reported again', async () => {
+    const controller = await runTurn('pin-idempotent', PIN, PIN, PIN, {
+      type: 'Finish',
+      reason: 'done',
+      token_state: tokenState,
+    } as MessageEvent);
+
+    const first = controller.getSnapshot().pinnedModel;
+    await controller.handleSubmit('again');
+    expect(controller.getSnapshot().pinnedModel).toBe(first);
+  });
+});

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -484,6 +484,33 @@ export interface ChatStreamSnapshot {
    * JSON equality, so a partial and its completed form would BOTH survive).
    */
   pendingToolCalls: PendingToolCallView[];
+  /**
+   * Issue #56 Gate B, repair arm: the provider and model that actually served
+   * the most recent turn in this chat, when the agent had to fall back to the
+   * one the SESSION ROW names because the chat's classification does not admit
+   * the globally selected one.
+   *
+   * ⚠ **Receiving it is not the same as "the user's choice was overridden".**
+   * The daemon sends this on EVERY repaired bind, including the ordinary ones
+   * (an LRU-rehydrated agent, a legacy row) where it names exactly what the
+   * composer is already showing. Compare it against the selection on screen and
+   * say nothing when they agree — `privacy/pinnedModel.ts` is where that
+   * comparison lives.
+   *
+   * It deliberately OUTLIVES the turn that reported it. The pin is a property
+   * of the chat, not of one turn: clearing it on `Finish` would put the wrong
+   * model back on the chip the moment the answer arrived, which is the defect.
+   */
+  pinnedModel?: PinnedModelView;
+}
+
+/**
+ * The binding a chat was pinned to by the privacy barrier (issue #56 Gate B).
+ * Provider is the registry's own id (`versa_azure`), not a display name.
+ */
+export interface PinnedModelView {
+  provider: string;
+  model: string;
 }
 
 /** A tool call announced before its arguments finished streaming (§6.1b). */
@@ -1316,6 +1343,21 @@ class ChatStreamController {
     });
   };
 
+  /**
+   * Record the binding the privacy barrier pinned this chat to.
+   *
+   * Idempotent by value: the frame arrives on every repaired turn, and a fresh
+   * object each time would re-render the composer — including its model chip
+   * and context gauge — once per turn for no change at all.
+   */
+  private setPinnedModel = (pinned: PinnedModelView): void => {
+    this.updateSnapshot((prev) =>
+      prev.pinnedModel?.provider === pinned.provider && prev.pinnedModel?.model === pinned.model
+        ? prev
+        : { ...prev, pinnedModel: pinned }
+    );
+  };
+
   private clearPendingToolCalls = (): void => {
     this.updateSnapshot((prev) =>
       prev.pendingToolCalls.length === 0 ? prev : { ...prev, pendingToolCalls: [] }
@@ -1979,6 +2021,9 @@ class ChatStreamController {
             await this.finishCurrentStream();
             return;
           case 'MessagesPersisted':
+            break;
+          case 'PrivacyProviderPinned':
+            this.setPinnedModel({ provider: event.provider, model: event.model });
             break;
           case 'ModelChange':
           case 'Ping':

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -6,6 +6,7 @@ import {
   useChatStreamController,
   type PendingContinuationView,
   type PendingToolCallView,
+  type PinnedModelView,
 } from './chatStreamStore';
 import type { ContinuationRecoveryAction } from '../utils/continuationLease';
 import type { ChatTurnErrorData } from '../types/turnError';
@@ -72,6 +73,12 @@ interface UseChatStreamReturn {
    * removed the instant its authoritative `ToolRequest` lands.
    */
   pendingToolCalls: PendingToolCallView[];
+  /**
+   * Issue #56 Gate B: the binding the privacy barrier pinned this chat to, or
+   * `undefined` when no turn has been repaired. Not by itself a statement that
+   * anything is wrong — see `privacy/pinnedModel.ts`.
+   */
+  pinnedModel?: PinnedModelView;
   onMessageUpdate: (
     messageId: string,
     newContent: string,
@@ -134,6 +141,7 @@ export function useChatStream({
     agentReady: snapshot.agentReady,
     notifications: notificationsMap,
     pendingToolCalls: snapshot.pendingToolCalls,
+    pinnedModel: snapshot.pinnedModel,
     onMessageUpdate: controller.onMessageUpdate,
   };
 }


### PR DESCRIPTION
Round-2 walkthrough findings **F2** (a private chat's turn silently runs on a model other than the one shown), **F14** (the private-chat refusal is invisible), **F8** (vendor errors shown as a raw JSON envelope) and **F10** (the context gauge reports 128k with no model selected).

## Why

### F2 — and a corrected diagnosis

Verbatim repro (measured in a sandboxed dev instance on 2026-09-08):

1. Settings → Models → Switch models → **Claude Code / claude-opus-5**. Toast: *"Model changed — Switched models -- using claude-opus-5 from Claude Code"*.
2. Open a chat whose `privacy_tier` is `private` (`20260610_28`, created on `versa_azure`).
3. Composer chip reads `claude-opus-5 (Public model)`; gauge reads *"998.6k of 1M tokens remaining"*.
4. Send "Reply with the single word ready." It answers.
5. The row is unchanged: `provider_name = versa_azure`, `privacy_tier = private`, and `input_tokens` moved 1444 → **27833** — a Versa turn. The chat's real model is `gpt-5.2-2025-12-11` on a **400k** window.

⚠ **The report attributed this to Gate B arm 2 (`agent.rs:8198-8206`). It measured otherwise, and the correction matters.** A resumed chat is bound by `restore_provider_from_session` (`routes/agent.rs:2054`) to the provider the SESSION ROW names — so Gate B sees an already-admissible binding, has nothing to repair, and never fires. The visible defect is broader and simpler: **the composer's model chip and context gauge state the app-wide selection, while the agent runs the chat's own binding.** For a private chat that binding is the only one the barrier admits, so the two can never agree while a public model is selected.

The barrier itself is intact and unchanged. Nothing here alters what any gate permits or refuses, and no second call site for `raise_privacy`, `floor` or `.call_tool(` is added.

### F14

Opening a private chat with a public model bound refuses `GET /knowledge/active` with a ~900-character paragraph addressed to an **AI agent** (*"Do not retry as you are… stop and ask the user to open it for you"*), printed in full in the devtools console of a desktop app where the chat had opened and rendered correctly. A normal, correct outcome printed as a wall of red-flag prose reads as a crash.

### F8

Codex rendered `Ran into this error: Request failed: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade…"}}.` — the one actionable sentence buried in JSON. Claude Code's was unwrapped but ended `…then try again..` (vendor stop + appended stop).

### F10

`main-onboarding`, no provider: the chip correctly said *"No model yet — choose a provider"*, and the gauge beside it read *"Context window usage. 128k of 128k tokens remaining"* — a precise figure for a model that does not exist.

## What changed

### The daemon says where a repaired turn went (F2, part 1)

- `crates/biorouter/src/agents/agent.rs:3526` — new `AgentEvent::PrivacyProviderPinned { provider, model }`.
- `agent.rs:6390` `Agent::pinned_provider_event`, emitted from Gate B's repair arm at `agent.rs:8205`, yielded near the front of the turn stream at `agent.rs:8578`.
- ⚠ It carries **only** the binding that served the turn, and no "requested" one. An LRU-rehydrated agent holds nothing at all, so the agent cannot tell a silent correction from a contradiction; the client, which knows exactly what it is showing, can.
- `crates/biorouter-server/src/routes/reply.rs:384` + `routes/session_events.rs:127` — one shared mapper, so `/reply` and the observer feed cannot disagree. Contract regenerated (`ui/desktop/openapi.json`, `src/api/types.gen.ts`).
- Non-desktop consumers get named arms rather than a wildcard (`session/mod.rs`, `commands/web.rs`, `session/tui/mod.rs`, `subagent_handler.rs`), each saying why it does nothing.

### The composer states the chat's own binding (F2, part 2)

- `ui/desktop/src/components/privacy/pinnedModel.ts` — `chatBinding` (session row, with a turn's report outranking it), `bindingDiffersFromSelection`, `selectionBarredByPrivacy`, and the copy.
- `components/BaseChat.tsx:2088` derives it from `session` + `pinnedModel` — **no new request**: both facts already ride the `/agent/resume` payload the chat stream holds.
- `components/ChatInput.tsx:1090` — the gauge resolves the window for the chat's binding, not the app's.
- `components/settings/models/bottom_bar/ModelsBottomBar.tsx` — the chip's name, tier padlock and affiliation come off the **bound** provider's catalog row.
- `components/privacy/PinnedModelNote.tsx` — one neutral `Note`, above the composer in the slot the Stop-and-send banner already uses.
- `components/privacy/usePinnedModel.ts` — the one rule, and both consumers of it.

**One rule: the composer states the chat's own binding exactly when the app-wide selection cannot run here.** Otherwise the selection stands.

⚠ **The second half is a correctness requirement, not a hedge — self-review caught it as a regression before it shipped** (third commit). `ModelAndProviderContext.changeModel` writes BOTH the session row and the global default, so after a per-chat model switch the daemon holds them in step while the client's cached copy of the row is the value from *before* the switch. Preferring the row on every disagreement answered a switch by showing the model the user had just switched away from. When the selection is barred there is no such ambiguity: Gate A refuses to bind it at all, so it provably is not what runs here.

⚠ **Two statements, deliberately separate.** *What runs here* drives the chip, its tier padlock, its affiliation and the gauge's window. *Why your choice is not in effect* is a sentence only `selectionBarredByPrivacy` earns. A private chat switched by hand to a different **private** provider gets **no** sentence, because privacy is not the reason.

⚠ **Residual, deliberate, identical to `main`:** that same private-on-private chat also keeps showing the selection rather than its own binding. It is not what F2 reported, and fixing it needs the cached row invalidated on a switch rather than a heuristic in the composer. A public chat now reads no provider catalog at all.

### F14

- `components/knowledge/selectionWarning.ts` — one line, first sentence, 160-char cap; the refusal itself is untouched.
- ⚠ **Caught only at runtime:** routing through `conversionUtils.errorMessage(err, 'unknown error')` printed `Knowledge selection not hydrated: unknown error`. This route answers `text/plain`, so the client throws a bare **string**, and that helper's last arm returns the DEFAULT for a string. Quieting a warning is not the same as emptying it.

### F8

- `crates/biorouter/src/providers/coding_agent/mod.rs:189` — `unwrap_json_error`, read by **all four** places a vendor payload becomes a provider error: both streaming decoders (`codex_stream.rs`, `claude_stream.rs`) and both blocking parsers (`providers/codex.rs`, which had its own second copy of the extraction, and `providers/claude_code.rs`). A streamed turn and a blocking one therefore cannot say different things about the same failure. Best-effort by construction: anything it cannot improve on is returned verbatim.
- `crates/biorouter/src/agents/mistakes.rs:437` — `end_sentence`; the frame supplies a full stop only when the text has none.
- `crates/biorouter-cli/src/session/builder.rs:1114` — the keychain paragraph is withheld from providers that declare no secret config keys. ⚠ This is a **different** path from the vendor-payload boundary (the CLI's `providers::create` wrapper); it is fixed because it is small and the advice is nonsense for a coding agent, not because it is the same bug.

### F10

- `components/ContextWindowIndicator.tsx` — both the ring and the popover gauge render nothing when there is no window. Asserted on the LIMIT, not only on the loaded flag: a lookup that finished and found nothing is exactly the case.
- `ChatInput.tsx` no longer announces the 128k fallback as a loaded limit.

## Tests

Every line below was run in this worktree after the change.

| Gate | Result |
| --- | --- |
| `cargo test -p biorouter --lib -- privacy::` | **232 passed**, 0 failed |
| `cargo test -p biorouter --lib -- agents::agent::gate` | **31 passed**, 0 failed (baseline 28; +3) |
| `cargo test -p biorouter --lib -- agents::agent::gate_b` | **9 passed** — incl. `a_repaired_bind_reports_the_provider_that_actually_served_the_turn`, `a_turn_that_needed_no_repair_reports_nothing`, `a_refused_turn_reports_no_pinned_provider` |
| `cargo test -p biorouter --lib -- providers::coding_agent providers::claude_code providers::codex` | **207 passed**, 0 failed |
| `cargo test -p biorouter --lib -- agents::mistakes` | **18 passed**, 0 failed |
| `cargo test -p biorouter --lib` | **3713 passed**, 0 failed, 1 ignored |
| `cargo test -p biorouter-server --lib routes::reply` | **73 passed**, 0 failed |
| `cargo test -p biorouter-server --lib` | **572 passed**, 0 failed |
| `cargo test -p biorouter-cli --lib` (isolated `HOME`, literal `CARGO_HOME`/`RUSTUP_HOME`) | **385 passed**, 0 failed |
| `cargo test -p biorouter --test privacy_toggle` | **4 passed** |
| `cargo test -p biorouter --test privacy_capability` | **4 passed** |
| `cargo test -p biorouter --test privacy_disclosure_toggle` | **1 passed** |
| `cargo test -p biorouter-server --test privacy_toggle_config` | **12 passed** |
| `cargo test -p biorouter-mcp --test privacy_toggle_export` | **1 passed** |
| `cargo fmt --all -- --check` | clean |
| `./scripts/clippy-lint.sh` | ✅ all baseline checks passed, `too_many_lines` ok, no banned TLS crates |
| `cd ui/desktop && npm run test:run` | 427 files, **4792 passed**, 1 skipped (baseline 4781; +11 new cases) |
| `cd ui/desktop && npm run lint:check` | clean — 3 themes current, 332 contrast assertions, token mirrors |
| `npx prettier --check` on all 10 changed `ui/desktop/src` files | All matched files use Prettier code style |

All Rust runs carried `BIOROUTER_DISABLE_KEYRING=true`. `just generate-openapi` was run from this worktree; the regenerated contract is committed.

The coding-agent tests use both vendors' **real** payloads, quoted from PR #180's live verification rather than invented.

## Runtime verification

Own seam-built daemon (`cargo build --features biorouter/privacy-test-auth`, staged into this worktree's `ui/desktop/src/bin/`, `strings … | grep -c TEST-AUTH` = 1), sandboxed instances `fix-privacy` (CDP 9343) and `fix-privacy-onboarding` (CDP 9344). Screenshots under `~/biorouter-runs/test-drive/round3/shots/fix-privacy/`.

| Step | Evidence |
| --- | --- |
| F2 **before** — chip `claude-opus-5 (Public model)`, gauge "998.6k of 1M", row `versa_azure`/private, no note | `07-before-turn-chip-and-gauge-wrong.png`, `07-db-row-before.txt` |
| F2 turn ran on Versa — `input_tokens` 1444 → 27833, `output_tokens` 5, row still `versa_azure`/`private` | sqlite read, quoted above |
| F2 **after** — note *"This chat is marked private, so it stays on Versa API Azure / gpt-5.2-2025-12-11. Claude Code / claude-opus-5 is not used here."*; chip `gpt-5.2-2025-12-11 (Private model, UCSF)`; gauge "372.2k of **400k**" | `08-after-note-chip-gauge-correct.png` (light), `14-final-note-chip-gauge.png` (dark, after the rule correction) |
| The note is not noise, and neither is the override — with the app back on `versa_azure`/`gpt-5.5-2026-04-24` (**private**, so admissible) the note is gone and the composer states the selection again, exactly as `main` does | re-measured after the third commit: chip `gpt-5.5-2026-04-24`, gauge "1.0M of 1.1M", note `null`. `11-note-gone-on-a-private-selection.png` is the pre-correction shot of the same step |
| F14 — console is one line: `Knowledge selection not hydrated: That chat is private, or there is no chat with that id.` Zero page errors | `agent_browser_console` / `agent_browser_errors` |
| F8 Codex — `Ran into this error: Request failed: The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.` No JSON envelope | `09-codex-vendor-error-unwrapped.png` |
| F8 Claude Code — `…Run 'claude update', or update the Claude desktop app, then try again.` — one full stop, not two | `10-claude-code-single-full-stop.png` |
| F10 — composer says "No model yet — choose a provider to start chatting"; **no gauge renders at all** (0 `Context window` controls, no "tokens remaining" anywhere) | `13-onboarding-no-gauge.png` |

Sandbox restored to `versa_azure` / `gpt-5.5-2026-04-24`; both probe chats deleted; both instances stopped. `git status --porcelain` in the main checkout is unchanged (`?? .agents/`, as before).

## Out of scope

- **The Gate B frame is not what fixes the desktop.** It is correct and tested, and it covers the paths where the live agent and the row genuinely disagree (LRU rehydration, a legacy row) — but on the desktop the row-derived binding is what drives the chip, the gauge and the note. Kept because it is the authoritative statement of what served a turn and because it outranks the row when the two differ; not claimed to be more than that.
- **A subagent, the web bridge and the TUI do nothing with the frame.** Each has a named arm saying why. Adding a `StreamEvent` variant for `--output-format stream-json` would change a public contract for a display nicety and is left alone.
- **F11's `--` in the model-switch toast** is visible in `06-model-switched-toast.png` and belongs to the copy pass, not here.
- The keychain-suffix fix (`biorouter-cli`) is unit-tested but not runtime-verified: forcing `providers::create` to fail for a coding agent in the GUI is not reachable, and the path is CLI-only.
- The note is turn-independent now, but it still depends on `GET /config/providers` resolving the selected provider's tier; a catalog that cannot be read yields no note (asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
