### PR TITLE
Desktop: a quiet focus edge on keyboard-scrollable regions, and the last Title Case buttons

### DIFF
--- a/design.md
+++ b/design.md
@@ -682,6 +682,24 @@ all three families in both modes; the next Tab lands on the summary's own "Make 
 shows its focus surface; and under `prefers-contrast: more` the list takes the `2px solid --ring`
 outline through the same `[tabindex]` arm. Guarded in `styles/tabFocus.test.ts` beside the other two.
 
+**Amendment, 2026-09-08 (fourth) — that region gets a quiet inset edge, because "no treatment" is not
+an indicator.** The third amendment put the class into BOTH arms — the fill exemption and the
+`outline: none` restoration — so the UA ring was suppressed with nothing in its place: measured on the
+running app (Parchment dark, the real popover, focus reached with a real Tab so `:focus-visible` was
+Chrome's own verdict), `background-color`, `outline`, `box-shadow`, `border-width` and every `<li>` were
+byte-identical focused and unfocused. That is WCAG 2.4.7 with nothing on screen. The tabpanel's argument
+— the next Tab lands on a control inside — does not reach a role-less region: the To Do list has **zero**
+focusable children and is its own scroll container, so it is the thing being operated. So
+`.biorouter-focus-region:focus-visible` takes `box-shadow: inset 0 0 0 1px var(--border-accent)` — one
+pixel, inset, in the composer focus edge's own token, needing no border and no geometry change, and
+painted on the element's box so it stays put while the list scrolls. `--border-accent` is the only accent
+that clears the 3:1 non-text floor against the popover's `--background-default` ground in all three
+families in both modes (Parchment 4.62 / 6.71, Alma Mater 4.56 / 9.47, Roche Limit 3.09 / 5.58);
+`--accent-bar` falls to 2.66:1 in Alma Mater light. The rule is **unlayered**, for the same reason the
+tab underline is: inside `@layer base` a `:where()` rule sits at specificity 0 and every Tailwind
+utility beats it. The panel keeps the third amendment's treatment unchanged, the `outline: none` stays
+in the layered rule so there is exactly one indicator, and `prefers-contrast: more` is still untouched.
+
 All three tokens are **shared** — the focus treatment was always explicitly neutral rather than accented
 (D-15), so unifying it changed its values without changing its intent.
 
@@ -1326,7 +1344,7 @@ ground*, which is what the ANSI dim slot is for. See **[Decision D-11](#d-11--te
 >
 > | ID | Decision | Resolved value |
 > |---|---|---|
-> | D-15 | Focus indication | **A surface shift, not a ring.** No outline anywhere. Focused fill — as decided `#e4dcc9` / `#4d4430`, **now the shared `#e0e0dc` / `#35342f`**; the ring returns only under `prefers-contrast: more`. *Supersedes the D-03 answer.* **Amended 2026-09-08: a `[role='tab']` trigger takes no fill** — it activates on focus, so the fill sat permanently on the active tab as a grey box; its underline firming (2px → 3px, label at `--text-default`) is its focus indicator instead. |
+> | D-15 | Focus indication | **A surface shift, not a ring.** No outline anywhere. Focused fill — as decided `#e4dcc9` / `#4d4430`, **now the shared `#e0e0dc` / `#35342f`**; the ring returns only under `prefers-contrast: more`. *Supersedes the D-03 answer.* **Amended 2026-09-08: a `[role='tab']` trigger takes no fill** — it activates on focus, so the fill sat permanently on the active tab as a grey box; its underline firming (2px → 3px, label at `--text-default`) is its focus indicator instead. **Amended 2026-09-08 (fourth): a keyboard-scrollable region with no role (`.biorouter-focus-region`) takes a 1px inset `--border-accent` edge** — it was exempted from the fill *and* from the UA ring, leaving no indicator at all. |
 > | D-16 | The user's turn | **Tinted, not accent.** `--background-medium` + hairline + `--text-default`. A solid coral block shouted. |
 > | D-17 | Tool calls | **Lines, not cards.** No outline, collapsed or expanded. Failure = colour + a 5% wash. A persistent rectangle reads as a stuck focus ring. |
 > | D-18 | Hairlines | **One value.** `border-border-subtle` at full strength. Eight alpha-diluted variants (`/35`…`/70`) made adjacent panels' edges read at different weights, so they never visually aligned. |

--- a/docs/desktop-ui/summary-and-figures-qa.md
+++ b/docs/desktop-ui/summary-and-figures-qa.md
@@ -11,6 +11,9 @@ replacement and chat switching must not show another chat's or an obsolete list.
 The task list is a scroll region with a tab stop so a keyboard user can scroll
 it; it takes no focus fill (D-15's third amendment, `.biorouter-focus-region`),
 and the next Tab lands on the panel's own buttons, which do.
+Amended 2026-09-08 (D-15's fourth): the focused list draws a 1px inset
+`--border-accent` edge — the exemption had removed the fill *and* the UA ring,
+leaving a keyboard user with no indicator at all (WCAG 2.4.7).
 
 Generated figures prioritize the data: meaningful titles, units, source or
 assumption notes when relevant, restrained theme-aware colors, and large legible

--- a/ui/desktop/src/components/ChatSummary.tsx
+++ b/ui/desktop/src/components/ChatSummary.tsx
@@ -101,7 +101,11 @@ export function ChatSummary({
           {/* A scroll container with a tab stop so a keyboard user can scroll
               it — a region, not a control, so it opts out of D-15's focus fill
               with `.biorouter-focus-region` (authored in main.css). It keeps
-              its implicit `list` role: `role="region"` would orphan the rows. */}
+              its implicit `list` role: `role="region"` would orphan the rows.
+              The class is not "no focus treatment": it also carries the 1px
+              inset `--border-accent` edge that is this list's only focus
+              indicator (D-15's fourth amendment) — it has no focusable child to
+              hand the signal to. */}
           <ol
             aria-label="To Do tasks"
             tabIndex={0}

--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -164,7 +164,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
               }}
             >
               <Settings />
-              Open Settings
+              Open settings
             </Button>
           </div>
 
@@ -282,7 +282,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
             }}
             variant="secondary"
           >
-            Report a Bug
+            Report a bug
           </Button>
           <Button
             onClick={() => {
@@ -293,7 +293,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
             }}
             variant="secondary"
           >
-            Request a Feature
+            Request a feature
           </Button>
         </div>
       </div>

--- a/ui/desktop/src/components/settings/app/UpdateSection.tsx
+++ b/ui/desktop/src/components/settings/app/UpdateSection.tsx
@@ -116,7 +116,7 @@ export default function UpdateSection() {
             ) : (
               <ExternalLink className="w-4 h-4" />
             )}
-            Check for Updates
+            Check for updates
           </Button>
         )}
         <p className="text-supporting text-text-muted">

