### PR TITLE
Agents: the callable-tool count reads explicit inputs, not whatever the binary's other tests left behind

### DIFF
--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -7803,6 +7803,11 @@ impl Agent {
     /// lists is issue #141. `code_execution`'s catalogue is not such a reader —
     /// it consumes no gates at all, since the platform tools are never in it.
     pub(crate) async fn platform_tool_gates(&self) -> platform_tools::PlatformToolGates {
+        // ONE read of the proof-of-user flag, feeding the two decisions that
+        // ask it. `PlatformToolGates::tools` used to re-read it for
+        // `manage_workflow_tool` while `bug_report` carried the first read —
+        // two instants, one value, and the struct's own doc already forbade it.
+        let user_proof_available = crate::pending_user_action::user_proof_available();
         platform_tools::PlatformToolGates {
             scheduler: self.config.scheduler_service.is_some(),
             // Ingestion belongs to the Knowledge capability. If the user
@@ -7825,7 +7830,10 @@ impl Agent {
             // no proof-of-user key can never grant. Sampled here, once, for the
             // reason every other gate is: a process-global read inside the gate
             // itself is a second read the value could change between.
-            bug_report: crate::pending_user_action::user_proof_available(),
+            bug_report: user_proof_available,
+            // The same sample, for the other decision it governs — which
+            // actions `platform__manage_workflow` advertises.
+            can_ask_a_person: user_proof_available,
         }
     }
 
@@ -12426,6 +12434,7 @@ mod tests {
             session_blobs: true,
             workflows: true,
             bug_report: true,
+            can_ask_a_person: true,
         };
         let none = PlatformToolGates {
             scheduler: false,
@@ -12433,6 +12442,7 @@ mod tests {
             session_blobs: false,
             workflows: false,
             bug_report: false,
+            can_ask_a_person: false,
         };
 
         assert_eq!(
@@ -12518,6 +12528,7 @@ mod tests {
                 session_blobs: true,
                 workflows: false,
                 bug_report,
+                can_ask_a_person: bug_report,
             }
             .tools(None)
             .into_iter()
@@ -16301,33 +16312,53 @@ mod tests {
     async fn code_execution_mode_keeps_the_agent_dispatched_platform_tools_callable() {
         let path_root = tempfile::TempDir::new().expect("an isolated capability root");
         let path_root_value = path_root.path().to_string_lossy().into_owned();
-        let _env = env_lock::lock_env([
-            ("BIOROUTER_PATH_ROOT", Some(path_root_value.as_str())),
-            ("BIOROUTER_SESSION_BLOB_LAZY_LOAD", Some("true")),
-        ]);
+        let _env = env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(path_root_value.as_str()))]);
 
-        let (agent, session_id) = agent_with_one_extension_for_tests().await;
-        for name in ["knowledge", "code_execution"] {
-            let target = resolve_bundled_extension(name)
-                .unwrap_or_else(|| panic!("{name} must resolve as a bundled capability"));
-            agent
-                .add_extension(target.into_config(format!("{name} for issue #141")))
+        // ⚠ `BIOROUTER_SESSION_BLOB_LAZY_LOAD` is set as a TASK-LOCAL config
+        // override, never in the process environment. It decides whether
+        // `platform__read_session_blob` is on the model-facing roster
+        // (`PlatformToolGates::session_blobs`), and every agent in this binary
+        // reads it live through `Config::get_param` without asking for
+        // `env_lock` — so parking it in the environment silently changed the
+        // callable-tool count of every concurrently running test. It did:
+        // `reply_parts::tests::callable_count_is_pure_while_turn_prep_grades_
+        // sorted_frontend_tools` failed on CI with `left: 4, right: 5`, the
+        // missing tool being this one, because the flag flipped between its two
+        // reads. `no_test_parks_the_session_blob_flag_in_the_process_environment`
+        // in `platform_tools.rs` is the standing guard.
+        let overrides = std::collections::HashMap::from([(
+            "BIOROUTER_SESSION_BLOB_LAZY_LOAD".to_string(),
+            "true".to_string(),
+        )]);
+        let names_owned = crate::config::with_config_overrides(overrides, async {
+            let (agent, session_id) = agent_with_one_extension_for_tests().await;
+            for name in ["knowledge", "code_execution"] {
+                let target = resolve_bundled_extension(name)
+                    .unwrap_or_else(|| panic!("{name} must resolve as a bundled capability"));
+                agent
+                    .add_extension(target.into_config(format!("{name} for issue #141")))
+                    .await
+                    .unwrap_or_else(|error| panic!("enable {name}: {error}"));
+            }
+
+            let provider: Arc<dyn Provider> = Arc::new(BridgedChildProvider { name: "anthropic" });
+            let session = agent
+                .config
+                .session_manager
+                .get_session(&session_id, false)
                 .await
-                .unwrap_or_else(|error| panic!("enable {name}: {error}"));
-        }
-
-        let provider: Arc<dyn Provider> = Arc::new(BridgedChildProvider { name: "anthropic" });
-        let session = agent
-            .config
-            .session_manager
-            .get_session(&session_id, false)
-            .await
-            .expect("read the session under test");
-        let (tools, _, _, _) = agent
-            .prepare_tools_and_prompt_for_provider(&session_id, &session.working_dir, &provider)
-            .await
-            .expect("prepare an ordinary Code Execution turn");
-        let names: Vec<_> = tools.iter().map(|tool| tool.name.as_ref()).collect();
+                .expect("read the session under test");
+            let (tools, _, _, _) = agent
+                .prepare_tools_and_prompt_for_provider(&session_id, &session.working_dir, &provider)
+                .await
+                .expect("prepare an ordinary Code Execution turn");
+            tools
+                .iter()
+                .map(|tool| tool.name.to_string())
+                .collect::<Vec<_>>()
+        })
+        .await;
+        let names: Vec<&str> = names_owned.iter().map(String::as_str).collect();
 
         assert!(
             names.contains(&"code_execution__execute_code"),

--- a/crates/biorouter/src/agents/platform_tools.rs
+++ b/crates/biorouter/src/agents/platform_tools.rs
@@ -127,6 +127,19 @@ pub struct PlatformToolGates {
     /// than one that is absent: the model reaches it, produces a report, and
     /// the turn ends with nowhere to put it.
     pub bug_report: bool,
+    /// `pending_user_action::user_proof_available()` again — the SAME
+    /// process-global, sampled in the same breath as [`Self::bug_report`], for
+    /// a different decision: it narrows `platform__manage_workflow`'s action
+    /// list rather than deciding whether a tool is offered at all.
+    ///
+    /// It is a field rather than a read inside [`Self::tools`] because this
+    /// struct's whole contract is that a gate is sampled ONCE by
+    /// `Agent::platform_tool_gates` and passed in — the doc above says so, and
+    /// `manage_workflow_tool`'s own doc already claimed the value was "sampled
+    /// by the caller" while the assembly quietly re-read it. A second read is a
+    /// second instant: two tools built from one `PlatformToolGates` could
+    /// disagree about whether a person is reachable.
+    pub can_ask_a_person: bool,
 }
 
 impl PlatformToolGates {
@@ -139,6 +152,12 @@ impl PlatformToolGates {
     /// `Agent::list_tools_for`, which is how the model's roster and
     /// `code_execution`'s view of the world came to disagree about the same
     /// tools (issue #141).
+    ///
+    /// A pure function of `self`. Nothing here reads the environment, the
+    /// config layer or a process-global — every such value is a field, sampled
+    /// once by `Agent::platform_tool_gates`. That is what lets a test state the
+    /// platform roster as an input instead of inheriting whatever the binary's
+    /// other tests last left behind.
     pub fn tools(self, extension_name: Option<&str>) -> Vec<Tool> {
         if !matches!(extension_name, None | Some(PLATFORM_EXTENSION_NAME)) {
             return Vec::new();
@@ -155,9 +174,7 @@ impl PlatformToolGates {
             tools.push(read_session_blob_tool());
         }
         if self.workflows {
-            tools.push(manage_workflow_tool(
-                crate::pending_user_action::user_proof_available(),
-            ));
+            tools.push(manage_workflow_tool(self.can_ask_a_person));
         }
         if self.bug_report {
             tools.push(report_bug_tool());
@@ -695,6 +712,122 @@ mod tests {
             description.contains("kb_write_page"),
             "the description must name the primitive it is replacing, or the model \
              reaches for it anyway"
+        );
+    }
+    /// The standing guard against the race that `session_blobs` opened.
+    ///
+    /// `PlatformToolGates::session_blobs` is `message_blobs::lazy_load_enabled()`,
+    /// which resolves `BIOROUTER_SESSION_BLOB_LAZY_LOAD` through
+    /// `Config::get_param` — a LIVE read of the process environment, made by
+    /// every agent in the binary, on every tool listing, without asking for
+    /// `env_lock`. So a test that parks the flag in the environment — however
+    /// correctly it holds the lock, and both offenders did — silently adds
+    /// `platform__read_session_blob` to the model-facing roster of every
+    /// CONCURRENT test. `env_lock` cannot help: it serialises the callers that
+    /// ask for it, and these readers never do.
+    ///
+    /// It is not hypothetical. On `test (ubuntu-latest)` for PR #195 — a
+    /// CSS-and-copy change — `agents::reply_parts::tests::callable_count_is_
+    /// pure_while_turn_prep_grades_sorted_frontend_tools` failed with
+    /// `left: 4, right: 5`: the flag was set between its two reads of the
+    /// surface, and the fifth tool was this one.
+    ///
+    /// Use `config::with_config_overrides` instead. It is a task-local that
+    /// `Config::get_param` consults BEFORE the environment, so it wins for the
+    /// test that sets it and is invisible to every other one.
+    ///
+    /// Deliberately a source scan rather than a runtime assertion, for the same
+    /// reason as `model::tests::no_test_poisons_a_shared_setting`, of which this
+    /// is a sibling: the race needs an interleaving CI produces and a laptop
+    /// rarely does, so a green stress run is weak evidence. This check cannot
+    /// flake.
+    #[test]
+    fn no_test_parks_the_session_blob_flag_in_the_process_environment() {
+        // CARGO_MANIFEST_DIR is <workspace>/crates/biorouter; go up twice.
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let crates = root.join("crates");
+        assert!(
+            crates.is_dir(),
+            "the audit walks {}; if that path is wrong it passes for the wrong reason",
+            crates.display()
+        );
+
+        // The two shapes the flag is actually written in:
+        //   `("BIOROUTER_SESSION_BLOB_LAZY_LOAD", Some("true"))` — the
+        //   `env_lock::lock_env` / `temp_env::with_vars` tuple, which also
+        //   covers `temp_env::with_var(KEY, Some(v), …)` because the call's own
+        //   paren plays the part of the tuple's; and
+        //   `set_var("BIOROUTER_SESSION_BLOB_LAZY_LOAD", "true")`.
+        // A `None::<&str>` entry is NOT matched and must not be: clearing the
+        // flag for the duration of a test is the safe direction — it restores
+        // the default every other reader already assumes.
+        //
+        // Comment lines are skipped before matching, and that is load-bearing
+        // rather than tidiness: the two shapes are spelled out literally in the
+        // comment directly above, so a scan that read comments would report
+        // this guard as its own first offender.
+        let key = "BIOROUTER_SESSION_BLOB_LAZY_LOAD";
+        let tuple = regex::Regex::new(&format!(r#"\(\s*"{key}"\s*,\s*Some\(\s*""#)).unwrap();
+        let set_var = regex::Regex::new(&format!(r#"set_var\(\s*"{key}"\s*,"#)).unwrap();
+
+        let mut scanned = 0usize;
+        let mut mentions = 0usize;
+        let mut offenders: Vec<String> = Vec::new();
+        for entry in walkdir::WalkDir::new(&crates) {
+            let entry = entry.expect("the audit must not silently skip an unreadable directory");
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                continue;
+            }
+            scanned += 1;
+            let Ok(source) = std::fs::read_to_string(path) else {
+                continue;
+            };
+            if source.contains(key) {
+                mentions += 1;
+            }
+            for (number, line) in source.lines().enumerate() {
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                if tuple.is_match(line) || set_var.is_match(line) {
+                    offenders.push(format!(
+                        "{}:{}",
+                        path.strip_prefix(&root)
+                            .unwrap_or(path)
+                            .to_string_lossy()
+                            .replace('\\', "/"),
+                        number + 1
+                    ));
+                }
+            }
+        }
+
+        // A walk that reads nothing agrees with a walk that finds nothing.
+        assert!(
+            scanned > 500,
+            "the audit only scanned {scanned} files, which is too few to have walked the \
+             workspace"
+        );
+        assert!(
+            mentions >= 2,
+            "the audit found {key} named in only {mentions} files. Either the flag was \
+             renamed — in which case this guard now watches nothing — or its readers were \
+             removed and this guard can go with them"
+        );
+        assert!(
+            offenders.is_empty(),
+            "these tests park `{key}` in the PROCESS environment, which changes the \
+             model-facing tool roster of every concurrently running test in the same \
+             binary — `env_lock` does not help, because the readers never ask for it. \
+             Use `config::with_config_overrides`, a task-local that wins over the \
+             environment for the setting task alone:\n  {}",
+            offenders.join("\n  ")
         );
     }
 }

--- a/crates/biorouter/src/agents/reply_parts.rs
+++ b/crates/biorouter/src/agents/reply_parts.rs
@@ -1049,76 +1049,126 @@ mod tests {
         );
     }
 
+    /// Two routes describe ONE model-facing surface: the read-only count
+    /// (`callable_tool_count`, behind `GET /agent/callable_tool_count`) and the
+    /// turn's own preparation. They must agree — and the count route must not
+    /// grade, because grading replaces the execution policy a running turn
+    /// approves against.
+    ///
+    /// ⚠ Both reads resolve the platform gates independently
+    /// (`Agent::platform_tool_gates`), and one of those gates —
+    /// `session_blobs` — is `message_blobs::lazy_load_enabled()`, a LIVE read
+    /// of the config layer, which resolves `BIOROUTER_SESSION_BLOB_LAZY_LOAD`
+    /// from the process environment. So this test's surface used to be
+    /// whatever the binary's other tests had left in the environment at each of
+    /// the two instants, and CI caught it: `left: 4, right: 5`, the fifth tool
+    /// being `platform__read_session_blob`, which appeared between the two
+    /// reads because a concurrent `#[serial]` test had just parked the flag.
+    ///
+    /// The gate is therefore an INPUT here, stated once as a task-local config
+    /// override — invisible to every other test, so it needs no lock and gives
+    /// none — and the expected roster is derived from a single sample of the
+    /// same gates rather than from a hard-coded number. A tool that appears
+    /// from somewhere else now names itself instead of moving a count by one.
     #[tokio::test]
     async fn callable_count_is_pure_while_turn_prep_grades_sorted_frontend_tools(
     ) -> anyhow::Result<()> {
-        let agent = crate::agents::Agent::new();
+        let overrides = std::collections::HashMap::from([(
+            "BIOROUTER_SESSION_BLOB_LAZY_LOAD".to_string(),
+            "true".to_string(),
+        )]);
+        crate::config::with_config_overrides(overrides, async {
+            let agent = crate::agents::Agent::new();
 
-        let session = agent
-            .config
-            .session_manager
-            .create_session(
-                std::path::PathBuf::default(),
-                "test-prepare-tools".to_string(),
-                SessionType::Hidden,
-            )
-            .await?;
+            let session = agent
+                .config
+                .session_manager
+                .create_session(
+                    std::path::PathBuf::default(),
+                    "test-prepare-tools".to_string(),
+                    SessionType::Hidden,
+                )
+                .await?;
 
-        let model_config = ModelConfig::new("test-model").unwrap();
-        let provider = std::sync::Arc::new(MockProvider { model_config });
-        agent.update_provider(provider, &session.id).await?;
+            let model_config = ModelConfig::new("test-model").unwrap();
+            let provider = std::sync::Arc::new(MockProvider { model_config });
+            agent.update_provider(provider, &session.id).await?;
 
-        // Add unsorted frontend tools
-        let frontend_tools = vec![
-            Tool::new(
-                "frontend__z_tool".to_string(),
-                "Z tool".to_string(),
-                object!({ "type": "object", "properties": { } }),
-            ),
-            Tool::new(
-                "frontend__a_tool".to_string(),
-                "A tool".to_string(),
-                object!({ "type": "object", "properties": { } }),
-            ),
-        ];
+            // Add unsorted frontend tools
+            let frontend_tools = vec![
+                Tool::new(
+                    "frontend__z_tool".to_string(),
+                    "Z tool".to_string(),
+                    object!({ "type": "object", "properties": { } }),
+                ),
+                Tool::new(
+                    "frontend__a_tool".to_string(),
+                    "A tool".to_string(),
+                    object!({ "type": "object", "properties": { } }),
+                ),
+            ];
 
-        agent
-            .add_extension(crate::agents::extension::ExtensionConfig::Frontend {
-                name: "frontend".to_string(),
-                description: "desc".to_string(),
-                tools: frontend_tools,
-                instructions: None,
-                bundled: None,
-                available_tools: vec![],
-            })
-            .await
-            .unwrap();
+            agent
+                .add_extension(crate::agents::extension::ExtensionConfig::Frontend {
+                    name: "frontend".to_string(),
+                    description: "desc".to_string(),
+                    tools: frontend_tools,
+                    instructions: None,
+                    bundled: None,
+                    available_tools: vec![],
+                })
+                .await
+                .unwrap();
 
-        let working_dir = std::env::current_dir()?;
-        assert!(agent.tool_risks.is_empty());
-        let callable_count = agent.callable_tool_count(&session.id).await?;
-        assert!(callable_count >= 2);
-        assert!(
-            agent.tool_risks.is_empty(),
-            "a read-only count request mutated the shared risk registry"
-        );
+            // The whole roster this agent may advertise, stated rather than
+            // inherited: the two frontend tools registered above, plus whatever the
+            // platform gates open — sampled ONCE, here, from the same accessor both
+            // routes use.
+            let mut expected: Vec<String> = agent
+                .platform_tool_gates()
+                .await
+                .tools(None)
+                .into_iter()
+                .map(|tool| tool.name.to_string())
+                .chain([
+                    "frontend__a_tool".to_string(),
+                    "frontend__z_tool".to_string(),
+                ])
+                .collect();
+            expected.sort();
+            assert!(
+                expected.contains(&"platform__read_session_blob".to_string()),
+                "the override above must reach the gates, else this test is back to \
+             reading the ambient environment: {expected:?}"
+            );
 
-        let (tools, _toolshim_tools, _system_prompt) = agent
-            .prepare_tools_and_prompt(&session.id, &working_dir)
-            .await?;
-        assert_eq!(callable_count, tools.len());
-        assert_eq!(agent.tool_risks.len(), tools.len());
+            let working_dir = std::env::current_dir()?;
+            assert!(agent.tool_risks.is_empty());
+            let callable_count = agent.callable_tool_count(&session.id).await?;
+            assert_eq!(
+                callable_count,
+                expected.len(),
+                "the count route must report the model-facing surface"
+            );
+            assert!(
+                agent.tool_risks.is_empty(),
+                "a read-only count request mutated the shared risk registry"
+            );
 
-        let names: Vec<String> = tools.iter().map(|t| t.name.clone().into_owned()).collect();
-        assert!(names.iter().any(|n| n == "frontend__a_tool"));
-        assert!(names.iter().any(|n| n == "frontend__z_tool"));
+            let (tools, _toolshim_tools, _system_prompt) = agent
+                .prepare_tools_and_prompt(&session.id, &working_dir)
+                .await?;
+            assert_eq!(callable_count, tools.len());
+            assert_eq!(agent.tool_risks.len(), tools.len());
 
-        // Verify the names are sorted ascending
-        let mut sorted = names.clone();
-        sorted.sort();
-        assert_eq!(names, sorted);
+            // Sorted ascending, and exactly the roster named above — a stable order
+            // is what preserves multi-session prompt caching.
+            let names: Vec<String> = tools.iter().map(|t| t.name.clone().into_owned()).collect();
+            assert_eq!(names, expected);
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 
     #[tokio::test]
@@ -1256,155 +1306,171 @@ mod tests {
     async fn every_tool_absent_from_the_code_execution_catalogue_stays_directly_callable() {
         let path_root = tempfile::TempDir::new().expect("an isolated capability root");
         let path_root_value = path_root.path().to_string_lossy().into_owned();
-        let _env = env_lock::lock_env([
-            ("BIOROUTER_PATH_ROOT", Some(path_root_value.as_str())),
-            ("BIOROUTER_SESSION_BLOB_LAZY_LOAD", Some("true")),
-        ]);
+        let _env = env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(path_root_value.as_str()))]);
 
-        let store = tempfile::TempDir::new().expect("an isolated session store");
-        let session_manager = Arc::new(crate::session::SessionManager::new(
-            store.path().to_path_buf(),
-        ));
-        let session = session_manager
-            .create_session(
+        // ⚠ `BIOROUTER_SESSION_BLOB_LAZY_LOAD` is set as a TASK-LOCAL config
+        // override, never in the process environment. It decides whether
+        // `platform__read_session_blob` reaches the model-facing roster
+        // (`PlatformToolGates::session_blobs`), and every agent in this binary
+        // reads it live through `Config::get_param` without asking for
+        // `env_lock` — so parking it in the environment silently changed the
+        // callable-tool count of every concurrently running test. It did:
+        // `callable_count_is_pure_while_turn_prep_grades_sorted_frontend_tools`
+        // below failed on CI with `left: 4, right: 5`, the missing tool being
+        // this one, because the flag flipped between its two reads.
+        // `no_test_parks_the_session_blob_flag_in_the_process_environment` in
+        // `platform_tools.rs` is the standing guard.
+        let overrides = std::collections::HashMap::from([(
+            "BIOROUTER_SESSION_BLOB_LAZY_LOAD".to_string(),
+            "true".to_string(),
+        )]);
+        crate::config::with_config_overrides(overrides, async {
+            let store = tempfile::TempDir::new().expect("an isolated session store");
+            let session_manager = Arc::new(crate::session::SessionManager::new(
                 store.path().to_path_buf(),
-                "code-execution-catalogue".to_string(),
-                SessionType::User,
-            )
-            .await
-            .expect("create the session under test");
-        let agent = crate::agents::Agent::with_config(crate::agents::AgentConfig::new(
-            Arc::clone(&session_manager),
-            crate::config::permission::PermissionManager::instance(),
-            None,
-            crate::config::BioRouterMode::Auto,
-        ));
-
-        // One ordinary extension, so the catalogue is not empty …
-        agent
-            .add_extension(crate::agents::extension::ExtensionConfig::Platform {
-                name: "todo".into(),
-                description: "todo".into(),
-                bundled: Some(true),
-                available_tools: vec![],
-            })
-            .await
-            .expect("add the ordinary extension");
-        // … Knowledge, which is what opens two of the platform tools …
-        for name in ["knowledge", "code_execution"] {
-            let target = crate::agents::extension_manager::resolve_bundled_extension(name)
-                .unwrap_or_else(|| panic!("{name} must resolve as a bundled capability"));
-            agent
-                .add_extension(target.into_config(format!("{name} for the catalogue guard")))
+            ));
+            let session = session_manager
+                .create_session(
+                    store.path().to_path_buf(),
+                    "code-execution-catalogue".to_string(),
+                    SessionType::User,
+                )
                 .await
-                .unwrap_or_else(|error| panic!("enable {name}: {error}"));
-        }
-        // … a frontend tool, which lives only in `Agent::frontend_tools` …
-        agent
-            .add_extension(crate::agents::extension::ExtensionConfig::Frontend {
-                name: "frontend".to_string(),
-                description: "desc".to_string(),
-                tools: vec![Tool::new(
-                    "frontend__pick_a_file".to_string(),
-                    "Ask the interface for a file".to_string(),
-                    object!({ "type": "object", "properties": { } }),
-                )],
-                instructions: None,
-                bundled: None,
-                available_tools: vec![],
-            })
-            .await
-            .expect("register the frontend tool");
-        // … and an armed structured-output response, which is the whole reason
-        // a workflow ever has `workflow__final_output` on its roster.
-        agent
-            .add_final_output_tool(crate::workflow::Response {
-                json_schema: Some(json!({ "type": "object" })),
-            })
-            .await;
+                .expect("create the session under test");
+            let agent = crate::agents::Agent::with_config(crate::agents::AgentConfig::new(
+                Arc::clone(&session_manager),
+                crate::config::permission::PermissionManager::instance(),
+                None,
+                crate::config::BioRouterMode::Auto,
+            ));
 
-        let provider: Arc<dyn Provider> = Arc::new(MockProvider {
-            model_config: ModelConfig::new("test-model").unwrap(),
-        });
-        agent
-            .update_provider(Arc::clone(&provider), &session.id)
-            .await
-            .expect("bind the mock provider");
+            // One ordinary extension, so the catalogue is not empty …
+            agent
+                .add_extension(crate::agents::extension::ExtensionConfig::Platform {
+                    name: "todo".into(),
+                    description: "todo".into(),
+                    bundled: Some(true),
+                    available_tools: vec![],
+                })
+                .await
+                .expect("add the ordinary extension");
+            // … Knowledge, which is what opens two of the platform tools …
+            for name in ["knowledge", "code_execution"] {
+                let target = crate::agents::extension_manager::resolve_bundled_extension(name)
+                    .unwrap_or_else(|| panic!("{name} must resolve as a bundled capability"));
+                agent
+                    .add_extension(target.into_config(format!("{name} for the catalogue guard")))
+                    .await
+                    .unwrap_or_else(|error| panic!("enable {name}: {error}"));
+            }
+            // … a frontend tool, which lives only in `Agent::frontend_tools` …
+            agent
+                .add_extension(crate::agents::extension::ExtensionConfig::Frontend {
+                    name: "frontend".to_string(),
+                    description: "desc".to_string(),
+                    tools: vec![Tool::new(
+                        "frontend__pick_a_file".to_string(),
+                        "Ask the interface for a file".to_string(),
+                        object!({ "type": "object", "properties": { } }),
+                    )],
+                    instructions: None,
+                    bundled: None,
+                    available_tools: vec![],
+                })
+                .await
+                .expect("register the frontend tool");
+            // … and an armed structured-output response, which is the whole reason
+            // a workflow ever has `workflow__final_output` on its roster.
+            agent
+                .add_final_output_tool(crate::workflow::Response {
+                    json_schema: Some(json!({ "type": "object" })),
+                })
+                .await;
 
-        let surface = agent
-            .prepare_model_tool_surface(&session.id, &provider)
-            .await;
-        assert!(
-            surface.code_execution_active,
-            "precondition: Code Execution narrowing must be in force, else this proves nothing"
-        );
+            let provider: Arc<dyn Provider> = Arc::new(MockProvider {
+                model_config: ModelConfig::new("test-model").unwrap(),
+            });
+            agent
+                .update_provider(Arc::clone(&provider), &session.id)
+                .await
+                .expect("bind the mock provider");
 
-        let catalogue: HashSet<String> = agent
-            .extension_manager
-            .get_prefixed_tools_excluding(CODE_EXECUTION_EXTENSION, None)
-            .await
-            .expect("build the importable-module catalogue")
-            .into_iter()
-            .map(|tool| tool.name.to_string())
-            .collect();
-        assert!(
-            !catalogue.is_empty(),
-            "an empty catalogue satisfies the implication for free"
-        );
-
-        let code_exec_prefix = format!("{CODE_EXECUTION_EXTENSION}__");
-        let uncatalogued: Vec<String> = surface
-            .available_tools
-            .iter()
-            .map(|tool| tool.name.to_string())
-            .filter(|name| !catalogue.contains(name))
-            .filter(|name| !name.starts_with(&code_exec_prefix))
-            .collect();
-
-        // Non-vacuity, family by family: each of these is in the roster and NOT
-        // in the catalogue, so each is a real obligation rather than a name the
-        // loop below never sees.
-        for expected in [
-            crate::agents::platform_tools::PLATFORM_INGEST_SOURCE_TOOL_NAME,
-            crate::agents::platform_tools::PLATFORM_INGEST_CONVERSATION_TOOL_NAME,
-            crate::agents::platform_tools::PLATFORM_READ_SESSION_BLOB_TOOL_NAME,
-            FINAL_OUTPUT_TOOL_NAME,
-            "frontend__pick_a_file",
-            // The fifth family, and the one whose absence from the catalogue is
-            // a POLICY rather than a plumbing fact: the sandbox could dispatch
-            // `kb_delete_base` perfectly well, and must not, because the
-            // approval it is contracted to show cannot be raised from there.
-            // Listed here so removing the catalogue strip cannot quietly retire
-            // the obligation below along with it.
-            "knowledge__kb_delete_base",
-        ] {
+            let surface = agent
+                .prepare_model_tool_surface(&session.id, &provider)
+                .await;
             assert!(
-                uncatalogued.iter().any(|name| name == expected),
-                "{expected} must be in the roster and outside the catalogue for this \
+                surface.code_execution_active,
+                "precondition: Code Execution narrowing must be in force, else this proves nothing"
+            );
+
+            let catalogue: HashSet<String> = agent
+                .extension_manager
+                .get_prefixed_tools_excluding(CODE_EXECUTION_EXTENSION, None)
+                .await
+                .expect("build the importable-module catalogue")
+                .into_iter()
+                .map(|tool| tool.name.to_string())
+                .collect();
+            assert!(
+                !catalogue.is_empty(),
+                "an empty catalogue satisfies the implication for free"
+            );
+
+            let code_exec_prefix = format!("{CODE_EXECUTION_EXTENSION}__");
+            let uncatalogued: Vec<String> = surface
+                .available_tools
+                .iter()
+                .map(|tool| tool.name.to_string())
+                .filter(|name| !catalogue.contains(name))
+                .filter(|name| !name.starts_with(&code_exec_prefix))
+                .collect();
+
+            // Non-vacuity, family by family: each of these is in the roster and NOT
+            // in the catalogue, so each is a real obligation rather than a name the
+            // loop below never sees.
+            for expected in [
+                crate::agents::platform_tools::PLATFORM_INGEST_SOURCE_TOOL_NAME,
+                crate::agents::platform_tools::PLATFORM_INGEST_CONVERSATION_TOOL_NAME,
+                crate::agents::platform_tools::PLATFORM_READ_SESSION_BLOB_TOOL_NAME,
+                FINAL_OUTPUT_TOOL_NAME,
+                "frontend__pick_a_file",
+                // The fifth family, and the one whose absence from the catalogue is
+                // a POLICY rather than a plumbing fact: the sandbox could dispatch
+                // `kb_delete_base` perfectly well, and must not, because the
+                // approval it is contracted to show cannot be raised from there.
+                // Listed here so removing the catalogue strip cannot quietly retire
+                // the obligation below along with it.
+                "knowledge__kb_delete_base",
+            ] {
+                assert!(
+                    uncatalogued.iter().any(|name| name == expected),
+                    "{expected} must be in the roster and outside the catalogue for this \
                  guard to mean anything: {uncatalogued:?}"
-            );
-        }
+                );
+            }
 
-        let frontend_tool_names: HashSet<String> =
-            agent.frontend_tools.lock().await.keys().cloned().collect();
-        let callable: HashSet<String> = surface
-            .directly_callable_tools
-            .iter()
-            .map(|tool| tool.name.to_string())
-            .collect();
-        for name in &uncatalogued {
-            assert!(
-                survives_code_execution_filter(name, &code_exec_prefix, &frontend_tool_names),
-                "`{name}` is in the model's roster and in no importable module, so Code \
+            let frontend_tool_names: HashSet<String> =
+                agent.frontend_tools.lock().await.keys().cloned().collect();
+            let callable: HashSet<String> = surface
+                .directly_callable_tools
+                .iter()
+                .map(|tool| tool.name.to_string())
+                .collect();
+            for name in &uncatalogued {
+                assert!(
+                    survives_code_execution_filter(name, &code_exec_prefix, &frontend_tool_names),
+                    "`{name}` is in the model's roster and in no importable module, so Code \
                  Execution mode would leave it reachable from NOWHERE"
-            );
-            // The same statement one layer out: the exemption has to actually
-            // reach the surface the model is handed.
-            assert!(
-                callable.contains(name),
-                "`{name}` survives the predicate but is missing from the prepared roster"
-            );
-        }
+                );
+                // The same statement one layer out: the exemption has to actually
+                // reach the surface the model is handed.
+                assert!(
+                    callable.contains(name),
+                    "`{name}` survives the predicate but is missing from the prepared roster"
+                );
+            }
+        })
+        .await;
     }
 
     #[test]


### PR DESCRIPTION
## Why

`test (ubuntu-latest)` on PR #195 — a change that touched **only CSS and UI copy** — run
`34310281371`, job `102335346569`:

```
agents::reply_parts::tests::callable_count_is_pure_while_turn_prep_grades_sorted_frontend_tools ... FAILED
panicked at crates/biorouter/src/agents/reply_parts.rs:1109:9:
assertion `left == right` failed
  left: 4
 right: 5
test result: FAILED. 3719 passed; 1 failed; 1 ignored
```

A CSS diff cannot change a tool count. The test read the process environment.

## Root cause

**The writers.** Two `#[serial]` tests in the same `--lib` binary parked
`BIOROUTER_SESSION_BLOB_LAZY_LOAD=true` in the **process environment**, under `env_lock`:

- `crates/biorouter/src/agents/reply_parts.rs:1258` —
  `every_tool_absent_from_the_code_execution_catalogue_stays_directly_callable`
- `crates/biorouter/src/agents/agent.rs:16305` —
  `code_execution_mode_keeps_the_agent_dispatched_platform_tools_callable`

**The route.** `Agent::platform_tool_gates` (`agent.rs:7805`) samples
`PlatformToolGates::session_blobs` from `message_blobs::lazy_load_enabled()`
(`session/message_blobs.rs:85`), which is `Config::get_param("BIOROUTER_SESSION_BLOB_LAZY_LOAD")`
— and `get_param` reads `env::var` **live, on every call, with no cache**
(`config/base.rs:847`). That gate decides whether `platform__read_session_blob` is pushed onto
the model-facing roster (`platform_tools.rs`, `PlatformToolGates::tools`). Every agent in the
binary takes that read on every tool listing, and none of them asks for `env_lock`.

`env_lock` therefore cannot help, and this is the same shape already recorded in
`crates/biorouter/src/model.rs:505-530`: *"`env_lock` only serialises callers that ask for it,
and these readers never do."*

**The interleaving.** The failing test is neither `#[serial]` nor a lock-taker, so it runs
alongside both writers:

| | failing test | a writer |
|---|---|---|
| t0 | `callable_tool_count` → **4** | |
| t1 | | `env_lock` sets `BIOROUTER_SESSION_BLOB_LAZY_LOAD=true` |
| t2 | `prepare_tools_and_prompt` → **5** | |
| t3 | `assert_eq!(4, 5)` → FAIL | |

Measured on `origin/main`, printing the roster in both states — exactly 4 vs 5, and the fifth
tool named:

```
no env:        callable_count=4 names=["frontend__a_tool", "frontend__z_tool",
                                       "platform__manage_workflow", "platform__report_bug"]
lazy load on:  callable_count=5 names=["frontend__a_tool", "frontend__z_tool",
                                       "platform__manage_workflow", "platform__read_session_blob",
                                       "platform__report_bug"]
```

## What changed

**1. The writers stop mutating the process environment.**
`reply_parts.rs` and `agent.rs`: the flag is now a **task-local** config override
(`config::with_config_overrides`), which `get_param` consults *before* the environment
(`config/base.rs:843`) and which no other test can observe. `BIOROUTER_PATH_ROOT` stays in
`env_lock` — it is read through `std::env::var`, not the config layer. Neither test loses
coverage: `platform__read_session_blob` is still on the roster each one asserts against.

**2. The failing test states its inputs instead of inheriting them**
(`reply_parts.rs`, `callable_count_is_pure_while_turn_prep_grades_sorted_frontend_tools`). The
gate is pinned once for the whole test as a task-local override, and the expected roster is
derived from **one** sample of `Agent::platform_tool_gates` — the same accessor both routes use
— rather than from a hard-coded number. The final assertion is now `assert_eq!(names, expected)`,
so a tool arriving from somewhere else names itself instead of moving a count by one.

**3. `PlatformToolGates::tools` is a pure function of its fields**
(`platform_tools.rs`). It re-read `pending_user_action::user_proof_available()` for
`manage_workflow_tool` while `bug_report` already carried an earlier read of the *same*
process-global — two instants, one value, against the struct's own documented rule
("a process-global read inside the gate itself is a second read the value could change
between") and against `manage_workflow_tool`'s own doc, which already claimed the value was
"sampled by the caller". `Agent::platform_tool_gates` now takes one sample and feeds both the
`bug_report` and the new `can_ask_a_person` field. **What the gates permit is unchanged** —
same expression, sampled once instead of twice.

**4. A standing guard**: `platform_tools.rs`,
`no_test_parks_the_session_blob_flag_in_the_process_environment` — a source scan, sibling to
`model::tests::no_test_poisons_a_shared_setting`, for the reason that one gives: the race needs
an interleaving CI produces and a laptop rarely does, so a green stress run is weak evidence and
this check cannot flake. It skips comment lines (the two offending shapes are spelled out
literally in its own comment) and asserts non-vacuity on both the file count and the number of
files naming the key. A `None::<&str>` entry is deliberately **not** an offence — clearing the
flag is the safe direction.

No new locks; no `#[serial]` added anywhere.

## Tests

**Fail-before.** The standing guard, run against the pre-fix test bodies, names both offenders:

```
---- agents::platform_tools::tests::no_test_parks_the_session_blob_flag_in_the_process_environment stdout ----
these tests park `BIOROUTER_SESSION_BLOB_LAZY_LOAD` in the PROCESS environment, which changes the
model-facing tool roster of every concurrently running test in the same binary — `env_lock` does
not help, because the readers never ask for it. Use `config::with_config_overrides` […]:
  crates/biorouter/src/agents/agent.rs:16310
  crates/biorouter/src/agents/reply_parts.rs:1261
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3725 filtered out
```

**The interleaving, made deterministic.** Pre-fix test body, with the writers' env write
injected between its two reads — byte-for-byte the CI failure:

```
---- agents::reply_parts::tests::callable_count_is_pure_while_turn_prep_grades_sorted_frontend_tools stdout ----
panicked at crates/biorouter/src/agents/reply_parts.rs:1116:9:
assertion `left == right` failed
  left: 4
 right: 5
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3725 filtered out
```

**Pass-after, under the same interleaving.** The fixed test with a mid-test
`env_lock::lock_env([("BIOROUTER_SESSION_BLOB_LAZY_LOAD", Some("false"))])` — the direction that
would remove the tool — is unaffected, because the task-local pin wins over the environment:

```
test agents::reply_parts::tests::callable_count_is_pure_while_turn_prep_grades_sorted_frontend_tools ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3725 filtered out; finished in 0.11s
```

**Stress**, `BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib -- agents::reply_parts
agents::agent::gate agents::skill --test-threads=32`:

| batch | result |
|---|---|
| runs 1-20 | 19 pass / **1 fail** (see below) |
| runs 21-45 | 25 pass / 0 fail |
| runs 46-80 | 35 pass / 0 fail |
| `agents::agent::gate` alone ×20 | 20 pass / 0 fail |
| `agents::skill` alone ×20 | 20 pass / 0 fail |

**119 of 120 runs green.** The single failure (run 9 of the first batch, `176 passed; 1 failed`)
was not captured by name — that batch did not keep logs — and did not reproduce in the 100 runs
that followed. It landed immediately after a run that took 40 s against a ~15 s baseline, i.e. a
load spike from another build on this shared machine. The most likely candidate is
`agents::agent::gate_a_bind_tests::the_unconstrained_race_observes_both_outcomes`, whose own
comment records the hazard: *"the minority arm is thin — 11, 13 and 20 refusals per 200 […] A
runner that serialises the two spawns harder could go one-sided against a perfectly correct
implementation."* It is in neither file this PR touches. Recorded rather than glossed over.

**Full suite**, `BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib`:

```
test result: ok. 3725 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 31.02s
```

**Gates:**

```
cargo fmt --all -- --check          → clean
cargo check --workspace --tests     → Finished `dev` profile in 1m 54s
./scripts/clippy-lint.sh            → ✅ All baseline clippy checks passed!
                                      ✓ No banned TLS crates found
```

## Follow-ups

- `PlatformToolGates::bug_report` / `can_ask_a_person` still read
  `pending_user_action::user_proof_available()`, a process-global `AtomicBool`. Nothing in the
  `--lib` binary writes it (the only writer is `tests/bug_report_agent_loop.rs`, a separate
  process, which is `#[serial(user_proof_available)]` and restores it), so it is not a live race
  today — but it is the same shape, and a future `--lib` test that calls
  `set_user_proof_available` would reopen it against `platform__report_bug`. A sibling guard
  could cover it if one ever appears.
- The guard is scoped to `BIOROUTER_SESSION_BLOB_LAZY_LOAD`. `model.rs`'s
  `no_test_poisons_a_shared_setting` covers five more keys on a different principle (invalid
  values only). Every *other* config key an unguarded reader resolves live is uncovered; a
  general "no test writes a config key an unlocked reader consults" audit is a larger piece of
  work than this fix.
- `Agent::callable_tool_count` and `prepare_tools_and_prompt` still sample the platform gates
  independently, which is correct in production — a later turn should see a later value. Only
  the test needed the two samples pinned to one world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
