### PR TITLE
Desktop: the composer states the model a chat actually runs on, for every chat

### DIFF
--- a/ui/desktop/src/components/ModelAndProviderContext.test.tsx
+++ b/ui/desktop/src/components/ModelAndProviderContext.test.tsx
@@ -3,8 +3,9 @@
  */
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ModelAndProviderProvider, useModelAndProvider } from './ModelAndProviderContext';
+import { subscribeSessionBindingChanges } from '../utils/sessionBindingSync';
 import type Model from './settings/models/modelInterface';
 
 const mocks = vi.hoisted(() => ({
@@ -428,6 +429,130 @@ describe('ModelAndProviderProvider privacy barrier', () => {
       })
     );
     window.removeEventListener('session-tools:changed', changed);
+  });
+});
+
+/**
+ * Round 3 / N1 — the composer now states the chat's own binding whenever it
+ * differs from the app-wide selection, which is only correct while this
+ * renderer's copy of the row is current. A per-chat switch is one of the two
+ * things that makes it stale, and this is where it is closed.
+ */
+describe('ModelAndProviderProvider announces the binding it just wrote', () => {
+  const seen: Array<Record<string, unknown>> = [];
+  let unsubscribe: () => void = () => {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seen.length = 0;
+    mocks.read.mockImplementation(async (key: string) => {
+      if (key === 'BIOROUTER_MODEL') return 'gpt-5.5';
+      if (key === 'BIOROUTER_PROVIDER') return 'versa_azure';
+      return null;
+    });
+    mocks.getProviders.mockResolvedValue([]);
+    mocks.setConfigProvider.mockResolvedValue(undefined);
+    mocks.refreshConfig.mockResolvedValue(undefined);
+    unsubscribe = subscribeSessionBindingChanges((change) =>
+      seen.push(change as unknown as Record<string, unknown>)
+    );
+  });
+
+  afterEach(() => unsubscribe());
+
+  it('carries the session, the provider, the model and the window', async () => {
+    mocks.updateAgentProvider.mockResolvedValue({ data: '' });
+    render(
+      <ModelAndProviderProvider>
+        <SessionSwitchHarness />
+      </ModelAndProviderProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch this chat' }));
+
+    await waitFor(() => expect(screen.getByTestId('change-result')).toHaveTextContent('true'));
+    expect(seen).toEqual([
+      {
+        sessionId: 'sess-1',
+        provider: 'anthropic',
+        model: 'claude-opus-4',
+        contextLimit: 200000,
+      },
+    ]);
+  });
+
+  /**
+   * ⚠ **Ordering, not just occurrence.** The announcement lands BEFORE
+   * `setConfigProvider` moves the global default, so in the only render where
+   * the row and the selection can disagree it is the ROW that holds the new
+   * binding. Announcing afterwards would invert that window and flash the model
+   * the user had just switched away from — the regression PR #192 narrowed its
+   * rule to avoid.
+   */
+  it('before the global default moves, not after', async () => {
+    const order: string[] = [];
+    unsubscribe();
+    unsubscribe = subscribeSessionBindingChanges(() => order.push('announce'));
+    mocks.updateAgentProvider.mockImplementation(async () => {
+      order.push('bind');
+      return { data: '' };
+    });
+    mocks.setConfigProvider.mockImplementation(async () => {
+      order.push('global');
+    });
+
+    render(
+      <ModelAndProviderProvider>
+        <SessionSwitchHarness />
+      </ModelAndProviderProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch this chat' }));
+
+    await waitFor(() => expect(screen.getByTestId('change-result')).toHaveTextContent('true'));
+    expect(order).toEqual(['bind', 'announce', 'global']);
+  });
+
+  /** A refused bind wrote no row, so there is nothing to announce. */
+  it('says nothing when the bind was refused', async () => {
+    mocks.updateAgentProvider.mockImplementation(clientRejecting(privacyBarrier409));
+    render(
+      <ModelAndProviderProvider>
+        <SessionSwitchHarness />
+      </ModelAndProviderProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch this chat' }));
+
+    await waitFor(() => expect(screen.getByTestId('change-result')).toHaveTextContent('false'));
+    expect(seen).toEqual([]);
+  });
+
+  /**
+   * The app-wide picker (Settings → Models, Settings → Providers) passes
+   * `sessionId = null` and writes no row at all — which is exactly why an
+   * existing chat goes on running its own model after such a switch, and why the
+   * composer must say so. Nothing to announce here either.
+   */
+  it('says nothing for an app-wide switch, which writes no row', async () => {
+    // Already loaded, so the switch takes no warm-up dialog and no download.
+    mocks.llamacppStatus.mockResolvedValue({
+      data: {
+        ...statusResponse.data,
+        sidecar: { ...sidecar, state: 'ready', model: 'qwen3.6', warmed: true },
+      },
+    });
+    render(
+      <ModelAndProviderProvider>
+        <SwitchHarness />
+      </ModelAndProviderProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to local' }));
+
+    await waitFor(() => expect(mocks.setConfigProvider).toHaveBeenCalled());
+    expect(mocks.updateAgentProvider).not.toHaveBeenCalled();
+    expect(seen).toEqual([]);
   });
 });
 

--- a/ui/desktop/src/components/ModelAndProviderContext.tsx
+++ b/ui/desktop/src/components/ModelAndProviderContext.tsx
@@ -32,6 +32,7 @@ import {
 } from './ui/dialog';
 import { Button } from './ui/button';
 import { notifySessionToolsChanged } from '../utils/sessionToolEvents';
+import { announceSessionBinding } from '../utils/sessionBindingSync';
 
 // titles
 export const UNKNOWN_PROVIDER_TITLE = 'Provider name lookup';
@@ -364,6 +365,27 @@ export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> =
           });
           boundNotice = bound.data;
           notifySessionToolsChanged(sessionId);
+          // Round 3 / N1. The row this chat runs on has just been rewritten, and
+          // the renderer's copy of it is a cache nothing else refreshes — so the
+          // composer, which now states the chat's own binding whenever it
+          // differs from the app-wide selection, would keep naming the model the
+          // user just switched away from.
+          //
+          // ⚠ **Here, not below.** This lands BEFORE `setConfigProvider` and
+          // before `setCurrentProvider`/`setCurrentModel`, so in the only render
+          // where the two can disagree the ROW holds the new binding and the
+          // selection still holds the old one. Announcing after the selection
+          // moved would invert that window and flash the old model.
+          //
+          // ⚠ And only after `updateAgentProvider` RESOLVED: a refusal (Gate A's
+          // 409 for a public model on a private chat) throws past this line, and
+          // the row it did not write must not be reported as written.
+          announceSessionBinding({
+            sessionId,
+            provider: providerName,
+            model: modelName,
+            contextLimit: model.context_limit,
+          });
         }
 
         phase = 'config';