--- a/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
+++ b/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
@@ -379,7 +379,7 @@ export function WorkflowFormFields({
               Initial prompt
             </label>
             <p className="text-supporting text-text-muted mt-2 mb-2">
-              (Optional - Instructions or Prompt are required)
+              (optional — instructions or a prompt are required)
             </p>
             <textarea
               id="workflow-prompt"

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -1541,9 +1541,9 @@
      `:focus-visible { outline: auto 1px -webkit-focus-ring-color }` matched the
      panel in the same `CSS.getMatchedStylesForNode` dump; without this rule the
      grey box is traded for a focus ring drawn around the same 712 × 2676 px
-     body, which is the louder half of what D-15 exists to prevent. A region
-     gets NO focus treatment: the next Tab lands on the first control inside,
-     which has its own indicator.
+     body, which is the louder half of what D-15 exists to prevent. A PANEL gets
+     no focus treatment: the next Tab lands on the first control inside, which
+     has its own indicator.
 
      The tabpanel and every `.biorouter-focus-region` need this — the class is
      the one way a region with no role can join the exemption, so it joins the
@@ -1552,6 +1552,17 @@
      utilities — and for any future region that draws nothing and carries
      neither the role nor the class, the UA ring is the better fallback than
      silence.
+
+     ⚠ **The class arm is a SUPPRESSION here and an INDICATOR below; the panel
+     arm is only the suppression (2026-09-08, fourth).** Suppressing the ring
+     with nothing in its place is what shipped, and for a `.biorouter-focus-
+     region` it is wrong: the tabpanel's argument is that the next Tab reaches a
+     control inside, and the To Do list has ZERO focusable children. It is
+     entered AND operated — its own scroll container, scrolled with ↓/PageDown —
+     so a keyboard user who lands on it saw no change at all. The indicator is
+     the unlayered `.biorouter-focus-region:focus-visible` rule after this
+     layer; it must stay unlayered, and this rule must stay a bare
+     `outline: none`, or the two halves start fighting.
 
      The `prefers-contrast: more` / `forced-colors` block below is deliberately
      NOT narrowed by any of this: it still reaches the panel and the region
@@ -1652,6 +1663,56 @@
 :where([role='tab']:not(.br-tab)):focus-visible::after {
   height: 3px;
   background-color: var(--accent-bar);
+}
+
+/* D-15, amended 2026-09-08 (fourth) — a KEYBOARD-SCROLLABLE REGION's focus
+ * indicator is a quiet inset edge, because "no treatment" is not an indicator.
+ *
+ * The amendment above exempted `.biorouter-focus-region` from the fill AND put
+ * it into the `outline: none` restoration, so the UA ring was suppressed with
+ * nothing in its place. Measured on the running app afterwards (Parchment dark,
+ * the real chat-summary popover, a 3-row list, focus reached with a real Tab so
+ * `:focus-visible` was Chrome's own verdict): `backgroundColor`
+ * `rgba(0, 0, 0, 0)`, `outline` `rgb(244, 240, 230) none 0px`, `box-shadow`
+ * `none`, `border-width` `0px` and every `<li>` — byte-identical focused and
+ * unfocused. WCAG 2.4.7 with nothing on screen.
+ *
+ * ⚠ **The tabpanel's argument does not reach a region with no role.** A panel
+ * takes nothing because the next Tab lands on the first control inside; the To
+ * Do list has ZERO focusable children (counted on the running app) and is its
+ * own scroll container, so the tab stop exists precisely so ↓/PageDown can
+ * scroll it. It is the thing being operated. `[role='tabpanel']` is deliberately
+ * NOT in this rule.
+ *
+ * D-15's vocabulary decides the shape: a surface shift, never a ring. The
+ * precedent is the composer's own focus edge
+ * (`.biorouter-composer-card:has(textarea:focus)` → `--border-accent`), and
+ * `role="application"` already draws a 2px inset `--border-accent` ring for the
+ * same reason. So: ONE PIXEL, INSET, in `--border-accent`. Inset needs no border
+ * and no geometry change (a real border would reflow the 334px list), and an
+ * inset shadow is painted on the element's own box, so it stays put while the
+ * content scrolls under it.
+ *
+ * ⚠ **`--border-accent`, and the ground it is measured against is
+ * `--background-default`** — the popover surface (`bg-background-default`,
+ * measured `rgb(27, 27, 25)` under the real list). Against that ground the token
+ * clears the 3:1 non-text floor in all three families in both modes: Parchment
+ * 4.62 / 6.71, Alma Mater 4.56 / 9.47, Roche Limit 3.09 / 5.58. It is the only
+ * accent that does — `--accent-bar` falls to 2.66:1 in Alma Mater light, which
+ * is why the tab underline above keeps `--accent-bar` for a job where thickness
+ * carries the signal and this rule does not.
+ *
+ * ⚠ **Unlayered, deliberately — same mechanism as the tab underline above.**
+ * The D-15 block lives in `@layer base`, where a `:where()` rule sits at
+ * specificity 0 and every Tailwind utility in the `utilities` layer beats it
+ * whatever the specificity. A copy of this rule inside `@layer base` would lose
+ * silently the first time the `<ol>` gained a `shadow-*` utility. The
+ * `outline: none` stays in the layered rule, so there is exactly one indicator,
+ * and the `prefers-contrast: more` / `forced-colors` block is still untouched:
+ * a user who asked their OS for a stronger signal keeps the 2px `--ring`
+ * outline through the same `[tabindex]` arm. */
+:where(.biorouter-focus-region):focus-visible {
+  box-shadow: inset 0 0 0 1px var(--border-accent);
 }
 
 /* Motion is short and informative. Everything animated must null out here —

--- a/ui/desktop/src/styles/tabFocus.test.ts
+++ b/ui/desktop/src/styles/tabFocus.test.ts
@@ -412,6 +412,10 @@ describe('a scroll region with no role opts out of the focus fill by class', () 
    * `outline: none`, and Chrome's UA `:focus-visible { outline: auto }` is
    * underneath. The restoration that covers the panel has to cover the class,
    * or the grey list becomes a ringed list.
+   *
+   * The suppression stays a suppression: it paints no fill of its own, and it
+   * does not carry the edge either. The edge is the unlayered rule asserted
+   * below, for the reason the tab underline is unlayered.
    */
   it('still suppresses the UA focus ring on the region', () => {
     const match = CSS.replace(/\/\*[\s\S]*?\*\//g, '').match(
@@ -421,9 +425,73 @@ describe('a scroll region with no role opts out of the focus fill by class', () 
       (rule) => rule.includes(HOOK) && /outline:\s*none/.test(rule)
     );
     expect(restoring, `nothing restores \`outline: none\` on ${HOOK}`).toHaveLength(1);
-    // A region gets NO treatment: no fill under another selector, no ring.
     expect(restoring[0]).not.toContain('--background-focus');
-    expect(restoring[0]).not.toMatch(/box-shadow|background/);
+    expect(restoring[0]).not.toMatch(/background/);
+  });
+
+  /**
+   * ⚠ **The half #187 left out, and the reason this block exists twice.**
+   * #187 put the class into BOTH arms — the fill exemption and the
+   * `outline: none` restoration — so the UA ring was suppressed with nothing in
+   * its place. Measured on the running app afterwards (Parchment dark, the real
+   * popover, a 3-row list, focus reached with a real Tab so `:focus-visible`
+   * was Chrome's own verdict): `backgroundColor`, `outline`, `boxShadow`,
+   * `borderWidth` and every `<li>` were byte-identical focused and unfocused —
+   * `rgba(0, 0, 0, 0)` / `rgb(244, 240, 230) none 0px` / `none` / `0px`. WCAG
+   * 2.4.7 with no indicator at all.
+   *
+   * The argument recorded for the tabpanel — "the next Tab lands on the first
+   * control inside, which has its own indicator" — does not reach here: the list
+   * has ZERO focusable children (asserted on the running app) and is its own
+   * scroll container, so it is genuinely operable and the tab stop is the whole
+   * point. A PANEL is still treated as #185 decided; only the class arm moves.
+   *
+   * D-15's vocabulary gives the shape: focus is a surface shift, never a ring,
+   * and the precedent for a region is the composer's own focus edge
+   * (`.biorouter-composer-card:has(textarea:focus)` → `--border-accent`). So the
+   * region takes a 1px INSET edge in the same token — no fill, no geometry
+   * change, no border to add, and it does not scroll with the list's content.
+   *
+   * ⚠ **Unlayered, for the reason the tab underline is unlayered.** The D-15
+   * block lives in `@layer base`, where a `:where()` rule sits at specificity 0
+   * and every Tailwind utility in the `utilities` layer beats it whatever the
+   * specificity. A copy of this rule inside `@layer base` would lose silently
+   * the first time the `<ol>` gained a `shadow-*` utility, and a focus indicator
+   * is the wrong place to depend on that not happening.
+   */
+  it('gives the region a quiet inset edge instead of nothing', () => {
+    const stripped = CSS.replace(/\/\*[\s\S]*?\*\//g, '');
+    const re = /([^{}]*:focus-visible[^{}]*)\{([^}]*)\}/g;
+    const edges: Array<{ selector: string; body: string; depth: number }> = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(stripped))) {
+      const selector = m[1].trim();
+      if (!selector.includes(HOOK)) continue;
+      // Naming the hook only in order to exclude it is not an indicator.
+      if (new RegExp(`:not\\([^)]*\\${HOOK}[^)]*\\)`).test(selector.replace(/\s+/g, ''))) continue;
+      if (!/box-shadow\s*:/.test(m[2])) continue;
+      const before = stripped.slice(0, m.index);
+      const depth = (before.match(/\{/g) ?? []).length - (before.match(/\}/g) ?? []).length;
+      edges.push({ selector, body: m[2].trim(), depth });
+    }
+    expect(
+      edges,
+      `nothing draws a focus indicator on ${HOOK}: a keyboard user sees no change at all (WCAG 2.4.7)`
+    ).toHaveLength(1);
+    // One pixel, inset, in the accent — the composer's edge, not a ring.
+    expect(edges[0].body.replace(/\s+/g, ' ')).toContain(
+      'box-shadow: inset 0 0 0 1px var(--border-accent)'
+    );
+    // Still a surface shift, never a fill: D-15's rule for a region is unchanged.
+    expect(edges[0].body).not.toMatch(/background/);
+    // And never an outline — the suppression above must not be undone here.
+    expect(edges[0].body).not.toMatch(/outline\s*:\s*(?!none)/);
+    // ⚠ Top level, NOT inside `@layer base`: depth 0 counted in braces.
+    expect(
+      edges[0].depth,
+      `the region's focus edge is inside a layer (depth ${edges[0].depth}); every ` +
+        'Tailwind utility would beat it. Author it unlayered, like the tab underline.'
+    ).toBe(0);
   });
 
   /**


### PR DESCRIPTION
## Why

Two findings from the round-3 verification of the desktop app.

**N2 — MEDIUM: the chat summary's To Do list has no focus indication at all (WCAG 2.4.7).**
#187 exempted `.biorouter-focus-region` from D-15's focus fill **and** put the same class into
the `outline: none` restoration (`:where([role='tabpanel'], .biorouter-focus-region):focus-visible
{ outline: none }`), so the UA ring was suppressed with nothing in its place.

Repro (running app, Parchment dark, the real chat-summary popover on a chat with a To Do list,
focus reached with a real `Tab` so `:focus-visible` was Chrome's own verdict — `fv: true`):

| property | unfocused | focused |
|---|---|---|
| `background-color` | `rgba(0, 0, 0, 0)` | `rgba(0, 0, 0, 0)` |
| `outline` | `rgb(244, 240, 230) none 0px` | `rgb(244, 240, 230) none 0px` |
| `box-shadow` | `none` | `none` |
| `border-width` | `0px` | `0px` |
| each `<li>` bg / border / shadow | transparent / `0px` / `none` | transparent / `0px` / `none` |

Byte-identical. The element is genuinely operable — measured `focusableChildren: 0`, its own
scroll container — so the tabpanel's recorded argument ("the next Tab lands on the first control
inside, which has its own indicator") does not reach it.

**N4 — LOW: Title Case leftovers and a hyphenated hint.** Settings → App still read "Open
Settings", "Report a Bug", "Request a Feature", "Check for Updates"; the Create-workflow field
hint read "(Optional - Instructions or Prompt are required)".

## What changed

**N2 — the indicator (`ui/desktop/src/styles/main.css`)**

- `main.css:1714` — a new **unlayered** rule:
  `:where(.biorouter-focus-region):focus-visible { box-shadow: inset 0 0 0 1px var(--border-accent) }`.
  D-15's vocabulary decides the shape: focus is a surface shift, never a ring, and the precedent
  for a region is the composer's own focus edge (`.biorouter-composer-card:has(textarea:focus)` →
  `--border-accent`; `role="application"` already draws a 2px inset ring in the same token). Inset
  needs no border and no geometry change, and an inset shadow is painted on the element's own box,
  so it stays put while the list scrolls.
- `main.css:1571` — the layered restoration is **unchanged** (`outline: none` on the panel and the
  class), so there is exactly one indicator and no double signal. `[role='tabpanel']` is
  deliberately NOT in the new rule: #185's argument holds there, and the panel was re-measured to
  confirm it still takes nothing (below).
- **`--border-accent`, and the ground is measured, not assumed.** The list sits on the popover
  surface (`bg-background-default`, read as `rgb(255, 255, 255)` light / `rgb(27, 27, 25)` dark).
  Against that ground `--border-accent` clears the 3:1 non-text floor in all three families in both
  modes — Parchment 4.62 / 6.71, Alma Mater 4.56 / 9.47, Roche Limit 3.09 / 5.58. It is the only
  accent that does: `--accent-bar` falls to **2.66:1** in Alma Mater light, which is why the tab
  underline keeps `--accent-bar` for a job where thickness carries the signal and this rule does not.
- **Unlayered, deliberately** — the same mechanism the tab underline records. The D-15 block lives
  in `@layer base`, where a `:where()` rule sits at specificity 0 and every Tailwind utility in the
  `utilities` layer beats it whatever the specificity; a copy inside the layer would lose silently
  the first time the `<ol>` gained a `shadow-*` utility.
- `ui/desktop/src/components/ChatSummary.tsx:104` — the call-site comment no longer says the class
  means "no focus treatment".
- `design.md` (D-15's fourth amendment + the decision-table row) and
  `docs/desktop-ui/summary-and-figures-qa.md` (the contract paragraph) carry dated amendments where
  #187 recorded its third. Lines added; nothing reformatted — both files already fail
  `format:check` on `main`.

**N2 — the test (`ui/desktop/src/styles/tabFocus.test.ts:462`)**

A new arm in the existing region block, `gives the region a quiet inset edge instead of nothing`.
It scans the comment-stripped stylesheet for a `:focus-visible` rule that names the hook (excluding
rules that merely `:not()` it away) and sets a `box-shadow`, then asserts: exactly one exists; its
body is `inset 0 0 0 1px var(--border-accent)`; it paints no background; it does not re-introduce an
outline; and it sits at **brace depth 0** — i.e. outside `@layer base`, the property that keeps a
Tailwind utility from beating it. The sibling arm's now-false "a region gets NO treatment" clause
was narrowed to "the *restoration* paints no background", which is still #187's point.

**Confirmed failing on `main`** before the CSS change, with the message it was written to produce:

```
FAIL src/styles/tabFocus.test.ts > a scroll region with no role opts out of the focus fill by class
     > gives the region a quiet inset edge instead of nothing
AssertionError: nothing draws a focus indicator on .biorouter-focus-region:
a keyboard user sees no change at all (WCAG 2.4.7): expected [] to have a length of 1 but got +0
 Tests  1 failed | 24 passed (25)
```

**N4 — copy**

- `settings/app/AppSettingsSection.tsx:167,285,296` — "Open settings", "Report a bug",
  "Request a feature".
- `settings/app/UpdateSection.tsx:119` — "Check for updates".
- `workflows/shared/WorkflowFormFields.tsx:382` — "(optional — instructions or a prompt are required)".

No test asserted the old strings. `UpdateSection.test.tsx` matches on `/Check for Updates/i`, so it
keeps passing and needed no edit — the `i` flag means it was never asserting the casing.

## Tests

```
npx vitest run src/styles src/components/ChatSummary.test.tsx src/components/settings/app/UpdateSection.test.tsx
 Test Files  21 passed (21)
      Tests  281 passed (281)

npm run test:run
 Test Files  433 passed (433)
      Tests  4858 passed | 1 skipped (4859)

npm run lint:check                       EXIT=0
  OK — all 332 contrast assertions pass
  OK — every semantic colour token used by a utility has a @theme inline mirror

npx prettier --check <6 changed src files>   All matched files use Prettier code style!
```

## Runtime verification

Own sandboxed instance (`launch-dev-gui.sh`, CDP 9346), restarted after the `main.css` edit so
frozen vite could not serve the stale stylesheet — the served sheet was re-fetched from the page and
confirmed to carry the new rule before any measurement. One real `versa_azure` turn created the To
Do list; the probe chat was deleted afterwards.

Focused list, `:focus-visible === true` in every row (`fv: true`), unfocused `box-shadow: none`
throughout:

| family / mode | ground | `--border-accent` | focused `box-shadow` | contrast |
|---|---|---|---|---|
| Parchment light | `rgb(255,255,255)` | `#b85a32` | `rgb(184, 90, 50) 0px 0px 0px 1px inset` | 4.62:1 |
| Parchment dark | `rgb(27,27,25)` | `#e8895f` | `rgb(232, 137, 95) 0px 0px 0px 1px inset` | 6.71:1 |
| Alma Mater light | `rgb(255,255,255)` | `#14828c` | `rgb(20, 130, 140) 0px 0px 0px 1px inset` | 4.56:1 |
| Alma Mater dark | `rgb(27,27,25)` | `#60d0da` | `rgb(96, 208, 218) 0px 0px 0px 1px inset` | 9.47:1 |
| Roche Limit light | `rgb(255,255,255)` | `#ee6c1a` | `rgb(238, 108, 26) 0px 0px 0px 1px inset` | 3.09:1 |
| Roche Limit dark | `rgb(27,27,25)` | `#ee6c1a` | `rgb(238, 108, 26) 0px 0px 0px 1px inset` | 5.58:1 |

`background-color` stayed `rgba(0, 0, 0, 0)`, `outline` stayed `… none 0px` and `border-width`
stayed `0px` in all six — the edge is the only change, and it is not a fill.

**Regression check on the tabpanel** (Settings, `[role="tabpanel"]`, `:focus-visible === true`):
unfocused and focused both `background-color: rgba(0, 0, 0, 0)`, `outline: … none 0px`,
`box-shadow: none`. #185/#187's decision for panels is untouched.

**N4 at runtime:** Settings → App reads `["Open settings", "Report a bug", "Request a feature",
"Check for updates"]`, and a regex for the four old strings over `document.body.innerText` returns
`null`. The Create-workflow dialog's hint reads `(optional — instructions or a prompt are required)`.

Screenshots (1× element captures plus 4× nearest-neighbour zooms) in
`~/biorouter-runs/test-drive/round3/shots/fix-focus-edge/`:
`before-parchment-dark-focused.png` (the finding: focused, nothing drawn),
`after-{parchment,alma-mater,roche-limit}-{light,dark}-focused-{1x,4x}.png`,
`after-settings-app-sentence-case.png`, `after-settings-app-help-buttons.png`,
`after-workflow-prompt-hint.png`.

## Out of scope

- **`prefers-contrast: more` / `forced-colors`** is untouched and still reaches the list through the
  same `[tabindex]` arm, so that path keeps its `2px solid var(--ring)` outline. I could not emulate
  `prefers-contrast` — the available media-emulation tool exposes only `colorScheme`/`reducedMotion`
  — so that half is read off the served CSS and asserted in the test, not observed on screen.
- **macOS menu-bar and tray labels** (`main.ts:4948,5213,5221`, `autoUpdater.ts:876`) keep Title
  Case: platform chrome follows the OS convention, not the app's sentence case.
- **The notification dialog's `<li>Open Settings</li>` / `<li>Open System Preferences</li>`** keep
  their capitals — they name the OS app, beside the sibling macOS branch that reads the same way.
- **"chat behavior" in the Settings subtitle** (round-3 N5) is left alone as instructed; it is still
  US spelling beside the app's "-ise" forms ("Auto Visualiser", "personalised").
- Nothing in `usePinnedModel`, `chatStreamStore` or `ModelsBottomBar` — another agent owns those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
