### PR TITLE
Skills: seed the soul skill into the root its owner was built with, not the ambient one

### DIFF
--- a/crates/biorouter-cli/src/cli.rs
+++ b/crates/biorouter-cli/src/cli.rs
@@ -2367,10 +2367,15 @@ async fn handle_knowledge_subcommand(command: KnowledgeCommand) -> Result<()> {
     // deleting part of it is indefensible. They see the legacy bases named and
     // choose. `install_assets` still registers the built-in Soul, which it does
     // without purging.
+    // Resolved once here, at the top of the command, and passed down: the
+    // seeders take their root explicitly so nothing re-reads the process
+    // environment part-way through. For a real CLI invocation this is exactly
+    // the ambient root, as it always was.
+    let config_dir = biorouter::config::paths::Paths::config_dir();
     if !matches!(command, KnowledgeCommand::List { .. }) {
-        biorouter::knowledge::soul::ensure_soul_kb()?;
+        biorouter::knowledge::soul::ensure_soul_kb(&config_dir)?;
     }
-    biorouter::knowledge::soul::install_assets();
+    biorouter::knowledge::soul::install_assets(&config_dir);
     match command {
         KnowledgeCommand::List { format } => knowledge::handle_list(&format).await,
         KnowledgeCommand::Active {

--- a/crates/biorouter-mcp/src/knowledge/paths.rs
+++ b/crates/biorouter-mcp/src/knowledge/paths.rs
@@ -41,7 +41,17 @@ pub enum KbIdError {
 /// macOS; they differ only on Windows, where the old path was never the one the
 /// rest of Biorouter used anyway.
 pub fn knowledge_root() -> anyhow::Result<PathBuf> {
-    Ok(crate::paths::in_config_dir("knowledge"))
+    Ok(knowledge_root_in(&crate::paths::config_dir()))
+}
+
+/// The same store, under a config root the caller resolved itself.
+///
+/// Exists so a caller that must NOT re-read the ambient `BIOROUTER_PATH_ROOT`
+/// at write time — `knowledge::soul`'s seeders, which run in a task spawned by
+/// `AgentManager::new` — can still spell the `<config>/knowledge` join exactly
+/// once, here, rather than growing a second copy of it that drifts.
+pub fn knowledge_root_in(config_dir: &Path) -> PathBuf {
+    config_dir.join("knowledge")
 }
 
 pub fn kb_root(root: &Path, id: &str) -> PathBuf {

--- a/crates/biorouter-server/src/routes/reset.rs
+++ b/crates/biorouter-server/src/routes/reset.rs
@@ -242,8 +242,11 @@ async fn reset_schedules(state: &AppState) -> Result<u64> {
             .await
             .map_err(|error| anyhow::anyhow!(error))?;
     }
-    let workflow_path =
-        tokio::task::spawn_blocking(biorouter::knowledge::soul::ensure_meditation_workflow).await?;
+    let config_dir = biorouter::config::paths::Paths::config_dir();
+    let workflow_path = tokio::task::spawn_blocking(move || {
+        biorouter::knowledge::soul::ensure_meditation_workflow(&config_dir)
+    })
+    .await?;
     let workflow_path = workflow_path?;
     biorouter::knowledge::soul::ensure_meditation_schedule(&scheduler, workflow_path).await?;
     Ok(count)

--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -15291,7 +15291,7 @@ mod tests {
             ("BIOROUTER_PATH_ROOT", Some(path_root_value.as_str())),
             ("BIOROUTER_KNOWLEDGE_TEST_MODE", Some("true")),
         ]);
-        crate::knowledge::soul::install_assets();
+        crate::knowledge::soul::install_assets(&crate::config::paths::Paths::config_dir());
 
         let (agent, session_id) = agent_with_one_extension_for_tests().await;
         let knowledge_target = resolve_bundled_extension("knowledge").expect("bundled Knowledge");

--- a/crates/biorouter/src/agents/skills_extension.rs
+++ b/crates/biorouter/src/agents/skills_extension.rs
@@ -208,8 +208,25 @@ pub fn shipped_skills() -> impl Iterator<Item = &'static (&'static str, &'static
     BUILTIN_SKILLS.iter().chain(KNOWLEDGE_SKILLS.iter())
 }
 
-pub(crate) fn install_builtin_skills() {
-    SkillsClient::ensure_builtin_skills(&Paths::config_dir().join("skills"));
+/// Seed the shipped skills into a skills root the caller resolved.
+///
+/// ⚠ **`skills_dir` is a parameter for the same reason `knowledge::soul`'s
+/// seeders take one.** This used to spell `Paths::config_dir().join("skills")`
+/// itself, and one of its two callers is a task `AgentManager::new` *spawns* —
+/// so the read landed at an arbitrary point after the constructor returned,
+/// which in the test binary is whichever unrelated test holds `env_lock` by
+/// then. The owner resolves the root once, when it is constructed, and threads
+/// it here.
+pub(crate) fn install_builtin_skills(skills_dir: &Path) {
+    SkillsClient::ensure_builtin_skills(skills_dir);
+}
+
+/// Where Biorouter's own skills live under a given config root. Must stay the
+/// same join [`skill_catalog::roots`] makes for its `SkillSourceKind::Biorouter`
+/// entry — a seeder that writes somewhere the discoverer does not look installs
+/// nothing, silently.
+pub fn skills_root(config_dir: &Path) -> PathBuf {
+    config_dir.join("skills")
 }
 
 /// Every shipped **Context**, by the identifier its enablement is keyed on.
@@ -783,7 +800,11 @@ impl SkillsClient {
             instructions: Some(String::new()),
         };
 
-        install_builtin_skills();
+        // Resolved HERE, in the constructor, and not inside the seeder: this
+        // call is synchronous, so the root a `SkillsClient` seeds into is the
+        // one that was ambient when the client was built. Nothing defers it to
+        // a later task.
+        install_builtin_skills(&skills_root(&Paths::config_dir()));
 
         // The catalog is refreshed here rather than merely read, because a
         // client is constructed when a conversation starts and the seeding

--- a/crates/biorouter/src/execution/manager.rs
+++ b/crates/biorouter/src/execution/manager.rs
@@ -44,6 +44,23 @@ impl AgentManager {
     ) -> Result<Self> {
         let scheduler = Scheduler::new(schedule_file_path, session_manager.clone()).await?;
 
+        // ⚠ **Resolved ONCE, here, and threaded from here on.** Everything this
+        // constructor seeds — the Soul KB, the built-in skills, the update-soul
+        // skill, the Meditation workflow — used to call `Paths::config_dir()`
+        // for itself, at the moment it wrote. The seeding below is *spawned*
+        // (BR-55), so that moment is an arbitrary point after `new` has
+        // returned, and `BIOROUTER_PATH_ROOT` is process-global: in the lib test
+        // binary the root it read belonged to whichever unrelated test held
+        // `env_lock` by then. That is how
+        // `knowledge::conversation_ingest::tests::missing_or_disabled_soul_\
+        // skill_fails_before_raw_staging` — whose entire assertion is that no
+        // `update-soul` skill exists in the temp root it owns — was handed one
+        // by a manager it never built (CI `test (ubuntu-latest)`, PR #191 run
+        // 34304297956). A lock in the reader could not help; the writer never
+        // asked for one. A manager now writes only into the root it was
+        // constructed with.
+        let config_dir = Paths::config_dir();
+
         // Runs to completion before this constructor returns, so on the success
         // path no client ever observes a pre-OKF base or a store without its
         // built-in OKF Soul. It deliberately does NOT gate construction: a
@@ -52,7 +69,12 @@ impl AgentManager {
         // message names — strictly worse than a degraded Knowledge surface, and
         // the reconciliation is retried on every startup and every
         // `biorouter knowledge` command anyway.
-        match tokio::task::spawn_blocking(crate::knowledge::soul::ensure_soul_kb).await {
+        let reconcile_root = config_dir.clone();
+        match tokio::task::spawn_blocking(move || {
+            crate::knowledge::soul::ensure_soul_kb(&reconcile_root)
+        })
+        .await
+        {
             Ok(Ok(())) => {}
             Ok(Err(error)) => {
                 tracing::error!("failed to reconcile the Soul knowledge base: {error:#}");
@@ -78,9 +100,9 @@ impl AgentManager {
         // exists.
         let scheduler = Arc::clone(&manager.scheduler);
         if std::env::var_os("BIOROUTER_BLOCKING_STARTUP").is_some() {
-            Self::run_first_run_init(scheduler).await;
+            Self::run_first_run_init(scheduler, config_dir).await;
         } else {
-            tokio::spawn(Self::run_first_run_init(scheduler));
+            tokio::spawn(Self::run_first_run_init(scheduler, config_dir));
         }
 
         Ok(manager)
@@ -94,14 +116,24 @@ impl AgentManager {
     /// request, so [`AgentManager::new`] runs it in the background (BR-55). The
     /// synchronous skills seeding is blocking file I/O, so it goes through
     /// `spawn_blocking` to keep it off the async runtime.
-    async fn run_first_run_init(scheduler: Arc<dyn SchedulerTrait>) {
-        if let Err(e) =
-            tokio::task::spawn_blocking(crate::agents::skills_extension::install_builtin_skills)
-                .await
+    ///
+    /// ⚠ `config_dir` is **passed in**, never resolved here. This function runs
+    /// detached from the constructor that scheduled it, so a `Paths::config_dir()`
+    /// call in this body reads whatever the process environment says at some
+    /// later, unowned instant — see the note in [`AgentManager::new`].
+    async fn run_first_run_init(
+        scheduler: Arc<dyn SchedulerTrait>,
+        config_dir: std::path::PathBuf,
+    ) {
+        let skills_dir = crate::agents::skills_extension::skills_root(&config_dir);
+        if let Err(e) = tokio::task::spawn_blocking(move || {
+            crate::agents::skills_extension::install_builtin_skills(&skills_dir)
+        })
+        .await
         {
             tracing::warn!("Failed to seed built-in skills: {e}");
         }
-        crate::knowledge::soul::install(&scheduler).await;
+        crate::knowledge::soul::install(&config_dir, &scheduler).await;
     }
 
     pub async fn instance() -> Result<Arc<Self>> {
@@ -389,8 +421,9 @@ mod tests {
 
         // Running the deferred init directly must be panic-free and idempotent
         // (best-effort: every step logs a warning on failure rather than erroring).
-        AgentManager::run_first_run_init(manager.scheduler()).await;
-        AgentManager::run_first_run_init(manager.scheduler()).await;
+        let config_dir = temp_dir.path().join("config");
+        AgentManager::run_first_run_init(manager.scheduler(), config_dir.clone()).await;
+        AgentManager::run_first_run_init(manager.scheduler(), config_dir).await;
     }
 
     /// BR-71: `peek_agent` is a LOOKUP. Its whole reason to exist is that
@@ -1059,5 +1092,93 @@ mod tests {
         let result = manager.remove_session(&session).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    /// The first-run seeding must land in the root the manager was BUILT with,
+    /// never in whatever `BIOROUTER_PATH_ROOT` happens to be ambient by the
+    /// time the background task actually runs.
+    ///
+    /// This is the root cause of the `missing_or_disabled_soul_skill_fails_\
+    /// before_raw_staging` flake (CI `test (ubuntu-latest)`, PR #191 run
+    /// 34304297956): `new` **spawns** `run_first_run_init`, which used to
+    /// resolve `Paths::config_dir()` at seed time — inside a detached task,
+    /// long after `new` returned and after the constructing test had let go of
+    /// the environment. Whichever other test held `env_lock` at that moment
+    /// owned the directory the soul skill was written into, so a test whose
+    /// entire assertion is "no `update-soul` skill exists in MY root" was
+    /// handed one by a manager it never built. A lock in the reader cannot
+    /// close that — the writer never asks for it (the family recorded in
+    /// `model.rs`, "only serialises callers that *ask* for it").
+    ///
+    /// The runtime is deliberately `current_thread`: the spawned init can then
+    /// only run when this test yields, so the swap below is ordered rather than
+    /// raced, and the pre-fix tree fails this every time instead of sometimes.
+    #[tokio::test(flavor = "current_thread")]
+    async fn first_run_seeding_lands_in_the_root_the_manager_was_built_with() {
+        fn soul_skill(root: &std::path::Path) -> std::path::PathBuf {
+            root.join("config")
+                .join("skills")
+                .join(crate::agents::skills_extension::KNOWLEDGE_BUNDLE)
+                .join(crate::knowledge::soul::SOUL_SKILL_DIR)
+                .join("SKILL.md")
+        }
+
+        let built_with = TempDir::new().unwrap();
+        let ambient_later = TempDir::new().unwrap();
+        let sessions = TempDir::new().unwrap();
+
+        let manager = {
+            // The manager is constructed while THIS root is the ambient one …
+            let _env = env_lock::lock_env([(
+                "BIOROUTER_PATH_ROOT",
+                Some(built_with.path().to_str().unwrap()),
+            )]);
+            let session_manager = Arc::new(SessionManager::new(sessions.path().to_path_buf()));
+            AgentManager::new(
+                session_manager,
+                sessions.path().join("schedule.json"),
+                Some(4),
+            )
+            .await
+            .unwrap()
+            // … and `new` returns without ever yielding after the spawn, so on
+            // a current-thread runtime the init has provably not run yet.
+        };
+
+        // … and some *other* test now owns the environment. Nothing this
+        // manager does may follow it there.
+        let _env = env_lock::lock_env([(
+            "BIOROUTER_PATH_ROOT",
+            Some(ambient_later.path().to_str().unwrap()),
+        )]);
+
+        // The loop exits as soon as the seed lands in EITHER root — ~50 ms in
+        // practice, in both the passing and the failing direction — so the
+        // generous cap is paid only by a genuinely stuck run, never by a green
+        // one. A fix for a flake must not itself be timing-sensitive on a
+        // loaded runner: the first `ensure_soul_kb` initialises a git repo.
+        for _ in 0..3_000 {
+            if soul_skill(built_with.path()).is_file() || soul_skill(ambient_later.path()).exists()
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        assert!(
+            !soul_skill(ambient_later.path()).exists(),
+            "the first-run seeding followed the ambient BIOROUTER_PATH_ROOT into \
+             {} — a root this manager was never given. That is the flake: any \
+             test holding the environment when a background init fires is handed \
+             an `update-soul` skill it did not install.",
+            ambient_later.path().display()
+        );
+        assert!(
+            soul_skill(built_with.path()).is_file(),
+            "the first-run seeding never reached the manager's own root at {}",
+            built_with.path().display()
+        );
+
+        drop(manager);
     }
 }

--- a/crates/biorouter/src/knowledge/conversation_ingest.rs
+++ b/crates/biorouter/src/knowledge/conversation_ingest.rs
@@ -837,21 +837,23 @@ mod tests {
             "{missing}\n\n\
              ⚠ If this failed with `Ok(Some(Soul {{ … }}))`, the soul skill was \
              planted in this test's own root by a CONCURRENT test, and the cause \
-             is not in this file. `execution::manager` line ~104 calls \
-             `soul::install`, which seeds `update-soul` into \
-             `Paths::config_dir()` — i.e. whatever `BIOROUTER_PATH_ROOT` is \
-             ambient — and it takes no env lock. While this test holds the lock, \
-             that ambient value is OUR temp dir, so any test in this binary that \
-             starts an execution manager writes the skill here.\n\
-             This is the family recorded at `model.rs` (search \
-             \"only serialises callers that *ask* for it\"): the guard is \
-             present and correct and cannot help, because the writer never asks \
-             for it. Observed once, in a full `cargo test --workspace` on a \
-             machine also running another repository's suite; 8 targeted runs \
-             (alone x5, this binary x2, --test-threads=1) and all three CI \
-             platforms pass. Do NOT add a lock here — it is already here. The \
-             fix, if this recurs, is to stop the assertion depending on the \
-             ABSENCE of a file in a process-global location."
+             is not in this file.\n\
+             That used to be a live bug and is now fixed at the writer: \
+             `soul::install` seeded `update-soul` into `Paths::config_dir()` — \
+             whatever `BIOROUTER_PATH_ROOT` was ambient — from inside the task \
+             `AgentManager::new` *spawns*, so while this test held the env lock \
+             any manager in this binary wrote its skill here. It observed as a \
+             flake once locally and once on CI (`test (ubuntu-latest)`, PR #191 \
+             run 34304297956) before the seeders were changed to take their root \
+             as an argument, captured when the manager is constructed.\n\
+             So do NOT add a lock here — a lock in the READER never could help, \
+             because the writer never asked for one (the family recorded at \
+             `model.rs`, search \"only serialises callers that *ask* for it\"). \
+             A recurrence means a seeder has gone back to resolving its own root: \
+             see `knowledge::soul::tests::\
+             every_seeder_takes_its_root_as_an_argument`, and the behavioural pin \
+             `execution::manager::tests::\
+             first_run_seeding_lands_in_the_root_the_manager_was_built_with`."
         );
         assert_eq!(
             raw_source_count(&svc, crate::knowledge::soul::SOUL_KB_ID),

--- a/crates/biorouter/src/knowledge/soul.rs
+++ b/crates/biorouter/src/knowledge/soul.rs
@@ -25,8 +25,13 @@ use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+// ⚠ `crate::config::paths::Paths` is deliberately NOT imported here. Every
+// seeder in this module takes its config root as an argument, because the
+// startup path that drives them is a task `AgentManager::new` spawns — a
+// `Paths::config_dir()` call in this file therefore reads the process-global
+// `BIOROUTER_PATH_ROOT` at an instant nobody owns. Pinned by
+// `every_seeder_takes_its_root_as_an_argument`.
 use crate::agents::skills_extension;
-use crate::config::paths::Paths;
 use crate::scheduler::ScheduledJob;
 use crate::scheduler_trait::SchedulerTrait;
 use anyhow::Context as _;
@@ -108,16 +113,34 @@ impl Drop for SoulFileLock {
     }
 }
 
-/// Install every Soul component that is missing. Best-effort: a failure in one
-/// component is logged and does not abort the others or block startup.
-pub async fn install(scheduler: &Arc<dyn SchedulerTrait>) {
-    if let Err(e) = ensure_soul_kb() {
+/// Install every Soul component that is missing, under `config_dir`.
+/// Best-effort: a failure in one component is logged and does not abort the
+/// others or block startup.
+///
+/// ⚠ **The root is a PARAMETER, and it is not decoration.** Every seeder below
+/// used to resolve `Paths::config_dir()` — i.e. the ambient
+/// `BIOROUTER_PATH_ROOT` — at the moment it wrote. `AgentManager::new` *spawns*
+/// this whole chain (BR-55, to keep it off the listener's hot path), so "the
+/// moment it wrote" is an arbitrary point after the constructor returned, and
+/// in the test binary that is whichever unrelated test happens to be holding
+/// `env_lock` by then. The result was a `update-soul` skill appearing inside a
+/// temp directory owned by a test that had installed nothing
+/// (`knowledge::conversation_ingest`'s
+/// `missing_or_disabled_soul_skill_fails_before_raw_staging`, CI
+/// `test (ubuntu-latest)`, PR #191 run 34304297956).
+///
+/// A lock in the *reader* cannot close that — the writer never asked for one.
+/// The caller resolves the root once, when the object that owns this work is
+/// constructed, and threads it; a seeder that reads no process-global state has
+/// no race to lose.
+pub async fn install(config_dir: &Path, scheduler: &Arc<dyn SchedulerTrait>) {
+    if let Err(e) = ensure_soul_kb(config_dir) {
         tracing::warn!("Soul: failed to create knowledge base: {e}");
     }
-    if let Err(e) = ensure_soul_skill() {
+    if let Err(e) = ensure_soul_skill(config_dir) {
         tracing::warn!("Soul: failed to install skill: {e}");
     }
-    match ensure_meditation_workflow() {
+    match ensure_meditation_workflow(config_dir) {
         Ok(path) => {
             if let Err(e) = ensure_meditation_schedule(scheduler, path).await {
                 tracing::warn!("Soul: failed to register Daily Meditation schedule: {e}");
@@ -128,23 +151,32 @@ pub async fn install(scheduler: &Arc<dyn SchedulerTrait>) {
 }
 
 /// Install the assets that don't need a running scheduler (KB, skill, workflow
-/// file). Used on surfaces that have no scheduler handy (e.g. CLI-only flows).
-pub fn install_assets() {
-    let _ = ensure_soul_kb_without_purge();
-    let _ = ensure_soul_skill();
-    let _ = ensure_meditation_workflow();
+/// file) under `config_dir`. Used on surfaces that have no scheduler handy
+/// (e.g. CLI-only flows).
+pub fn install_assets(config_dir: &Path) {
+    let _ = ensure_soul_kb_without_purge(config_dir);
+    let _ = ensure_soul_skill(config_dir);
+    let _ = ensure_meditation_workflow(config_dir);
 }
 
-fn ensure_soul_kb_without_purge() -> anyhow::Result<()> {
-    let svc = KnowledgeService::new_default()?;
+/// The knowledge store under a given config root — the same join
+/// [`biorouter_mcp::knowledge::paths::knowledge_root`] makes from the ambient
+/// one, spelled once so the two can never disagree.
+fn knowledge_service(config_dir: &Path) -> KnowledgeService {
+    KnowledgeService::new(paths::knowledge_root_in(config_dir))
+}
+
+fn ensure_soul_kb_without_purge(config_dir: &Path) -> anyhow::Result<()> {
+    let svc = knowledge_service(config_dir);
     let _reconcile_lock = SoulFileLock::acquire(&svc.root().join(SOUL_RECONCILE_LOCK))?;
     ensure_registered_native_soul(&svc)
 }
 
-/// Remove every pre-OKF knowledge base and ensure the built-in Soul is current
-/// plain OKF. Existing OKF and BioOKF bases are preserved.
-pub fn ensure_soul_kb() -> anyhow::Result<()> {
-    let svc = KnowledgeService::new_default()?;
+/// Remove every pre-OKF knowledge base under `config_dir` and ensure the
+/// built-in Soul is current plain OKF. Existing OKF and BioOKF bases are
+/// preserved.
+pub fn ensure_soul_kb(config_dir: &Path) -> anyhow::Result<()> {
+    let svc = knowledge_service(config_dir);
     for id in reconcile_soul_kb(&svc)?.removed {
         tracing::info!("Soul: removed legacy knowledge base '{id}'");
     }
@@ -610,10 +642,10 @@ fn require_registered_native_soul(svc: &KnowledgeService) -> anyhow::Result<()> 
     Ok(())
 }
 
-/// Keep the shipped "Meditation" workflow current in the global workflow
-/// library. Returns the workflow file path.
-pub fn ensure_meditation_workflow() -> anyhow::Result<PathBuf> {
-    let dir = Paths::config_dir().join("workflows");
+/// Keep the shipped "Meditation" workflow current in the workflow library under
+/// `config_dir`. Returns the workflow file path.
+pub fn ensure_meditation_workflow(config_dir: &Path) -> anyhow::Result<PathBuf> {
+    let dir = config_dir.join("workflows");
     std::fs::create_dir_all(&dir)?;
     let path = dir.join(MEDITATION_WORKFLOW_FILE);
     if create_or_upgrade_built_in_file(
@@ -680,8 +712,8 @@ fn create_built_in_file_if_missing(path: &std::path::Path, content: &str) -> any
 /// is the Context row Settings offers. Seeding it flat would give it a
 /// `bundle_name` of `None`, which is a standalone picker row that the bundle's
 /// Context toggle does not reach.
-pub fn ensure_soul_skill() -> anyhow::Result<()> {
-    if place_soul_skill(&Paths::config_dir().join("skills"))? {
+pub fn ensure_soul_skill(config_dir: &Path) -> anyhow::Result<()> {
+    if place_soul_skill(&skills_extension::skills_root(config_dir))? {
         // Creating `<bundle>/<child>/` bumps the bundle's mtime and not the
         // root's, and mtime is one-second granular — see `skill_catalog`'s
         // header. A writer says what it did rather than hoping to be noticed.
@@ -695,7 +727,9 @@ pub fn ensure_soul_skill() -> anyhow::Result<()> {
 ///
 /// Split out so a test can drive the migration over a `TempDir` without setting
 /// `BIOROUTER_PATH_ROOT`, whose process-global reach would make it depend on
-/// whatever ran before it.
+/// whatever ran before it. That reasoning has since been generalised: its
+/// caller takes a config root for the same reason, so *nothing* on this path
+/// reads the environment any more.
 fn place_soul_skill(skills_root: &Path) -> anyhow::Result<bool> {
     let bundle = skills_extension::knowledge_bundle_dir(skills_root);
 
@@ -971,6 +1005,89 @@ user**, not to log conversations verbatim.
 mod tests {
     use super::*;
     use crate::workflow::Workflow;
+
+    /// The production half of a source file: everything before its first
+    /// test module. Slicing matters — a guard that read the whole file would
+    /// report every `Paths::` a *test* legitimately spells.
+    fn production_half(source: &str) -> &str {
+        source.split("\n#[cfg(test)]").next().unwrap_or(source)
+    }
+
+    /// `source` with every `//` comment removed.
+    ///
+    /// Required, not tidiness: the comments this guard protects *name* the
+    /// call they forbid — that is how a reader learns why it is forbidden — so
+    /// a guard reading raw text fails on its own explanation and gets deleted.
+    fn without_comments(source: &str) -> String {
+        source
+            .lines()
+            .map(|line| line.split("//").next().unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The body of `fn <name>` in `source`, from its signature to the first
+    /// line that closes a block at the given indentation.
+    fn function_body<'a>(source: &'a str, signature: &str, closer: &str) -> &'a str {
+        let after = source
+            .split(signature)
+            .nth(1)
+            .unwrap_or_else(|| panic!("`{signature}` must exist"));
+        after
+            .split(closer)
+            .next()
+            .unwrap_or_else(|| panic!("`{signature}` must have a block body"))
+    }
+
+    /// **Nothing that seeds Soul may resolve its own root.**
+    ///
+    /// This is the fix for the `missing_or_disabled_soul_skill_fails_before_\
+    /// raw_staging` flake (CI `test (ubuntu-latest)`, PR #191 run
+    /// 34304297956), and it is the kind of fix that reverts by accident: adding
+    /// one convenient `Paths::config_dir()` back into any of these three bodies
+    /// restores the bug in full, with every test still green, because the
+    /// damage lands in a *different* test's temp directory.
+    ///
+    /// The rule is not "don't call `Paths`" in general — `AgentManager::new`,
+    /// the CLI and the reset route all call it, and must. It is that a writer
+    /// which runs **detached from the call that scheduled it** takes its root as
+    /// an argument, so it can only ever write where its owner said.
+    ///
+    /// Asserted over source text because there is no runtime signal: a seeder
+    /// that reads the environment is indistinguishable from one that does not
+    /// until two roots exist at once, which is exactly the situation a passing
+    /// suite does not create.
+    #[test]
+    fn every_seeder_takes_its_root_as_an_argument() {
+        let soul = without_comments(production_half(include_str!("soul.rs")));
+        assert!(
+            !soul.contains("Paths::"),
+            "knowledge::soul must resolve no path of its own — every seeder here \
+             runs inside a task `AgentManager::new` spawned, so a `Paths::` call \
+             reads whatever BIOROUTER_PATH_ROOT says at an instant nobody owns."
+        );
+
+        let manager = without_comments(production_half(include_str!("../execution/manager.rs")));
+        let first_run_init = function_body(&manager, "async fn run_first_run_init(", "\n    }");
+        assert!(
+            !first_run_init.contains("Paths::") && !first_run_init.contains("config_dir()"),
+            "`run_first_run_init` is spawned, not awaited — it must receive its \
+             config root, never resolve one. Body was:\n{first_run_init}"
+        );
+        assert!(
+            first_run_init.contains("soul::install(&config_dir"),
+            "the Soul seeding must be handed the root this manager was built \
+             with. Body was:\n{first_run_init}"
+        );
+
+        let skills = without_comments(include_str!("../agents/skills_extension.rs"));
+        let seeder = function_body(&skills, "pub(crate) fn install_builtin_skills(", "\n}");
+        assert!(
+            !seeder.contains("Paths::"),
+            "`install_builtin_skills` is called from `run_first_run_init`, which \
+             is spawned — it must take its skills root. Body was:\n{seeder}"
+        );
+    }
 
     #[test]
     fn workflow_yaml_parses_into_a_valid_workflow() {


### PR DESCRIPTION
## Why

`test (ubuntu-latest)` on PR #191 — a PR that changed only UI copy — failed in the
`biorouter` lib binary (run 34304297956, job 102317657969):

```
test knowledge::conversation_ingest::tests::missing_or_disabled_soul_skill_fails_before_raw_staging ... FAILED
panicked at crates/biorouter/src/knowledge/conversation_ingest.rs:833:10
```

That test isolates itself properly — `env_lock::lock_env` over both
`BIOROUTER_PATH_ROOT` and `HOME`, plus a catalog invalidation — and then asserts
that `platform_curation_profile` fails with "not installed" because no
`update-soul` skill exists in the root it owns. Its own assertion message had
already named the culprit:

> `execution::manager` line ~104 calls `soul::install`, which seeds `update-soul`
> into `Paths::config_dir()` — i.e. whatever `BIOROUTER_PATH_ROOT` is ambient —
> and it takes no env lock. While this test holds the lock, that ambient value is
> OUR temp dir, so any test in this binary that starts an execution manager
> writes the skill here.

It was right, and it drew the right conclusion about locks: a guard held by the
**reader** cannot help, because the writer never asks for one (the family
recorded at `model.rs`, "only serialises callers that *ask* for it"). What it
proposed as the fix — weaken the assertion — would have thrown away the only
thing the test checks. The fix belongs at the writer.

## Root cause

`AgentManager::new` (`crates/biorouter/src/execution/manager.rs:40`) **spawns**
the first-run seeding rather than awaiting it — BR-55, to keep skill/workflow/
schedule I/O off the listener's hot path:

```rust
tokio::spawn(Self::run_first_run_init(scheduler));   // pre-fix
```

Every writer that task reaches then resolved its own root, at the moment it
wrote:

Line numbers in this table are from the **pre-fix** tree.

| writer | pre-fix root |
|---|---|
| `skills_extension::install_builtin_skills` (`skills_extension.rs:211`) | `Paths::config_dir().join("skills")` |
| `soul::ensure_soul_kb` (`soul.rs:146`) | `KnowledgeService::new_default()` → `<ambient config>/knowledge` |
| `soul::ensure_soul_skill` (`soul.rs:683`) | `Paths::config_dir().join("skills")` |
| `soul::ensure_meditation_workflow` (`soul.rs:615`) | `Paths::config_dir().join("workflows")` |

`Paths::config_dir()` reads the process-global `BIOROUTER_PATH_ROOT`. So the root
those four wrote into was decided at an instant no caller owns — an arbitrary
point after the constructor had already returned. The interleaving, all inside
one `cargo test -p biorouter --lib` process:

```
thread A (e.g. execution::manager::tests::create_test_manager, or the first
          test to touch AgentManager::instance() — neither takes an env lock)

  AgentManager::new(..)
    └─ tokio::spawn(run_first_run_init)        ← task queued, has not run yet
  new() returns

thread B (knowledge::conversation_ingest::tests::
          missing_or_disabled_soul_skill_fails_before_raw_staging)

  env_lock::lock_env([BIOROUTER_PATH_ROOT = /tmp/B, HOME = /tmp/B])
  skill_catalog::invalidate()
                                     ← A's task is polled HERE
                                       soul::install → ensure_soul_skill
                                       → Paths::config_dir() == /tmp/B/config
                                       → writes /tmp/B/config/skills/
                                            knowledge-bases/update-soul/SKILL.md
  platform_curation_profile(..)  ⇒ Ok(Some(Soul { … }))   ← should have been Err
```

Nothing in B is wrong. B holds the only lock there is, and the writer is not a
party to it. The same shape reaches `ensure_soul_kb` through the `spawn_blocking`
higher up in `new`, and `ensure_meditation_workflow` through `soul::install`.

## What changed

The seeders take their target root **explicitly**; the owner resolves it once,
when it is constructed, and threads it.

- `crates/biorouter/src/execution/manager.rs:62` — `let config_dir = Paths::config_dir();`
  captured at the top of `new`, before either seeding path, and passed to the
  `spawn_blocking` reconcile (`:73`) and to `run_first_run_init` (`:103`/`:105`).
  `run_first_run_init` (`:124`) now takes a `PathBuf` and resolves nothing.
- `crates/biorouter/src/knowledge/soul.rs` — `install`, `install_assets`,
  `ensure_soul_kb`, `ensure_soul_skill` and `ensure_meditation_workflow` all take
  `config_dir: &Path`. `crate::config::paths::Paths` is no longer imported by the
  module at all, and a new private `knowledge_service(config_dir)` replaces
  `KnowledgeService::new_default()`.
- `crates/biorouter/src/agents/skills_extension.rs:220` —
  `install_builtin_skills(skills_dir: &Path)`. New `skills_root(config_dir)`
  spells the `<config>/skills` join for both seeders. `SkillsClient::new` (`:807`)
  resolves `Paths::config_dir()` at the call site — that call is *synchronous
  inside the constructor*, so the root is the one that was ambient when the
  client was built, which is the property we want.
- `crates/biorouter-mcp/src/knowledge/paths.rs:53` — new `knowledge_root_in(config_dir)`;
  `knowledge_root()` is now defined in terms of it, so `<config>/knowledge` is
  still spelled exactly once.
- Call sites that genuinely want the ambient root now say so, at their own entry
  point rather than four frames down:
  `crates/biorouter-cli/src/cli.rs:2378`, `crates/biorouter-server/src/routes/reset.rs:247`,
  and the env-locked test at `crates/biorouter/src/agents/agent.rs:15294`.

Production behaviour is unchanged for real users: the root resolved is the same
`Paths::config_dir()` it always was, only resolved once by the caller instead of
repeatedly by the callee. Nothing mutates `BIOROUTER_PATH_ROOT` at runtime
outside tests.

The stale guidance in the flaky test's own assertion message
(`conversation_ingest.rs:836`) is replaced: it now records that the writer was
fixed, keeps the "do not add a lock here" rule with the reason intact, and points
at the two tests below.

## Tests

**New behavioural pin** —
`execution::manager::tests::first_run_seeding_lands_in_the_root_the_manager_was_built_with`.
It builds a manager while root A is ambient, hands the environment to root B, and
asserts the seed reached A and never B. `flavor = "current_thread"` makes the
ordering a fact rather than a hope: `new` does not await after the spawn, so the
init provably cannot have run before the swap.

Fail-before, on the tree without the production change (only the test added):

```
running 1 test
thread 'execution::manager::tests::first_run_seeding_lands_in_the_root_the_manager_was_built_with' panicked at crates/biorouter/src/execution/manager.rs:1128:9:
the first-run seeding followed the ambient BIOROUTER_PATH_ROOT into /var/folders/j_/fswqqly12zj4w_q484q3yfgw0000gn/T/.tmpYZsQ42 — a root this manager was never given. That is the flake: any test holding the environment when a background init fires is handed an `update-soul` skill it did not install.
test execution::manager::tests::first_run_seeding_lands_in_the_root_the_manager_was_built_with ... FAILED

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3722 filtered out; finished in 0.09s
```

Pass-after, together with the guard and the original flake:

```
running 3 tests
test knowledge::soul::tests::every_seeder_takes_its_root_as_an_argument ... ok
test knowledge::conversation_ingest::tests::missing_or_disabled_soul_skill_fails_before_raw_staging ... ok
test execution::manager::tests::first_run_seeding_lands_in_the_root_the_manager_was_built_with ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 3721 filtered out; finished in 0.09s
```

**New source guard** — `knowledge::soul::tests::every_seeder_takes_its_root_as_an_argument`.
This is a fix that reverts by accident: one convenient `Paths::config_dir()` back
inside `run_first_run_init`, `install_builtin_skills` or any `soul.rs` seeder
restores the bug in full with every test still green, because the damage lands in
a *different* test's directory. Falsified by deliberately regressing
`manager.rs:125` to `skills_root(&Paths::config_dir())`:

```
thread 'knowledge::soul::tests::every_seeder_takes_its_root_as_an_argument' panicked at crates/biorouter/src/knowledge/soul.rs:
`run_first_run_init` is spawned, not awaited — it must receive its config root, never resolve one.
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3723 filtered out; finished in 0.03s
```

**Stress**, 20 consecutive runs of the affected area at 32 threads
(`BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib -- knowledge::conversation_ingest execution:: agents::skill --test-threads=32`):

```
run  1: test result: ok. 179 passed; 0 failed; 0 ignored; 0 measured; 3545 filtered out; finished in 9.08s
run  2: test result: ok. 179 passed; …  9.24s
run  3: ok  8.97s   run  4: ok  9.76s   run  5: ok  9.63s
run  6: ok  9.36s   run  7: ok 10.41s   run  8: ok  9.27s
run  9: ok  9.37s   run 10: ok  9.22s   run 11: ok  9.50s
run 12: ok  9.93s   run 13: ok 10.13s   run 14: ok  9.40s
run 15: ok  9.64s   run 16: ok  9.55s   run 17: ok 10.04s
run 18: ok  8.97s   run 19: ok  9.10s   run 20: ok  9.15s
TALLY: 20 passed, 0 failed
```

**Gates**

```
cargo test -p biorouter --lib
  test result: ok. 3723 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 30.13s

HOME=$(mktemp -d) CARGO_HOME=/Users/wgu/.cargo RUSTUP_HOME=/Users/wgu/.rustup cargo test -p biorouter-cli --lib
  test result: ok. 386 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 22.03s

cargo test -p biorouter --test path_resolver_agreement
  test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test -p biorouter-mcp --lib knowledge::paths
  test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1637 filtered out

cargo test -p biorouter-server --lib routes::reset
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 573 filtered out

cargo test -p biorouter-server --lib
  test result: ok. 575 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.40s

cargo check --workspace --all-targets   → clean, no warnings
cargo fmt --all -- --check              → clean
./scripts/clippy-lint.sh                → ✅ All baseline clippy checks passed! (incl. too_many_lines)
```

## Runtime verification

None, deliberately. The change is a signature refactor of startup seeding with
identical resolved paths for a real user; the property under test is a
concurrency interleaving that only exists inside a test binary, and it is pinned
by the two tests above rather than by a screenshot.

## Follow-ups / out of scope

- `SkillsClient::new` still resolves `Paths::config_dir()` for its own seeding.
  That is construction-time resolution — the call is synchronous inside the
  constructor, so the caller owns the instant — and it seeds only the four
  `KNOWLEDGE_SKILLS`, never `update-soul`. It is spelled at the call site now so
  it is greppable, but it was not moved into a threaded root: the client has no
  longer-lived owner to capture one from.
- `skill_catalog::roots()` still spells `Paths::config_dir().join("skills")`
  directly rather than going through the new `skills_extension::skills_root`.
  Correct — discovery *should* follow the ambient root — but the two joins are
  now only kept in step by a doc comment.
- Nothing here changes the general hazard that `BIOROUTER_PATH_ROOT` is
  process-global. Other detached writers may exist; this PR fixes the one the CI
  log named and adds a guard shaped so the next one is easy to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