--- a/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
+++ b/ui/desktop/src/components/privacy/PinnedModelNote.test.tsx
@@ -173,13 +173,19 @@ describe('PinnedModelNote', () => {
 });
 
 /**
- * ⚠ The regression this gate exists to prevent, and it is not hypothetical:
- * `ModelAndProviderContext.changeModel` writes BOTH the session row and the
- * global default, so right after a per-chat model switch the daemon has them in
- * step while the client's cached `/agent/resume` copy of the row is the value
- * from BEFORE the switch. A composer that preferred the row on every
- * disagreement would answer the switch by showing the model the user had just
- * switched away from.
+ * Round 3 / N1 — the chip and gauge state the chat's own binding for EVERY chat
+ * that has one, not only for the chats the privacy barrier is holding.
+ *
+ * ⚠ The regression that kept #192 from shipping this, recorded because it is the
+ * thing to re-check if any of these change: `changeModel` writes BOTH the
+ * session row and the global default, so right after a per-chat switch the
+ * daemon had them in step while the client's cached `/agent/resume` copy of the
+ * row was the value from BEFORE the switch — and a composer preferring the row
+ * answered the switch by showing the model the user had just switched away from.
+ * It is closed at the source now (`utils/sessionBindingSync` on a switch,
+ * `ChatStreamController.refreshSessionBinding` after a turn), which is what this
+ * rule rests on; `hooks/chatStreamStore.binding.test.tsx` is where that half is
+ * pinned.
  */
 describe('what the chip and gauge are told to state', () => {
   it('states the chat’s own binding when the selection is barred from it', async () => {
@@ -187,27 +193,104 @@ describe('what the chip and gauge are told to state', () => {
     await waitFor(() => expect(result.current.effectiveModel).toEqual(BINDING));
   });
 
-  it('leaves the app-wide selection standing when it could run here', async () => {
-    // Both private: Gate A admits the selection, so the row may simply be this
-    // client's stale copy and the selection is the fresher fact.
+  /**
+   * The residual case #192 left open. Both private, so Gate A would admit the
+   * selection — but `restore_provider_from_session` binds the ROW, so the
+   * selection is still not what runs here and the chip must say so. No sentence:
+   * privacy is not the reason.
+   */
+  it('states the binding even when the selection would be admitted here', async () => {
     mocks.currentProvider = 'ollama';
     mocks.currentModel = 'qwen3.6';
     mocks.getProviders.mockResolvedValue([...CATALOG, providerRow('ollama', 'Ollama', 'private')]);
     const { result } = renderHook(() => usePinnedModel(chat('private'), undefined));
-    await waitFor(() => expect(mocks.getProviders).toHaveBeenCalled());
-    expect(result.current.effectiveModel).toBeUndefined();
+    await waitFor(() => expect(result.current.effectiveModel).toEqual(BINDING));
+    expect(result.current.notice).toBeNull();
   });
 
-  it('leaves a public chat entirely alone, and reads no catalog for it', async () => {
+  /**
+   * Round 3 / N1's verbatim repro, at the hook. Bind Codex / `gpt-6-astra`, run
+   * one turn (the row is written), switch the app to Claude Code /
+   * `claude-fable-5-1`, reopen the chat. Measured before the fix: the composer
+   * read `claude-fable-5-1` on a 1M gauge while the next turn's `token_events`
+   * recorded `model_id = gpt-6-astra, provider = codex`.
+   *
+   * Both endpoints are public, so there is no privacy sentence to earn — and no
+   * catalog read either, which is the property #192 established and this rule
+   * keeps: the tier is needed only for the sentence.
+   */
+  it('states a public chat’s own binding, with no sentence and no catalog read', async () => {
+    mocks.currentProvider = 'claude_code';
+    mocks.currentModel = 'claude-fable-5-1';
+    const codexChat = {
+      ...chat('public'),
+      provider_name: 'codex',
+      model_config: { model_name: 'gpt-6-astra' },
+    } as Session;
+
+    const { result } = renderHook(() => usePinnedModel(codexChat, undefined));
+
+    await waitFor(() =>
+      expect(result.current.effectiveModel).toEqual({ provider: 'codex', model: 'gpt-6-astra' })
+    );
+    expect(result.current.notice).toBeNull();
+    expect(mocks.getProviders).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The just-switched case: no stale flash. Once the row has been patched with
+   * the binding the daemon accepted, it AGREES with the selection, and agreement
+   * means there is nothing to override — the chip goes on rendering the
+   * selection exactly as it did before the switch.
+   */
+  it('overrides nothing once the fresh row and the selection agree', async () => {
+    mocks.currentProvider = 'versa_azure';
+    mocks.currentModel = BINDING.model;
     const { result } = renderHook(() => usePinnedModel(chat('public'), undefined));
     await waitFor(() => expect(result.current.effectiveModel).toBeUndefined());
-    expect(mocks.getProviders).not.toHaveBeenCalled();
+    expect(result.current.notice).toBeNull();
+  });
+
+  it('says nothing about a chat that has never named a provider', async () => {
+    const { result } = renderHook(() =>
+      usePinnedModel({ ...chat('public'), provider_name: null } as Session, undefined)
+    );
+    await waitFor(() => expect(result.current.effectiveModel).toBeUndefined());
+  });
+
+  /**
+   * Round 3 / N3 — a chat whose classification was established by a turn in THIS
+   * client session. The store re-reads the row after every turn, so the tier
+   * arriving as `private` is all it takes: the note appears without a reload.
+   */
+  it('picks up a classification a turn raised, without a reload', async () => {
+    const before = renderHook(({ session }) => usePinnedModel(session, undefined), {
+      initialProps: { session: chat('public') },
+    });
+    await waitFor(() => expect(before.result.current.effectiveModel).toEqual(BINDING));
+    expect(before.result.current.notice).toBeNull();
+
+    // …and the same row after `refreshSessionBinding` adopted the ratchet.
+    before.rerender({ session: chat('private') });
+    await waitFor(() =>
+      expect(before.result.current.notice).toBe(
+        'This chat is marked private, so it stays on Versa API Azure / gpt-5.2-2025-12-11. ' +
+          'Claude Code / claude-opus-5 is not used here.'
+      )
+    );
   });
 
   it('prefers what a turn reported over the row', async () => {
     const reported = { provider: 'llamacpp', model: 'gemma4' };
     const { result } = renderHook(() => usePinnedModel(chat('private'), reported));
     await waitFor(() => expect(result.current.effectiveModel).toEqual(reported));
+  });
+
+  it('states nothing while the selection is still unresolved', async () => {
+    mocks.currentProvider = null;
+    mocks.currentModel = null;
+    const { result } = renderHook(() => usePinnedModel(chat('public'), undefined));
+    await waitFor(() => expect(result.current.effectiveModel).toBeUndefined());
   });
 });
 

--- a/ui/desktop/src/components/privacy/pinnedModel.ts
+++ b/ui/desktop/src/components/privacy/pinnedModel.ts
@@ -35,6 +35,22 @@ import type { ProviderTier, Session, SessionClassification } from '../../api/typ
  * marked private, so it stays on X" about a chat that had simply been switched
  * to a different *private* provider by hand — true about the binding, wrong
  * about the reason.
+ *
+ * # Round 3 / N1 — statement 1 now holds for every chat
+ *
+ * PR #192 shipped statement 1 only where statement 2 also applied, because the
+ * client's copy of the row went stale on a model switch (see
+ * {@link ../privacy/usePinnedModel.usePinnedModel} for the regression that
+ * forced it). Measured consequence: bind Codex / `gpt-6-astra`, run one turn,
+ * switch the app to Claude Code / `claude-fable-5-1`, reopen the chat — the
+ * composer read `claude-fable-5-1` on a 1M gauge while `token_events` recorded
+ * `model_id = gpt-6-astra, provider = codex` for the next turn. Both endpoints
+ * public, so no privacy breach; the chip, the gauge and the cost attribution
+ * were all against the wrong model.
+ *
+ * The staleness is now fixed where it is (`utils/sessionBindingSync` on a
+ * switch, `ChatStreamController.refreshSessionBinding` after a turn), so
+ * statement 1 no longer has to borrow statement 2's proof.
  */
 
 /**

--- a/ui/desktop/src/components/privacy/usePinnedModel.ts
+++ b/ui/desktop/src/components/privacy/usePinnedModel.ts
@@ -29,30 +29,48 @@ export interface PinnedModelPresentation {
 /**
  * What this chat runs on, and whether that needs explaining.
  *
- * # One rule
+ * # Two rules, one per statement
  *
- * **The composer states the chat's own binding exactly when the app-wide
- * selection cannot run here.** Otherwise the selection stands.
+ * 1. **The chip and gauge state the chat's own binding whenever it differs from
+ *    the app-wide selection** — for every chat, private or not. That is simply
+ *    what runs: `restore_provider_from_session` binds the row's own
+ *    `provider_name`/`model_config` whenever the row names them, and only falls
+ *    back to the selection for a chat that names neither.
+ * 2. **The sentence is reserved for the case the privacy barrier causes.**
+ *    {@link selectionBarredByPrivacy} is the whole test.
  *
- * ⚠ The second half is not a hedge, it is a correctness requirement, and
- * dropping it was a regression this hook was written twice to avoid.
+ * ⚠ Rule 1 is what PR #192 could not yet ship, and the reason is worth keeping:
  * `ModelAndProviderContext.changeModel` writes BOTH the session row
  * (`updateAgentProvider`) and the global default (`setConfigProvider`), so after
- * a per-chat model switch the daemon has them in step — while the client's copy
- * of the row, cached in the `/agent/resume` payload the chat stream holds, is
- * the value from BEFORE the switch. A composer that preferred the row on every
- * disagreement would answer a switch by showing the model the user had just
- * switched away from, until the window reloaded.
+ * a per-chat model switch the daemon had them in step while this client's copy
+ * of the row — cached in the `/agent/resume` payload the chat stream holds, and
+ * refetched by nothing — was the value from BEFORE the switch. Preferring the
+ * row on every disagreement then answered a switch by showing the model the
+ * user had just switched away from. #192 narrowed the rule to the barred case,
+ * where Gate A proves the selection cannot be what runs here.
  *
- * When the selection is barred there is no such ambiguity: Gate A refuses to
- * bind it to this chat at all, so it provably is not what runs here, and the
- * row is the only binding that can be.
+ * That staleness is now fixed at its source rather than routed around, which is
+ * what lets rule 1 be the general rule:
  *
- * ⚠ The residual case is deliberate and unchanged from `main`: a PRIVATE chat
- * bound to a different PRIVATE model than the selection still shows the
- * selection. It is stale in the same narrow way it has always been, it is not
- * what F2 reported, and fixing it needs the client's cached row to be
- * invalidated on a switch rather than a heuristic here.
+ * - `utils/sessionBindingSync` — `changeModel` announces the binding the daemon
+ *   accepted, and the controller patches its row BEFORE the global selection
+ *   moves. So in the only render where the two can disagree, the row already
+ *   holds the new binding.
+ * - `ChatStreamController.refreshSessionBinding` — after every turn the row's
+ *   provider, model, classification and reason are re-read from
+ *   `GET /sessions/{id}?metadata_only=true`. A turn is the only other thing
+ *   that changes them, and it changes them in ways no client can compute.
+ *
+ * ⚠ **No sentence for the public case, deliberately.** A public chat on a
+ * different public model needs the chip and the gauge to be right, and once they
+ * are, the chip IS the statement — a standing banner above the composer would
+ * appear in every chat older than the user's last model switch, which is most of
+ * them, to say something the control beside it already says. The chip's own
+ * dropdown carries the one line that the chip cannot ("a model chosen elsewhere
+ * applies to new chats"), where a reader who wonders why the two disagree is
+ * already looking. The privacy sentence stays because it answers a different
+ * question — *why your choice is not in effect here* — which nothing else on
+ * screen answers.
  *
  * ⚠ The provider **display names** are resolved through `getProviders`, which
  * `ConfigContext` caches. `versa_azure` is not what that provider is called
@@ -77,10 +95,12 @@ export function usePinnedModel(
   const selectedProvider = currentProvider ?? undefined;
 
   useEffect(() => {
-    // ⚠ Nothing is fetched for a chat that cannot be barred. This hook runs in
-    // every chat, on every render of the composer, and only a PRIVATE one can
-    // ever refuse the selection — so a public chat costs no catalog read and no
-    // state update.
+    // ⚠ Nothing is fetched for a chat that cannot be barred, and that survives
+    // rule 1: the catalog is read only for the SENTENCE — the selected
+    // provider's tier, and the two display names the sentence names — and only a
+    // PRIVATE chat can ever earn one. The chip resolves its own provider's
+    // display name from the row it already reads (`ModelsBottomBar`), so a
+    // public chat still costs no catalog read and no state update here.
     if (chatTier !== 'private' || !selectedProvider) {
       setSelectedTier(undefined);
       return;
@@ -116,20 +136,28 @@ export function usePinnedModel(
     };
   }, [chatTier, getProviders, bindingProvider, selectedProvider]);
 
-  if (!binding || !selectionBarredByPrivacy(chatTier, selectedTier)) {
-    return { notice: null };
-  }
+  // A chat that has never named a provider genuinely has no binding of its own
+  // and correctly runs on — and states — the app-wide selection.
+  if (!binding) return { notice: null };
 
-  // The chip and gauge state the binding whether or not it is news; the
-  // SENTENCE needs the selection to be nameable and different.
+  // Rule 1. `bindingDiffersFromSelection` is also `false` on the first render of
+  // every chat, where the config has not landed and `currentProvider` /
+  // `currentModel` are still `null`. Overriding there would state something this
+  // hook cannot yet know, and would do it as a flash.
   const differs = bindingDiffersFromSelection(binding, {
     provider: currentProvider,
     model: currentModel,
   });
+  if (!differs) return { notice: null };
+
+  // Rule 2. The chip is already stating the binding by this point; the sentence
+  // is the separate claim that PRIVACY is why the user's choice is not in
+  // effect, and only a public selection on a private chat earns it.
+  const barred = selectionBarredByPrivacy(chatTier, selectedTier);
 
   return {
     effectiveModel: binding,
-    notice: differs
+    notice: barred
       ? pinnedModelNotice(
           bindingLabel(displayNames[binding.provider], binding.model),
           bindingLabel(displayNames[selectedProvider!], currentModel!)

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import ModelsBottomBar from './ModelsBottomBar';
+import ModelsBottomBar, { CHAT_KEEPS_ITS_MODEL_NOTE } from './ModelsBottomBar';
 import { __resetDisclosureStoreForTests } from '../../../privacy/disclosureCopy';
 
 /**
@@ -138,5 +138,39 @@ describe('a chat bound to something other than the app-wide selection', () => {
       ).toBeInTheDocument()
     );
     expect(screen.queryByText('gpt-5.5-2026-04-24')).toBeNull();
+  });
+
+  /**
+   * Round 3 / N1. The chip and gauge now state the chat's own binding for EVERY
+   * chat that has one, so they disagree with the app-wide selection in every
+   * chat older than the user's last model switch — the ordinary case. That
+   * raises a question the chip alone cannot answer ("did my switch fail?"), and
+   * this is where it is answered: inside the dropdown, which is what a reader
+   * opens to ask the chip what model this chat is on.
+   *
+   * ⚠ Deliberately NOT a note above the composer. That surface belongs to the
+   * privacy sentence, which is earned by a barrier and is rare; a standing
+   * banner for the ordinary case would be near-permanent chrome restating what
+   * the control beside it already says.
+   */
+  it('explains in the dropdown why the chip may differ from the app-wide choice', async () => {
+    renderBar(PINNED);
+    await screen.findByRole('button', { name: /Current model:/ });
+    fireEvent.pointerDown(screen.getByLabelText(/Current model/), { button: 0, ctrlKey: false });
+
+    const note = await screen.findByTestId('chat-binding-note');
+    expect(note).toHaveTextContent(CHAT_KEEPS_ITS_MODEL_NOTE);
+    // It names the mechanism, never privacy: this line appears on public chats
+    // too, where privacy is not the cause.
+    expect(note.textContent).not.toMatch(/private/i);
+  });
+
+  it('says nothing when the chat runs on exactly what is selected', async () => {
+    renderBar(undefined);
+    await screen.findByRole('button', { name: /Current model:/ });
+    fireEvent.pointerDown(screen.getByLabelText(/Current model/), { button: 0, ctrlKey: false });
+
+    await screen.findByText('Current model');
+    expect(screen.queryByTestId('chat-binding-note')).toBeNull();
   });
 });

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -32,6 +32,19 @@ import { isBrowserSurface } from '../../../../utils/surface';
 import type { ProviderTier, SessionClassification } from '../../../../api/types.gen';
 import type { PinnedModelView } from '../../../../hooks/chatStreamStore';
 
+/**
+ * Round 3 / N1 — the one line explaining why the chip may not name the model the
+ * user last chose.
+ *
+ * Two plain facts and no instruction: what governs this chat, and what the
+ * app-wide choice governs instead. It deliberately says nothing about privacy —
+ * that is a different cause with its own sentence
+ * (`privacy/pinnedModel.pinnedModelNotice`), and it is true of only some of the
+ * chats this line appears in.
+ */
+export const CHAT_KEEPS_ITS_MODEL_NOTE =
+  'This chat keeps the model it was last set to. A model chosen elsewhere applies to new chats.';
+
 interface ModelsBottomBarProps {
   sessionId: string | null;
   dropdownRef: React.RefObject<HTMLDivElement>;
@@ -524,6 +537,31 @@ export default function ModelsBottomBar({
             {affiliationWords && (
               <div className="mt-1.5 flex items-center gap-1.5">
                 <AffiliationBadge affiliation={affiliation} className="max-w-full" />
+              </div>
+            )}
+            {/*
+              Round 3 / N1 — why the two names above may not be the model the
+              user last chose in Settings.
+
+              ⚠ **Here and nowhere else.** The chip and gauge now state the
+              chat's own binding for EVERY chat that has one, which means they
+              disagree with the app-wide selection in every chat older than the
+              user's last model switch — the ordinary case, not an edge one. A
+              standing note above the composer would then be near-permanent
+              chrome restating what the control beside it already says. This is
+              the surface a reader reaches by asking the chip what model this
+              chat is on, so it is where the answer to "did my switch fail?"
+              belongs.
+
+              It names no cause and gives no instruction: the two ways to move
+              this chat are directly below it, and nothing here is broken.
+            */}
+            {effectiveModel && (
+              <div
+                data-testid="chat-binding-note"
+                className="mt-1.5 text-[11px] leading-4 text-text-muted"
+              >
+                {CHAT_KEEPS_ITS_MODEL_NOTE}
               </div>
             )}
             {/*

--- a/ui/desktop/src/hooks/chatStreamStore.binding.test.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.binding.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Round 3 / N1 + N3 — the renderer's copy of a chat's BINDING is kept fresh.
+ *
+ * The composer states the model a chat actually runs on, which is the model its
+ * session row names (`restore_provider_from_session`). That is only safe while
+ * this store's copy of the row is current, and until now nothing made it
+ * current: `loadSession` reads the row once from `/agent/resume` and every later
+ * path only patches the NAME. Two things change a binding, and each has its own
+ * half here.
+ *
+ * **A switch** (N1). Measured: bind Codex / `gpt-6-astra`, one turn, switch the
+ * app to Claude Code / `claude-fable-5-1`, reopen the chat — the composer read
+ * `claude-fable-5-1` on a 1M gauge while the next turn's `token_events` recorded
+ * `model_id = gpt-6-astra, provider = codex`. Preferring the row is the fix, but
+ * it is only correct if a per-chat switch reaches the row immediately — otherwise
+ * the composer answers the switch by showing the model just switched away from,
+ * which is the regression PR #192 caught in review.
+ *
+ * **A turn** (N3). Measured: new chat, one turn on `versa_azure` (the row becomes
+ * `versa_azure` / `private`), switch to Claude Code / `claude-opus-5`, return to
+ * the tab — chip `claude-opus-5`, gauge "972.5k of 1M", no note; after
+ * `location.reload()` all three were right. A turn writes fields no client can
+ * compute, so this half is a re-read rather than an announcement.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MessageEvent, Session, TokenState } from '../api';
+
+const USER_ACTION_KEY = 'proof-of-user';
+
+const mocks = vi.hoisted(() => ({
+  reply: vi.fn(),
+  observeSessionEvents: vi.fn(),
+  resumeAgent: vi.fn(),
+  cancelTurn: vi.fn(async () => ({ data: { cancelled: true } })),
+  // ⚠ The parameter is declared even though nothing reads it here: without it
+  // the mock's `.calls` type is `[][]`, and the census below — which is the
+  // whole point of one of these tests — cannot index element 0.
+  getSession: vi.fn(async (_options?: unknown) => ({ data: null }) as unknown),
+  interrupt: vi.fn(),
+  listSessions: vi.fn(async () => ({ data: { sessions: [] } })),
+  updateFromSession: vi.fn(async () => ({ data: {} })),
+  updateSessionUserWorkflowValues: vi.fn(async () => ({ data: {} })),
+}));
+
+vi.mock('../api', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, ...mocks };
+});
+
+import { ChatStreamRegistry } from './chatStreamStore';
+import { announceSessionBinding } from '../utils/sessionBindingSync';
+
+const tokenState: TokenState = {
+  accumulatedInputTokens: 0,
+  accumulatedOutputTokens: 0,
+  accumulatedTotalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+};
+
+const finishFrame = { type: 'Finish', reason: 'stop', token_state: tokenState } as MessageEvent;
+
+async function* streamOf(...frames: MessageEvent[]) {
+  for (const frame of frames) yield frame;
+}
+
+/**
+ * A row bound to Codex, classified public — the state N1 measured.
+ *
+ * ⚠ The name is deliberately NOT a default one. `finishCurrentStream` polls
+ * `GET /sessions/{id}` for an LLM-generated title whenever the name still looks
+ * like a placeholder, and that poll would put unrelated calls in the same mock.
+ */
+function boundSession(id: string, over: Partial<Session> = {}): Session {
+  return {
+    id,
+    name: 'A named chat',
+    working_dir: '/tmp',
+    conversation: [],
+    message_count: 0,
+    total_tokens: 0,
+    created_at: '',
+    updated_at: '',
+    extension_data: {},
+    user_set_name: true,
+    privacy_tier: 'public',
+    provider_name: 'codex',
+    model_config: { model_name: 'gpt-6-astra', toolshim: false, context_limit: 400000 },
+    ...over,
+  } as Session;
+}
+
+/** A fresh id per test: the transcript LRU in `sessionNameSync` is module-level
+ *  and keyed by id, so a reused id sends `loadSession` down the cached path. */
+let sessionSeq = 0;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSession.mockResolvedValue({ data: null });
+  Object.assign(window, {
+    electron: {
+      getUserActionKey: vi.fn(async () => USER_ACTION_KEY),
+      showNotification: vi.fn(),
+      logInfo: vi.fn(),
+    },
+  });
+});
+
+describe('a model switch reaches the row this store holds', () => {
+  it('patches the provider, the model and the window it was bound with', async () => {
+    const sid = `bind-switch-${++sessionSeq}`;
+    mocks.resumeAgent.mockResolvedValue({ data: { session: boundSession(sid) } });
+
+    const controller = new ChatStreamRegistry().getController(sid);
+    await controller.loadSession();
+    expect(controller.getSnapshot().session?.provider_name).toBe('codex');
+
+    announceSessionBinding({
+      sessionId: sid,
+      provider: 'versa_azure',
+      model: 'gpt-5.5-2026-04-24',
+      contextLimit: 1_050_000,
+    });
+
+    const row = controller.getSnapshot().session;
+    expect(row?.provider_name).toBe('versa_azure');
+    expect(row?.model_config?.model_name).toBe('gpt-5.5-2026-04-24');
+    // A row naming one model beside another model's window is the lie this
+    // patch exists to avoid: the gauge is sized from the pair.
+    expect(row?.model_config?.context_limit).toBe(1_050_000);
+    // Fields the bind did not name survive.
+    expect(row?.model_config?.toolshim).toBe(false);
+    expect(row?.name).toBe('A named chat');
+  });
+
+  it('clears a window it was not told, rather than keeping the previous model’s', async () => {
+    const sid = `bind-nolimit-${++sessionSeq}`;
+    mocks.resumeAgent.mockResolvedValue({ data: { session: boundSession(sid) } });
+
+    const controller = new ChatStreamRegistry().getController(sid);
+    await controller.loadSession();
+
+    announceSessionBinding({ sessionId: sid, provider: 'ollama', model: 'qwen3.6' });
+
+    expect(controller.getSnapshot().session?.model_config?.context_limit).toBeNull();
+  });
+
+  it('ignores an announcement for a different chat', async () => {
+    const sid = `bind-other-${++sessionSeq}`;
+    mocks.resumeAgent.mockResolvedValue({ data: { session: boundSession(sid) } });
+
+    const controller = new ChatStreamRegistry().getController(sid);
+    await controller.loadSession();
+
+    announceSessionBinding({
+      sessionId: `${sid}-someone-else`,
+      provider: 'versa_azure',
+      model: 'gpt-5.5-2026-04-24',
+    });
+
+    expect(controller.getSnapshot().session?.provider_name).toBe('codex');
+    expect(controller.getSnapshot().session?.model_config?.model_name).toBe('gpt-6-astra');
+  });
+
+  it('does nothing before the row has loaded', () => {
+    const sid = `bind-early-${++sessionSeq}`;
+    const controller = new ChatStreamRegistry().getController(sid);
+
+    announceSessionBinding({ sessionId: sid, provider: 'versa_azure', model: 'gpt-5.5' });
+
+    expect(controller.getSnapshot().session).toBeUndefined();
+  });
+});
+
+describe('a turn’s own writes are read back', () => {
+  /** Every `GET /sessions/{id}` this store made, with its options. */
+  function sessionReads() {
+    return mocks.getSession.mock.calls.map(
+      (call) =>
+        call[0] as {
+          path?: { session_id?: string };
+          query?: { metadata_only?: boolean };
+          headers?: Record<string, string>;
+        }
+    );
+  }
+
+  async function runOneTurn(sid: string) {
+    mocks.resumeAgent.mockResolvedValue({ data: { session: boundSession(sid) } });
+    mocks.reply.mockResolvedValue({ stream: streamOf(finishFrame) });
+    const controller = new ChatStreamRegistry().getController(sid);
+    await controller.loadSession();
+    await controller.handleSubmit('Reply with the single word ready.');
+    return controller;
+  }
+
+  /**
+   * N3, at the store. The turn raised the ratchet and rebound the provider; the
+   * refresh is what makes the composer notice without a reload.
+   */
+  it('adopts the classification and binding the turn established', async () => {
+    const sid = `bind-turn-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({
+      data: boundSession(sid, {
+        privacy_tier: 'private',
+        privacy_reason: 'turn:versa_azure',
+        provider_name: 'versa_azure',
+        model_config: { model_name: 'gpt-5.5-2026-04-24', toolshim: false },
+      }),
+    });
+
+    const controller = await runOneTurn(sid);
+
+    await vi.waitFor(() => expect(controller.getSnapshot().session?.privacy_tier).toBe('private'));
+    const row = controller.getSnapshot().session;
+    expect(row?.provider_name).toBe('versa_azure');
+    expect(row?.model_config?.model_name).toBe('gpt-5.5-2026-04-24');
+    expect(row?.privacy_reason).toBe('turn:versa_azure');
+  });
+
+  it('asks for the row alone, with the proof a private chat needs to be read', async () => {
+    const sid = `bind-read-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: boundSession(sid, { privacy_tier: 'private' }) });
+
+    await runOneTurn(sid);
+
+    await vi.waitFor(() => expect(sessionReads().length).toBeGreaterThan(0));
+    // ⚠ `metadata_only`, so this costs the row and not the whole transcript,
+    // once per turn — and the proof, because the chat this exists to notice has
+    // just become one a request without it is refused for.
+    expect(sessionReads()).toEqual([
+      {
+        path: { session_id: sid },
+        query: { metadata_only: true },
+        headers: { 'X-User-Action': USER_ACTION_KEY },
+        throwOnError: true,
+      },
+    ]);
+  });
+
+  /**
+   * The response carries no conversation. Adopting it wholesale would blank the
+   * transcript this store is the source of truth for — so only the four fields a
+   * turn can change are merged.
+   */
+  it('merges four fields and leaves the transcript alone', async () => {
+    const sid = `bind-merge-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({
+      data: {
+        id: sid,
+        privacy_tier: 'private',
+        provider_name: 'versa_azure',
+        model_config: { model_name: 'gpt-5.5-2026-04-24', toolshim: false },
+      } as Session,
+    });
+
+    const controller = await runOneTurn(sid);
+
+    await vi.waitFor(() => expect(controller.getSnapshot().session?.privacy_tier).toBe('private'));
+    expect(controller.getSnapshot().session?.name).toBe('A named chat');
+    expect(controller.getSnapshot().session?.working_dir).toBe('/tmp');
+    expect(controller.getSnapshot().messages.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * The turn has already been delivered by the time this runs. A refresh that
+   * cannot complete leaves the composer exactly as stale as it was before this
+   * method existed — which is not worth a toast, and must not surface as a
+   * failed turn.
+   */
+  it('fails silently when the row cannot be re-read', async () => {
+    const sid = `bind-fail-${++sessionSeq}`;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.getSession.mockRejectedValue(new Error('daemon restarting'));
+
+    const controller = await runOneTurn(sid);
+
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to refresh the chat'),
+        expect.any(Error)
+      )
+    );
+    expect(controller.getSnapshot().session?.provider_name).toBe('codex');
+    expect(controller.getSnapshot().turnError).toBeUndefined();
+    warn.mockRestore();
+  });
+});

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -25,6 +25,7 @@ import {
   renameSession,
   subscribeSessionNameChanges,
 } from '../utils/sessionNameSync';
+import { subscribeSessionBindingChanges } from '../utils/sessionBindingSync';
 import {
   createElicitationResponseMessage,
   createUserMessage,
@@ -791,6 +792,42 @@ class ChatStreamController {
         return {
           ...prev,
           session: { ...prev.session, name: change.name, user_set_name: change.userSetName },
+        };
+      });
+    });
+
+    // Round 3 / N1 — a per-chat model switch rewrites this session's row, and
+    // this store holds the only copy of it the composer reads. Same shape as the
+    // name subscription above, and for the same reason: the write has already
+    // landed on the daemon, so re-reading it would be a round trip to learn what
+    // the announcement already carries.
+    subscribeSessionBindingChanges((change) => {
+      if (change.sessionId !== sessionId) return;
+      this.updateSnapshot((prev) => {
+        if (!prev.session) return prev;
+        if (
+          prev.session.provider_name === change.provider &&
+          prev.session.model_config?.model_name === change.model
+        ) {
+          return prev;
+        }
+        return {
+          ...prev,
+          session: {
+            ...prev.session,
+            provider_name: change.provider,
+            // Spread, so the row keeps the fields the bind did not name
+            // (`toolshim`, `reasoning_effort`, …). `context_limit` is written
+            // even when the announcement carries none: a row naming one model
+            // beside another model's window is the lie this patch exists to
+            // avoid, and the post-turn refresh restores the daemon's own value.
+            model_config: {
+              ...prev.session.model_config,
+              model_name: change.model,
+              context_limit: change.contextLimit ?? null,
+              toolshim: prev.session.model_config?.toolshim ?? false,
+            },
+          },
         };
       });
     });
@@ -1722,6 +1759,69 @@ class ChatStreamController {
     onSessionLoaded?.();
   }
 
+  /**
+   * Round 3 / N3 — re-read the four row fields a TURN can change.
+   *
+   * The composer states the chat's own binding, and the classification decides
+   * whether the app-wide selection is barred from it at all. Both are written by
+   * the daemon during a turn and neither is derivable here: the binding may be
+   * `restore_provider_from_session`'s or Gate B's repair of it, and
+   * `privacy_tier` ratchets from whatever the turn touched. Without this, the
+   * measured symptom was a chat that had just gone private still showing a
+   * public model, its window, and no note — until the window was reloaded.
+   *
+   * ⚠ `metadata_only`, so this costs the row and not the transcript. The same
+   * `GET /sessions/{id}` without it re-serialises every message in the chat,
+   * once per turn, to learn three strings.
+   *
+   * ⚠ Four fields, merged — never the whole row. The response carries no
+   * conversation and stale token counters; adopting it wholesale would blank the
+   * transcript this store is the source of truth for.
+   *
+   * ⚠ Failure is silent by design. This runs after the turn has already been
+   * delivered; a refresh that could not complete leaves the composer exactly as
+   * stale as it was before this method existed, which is not worth a toast.
+   */
+  private async refreshSessionBinding(): Promise<void> {
+    if (!this.sessionId || !this.snapshot.session) return;
+    try {
+      const response = await getSession({
+        path: { session_id: this.sessionId },
+        query: { metadata_only: true },
+        // Issue #56 Task 58: reading a private chat needs the proof-of-user —
+        // and a chat this call exists to notice has JUST become private is
+        // exactly the one that would be refused without it.
+        headers: await userActionHeaders(),
+        throwOnError: true,
+      });
+      const row = response.data;
+      if (!row) return;
+      this.updateSnapshot((prev) => {
+        if (!prev.session) return prev;
+        if (
+          prev.session.provider_name === row.provider_name &&
+          prev.session.model_config?.model_name === row.model_config?.model_name &&
+          prev.session.privacy_tier === row.privacy_tier &&
+          prev.session.privacy_reason === row.privacy_reason
+        ) {
+          return prev;
+        }
+        return {
+          ...prev,
+          session: {
+            ...prev.session,
+            provider_name: row.provider_name,
+            model_config: row.model_config,
+            privacy_tier: row.privacy_tier,
+            privacy_reason: row.privacy_reason,
+          },
+        };
+      });
+    } catch (error) {
+      console.warn('Failed to refresh the chat’s model binding after a turn:', error);
+    }
+  }
+
   private finishCurrentStream = async (error?: ChatTurnErrorData): Promise<void> => {
     if (error) {
       this.updateSnapshot((prev) => ({ ...prev, turnError: error }));
@@ -1755,6 +1855,13 @@ class ChatStreamController {
     if (this.sessionId) {
       window.dispatchEvent(new CustomEvent('message-stream-finished'));
     }
+
+    // Round 3 / N3. A turn is the other thing that changes this chat's binding,
+    // and unlike a model switch it changes fields no client can compute: the
+    // daemon binds `restore_provider_from_session`'s provider, Gate B may repair
+    // it, and the privacy ratchet raises `privacy_tier` from whatever the turn
+    // touched. Not awaited — the turn is over and nothing on screen waits on it.
+    void this.refreshSessionBinding();
 
     if (
       this.sessionId &&

--- a/ui/desktop/src/utils/sessionBindingSync.ts
+++ b/ui/desktop/src/utils/sessionBindingSync.ts
@@ -1,0 +1,87 @@
+/**
+ * Round 3 / N1 — keeping the renderer's copy of a chat's BINDING fresh.
+ *
+ * # Why this exists
+ *
+ * The composer must state the model a chat actually runs on, and that is the
+ * chat's own session row: `restore_provider_from_session` binds
+ * `session.provider_name` + `session.model_config` whenever either is set, and
+ * only falls back to the app-wide selection for a chat that names neither.
+ *
+ * The renderer cannot simply prefer the row, though, because its copy of the
+ * row is a cache. `ChatStreamController` reads it once (from `/agent/resume`)
+ * and then only ever patches it; nothing refetches it. So a per-chat model
+ * switch — which writes the row through `updateAgentProvider` and the global
+ * default through `setConfigProvider`, in that order — left the daemon with the
+ * two in step and this renderer holding the value from BEFORE the switch. A
+ * composer preferring the row would answer the switch by showing the model the
+ * user had just switched away from. That regression is why PR #192 shipped the
+ * override only for the case where the privacy barrier proves the selection
+ * cannot run here.
+ *
+ * The fix is to make the cached row fresh rather than to guess around it, and
+ * this module is one of the two halves. `changeModel` announces the binding it
+ * just wrote, the controller for that session patches its snapshot
+ * SYNCHRONOUSLY, and only then does the global selection move. There is
+ * therefore no render in which the row is stale — during the gap the row holds
+ * the NEW binding and the selection still holds the old one, which is the
+ * direction that shows the user what they just chose.
+ *
+ * The other half is `ChatStreamController.refreshSessionBinding`, which
+ * re-reads the row after a turn: a turn can change `privacy_tier` (the ratchet)
+ * and the bound provider in ways only the daemon knows, so those cannot be
+ * announced from here.
+ *
+ * ⚠ **Announce only what the daemon accepted.** `updateAgentProvider` can be
+ * refused — Gate A returns 409 for a public model on a private chat — and a
+ * refused switch leaves the row exactly as it was. The announcement therefore
+ * belongs after that call has resolved, never beside the optimistic UI update.
+ *
+ * ⚠ **In-renderer only, deliberately.** Unlike `sessionNameSync`, this is not
+ * carried over a `BroadcastChannel`: a model switch is an act of one window,
+ * the row it writes is re-read by any other window on its next turn or resume,
+ * and a second window's own `ModelAndProviderContext` is not updated by this
+ * event either. Broadcasting the binding alone would make one of the two facts
+ * cross windows and not the other.
+ */
+
+export interface SessionBindingChange {
+  /** The chat whose row was rewritten. */
+  sessionId: string;
+  /** The provider id the daemon accepted, e.g. `versa_azure`. */
+  provider: string;
+  /** The model name the daemon accepted, e.g. `gpt-5.5-2026-04-24`. */
+  model: string;
+  /**
+   * The context window sent with the bind, when the picker knew one.
+   *
+   * Carried so a patched row cannot end up naming one model beside another's
+   * window. `undefined` means "not known here" and clears the stale value
+   * rather than keeping it — the daemon derives the real limit, and the
+   * post-turn refresh brings it back.
+   */
+  contextLimit?: number | null;
+}
+
+type Listener = (change: SessionBindingChange) => void;
+
+const listeners = new Set<Listener>();
+
+/** Subscribe to model-switch announcements. Returns the unsubscribe. */
+export function subscribeSessionBindingChanges(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Announce a binding the daemon has already accepted for `sessionId`.
+ *
+ * Synchronous by design: the caller is mid-switch, and the point of the
+ * announcement is that no render happens between the write landing and this
+ * renderer knowing about it.
+ */
+export function announceSessionBinding(change: SessionBindingChange): void {
+  for (const listener of [...listeners]) listener(change);
+}


### PR DESCRIPTION
Round-3 walkthrough findings **N1** (medium — a resumed chat runs on the session row's model while the composer names the app-wide selection) and **N3** (low — the private-chat note and chip do not appear until a reload).

## Why

### N1 — the chip, the gauge and the cost attribution were all against the wrong model

Verbatim repro (re-measured in a sandboxed dev instance on 2026-09-08, before and after):

1. Settings → Switch models → **Codex / `gpt-6-astra`**.
2. New chat, send `Reply with the single word ready.` The row is written `provider_name = codex`, `model_config.model_name = gpt-6-astra`, `context_limit = 1050000` (session `20260909_1`).
3. Settings → Switch models → **Claude Code / `claude-opus-5`**. This is the app-wide picker, which passes `sessionId = null` — **no row is written**, so the chat still runs on Codex.
4. Reopen the chat (`#/pair?resumeSessionId=20260909_1`).

On `main` the composer read `claude-fable-5-1` with the gauge at *"1M of 1M"*, and the next turn's `token_events` recorded `model_id = gpt-6-astra, provider = codex`. `restore_provider_from_session` binds the provider the **row** names; the composer never noticed.

Consequence: the chip is wrong, the gauge measures usage against the wrong window (1,000,000 vs 1,050,000 here), and cost follows the wrong provider. Both endpoints are Public — no privacy breach, and nothing about what any gate permits changes here.

`usePinnedModel`'s own doc comment already stated the intended rule as *"the chip and gauge must state [the chat's own binding] for EVERY chat, private or not"*. PR #192 shipped only the half where `selectionBarredByPrivacy` **proves** the selection cannot run here, and recorded exactly why: `changeModel` writes the session row (`updateAgentProvider`) and the global default (`setConfigProvider`) together, while the client's copy of the row — cached in the `/agent/resume` payload the chat stream holds, and refetched by nothing — is the value from *before* the switch. Preferring the row on every disagreement answered a switch by showing the model the user had just switched away from.

So the fix is not to widen the predicate. It is to make the cached row fresh, and then let the binding win.

### N3 — same root, and the instrumented answer to "which field lagged"

New chat → one turn on `versa_azure` (the row becomes `versa_azure` / `private`) → switch to Claude Code / `claude-opus-5` → return to that chat tab: chip `claude-opus-5`, gauge *"972.5k of 1M"*, no note. After `location.reload()` all three were correct.

The brief asked which cached field lags. Measured, not inferred — a `fetch` hook recording every session payload the renderer received for session `20260909_3`:

| what | `provider_name` | `model_name` | `context_limit` | `privacy_tier` | `privacy_reason` |
| --- | --- | --- | --- | --- | --- |
| `POST /agent/resume` @ 04:18:41.957 — *what the store cached* | `versa_azure` | `gpt-5.5-2026-04-24` | 1050000 | **`public`** | **`null`** |
| `GET /sessions/…?metadata_only=true` @ 04:18:44.910 — *the post-turn refresh* | `versa_azure` | `gpt-5.5-2026-04-24` | 1050000 | **`private`** | **`turn:versa_azure`** |

**`privacy_tier` (with `privacy_reason`) is the only field that lagged.** The binding was already right in the resume payload, because a new chat's row is seeded with the config's provider and model at creation. Under #192's rule a stale `public` tier suppresses the override *and* the note together, which is why all three symptoms appeared at once.

## What changed

Renderer only. No Rust, no route, no contract change.

### The cached row is kept fresh — two halves, one per thing that changes a binding

- **`ui/desktop/src/utils/sessionBindingSync.ts`** (new) — an in-renderer announcement carrying `{ sessionId, provider, model, contextLimit }`. Same shape and lifetime as `sessionNameSync`'s broadcast.
- **`components/ModelAndProviderContext.tsx:361`** — `changeModel` announces the binding **after `updateAgentProvider` resolved and before `setConfigProvider`**. Both halves of that placement are load-bearing: a refused bind (Gate A's 409) throws past the line and writes nothing, and announcing *before* the global default moves means that in the only render where the two can disagree the ROW holds the new binding while the selection still holds the old one. That is the direction that shows the user what they just chose. Ordering is asserted, not assumed (`order === ['bind', 'announce', 'global']`).
- **`hooks/chatStreamStore.tsx:801`** — the controller subscribes in its constructor, filters by session id, and patches `provider_name` + `model_config` synchronously. `context_limit` is written even when the announcement carries none, so a row can never name one model beside another model's window.
- **`hooks/chatStreamStore.tsx:1601` `refreshSessionBinding`** — after every turn, re-reads `provider_name`, `model_config`, `privacy_tier` and `privacy_reason` from `GET /sessions/{id}?metadata_only=true` and merges those four fields. `metadata_only` because the same route without it re-serialises the whole transcript to learn three strings; four fields merged rather than the row adopted because the response carries no conversation and this store is the transcript's source of truth. It carries the user-action proof — the chat this exists to notice has just become one that is refused without it. Failure is a `console.warn`: the turn has already been delivered, and a refresh that could not complete leaves the composer exactly as stale as before.

### …and only then, the rule

- **`components/privacy/usePinnedModel.ts`** — two rules, one per statement. The chip and gauge state the chat's own binding whenever it differs from the selection, for every chat; the **sentence** is still earned only by `selectionBarredByPrivacy`, unchanged. A public chat still costs no catalog read in this hook, because the tier is needed only for the sentence.
- **`components/privacy/pinnedModel.ts`** — the pure helpers are untouched; only the module doc records why statement 1 no longer has to borrow statement 2's proof.

### One line, in the chip's dropdown — and deliberately not a banner

`ModelsBottomBar.tsx` gains `CHAT_KEEPS_ITS_MODEL_NOTE`: *"This chat keeps the model it was last set to. A model chosen elsewhere applies to new chats."*

The brief asked whether a quieter "this chat runs on X" line is warranted. **A standing note above the composer is not**, and the reason is scale: the chip and gauge now disagree with the selection in every chat older than the user's last model switch, which is most of them. A near-permanent banner restating what the control beside it already says is noise. But the chip alone cannot answer the question it raises — *did my switch fail?* — so the answer goes in the dropdown, which is the surface a reader opens to ask the chip what model this chat is on. It names no cause and gives no instruction; the two ways to move the chat are directly below it.

The privacy sentence keeps its banner because it answers a different question — *why your choice is not in effect here* — which nothing else on screen answers, and because a barred chat cannot simply be switched.

## Tests

Every line below was run in this worktree after the change.

| Gate | Result |
| --- | --- |
| `cd ui/desktop && npm run test:run` | 434 files, **4875 passed**, 1 skipped (baseline 4857; **+18** new cases) |
| `npx vitest run src/components/privacy/PinnedModelNote.test.tsx` | **22 passed** (was 18) |
| `npx vitest run src/hooks/chatStreamStore.binding.test.tsx` | **8 passed** (new binary) |
| `npx vitest run src/components/ModelAndProviderContext.test.tsx` | **17 passed** (was 13) |
| `npx vitest run src/components/settings/models/bottom_bar/` | **24 passed** (was 22) |
| `cd ui/desktop && npm run lint:check` | clean — tsc, eslint, 3 themes current, 332 contrast assertions, token mirrors |
| `npx prettier --check` on all 10 changed `ui/desktop/src` files | All matched files use Prettier code style |

No Rust file is touched, so no Rust gate applies and no contract was regenerated.

**Both halves were falsified before being trusted.** With `refreshSessionBinding` and the constructor subscription removed, **6 of the 8** store tests fail (the two that still pass are the negative controls — "ignores another chat's announcement", "does nothing before the row has loaded"). With `usePinnedModel`'s rule narrowed back to the barred case, **3 of the 22** hook tests fail. The new cases cover exactly what the brief asked for: the public-chat case (row `codex`/`gpt-6-astra`, selection `claude_code`/`claude-fable-5-1` → chip and gauge state codex/astra, no privacy note, no catalog read), the just-switched case, #192's private cases unchanged, and the "established in this client session" case. The pure helpers in `pinnedModel.ts` are unchanged and still tested as pure.

## Runtime verification

Sandboxed instance `fix-binding` (CDP 9345), this worktree, the operator's `versa_azure` plus `codex` and `claude_code` from the seed. Screenshots under `~/biorouter-runs/test-drive/round3/shots/fix-binding/`.

**N1, following the repro exactly.** Row `20260909_1` = `codex` / `gpt-6-astra` / `public`; selection = `claude_code` / `claude-opus-5`.

| | on `main` (round-3 report) | here, after the fix |
| --- | --- | --- |
| chip | `claude-fable-5-1` | **`gpt-6-astra (Public model). Public chat`** |
| gauge | `1M of 1M` (Claude's) | **`1.0M of 1.1M`** (Codex's 1,050,000) |
| privacy note | none | none — correct, both endpoints public |
| dropdown | — | *"This chat keeps the model it was last set to…"* |
| next turn's `token_events` | `gpt-6-astra` / `codex` | `gpt-6-astra` / `codex` — unchanged, and now what the composer says |

Control: a fresh chat in the same window read `claude-opus-5` / `1M of 1M`, so the selection still governs new chats. `01a`, `02a`.

**N3, following the repro exactly**, and with **no reload** (`performance.getEntriesByType('navigation')[0].type === "navigate"` from the original load; `location.reload()` was never called). Row `20260909_3` = `versa_azure` / `private` / `turn:versa_azure`; selection = `claude_code` / `claude-opus-5`:

- chip `gpt-5.5-2026-04-24 (Private model, UCSF). Private chat. Biorouter only lets a private model open it.`
- gauge **`1.0M of 1.1M`** (Versa's 1,050,000, not the `972.5k of 1M` measured on `main`)
- note *"This chat is marked private, so it stays on Versa API Azure / gpt-5.5-2026-04-24. Claude Code / claude-opus-5 is not used here."* — `03a`

**The regression #192 feared, measured absent.** Per-chat switch on `20260909_1` (composer chip → Change Model → Claude Code / `claude-opus-5`), sampling the chip's accessible name every 16 ms across the whole switch: exactly **one** transition, `gpt-6-astra` → `claude-opus-5` at t = 134 ms, and no return. The row was rewritten to `claude_code` / `claude-opus-5` / ctx 1,000,000, chip and gauge followed (`974.9k of 1M`), and with the row and the selection agreeing there is no override, no note and no dropdown line. `04a`.

**Zero console messages and zero page errors** across the whole run.

Housekeeping: provider restored to `versa_azure` / `gpt-5.5-2026-04-24`; all three probe chats deleted (session count back to the 11,780 baseline) along with the four `token_events` rows `DELETE /sessions/{id}` leaves behind; instance stopped. The main checkout was never built in and is unchanged (`git status` is the pre-existing `?? .agents/` only).

## Out of scope

- **The row is refreshed after a turn, not at its start.** The ratchet fires at the top of `Agent::reply`, so during a long turn the composer can still hold the pre-turn classification. Both findings are about the state *between* turns, and a refresh on the submit path would put a request on the critical path of every send.
- **A row changed by something other than this window** — a second window, the CLI, a schedule — is still stale until the next turn or resume here. That is no worse than before, where the composer showed the selection, which was also not what runs.
- **The private-on-private case was verified by unit test only.** Only one non-local private provider is configured on this machine, and the brief forbids running local models, so a private → different-private per-chat switch could not be driven at runtime. It is covered by `states the binding even when the selection would be admitted here`.
- **N2 and N4** from the round-3 report belong to other agents' surfaces (`main.css` / `tabFocus.test.ts`, and Settings → App copy) and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
