### PR TITLE
Unsubscribe the extension-update reporter, and drop SessionListView's dead selectedSessionId prop

### DIFF
--- a/ui/desktop/src/components/ExtensionUpdateReporter.listeners.test.tsx
+++ b/ui/desktop/src/components/ExtensionUpdateReporter.listeners.test.tsx
@@ -32,15 +32,26 @@ import ExtensionUpdateReporter from './ExtensionUpdateReporter';
  * the renderer-side proxy for "how many listeners are on the IPC channel".
  */
 let live: Set<(event: ExtensionUpdateEvent) => void>;
+/**
+ * Totals, not just the live set. `live.size` alone cannot tell "subscribed
+ * twice and cleaned up once" apart from "only ever subscribed once", and those
+ * are exactly the two worlds the StrictMode test below has to separate.
+ */
+let subscribes: number;
+let disposes: number;
 
 beforeEach(() => {
   live = new Set();
+  subscribes = 0;
+  disposes = 0;
   // @ts-expect-error — partial stub, only what the reporter touches.
   window.electron = {
     onExtensionUpdateEvent: (cb: (event: ExtensionUpdateEvent) => void) => {
       live.add(cb);
+      subscribes++;
       return () => {
         live.delete(cb);
+        disposes++;
       };
     },
   };
@@ -71,5 +82,9 @@ describe('ExtensionUpdateReporter listener lifecycle', () => {
     );
 
     expect(live.size).toBe(1);
+    // Assert the mechanism, not just the total. A harness where StrictMode had
+    // stopped double-invoking would also leave one live listener, and would
+    // then pass this test while proving nothing about the cleanup.
+    expect({ subscribes, disposes }).toEqual({ subscribes: 2, disposes: 1 });
   });
 });

--- a/ui/desktop/src/components/ExtensionUpdateReporter.listeners.test.tsx
+++ b/ui/desktop/src/components/ExtensionUpdateReporter.listeners.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * ExtensionUpdateReporter.listeners.test.tsx
+ *
+ * The reporter's *lifecycle* contract, kept apart from its behaviour tests in
+ * ExtensionUpdateReporter.test.tsx so the two stubs cannot drift into each
+ * other: that file's stub captures the last callback so a test can emit events,
+ * this one tracks the live set so a test can count them.
+ *
+ * PR #189 measured `MaxListenersExceededWarning: 11 extension-update-event
+ * listeners` after a handful of route changes. The reporter subscribed in a
+ * `useEffect(..., [])` and returned no cleanup, and the claim that justified it
+ * — "mounted once, at the app shell, for the life of the window" — was false on
+ * two counts: the reporter sits inside AppLayout, under ProviderGuard >
+ * ChatProvider, so that subtree remounts; and React.StrictMode is on in dev, so
+ * every mount runs the effect twice regardless.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { ExtensionUpdateEvent } from '../utils/extensionUpdater';
+
+vi.mock('../toasts', () => ({
+  toastError: vi.fn(),
+  toastService: { success: vi.fn() },
+}));
+
+import ExtensionUpdateReporter from './ExtensionUpdateReporter';
+
+/**
+ * Stands in for the preload bridge, which registers a real `ipcRenderer.on`
+ * listener and hands back a disposer that removes it. Membership of this set is
+ * the renderer-side proxy for "how many listeners are on the IPC channel".
+ */
+let live: Set<(event: ExtensionUpdateEvent) => void>;
+
+beforeEach(() => {
+  live = new Set();
+  // @ts-expect-error — partial stub, only what the reporter touches.
+  window.electron = {
+    onExtensionUpdateEvent: (cb: (event: ExtensionUpdateEvent) => void) => {
+      live.add(cb);
+      return () => {
+        live.delete(cb);
+      };
+    },
+  };
+});
+
+describe('ExtensionUpdateReporter listener lifecycle', () => {
+  it('leaves no listener behind across repeated mounts', () => {
+    // 20 cycles, not 2: the warning fires at 11, so a leak that only shows up
+    // after a handful of remounts has to be visible here.
+    for (let i = 0; i < 20; i++) {
+      const { unmount } = render(<ExtensionUpdateReporter />);
+      expect(live.size, `one live listener while mounted (cycle ${i + 1})`).toBe(1);
+      unmount();
+      expect(live.size, `no live listener after unmount (cycle ${i + 1})`).toBe(0);
+    }
+
+    expect(live.size).toBe(0);
+  });
+
+  it('registers exactly one listener under StrictMode', () => {
+    // React 19 StrictMode runs effect → cleanup → effect on the first mount, so
+    // a component whose effect has no cleanup ends up subscribed twice. This is
+    // the dev-mode half of #189, and it needs no route change to reproduce.
+    render(
+      <React.StrictMode>
+        <ExtensionUpdateReporter />
+      </React.StrictMode>
+    );
+
+    expect(live.size).toBe(1);
+  });
+});

--- a/ui/desktop/src/components/ExtensionUpdateReporter.test.tsx
+++ b/ui/desktop/src/components/ExtensionUpdateReporter.test.tsx
@@ -20,8 +20,11 @@ beforeEach(() => {
   window.electron = {
     onExtensionUpdateEvent: (cb: (e: ExtensionUpdateEvent) => void) => {
       emit = cb;
-      // Matches the bridge's disposer shape. These tests never unmount, so the
-      // disposer is unused here; the leak it exists to prevent is counted in
+      // Matches the bridge's disposer shape, and it really is called: the
+      // shared setup installs an `afterEach(cleanup)` (src/test/setup.ts), so
+      // React unmounts the reporter after every test here. Clearing `emit` on
+      // dispose keeps a stale callback from a previous test out of the next
+      // one. Counting listeners across mounts is the other file's job,
       // ExtensionUpdateReporter.listeners.test.tsx.
       return () => {
         emit = () => {};

--- a/ui/desktop/src/components/ExtensionUpdateReporter.test.tsx
+++ b/ui/desktop/src/components/ExtensionUpdateReporter.test.tsx
@@ -20,6 +20,12 @@ beforeEach(() => {
   window.electron = {
     onExtensionUpdateEvent: (cb: (e: ExtensionUpdateEvent) => void) => {
       emit = cb;
+      // Matches the bridge's disposer shape. These tests never unmount, so the
+      // disposer is unused here; the leak it exists to prevent is counted in
+      // ExtensionUpdateReporter.listeners.test.tsx.
+      return () => {
+        emit = () => {};
+      };
     },
   };
 });

--- a/ui/desktop/src/components/ExtensionUpdateReporter.tsx
+++ b/ui/desktop/src/components/ExtensionUpdateReporter.tsx
@@ -62,6 +62,16 @@ export default function ExtensionUpdateReporter() {
     //
     // `dispose` is optional-chained for the same reason the subscribe call is:
     // a host without the channel returns nothing to call.
+    //
+    // One deliberate consequence: while the shell is unmounted — the user is on
+    // `/welcome`, `/launcher` or `/configure-providers` — nothing is listening,
+    // and an update event broadcast in that window is dropped rather than
+    // queued. The leak used to paper over this, because a listener left behind
+    // by an earlier mount kept firing into the `ToastContainer`, which lives
+    // outside the shell. That is not a behaviour worth keeping a leak for: the
+    // updater's own log still has the failure, and a toast for an extension the
+    // user cannot see from the onboarding wall is not worth a duplicate for
+    // every remount.
     return () => dispose?.();
   }, []);
 

--- a/ui/desktop/src/components/ExtensionUpdateReporter.tsx
+++ b/ui/desktop/src/components/ExtensionUpdateReporter.tsx
@@ -21,7 +21,7 @@ export default function ExtensionUpdateReporter() {
     // does not provide the channel — headless/browser mode, a partially stubbed
     // `window.electron` in a test — would otherwise take the whole app down over
     // a notification nobody asked for.
-    window.electron?.onExtensionUpdateEvent?.((event) => {
+    const dispose = window.electron?.onExtensionUpdateEvent?.((event) => {
       if (event.type === 'update-error') {
         toastError({
           title: `Could not update ${event.displayName || event.ext || 'an extension'}`,
@@ -48,8 +48,21 @@ export default function ExtensionUpdateReporter() {
         });
       }
     });
-    // `onExtensionUpdateEvent` returns no disposer, so there is nothing to clean
-    // up. Mounted once, at the app shell, for the life of the window.
+
+    // Unsubscribe on unmount. This is NOT belt-and-braces: the comment that
+    // used to sit here claimed the reporter was "mounted once, at the app
+    // shell, for the life of the window", and that was false twice over. It
+    // renders inside `AppLayout`, which sits under `ProviderGuard >
+    // ChatProvider`, so the subtree remounts; and React.StrictMode is on in
+    // dev, so even a single mount runs this effect twice (effect → cleanup →
+    // effect). Every one of those mounts used to add an IPC listener that was
+    // never removed, which is the `MaxListenersExceededWarning: 11
+    // extension-update-event listeners` measured in #189 — every surviving
+    // listener also fires its own duplicate toast.
+    //
+    // `dispose` is optional-chained for the same reason the subscribe call is:
+    // a host without the channel returns nothing to call.
+    return () => dispose?.();
   }, []);
 
   return null;

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -239,7 +239,6 @@ interface SearchContainerElement extends HTMLDivElement {
 
 interface SessionListViewProps {
   onSelectSession: (sessionId: string) => void;
-  selectedSessionId?: string | null;
 }
 
 const HISTORY_LOADING_GROUPS = [5, 4];
@@ -315,14 +314,12 @@ function HistoryLoading() {
  * never reaches that comparison.
  *
  * Everything it used to close over — `onSelectSession`, the diverged-from name
- * lookup, the ref registry — is a prop now, so the type is stable for the life
- * of the module.
+ * lookup — is a prop now, so the type is stable for the life of the module.
  */
 const SessionItem = React.memo(function SessionItem({
   session,
   onSelectSession,
   sessionNameById,
-  setSessionRef,
   onEditClick,
   onDeleteClick,
   onExportClick,
@@ -332,7 +329,6 @@ const SessionItem = React.memo(function SessionItem({
   onSelectSession: (sessionId: string) => void;
   /** id → name, so a diverged row can name its lineage parent. */
   sessionNameById: Map<string, string>;
-  setSessionRef: (itemId: string, element: HTMLDivElement | null) => void;
   onEditClick: (session: Session) => void;
   onDeleteClick: (session: Session) => void;
   onExportClick: (session: Session, e: React.MouseEvent) => void;
@@ -407,10 +403,7 @@ const SessionItem = React.memo(function SessionItem({
        Shift+F10, which dispatch `contextmenu` on the focused element; the `⋯`
        button is the other keyboard path and shows the identical list. */
     <ChatRowContextMenu target={rowActions}>
-      <div
-        className="biorouter-list-row session-item flex items-center gap-3 py-2 px-4 relative group"
-        ref={(el) => setSessionRef(session.id, el)}
-      >
+      <div className="biorouter-list-row session-item flex items-center gap-3 py-2 px-4 relative group">
         {/* BR-71: the badge lives INSIDE the row, and is derived from the row
           itself rather than from where it was rendered — so a subagent run
           whose parent is missing from the list is still labelled instead of
@@ -641,580 +634,540 @@ const SessionItem = React.memo(function SessionItem({
   );
 });
 
-const SessionListView: React.FC<SessionListViewProps> = React.memo(
-  ({ onSelectSession, selectedSessionId }) => {
-    const initialSessions = useRef(getCachedSessionList()).current;
-    const navigate = useNavigate();
-    const [sessions, setSessions] = useState<Session[]>(initialSessions ?? []);
-    // The toggle below starts off, so the warm cache — which a sibling pane may
-    // have filled with subagent rows — is filtered before it reaches the first
-    // paint.
-    const [filteredSessions, setFilteredSessions] = useState<Session[]>(() =>
-      withoutSubagents(initialSessions ?? [])
-    );
-    const [dateGroups, setDateGroups] = useState<DateGroup[]>(() =>
-      groupSessionsByDate(withoutSubagents(initialSessions ?? []))
-    );
-    const [isLoading, setIsLoading] = useState(initialSessions === null);
-    const [showSkeleton, setShowSkeleton] = useState(initialSessions === null);
-    const [showContent, setShowContent] = useState(initialSessions !== null);
-    const [error, setError] = useState<string | null>(null);
-    const [searchResults, setSearchResults] = useState<{
-      count: number;
-      currentIndex: number;
-    } | null>(null);
+const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSession }) => {
+  const initialSessions = useRef(getCachedSessionList()).current;
+  const navigate = useNavigate();
+  const [sessions, setSessions] = useState<Session[]>(initialSessions ?? []);
+  // The toggle below starts off, so the warm cache — which a sibling pane may
+  // have filled with subagent rows — is filtered before it reaches the first
+  // paint.
+  const [filteredSessions, setFilteredSessions] = useState<Session[]>(() =>
+    withoutSubagents(initialSessions ?? [])
+  );
+  const [dateGroups, setDateGroups] = useState<DateGroup[]>(() =>
+    groupSessionsByDate(withoutSubagents(initialSessions ?? []))
+  );
+  const [isLoading, setIsLoading] = useState(initialSessions === null);
+  const [showSkeleton, setShowSkeleton] = useState(initialSessions === null);
+  const [showContent, setShowContent] = useState(initialSessions !== null);
+  const [error, setError] = useState<string | null>(null);
+  const [searchResults, setSearchResults] = useState<{
+    count: number;
+    currentIndex: number;
+  } | null>(null);
 
-    const [visibleSessionCount, setVisibleSessionCount] = useState(INITIAL_VISIBLE_SESSIONS);
+  const [visibleSessionCount, setVisibleSessionCount] = useState(INITIAL_VISIBLE_SESSIONS);
 
-    // BR-71: subagent transcripts are hidden by default — they are machinery,
-    // not conversations the user started. Turning this on refetches with
-    // `include_subagents` and nests each run under the session that spawned it.
-    const [showSubagents, setShowSubagents] = useState(false);
+  // BR-71: subagent transcripts are hidden by default — they are machinery,
+  // not conversations the user started. Turning this on refetches with
+  // `include_subagents` and nests each run under the session that spawned it.
+  const [showSubagents, setShowSubagents] = useState(false);
 
-    // `showSubagents` is this pane's state, but the session cache behind it is
-    // module-global — a second History pane, or Home, can publish subagent rows
-    // into this one at any time (and an orphaned request can leave the cache
-    // holding the other identity for a moment). The toggle decides what is
-    // FETCHED; this decides what this pane will SHOW, so the two can never
-    // disagree on screen.
-    const visibleSessions = useMemo(
-      () => (showSubagents ? sessions : withoutSubagents(sessions)),
-      [sessions, showSubagents]
-    );
+  // `showSubagents` is this pane's state, but the session cache behind it is
+  // module-global — a second History pane, or Home, can publish subagent rows
+  // into this one at any time (and an orphaned request can leave the cache
+  // holding the other identity for a moment). The toggle decides what is
+  // FETCHED; this decides what this pane will SHOW, so the two can never
+  // disagree on screen.
+  const visibleSessions = useMemo(
+    () => (showSubagents ? sessions : withoutSubagents(sessions)),
+    [sessions, showSubagents]
+  );
 
-    // Parent grouping runs BEFORE date bucketing. `groupSessionsByDate` buckets
-    // on `updated_at` and a parent's advances every time the conversation is
-    // resumed, so a subagent that ran on an earlier day sits in a different
-    // bucket — grouping within each bucket would drop it back to top level,
-    // which is exactly the orphaned, unexplained row this feature removes.
-    const parentGroups = useMemo(() => groupSessionsByParent(filteredSessions), [filteredSessions]);
-    // Only top-level rows are dated and paginated; children ride with their
-    // parent, so `visibleSessionCount` counts rendered parents, not raw rows.
-    const topLevelSessions = useMemo(() => parentGroups.map((g) => g.session), [parentGroups]);
-    const childrenByParentId = useMemo(() => {
-      const map = new Map<string, Session[]>();
-      for (const { session, children } of parentGroups) {
-        if (children.length > 0) map.set(session.id, children);
+  // Parent grouping runs BEFORE date bucketing. `groupSessionsByDate` buckets
+  // on `updated_at` and a parent's advances every time the conversation is
+  // resumed, so a subagent that ran on an earlier day sits in a different
+  // bucket — grouping within each bucket would drop it back to top level,
+  // which is exactly the orphaned, unexplained row this feature removes.
+  const parentGroups = useMemo(() => groupSessionsByParent(filteredSessions), [filteredSessions]);
+  // Only top-level rows are dated and paginated; children ride with their
+  // parent, so `visibleSessionCount` counts rendered parents, not raw rows.
+  const topLevelSessions = useMemo(() => parentGroups.map((g) => g.session), [parentGroups]);
+  const childrenByParentId = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    for (const { session, children } of parentGroups) {
+      if (children.length > 0) map.set(session.id, children);
+    }
+    return map;
+  }, [parentGroups]);
+
+  // Edit modal state
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [editingSession, setEditingSession] = useState<Session | null>(null);
+
+  // Delete confirmation modal state
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+  const [sessionToDelete, setSessionToDelete] = useState<Session | null>(null);
+
+  // Import modal state
+  const [showImportModal, setShowImportModal] = useState(false);
+
+  // Issue #56 §12.1: declassification is attached to the History ROW, not to
+  // the chat title menu. The dialog is mounted from here (rather than inside
+  // `SessionItem`) because `SessionItem` is declared in this component's body,
+  // so every re-render is a fresh component type and a dialog owned by a row
+  // would be torn down and remounted mid-interaction.
+  const [declassifyTarget, setDeclassifyTarget] = useState<Session | null>(null);
+
+  // Search state for debouncing
+  const [searchTerm, setSearchTerm] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const debouncedSearchTerm = useDebounce(searchTerm, 300); // 300ms debounce
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const visibleDateGroups = useMemo(() => {
+    let remainingSessions = visibleSessionCount;
+
+    return dateGroups.flatMap((group) => {
+      if (remainingSessions <= 0) return [];
+      const sessions = group.sessions.slice(0, remainingSessions);
+      remainingSessions -= sessions.length;
+      return [{ ...group, sessions }];
+    });
+  }, [dateGroups, visibleSessionCount]);
+
+  // id → name lookup so a diverged session can show its lineage parent's name.
+  const sessionNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const s of sessions) map.set(s.id, s.name);
+    return map;
+  }, [sessions]);
+
+  const handleScroll = useCallback(
+    (target: HTMLDivElement) => {
+      const { scrollTop, scrollHeight, clientHeight } = target;
+      const threshold = 200;
+
+      if (
+        scrollHeight - scrollTop - clientHeight < threshold &&
+        visibleSessionCount < topLevelSessions.length
+      ) {
+        setVisibleSessionCount((previousCount) =>
+          Math.min(previousCount + VISIBLE_SESSION_BATCH, topLevelSessions.length)
+        );
       }
-      return map;
-    }, [parentGroups]);
+    },
+    [visibleSessionCount, topLevelSessions.length]
+  );
 
-    // Edit modal state
-    const [showEditModal, setShowEditModal] = useState(false);
-    const [editingSession, setEditingSession] = useState<Session | null>(null);
+  useEffect(() => {
+    if (debouncedSearchTerm) {
+      setVisibleSessionCount(topLevelSessions.length);
+    } else {
+      setVisibleSessionCount(INITIAL_VISIBLE_SESSIONS);
+    }
+  }, [debouncedSearchTerm, topLevelSessions.length]);
 
-    // Delete confirmation modal state
-    const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
-    const [sessionToDelete, setSessionToDelete] = useState<Session | null>(null);
-
-    // Import modal state
-    const [showImportModal, setShowImportModal] = useState(false);
-
-    // Issue #56 §12.1: declassification is attached to the History ROW, not to
-    // the chat title menu. The dialog is mounted from here (rather than inside
-    // `SessionItem`) because `SessionItem` is declared in this component's body,
-    // so every re-render is a fresh component type and a dialog owned by a row
-    // would be torn down and remounted mid-interaction.
-    const [declassifyTarget, setDeclassifyTarget] = useState<Session | null>(null);
-
-    // Search state for debouncing
-    const [searchTerm, setSearchTerm] = useState('');
-    const [caseSensitive, setCaseSensitive] = useState(false);
-    const debouncedSearchTerm = useDebounce(searchTerm, 300); // 300ms debounce
-
-    const containerRef = useRef<HTMLDivElement>(null);
-
-    // Track session to element ref
-    const sessionRefs = useRef<Record<string, HTMLElement>>({});
-    // Stable across renders: it is a prop of every row now, and a new function
-    // each render would defeat `SessionItem`'s `React.memo` on every row at
-    // once. It only ever writes to a ref, so it has nothing to close over.
-    const setSessionRefs = useCallback((itemId: string, element: HTMLDivElement | null) => {
-      if (element) {
-        sessionRefs.current[itemId] = element;
-      } else {
-        delete sessionRefs.current[itemId];
-      }
-    }, []);
-
-    const visibleDateGroups = useMemo(() => {
-      let remainingSessions = visibleSessionCount;
-
-      return dateGroups.flatMap((group) => {
-        if (remainingSessions <= 0) return [];
-        const sessions = group.sessions.slice(0, remainingSessions);
-        remainingSessions -= sessions.length;
-        return [{ ...group, sessions }];
-      });
-    }, [dateGroups, visibleSessionCount]);
-
-    // id → name lookup so a diverged session can show its lineage parent's name.
-    const sessionNameById = useMemo(() => {
-      const map = new Map<string, string>();
-      for (const s of sessions) map.set(s.id, s.name);
-      return map;
-    }, [sessions]);
-
-    const handleScroll = useCallback(
-      (target: HTMLDivElement) => {
-        const { scrollTop, scrollHeight, clientHeight } = target;
-        const threshold = 200;
-
-        if (
-          scrollHeight - scrollTop - clientHeight < threshold &&
-          visibleSessionCount < topLevelSessions.length
-        ) {
-          setVisibleSessionCount((previousCount) =>
-            Math.min(previousCount + VISIBLE_SESSION_BATCH, topLevelSessions.length)
-          );
-        }
-      },
-      [visibleSessionCount, topLevelSessions.length]
-    );
-
-    useEffect(() => {
-      if (debouncedSearchTerm) {
-        setVisibleSessionCount(topLevelSessions.length);
-      } else {
-        setVisibleSessionCount(INITIAL_VISIBLE_SESSIONS);
-      }
-    }, [debouncedSearchTerm, topLevelSessions.length]);
-
-    const loadSessions = useCallback(async () => {
-      const hasCachedSessions = getCachedSessionList() !== null;
-      if (!hasCachedSessions) {
-        setIsLoading(true);
-        setShowSkeleton(true);
-        setShowContent(false);
+  const loadSessions = useCallback(async () => {
+    const hasCachedSessions = getCachedSessionList() !== null;
+    if (!hasCachedSessions) {
+      setIsLoading(true);
+      setShowSkeleton(true);
+      setShowContent(false);
+      setError(null);
+    }
+    try {
+      const refreshedSessions = await refreshSessionList(showSubagents);
+      // Use startTransition to make state updates non-blocking
+      startTransition(() => {
+        setSessions(refreshedSessions);
+        setFilteredSessions(
+          showSubagents ? refreshedSessions : withoutSubagents(refreshedSessions)
+        );
         setError(null);
+      });
+    } catch (err) {
+      console.error('Failed to load sessions:', err);
+      if (!hasCachedSessions) {
+        setError('Could not load your chats. Try again in a moment.');
+        setSessions([]);
+        setFilteredSessions([]);
       }
-      try {
-        const refreshedSessions = await refreshSessionList(showSubagents);
-        // Use startTransition to make state updates non-blocking
-        startTransition(() => {
-          setSessions(refreshedSessions);
-          setFilteredSessions(
-            showSubagents ? refreshedSessions : withoutSubagents(refreshedSessions)
+    } finally {
+      if (!hasCachedSessions) setIsLoading(false);
+    }
+  }, [showSubagents]);
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  // Stay live while open. The shared cache is mutated (and emits here) by a
+  // rename on the name channel and by any create / diverge / delete on the
+  // list channel, in this window or a sibling — so See-all reflects a branch
+  // or a rename without a remount. The search effect re-derives
+  // `filteredSessions` from `sessions`, so refreshing the source keeps any
+  // active filter consistent.
+  useEffect(() => {
+    return subscribeSessionList(() => {
+      const cached = getCachedSessionList();
+      if (cached) startTransition(() => setSessions(cached));
+    });
+  }, []);
+
+  // Timing logic to prevent flicker between skeleton and content on initial
+  // load. `showContent` — not `showSkeleton` — is the "already revealed"
+  // guard, and that is load-bearing: this effect WRITES `showSkeleton`, so
+  // keeping it in the deps re-runs the effect on the very next render and the
+  // cleanup below would cancel the reveal it had just armed. The two guards
+  // admit the same states, because the only writer that re-arms a cold load
+  // (`loadSessions`, on a cache miss) sets `showSkeleton` and `showContent`
+  // together; this one just leaves the deps stable across the 10ms window.
+  useEffect(() => {
+    if (isLoading || showContent) return undefined;
+    setShowSkeleton(false);
+    // No `startTransition`: it used to wrap the `setTimeout` call, which
+    // marked nothing (the callback returns before either setState runs), and
+    // the reveal is one opacity class on a layer that is already mounted —
+    // `renderActualContent()` renders under the skeleton too. Deferring the
+    // frame the delay exists to schedule is the opposite of what it is for.
+    const revealTimer = setTimeout(() => setShowContent(true), 10);
+    // Unmounting inside that 10ms window (navigating away, or a test file
+    // finishing) must disarm it: the callback would otherwise setState on an
+    // unmounted tree, and on CI it fired after jsdom was gone and took the
+    // whole run down with `window is not defined`.
+    return () => clearTimeout(revealTimer);
+    // `isInitialLoad` used to sit here and in the callback above. It was
+    // write-only: the only thing that ever READ it was the guard around its
+    // own setter, so the whole cycle — the `useState`, the branch, the
+    // dependency — decided nothing. As a dependency it also re-ran this
+    // effect one extra time on the very tick the reveal landed, which is the
+    // opposite of the stable deps the comment above depends on.
+  }, [isLoading, showContent]);
+
+  // Memoize date groups calculation to prevent unnecessary recalculations
+  const memoizedDateGroups = useMemo(() => {
+    if (topLevelSessions.length > 0) {
+      return groupSessionsByDate(topLevelSessions);
+    }
+    return [];
+  }, [topLevelSessions]);
+
+  // Update date groups when filtered sessions change
+  useEffect(() => {
+    startTransition(() => {
+      setDateGroups(memoizedDateGroups);
+    });
+  }, [memoizedDateGroups]);
+
+  // Debounced search effect - performs actual filtering
+  useEffect(() => {
+    if (!debouncedSearchTerm) {
+      startTransition(() => {
+        setFilteredSessions(visibleSessions);
+        setSearchResults(null);
+      });
+      return;
+    }
+
+    // Use startTransition to make search non-blocking
+    startTransition(() => {
+      const searchTerm = caseSensitive ? debouncedSearchTerm : debouncedSearchTerm.toLowerCase();
+      const filtered = visibleSessions.filter((session) => {
+        const description = session.name;
+        const workingDir = session.working_dir;
+        const sessionId = session.id;
+
+        if (caseSensitive) {
+          return (
+            description.includes(searchTerm) ||
+            sessionId.includes(searchTerm) ||
+            workingDir.includes(searchTerm)
           );
-          setError(null);
-        });
-      } catch (err) {
-        console.error('Failed to load sessions:', err);
-        if (!hasCachedSessions) {
-          setError('Could not load your chats. Try again in a moment.');
-          setSessions([]);
-          setFilteredSessions([]);
+        } else {
+          return (
+            description.toLowerCase().includes(searchTerm) ||
+            sessionId.toLowerCase().includes(searchTerm) ||
+            workingDir.toLowerCase().includes(searchTerm)
+          );
         }
-      } finally {
-        if (!hasCachedSessions) setIsLoading(false);
-      }
-    }, [showSubagents]);
-
-    useEffect(() => {
-      loadSessions();
-    }, [loadSessions]);
-
-    // Stay live while open. The shared cache is mutated (and emits here) by a
-    // rename on the name channel and by any create / diverge / delete on the
-    // list channel, in this window or a sibling — so See-all reflects a branch
-    // or a rename without a remount. The search effect re-derives
-    // `filteredSessions` from `sessions`, so refreshing the source keeps any
-    // active filter consistent.
-    useEffect(() => {
-      return subscribeSessionList(() => {
-        const cached = getCachedSessionList();
-        if (cached) startTransition(() => setSessions(cached));
       });
-    }, []);
 
-    // Timing logic to prevent flicker between skeleton and content on initial
-    // load. `showContent` — not `showSkeleton` — is the "already revealed"
-    // guard, and that is load-bearing: this effect WRITES `showSkeleton`, so
-    // keeping it in the deps re-runs the effect on the very next render and the
-    // cleanup below would cancel the reveal it had just armed. The two guards
-    // admit the same states, because the only writer that re-arms a cold load
-    // (`loadSessions`, on a cache miss) sets `showSkeleton` and `showContent`
-    // together; this one just leaves the deps stable across the 10ms window.
-    useEffect(() => {
-      if (isLoading || showContent) return undefined;
-      setShowSkeleton(false);
-      // No `startTransition`: it used to wrap the `setTimeout` call, which
-      // marked nothing (the callback returns before either setState runs), and
-      // the reveal is one opacity class on a layer that is already mounted —
-      // `renderActualContent()` renders under the skeleton too. Deferring the
-      // frame the delay exists to schedule is the opposite of what it is for.
-      const revealTimer = setTimeout(() => setShowContent(true), 10);
-      // Unmounting inside that 10ms window (navigating away, or a test file
-      // finishing) must disarm it: the callback would otherwise setState on an
-      // unmounted tree, and on CI it fired after jsdom was gone and took the
-      // whole run down with `window is not defined`.
-      return () => clearTimeout(revealTimer);
-      // `isInitialLoad` used to sit here and in the callback above. It was
-      // write-only: the only thing that ever READ it was the guard around its
-      // own setter, so the whole cycle — the `useState`, the branch, the
-      // dependency — decided nothing. As a dependency it also re-ran this
-      // effect one extra time on the very tick the reveal landed, which is the
-      // opposite of the stable deps the comment above depends on.
-    }, [isLoading, showContent]);
+      setFilteredSessions(filtered);
+      setSearchResults(filtered.length > 0 ? { count: filtered.length, currentIndex: 1 } : null);
+    });
+  }, [debouncedSearchTerm, caseSensitive, visibleSessions]);
 
-    // Memoize date groups calculation to prevent unnecessary recalculations
-    const memoizedDateGroups = useMemo(() => {
-      if (topLevelSessions.length > 0) {
-        return groupSessionsByDate(topLevelSessions);
-      }
-      return [];
-    }, [topLevelSessions]);
+  // Handle immediate search input (updates search term for debouncing)
+  const handleSearch = useCallback((term: string, caseSensitive: boolean) => {
+    setSearchTerm(term);
+    setCaseSensitive(caseSensitive);
+  }, []);
 
-    // Update date groups when filtered sessions change
-    useEffect(() => {
-      startTransition(() => {
-        setDateGroups(memoizedDateGroups);
-      });
-    }, [memoizedDateGroups]);
+  // Handle search result navigation
+  const handleSearchNavigation = (direction: 'next' | 'prev') => {
+    if (!searchResults || filteredSessions.length === 0) return;
 
-    // Scroll to the selected session when returning from session history view
-    useEffect(() => {
-      if (selectedSessionId) {
-        // Indexes into the paginated top-level list; a nested child is not in
-        // it, so the count bump is skipped and the scroll falls through to the
-        // row's own ref, which children register too.
-        const selectedIndex = topLevelSessions.findIndex(
-          (session) => session.id === selectedSessionId
-        );
-        if (selectedIndex >= visibleSessionCount) {
-          setVisibleSessionCount(selectedIndex + 1);
-          return;
-        }
-        const element = sessionRefs.current[selectedSessionId];
-        if (element) {
-          element.scrollIntoView({
-            block: 'center',
-          });
-        }
-      }
-    }, [topLevelSessions, selectedSessionId, sessions, visibleSessionCount]);
+    let newIndex: number;
+    if (direction === 'next') {
+      newIndex = (searchResults.currentIndex % filteredSessions.length) + 1;
+    } else {
+      newIndex =
+        searchResults.currentIndex === 1 ? filteredSessions.length : searchResults.currentIndex - 1;
+    }
 
-    // Debounced search effect - performs actual filtering
-    useEffect(() => {
-      if (!debouncedSearchTerm) {
-        startTransition(() => {
-          setFilteredSessions(visibleSessions);
-          setSearchResults(null);
-        });
-        return;
-      }
+    setSearchResults({ ...searchResults, currentIndex: newIndex });
 
-      // Use startTransition to make search non-blocking
-      startTransition(() => {
-        const searchTerm = caseSensitive ? debouncedSearchTerm : debouncedSearchTerm.toLowerCase();
-        const filtered = visibleSessions.filter((session) => {
-          const description = session.name;
-          const workingDir = session.working_dir;
-          const sessionId = session.id;
+    // Find the SearchView's container element
+    const searchContainer =
+      containerRef.current?.querySelector<SearchContainerElement>('.search-container');
+    if (searchContainer?._searchHighlighter) {
+      // Update the current match in the highlighter
+      searchContainer._searchHighlighter.setCurrentMatch(newIndex - 1, true);
+    }
+  };
 
-          if (caseSensitive) {
-            return (
-              description.includes(searchTerm) ||
-              sessionId.includes(searchTerm) ||
-              workingDir.includes(searchTerm)
-            );
-          } else {
-            return (
-              description.toLowerCase().includes(searchTerm) ||
-              sessionId.toLowerCase().includes(searchTerm) ||
-              workingDir.toLowerCase().includes(searchTerm)
-            );
-          }
-        });
+  // Handle modal close
+  const handleModalClose = useCallback(() => {
+    setShowEditModal(false);
+    setEditingSession(null);
+  }, []);
 
-        setFilteredSessions(filtered);
-        setSearchResults(filtered.length > 0 ? { count: filtered.length, currentIndex: 1 } : null);
-      });
-    }, [debouncedSearchTerm, caseSensitive, visibleSessions]);
+  const handleModalSave = useCallback(async (sessionId: string, newDescription: string) => {
+    // Update state immediately for optimistic UI
+    const updateName = (currentSessions: Session[]) =>
+      currentSessions.map((session) =>
+        session.id === sessionId ? { ...session, name: newDescription } : session
+      );
+    updateCachedSessionList(updateName);
+    setSessions(updateName);
+  }, []);
 
-    // Handle immediate search input (updates search term for debouncing)
-    const handleSearch = useCallback((term: string, caseSensitive: boolean) => {
-      setSearchTerm(term);
-      setCaseSensitive(caseSensitive);
-    }, []);
+  const handleEditSession = useCallback((session: Session) => {
+    setEditingSession(session);
+    setShowEditModal(true);
+  }, []);
 
-    // Handle search result navigation
-    const handleSearchNavigation = (direction: 'next' | 'prev') => {
-      if (!searchResults || filteredSessions.length === 0) return;
+  const handleDeleteSession = useCallback((session: Session) => {
+    setSessionToDelete(session);
+    setShowDeleteConfirmation(true);
+  }, []);
 
-      let newIndex: number;
-      if (direction === 'next') {
-        newIndex = (searchResults.currentIndex % filteredSessions.length) + 1;
-      } else {
-        newIndex =
-          searchResults.currentIndex === 1
-            ? filteredSessions.length
-            : searchResults.currentIndex - 1;
-      }
+  const handleConfirmDelete = useCallback(async () => {
+    if (!sessionToDelete) return;
 
-      setSearchResults({ ...searchResults, currentIndex: newIndex });
+    setShowDeleteConfirmation(false);
+    const sessionToDeleteId = sessionToDelete.id;
+    const sessionName = sessionToDelete.name;
+    setSessionToDelete(null);
 
-      // Find the SearchView's container element
-      const searchContainer =
-        containerRef.current?.querySelector<SearchContainerElement>('.search-container');
-      if (searchContainer?._searchHighlighter) {
-        // Update the current match in the highlighter
-        searchContainer._searchHighlighter.setCurrentMatch(newIndex - 1, true);
-      }
-    };
-
-    // Handle modal close
-    const handleModalClose = useCallback(() => {
-      setShowEditModal(false);
-      setEditingSession(null);
-    }, []);
-
-    const handleModalSave = useCallback(async (sessionId: string, newDescription: string) => {
-      // Update state immediately for optimistic UI
-      const updateName = (currentSessions: Session[]) =>
-        currentSessions.map((session) =>
-          session.id === sessionId ? { ...session, name: newDescription } : session
-        );
-      updateCachedSessionList(updateName);
-      setSessions(updateName);
-    }, []);
-
-    const handleEditSession = useCallback((session: Session) => {
-      setEditingSession(session);
-      setShowEditModal(true);
-    }, []);
-
-    const handleDeleteSession = useCallback((session: Session) => {
-      setSessionToDelete(session);
-      setShowDeleteConfirmation(true);
-    }, []);
-
-    const handleConfirmDelete = useCallback(async () => {
-      if (!sessionToDelete) return;
-
-      setShowDeleteConfirmation(false);
-      const sessionToDeleteId = sessionToDelete.id;
-      const sessionName = sessionToDelete.name;
-      setSessionToDelete(null);
-
-      try {
-        await deleteSession({
-          path: { session_id: sessionToDeleteId },
-          throwOnError: true,
-        });
-        const removeDeletedSession = (currentSessions: Session[]) =>
-          currentSessions.filter((session) => session.id !== sessionToDeleteId);
-        updateCachedSessionList(removeDeletedSession);
-        setSessions(removeDeletedSession);
-        toastSuccess({
-          title: 'Chat deleted',
-          msg: `"${sessionName}" was removed from chat history.`,
-        });
-      } catch (error) {
-        console.error('Error deleting session:', error);
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-        toastError({
-          title: 'Failed to delete chat',
-          msg: `Could not delete "${sessionName}": ${errorMessage}`,
-        });
-      }
-      await loadSessions();
-    }, [sessionToDelete, loadSessions]);
-
-    const handleCancelDelete = useCallback(() => {
-      setShowDeleteConfirmation(false);
-      setSessionToDelete(null);
-    }, []);
-
-    const handleExportSession = useCallback(async (session: Session, e: React.MouseEvent) => {
-      e.stopPropagation();
-
-      const response = await exportSession({
-        path: { session_id: session.id },
+    try {
+      await deleteSession({
+        path: { session_id: sessionToDeleteId },
         throwOnError: true,
       });
-
-      const json = response.data;
-      const blob = new Blob([json], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${session.name}.json`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      const removeDeletedSession = (currentSessions: Session[]) =>
+        currentSessions.filter((session) => session.id !== sessionToDeleteId);
+      updateCachedSessionList(removeDeletedSession);
+      setSessions(removeDeletedSession);
       toastSuccess({
-        title: 'Chat exported',
-        msg: `"${session.name}" was downloaded.`,
+        title: 'Chat deleted',
+        msg: `"${sessionName}" was removed from chat history.`,
       });
-    }, []);
+    } catch (error) {
+      console.error('Error deleting session:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      toastError({
+        title: 'Failed to delete chat',
+        msg: `Could not delete "${sessionName}": ${errorMessage}`,
+      });
+    }
+    await loadSessions();
+  }, [sessionToDelete, loadSessions]);
 
-    const handleImportClick = useCallback(() => {
-      setShowImportModal(true);
-    }, []);
+  const handleCancelDelete = useCallback(() => {
+    setShowDeleteConfirmation(false);
+    setSessionToDelete(null);
+  }, []);
 
-    const handleImportSession = useCallback(
-      async (json: string) => {
-        await importSession({ body: { json }, throwOnError: true });
-        toastSuccess({
-          title: 'Chat imported',
-          msg: 'The imported chat is now available in chat history.',
-        });
-        await loadSessions();
-      },
-      [loadSessions]
-    );
+  const handleExportSession = useCallback(async (session: Session, e: React.MouseEvent) => {
+    e.stopPropagation();
 
-    const handleDeclassifyClick = useCallback((session: Session) => {
-      setDeclassifyTarget(session);
-    }, []);
+    const response = await exportSession({
+      path: { session_id: session.id },
+      throwOnError: true,
+    });
 
-    // The row is stale the moment the daemon answers: its badge and its
-    // overflow menu both key on `privacy_tier`. Patch the shared cache as well
-    // as this pane's list, exactly as the delete path does, so the sidebar's
-    // Recents and any second History pane stop badging it too.
-    const handleDeclassified = useCallback((sessionId: string) => {
-      const markPublic = (currentSessions: Session[]) =>
-        currentSessions.map((session) =>
-          session.id === sessionId
-            ? {
-                ...session,
-                privacy_tier: 'public' as const,
-                privacy_reason: 'declassified_by_user',
-              }
-            : session
-        );
-      updateCachedSessionList(markPublic);
-      setSessions(markPublic);
-      setDeclassifyTarget(null);
-    }, []);
+    const json = response.data;
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${session.name}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    toastSuccess({
+      title: 'Chat exported',
+      msg: `"${session.name}" was downloaded.`,
+    });
+  }, []);
 
-    const renderActualContent = () => {
-      if (error) {
-        // The error state is the empty state with a different cause: same icon
-        // plate, same title/description/action stack, same quiet register. It
-        // used to be a hand-rolled column with its own icon size, its own type
-        // ramp and a Title Case sentence — one of the four error dialects §4.5
-        // exists to close.
-        return (
-          <EmptyState
-            icon={AlertCircle}
-            title="Couldn't load your chat history"
-            description={error}
-            actions={
-              <Button onClick={loadSessions} variant="outline">
-                Try again
-              </Button>
+  const handleImportClick = useCallback(() => {
+    setShowImportModal(true);
+  }, []);
+
+  const handleImportSession = useCallback(
+    async (json: string) => {
+      await importSession({ body: { json }, throwOnError: true });
+      toastSuccess({
+        title: 'Chat imported',
+        msg: 'The imported chat is now available in chat history.',
+      });
+      await loadSessions();
+    },
+    [loadSessions]
+  );
+
+  const handleDeclassifyClick = useCallback((session: Session) => {
+    setDeclassifyTarget(session);
+  }, []);
+
+  // The row is stale the moment the daemon answers: its badge and its
+  // overflow menu both key on `privacy_tier`. Patch the shared cache as well
+  // as this pane's list, exactly as the delete path does, so the sidebar's
+  // Recents and any second History pane stop badging it too.
+  const handleDeclassified = useCallback((sessionId: string) => {
+    const markPublic = (currentSessions: Session[]) =>
+      currentSessions.map((session) =>
+        session.id === sessionId
+          ? {
+              ...session,
+              privacy_tier: 'public' as const,
+              privacy_reason: 'declassified_by_user',
             }
-          />
-        );
-      }
+          : session
+      );
+    updateCachedSessionList(markPublic);
+    setSessions(markPublic);
+    setDeclassifyTarget(null);
+  }, []);
 
-      if (sessions.length === 0) {
-        return (
-          <EmptyState
-            icon={MessageSquareText}
-            title="No chats yet"
-            description="Past chats will appear here after you start chatting. You can also import an existing chat."
-            actions={
-              <>
-                <Button onClick={() => navigate('/pair')}>Start a chat</Button>
-                <Button onClick={handleImportClick} variant="outline">
-                  <Upload className="h-4 w-4" />
-                  Import chat
-                </Button>
-              </>
-            }
-          />
-        );
-      }
-
-      if (dateGroups.length === 0 && searchResults !== null) {
-        return (
-          <EmptyState
-            icon={MessageSquareText}
-            title="No matching chats"
-            description="Try a different name, folder, or session ID."
-            compact
-          />
-        );
-      }
-
+  const renderActualContent = () => {
+    if (error) {
+      // The error state is the empty state with a different cause: same icon
+      // plate, same title/description/action stack, same quiet register. It
+      // used to be a hand-rolled column with its own icon size, its own type
+      // ramp and a Title Case sentence — one of the four error dialects §4.5
+      // exists to close.
       return (
-        <div className="space-y-8">
-          {visibleDateGroups.map((group) => (
-            <div key={group.label} className="space-y-4">
-              <div className="sticky top-0 z-10 bg-background-canvas pt-2 pb-2">
-                {/* `text-caps` IS the caps style — it carries the transform as
+        <EmptyState
+          icon={AlertCircle}
+          title="Couldn't load your chat history"
+          description={error}
+          actions={
+            <Button onClick={loadSessions} variant="outline">
+              Try again
+            </Button>
+          }
+        />
+      );
+    }
+
+    if (sessions.length === 0) {
+      return (
+        <EmptyState
+          icon={MessageSquareText}
+          title="No chats yet"
+          description="Past chats will appear here after you start chatting. You can also import an existing chat."
+          actions={
+            <>
+              <Button onClick={() => navigate('/pair')}>Start a chat</Button>
+              <Button onClick={handleImportClick} variant="outline">
+                <Upload className="h-4 w-4" />
+                Import chat
+              </Button>
+            </>
+          }
+        />
+      );
+    }
+
+    if (dateGroups.length === 0 && searchResults !== null) {
+      return (
+        <EmptyState
+          icon={MessageSquareText}
+          title="No matching chats"
+          description="Try a different name, folder, or session ID."
+          compact
+        />
+      );
+    }
+
+    return (
+      <div className="space-y-8">
+        {visibleDateGroups.map((group) => (
+          <div key={group.label} className="space-y-4">
+            <div className="sticky top-0 z-10 bg-background-canvas pt-2 pb-2">
+              {/* `text-caps` IS the caps style — it carries the transform as
                     well as the 11/500/+0.08em metrics, so `uppercase` and
                     `tracking-wider` beside it were spelling out what the role
                     already says. */}
-                <h2 className="text-caps text-text-muted">{group.label}</h2>
-              </div>
-              <div className="session-grid biorouter-list-shell">
-                {group.sessions.map((session) => {
-                  const children = childrenByParentId.get(session.id);
-                  return (
-                    <React.Fragment key={session.id}>
-                      <SessionItem
-                        session={session}
-                        onSelectSession={onSelectSession}
-                        sessionNameById={sessionNameById}
-                        setSessionRef={setSessionRefs}
-                        onEditClick={handleEditSession}
-                        onDeleteClick={handleDeleteSession}
-                        onExportClick={handleExportSession}
-                        onDeclassifyClick={handleDeclassifyClick}
-                      />
-                      {/* One indented block for all of a parent's children, not
+              <h2 className="text-caps text-text-muted">{group.label}</h2>
+            </div>
+            <div className="session-grid biorouter-list-shell">
+              {group.sessions.map((session) => {
+                const children = childrenByParentId.get(session.id);
+                return (
+                  <React.Fragment key={session.id}>
+                    <SessionItem
+                      session={session}
+                      onSelectSession={onSelectSession}
+                      sessionNameById={sessionNameById}
+                      onEditClick={handleEditSession}
+                      onDeleteClick={handleDeleteSession}
+                      onExportClick={handleExportSession}
+                      onDeclassifyClick={handleDeclassifyClick}
+                    />
+                    {/* One indented block for all of a parent's children, not
                           one wrapper each: a lone row inside its own wrapper is
                           `:last-child` and loses the separator every other row
                           in the list has. */}
-                      {children && (
-                        <div className="ml-6 flex flex-col border-l border-border-subtle pl-2">
-                          {children.map((child) => (
-                            <SessionItem
-                              key={child.id}
-                              session={child}
-                              onSelectSession={onSelectSession}
-                              sessionNameById={sessionNameById}
-                              setSessionRef={setSessionRefs}
-                              onEditClick={handleEditSession}
-                              onDeleteClick={handleDeleteSession}
-                              onExportClick={handleExportSession}
-                              onDeclassifyClick={handleDeclassifyClick}
-                            />
-                          ))}
-                        </div>
-                      )}
-                    </React.Fragment>
-                  );
-                })}
-              </div>
+                    {children && (
+                      <div className="ml-6 flex flex-col border-l border-border-subtle pl-2">
+                        {children.map((child) => (
+                          <SessionItem
+                            key={child.id}
+                            session={child}
+                            onSelectSession={onSelectSession}
+                            sessionNameById={sessionNameById}
+                            onEditClick={handleEditSession}
+                            onDeleteClick={handleDeleteSession}
+                            onExportClick={handleExportSession}
+                            onDeclassifyClick={handleDeclassifyClick}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </React.Fragment>
+                );
+              })}
             </div>
-          ))}
+          </div>
+        ))}
 
-          {visibleSessionCount < topLevelSessions.length && (
-            <div className="flex justify-center py-8">
-              {/* V6 — a status line is `text-supporting`, the same role the
+        {visibleSessionCount < topLevelSessions.length && (
+          <div className="flex justify-center py-8">
+            {/* V6 — a status line is `text-supporting`, the same role the
                   metadata under every row above it uses. `text-secondary` is
                   the dense-CONTROL exception, and this is not a control. */}
-              <div className="flex items-center gap-2 text-supporting text-text-muted">
-                <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />
-                <span>Loading more chats...</span>
-              </div>
+            <div className="flex items-center gap-2 text-supporting text-text-muted">
+              <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />
+              <span>Loading more chats...</span>
             </div>
-          )}
-        </div>
-      );
-    };
+          </div>
+        )}
+      </div>
+    );
+  };
 
-    return (
-      <>
-        <MainPanelLayout>
-          <div className="flex-1 flex flex-col min-h-0">
-            {/* ⚠ The header's column and the body's below it are BOTH
+  return (
+    <>
+      <MainPanelLayout>
+        <div className="flex-1 flex flex-col min-h-0">
+          {/* ⚠ The header's column and the body's below it are BOTH
                 `size="chat"`, and they move together or not at all — the
                 header's hairline is full-bleed (`PageHeader` owns the wrapper),
                 so a size on one box and not the other is a visible step in the
@@ -1242,29 +1195,28 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
                 longer shares its row with a button, so it no longer needs
                 `min-w-0 truncate` to give way to one, and a page title is no
                 longer a thing that can be clipped by its own controls. */}
-            <PageHeader
-              title="Chat history"
-              description={
-                <>
-                  View and search your past chats with Biorouter. {getSearchShortcutText()} to
-                  search.
-                </>
-              }
-              actions={
-                /* V7 — no `className`. It carried `flex flex-shrink-0
+          <PageHeader
+            title="Chat history"
+            description={
+              <>
+                View and search your past chats with Biorouter. {getSearchShortcutText()} to search.
+              </>
+            }
+            actions={
+              /* V7 — no `className`. It carried `flex flex-shrink-0
                    items-center gap-2`, and every token of that is already in
                    `buttonVariants`' base (`inline-flex items-center
                    justify-center gap-2 … shrink-0`). The bare `flex` was not
                    merely redundant: tailwind-merge lets it FLIP the base's
                    `inline-flex`, which is how a row action elsewhere became a
                    full-width bar. */
-                <Button onClick={handleImportClick} variant="outline">
-                  <Upload className="w-4 h-4" />
-                  Import chat
-                </Button>
-              }
-            >
-              {/* §3.3's checkbox, not the OS one. A bare `<input
+              <Button onClick={handleImportClick} variant="outline">
+                <Upload className="w-4 h-4" />
+                Import chat
+              </Button>
+            }
+          >
+            {/* §3.3's checkbox, not the OS one. A bare `<input
                   type="checkbox">` here rendered as macOS system blue in light
                   mode and a bare white square in dark — the only unstyled
                   control in the app, directly under a page title. `-ml-px`
@@ -1276,88 +1228,87 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
                   a filter that changes what the list shows is not an action the
                   page offers, and putting it in the strip would give it the
                   same standing as Import chat. */}
-              <label className="mt-3 flex cursor-pointer items-center gap-2 text-supporting text-text-muted">
-                <Checkbox
-                  className="-ml-px"
-                  checked={showSubagents}
-                  onChange={(e) => setShowSubagents(e.target.checked)}
-                />
-                Show subagent runs
-              </label>
-            </PageHeader>
+            <label className="mt-3 flex cursor-pointer items-center gap-2 text-supporting text-text-muted">
+              <Checkbox
+                className="-ml-px"
+                checked={showSubagents}
+                onChange={(e) => setShowSubagents(e.target.checked)}
+              />
+              Show subagent runs
+            </label>
+          </PageHeader>
 
-            <ReadableContent size="chat" className="flex-1 min-h-0 relative px-6 pt-6 pb-8">
-              <ScrollArea
-                handleScroll={handleScroll}
-                className="h-full"
-                paddingX={1}
-                data-search-scroll-area
-              >
-                <div ref={containerRef} className="h-full relative">
-                  <SearchView
-                    onSearch={handleSearch}
-                    onNavigate={handleSearchNavigation}
-                    searchResults={searchResults}
-                    className="relative"
-                    placeholder="Search history..."
+          <ReadableContent size="chat" className="flex-1 min-h-0 relative px-6 pt-6 pb-8">
+            <ScrollArea
+              handleScroll={handleScroll}
+              className="h-full"
+              paddingX={1}
+              data-search-scroll-area
+            >
+              <div ref={containerRef} className="h-full relative">
+                <SearchView
+                  onSearch={handleSearch}
+                  onNavigate={handleSearchNavigation}
+                  searchResults={searchResults}
+                  className="relative"
+                  placeholder="Search history..."
+                >
+                  {/* Loading layer - shaped like the rows that will replace it. */}
+                  <div
+                    className={`absolute inset-0 transition-opacity duration-[var(--motion-fast)] ease-[var(--ease-in)] ${isLoading || showSkeleton ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}
                   >
-                    {/* Loading layer - shaped like the rows that will replace it. */}
-                    <div
-                      className={`absolute inset-0 transition-opacity duration-[var(--motion-fast)] ease-[var(--ease-in)] ${isLoading || showSkeleton ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}
-                    >
-                      {(isLoading || showSkeleton) && <HistoryLoading />}
-                    </div>
+                    {(isLoading || showSkeleton) && <HistoryLoading />}
+                  </div>
 
-                    {/* Content layer - always rendered but conditionally visible */}
-                    <div
-                      className={`relative transition-opacity duration-[var(--motion-base)] ease-[var(--ease-out)] ${showContent ? 'opacity-100 z-10' : 'opacity-0 z-0'}`}
-                    >
-                      {renderActualContent()}
-                    </div>
-                  </SearchView>
-                </div>
-              </ScrollArea>
-            </ReadableContent>
-          </div>
-        </MainPanelLayout>
+                  {/* Content layer - always rendered but conditionally visible */}
+                  <div
+                    className={`relative transition-opacity duration-[var(--motion-base)] ease-[var(--ease-out)] ${showContent ? 'opacity-100 z-10' : 'opacity-0 z-0'}`}
+                  >
+                    {renderActualContent()}
+                  </div>
+                </SearchView>
+              </div>
+            </ScrollArea>
+          </ReadableContent>
+        </div>
+      </MainPanelLayout>
 
-        <EditSessionModal
-          session={editingSession}
-          isOpen={showEditModal}
-          onClose={handleModalClose}
-          onSave={handleModalSave}
-        />
+      <EditSessionModal
+        session={editingSession}
+        isOpen={showEditModal}
+        onClose={handleModalClose}
+        onSave={handleModalSave}
+      />
 
-        <ImportSessionModal
-          isOpen={showImportModal}
-          onClose={() => setShowImportModal(false)}
-          onImport={handleImportSession}
-        />
+      <ImportSessionModal
+        isOpen={showImportModal}
+        onClose={() => setShowImportModal(false)}
+        onImport={handleImportSession}
+      />
 
-        <ConfirmationModal
-          isOpen={showDeleteConfirmation}
-          title="Delete chat?"
-          message={`Are you sure you want to delete the chat "${sessionToDelete?.name}"? This action cannot be undone.`}
-          confirmLabel="Delete"
-          cancelLabel="Cancel"
-          confirmVariant="destructive"
-          onConfirm={handleConfirmDelete}
-          onCancel={handleCancelDelete}
-        />
+      <ConfirmationModal
+        isOpen={showDeleteConfirmation}
+        title="Delete chat?"
+        message={`Are you sure you want to delete the chat "${sessionToDelete?.name}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        confirmVariant="destructive"
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+      />
 
-        {/* Mounted only while a row is targeted, so a closed dialog holds no
+      {/* Mounted only while a row is targeted, so a closed dialog holds no
             session and cannot arrive pre-satisfied by a previous row's phrase. */}
-        {declassifyTarget && (
-          <DeclassifySessionDialog
-            session={declassifyTarget}
-            onClose={() => setDeclassifyTarget(null)}
-            onDeclassified={handleDeclassified}
-          />
-        )}
-      </>
-    );
-  }
-);
+      {declassifyTarget && (
+        <DeclassifySessionDialog
+          session={declassifyTarget}
+          onClose={() => setDeclassifyTarget(null)}
+          onDeclassified={handleDeclassified}
+        />
+      )}
+    </>
+  );
+});
 
 SessionListView.displayName = 'SessionListView';
 

--- a/ui/desktop/src/components/sessions/SessionsView.tsx
+++ b/ui/desktop/src/components/sessions/SessionsView.tsx
@@ -48,12 +48,12 @@ const SessionsView: React.FC = () => {
     }
   }, [location.state, handleSelectSession]);
 
-  // `selectedSessionId` is left unset rather than passed as `null`. It scrolls a
-  // named row into view "when returning from session history view" — the
-  // journey that no longer exists — and this view was already passing a value
-  // that could only ever be null. The prop stays on `SessionListView` because
-  // it is optional and describes something a caller may legitimately want; what
-  // is removed here is the pretence that this caller supplies it.
+  // The list takes no selection. `SessionListView` used to accept a
+  // `selectedSessionId` that scrolled a named row into view "when returning
+  // from session history view"; that journey was removed when history rows
+  // began resuming the chat directly, so the prop and its ref registry are
+  // gone rather than left unpassed. The `location.state` handover above is a
+  // different thing — it opens a chat, it does not scroll a row.
   return <SessionListView onSelectSession={handleSelectSession} />;
 };
 

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -496,10 +496,11 @@ type ElectronAPI = {
   disposeTerminalSession: (sessionId: string) => Promise<TerminalActionResult>;
   onTerminalData: (callback: (event: TerminalDataEvent) => void) => () => void;
   onTerminalExit: (callback: (event: TerminalExitEvent) => void) => () => void;
-  // Extension updater (events pushed via 'extension-update-event' channel)
+  // Extension updater (events pushed via 'extension-update-event' channel).
+  // Returns a disposer, like every other `on*` above — see the implementation.
   onExtensionUpdateEvent: (
     callback: (event: import('./utils/extensionUpdater').ExtensionUpdateEvent) => void
-  ) => void;
+  ) => () => void;
 
   // ── Tab tear-off and merge (docs/design/astryx-adoption/tab-tear-off-and-merge.md)
   //
@@ -816,7 +817,15 @@ const electronAPI: ElectronAPI = {
     return () => ipcRenderer.removeListener('terminal:exit', listener);
   },
   onExtensionUpdateEvent: (callback) => {
-    ipcRenderer.on('extension-update-event', (_event, data) => callback(data));
+    // Named, preload-scope wrapper for the same reason the generic `on` above
+    // has one: `removeListener` matches by identity, and an inline arrow passed
+    // straight to `ipcRenderer.on` can never be handed back to remove it.
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      data: import('./utils/extensionUpdater').ExtensionUpdateEvent
+    ) => callback(data);
+    ipcRenderer.on('extension-update-event', listener);
+    return () => ipcRenderer.removeListener('extension-update-event', listener);
   },
 
   // Tab tear-off and merge. Append-only, and deliberately thin: every one of

--- a/ui/desktop/src/renderer.tsx
+++ b/ui/desktop/src/renderer.tsx
@@ -530,8 +530,11 @@ if (needsHeadlessElectron || typeof window.appConfig === 'undefined') {
       // the honest answer for a server the browser cannot probe.
       checkDependencies: async () => [],
       // No background extension updater in browser mode; the app shell listens
-      // for this unconditionally, so the channel must at least exist.
-      onExtensionUpdateEvent: () => {},
+      // for this unconditionally, so the channel must at least exist. It hands
+      // back a no-op disposer rather than nothing: the reporter calls what it
+      // gets on unmount, so a stub returning `undefined` would work only for as
+      // long as that call stays optional-chained.
+      onExtensionUpdateEvent: () => () => {},
       dependencyEnvironment: async () => ({ platform: 'linux' }),
     };
   }


### PR DESCRIPTION
Handoff 06. Two independent renderer defects that PR #189 recorded in its "Not fixed, with reasons" section.

## Why

**A.** `ExtensionUpdateReporter` subscribed to the `extension-update-event` IPC channel and never unsubscribed. Every mount added a listener that nothing removed, so the app accumulated duplicate listeners — each of which fires its own duplicate toast for the same extension update — until Node printed `MaxListenersExceededWarning`.

**B.** `SessionListView` still carried a `selectedSessionId` prop and a scroll-into-view effect for a journey #189 deleted. Nothing passed the prop, and its ref registry existed only to serve that one effect.

## Root cause

`ExtensionUpdateReporter.tsx:24` called `window.electron?.onExtensionUpdateEvent?.(...)` inside `useEffect(..., [])` and returned no cleanup. The comment at `:51-52` justified that: the bridge *"returns no disposer, so there is nothing to clean up. Mounted once, at the app shell, for the life of the window."* Both halves were wrong.

- The bridge could have returned a disposer and didn't. `preload.ts:818-820` called `ipcRenderer.on('extension-update-event', …)` with an inline arrow and returned `void`, while its four neighbours (`onUpdaterEvent`, `onTerminalData`, `onTerminalExit`, the generic `on`) all keep a named preload-scope wrapper and return a `removeListener` closure. The generic `on` even carries a comment explaining why the wrapper must be named — removal matches by identity.
- It is not mounted once. `ExtensionUpdateReporter` renders in `AppLayout` (`Layout/AppLayout.tsx:199`), which is the route element for `path="/"` under `ProviderGuard > ChatProvider` (`App.tsx:706-715`). Routes declared outside that element — `launcher`, `welcome`, `configure-providers` — unmount the whole shell, and returning re-mounts it. `React.StrictMode` is on (`renderer.tsx:576`), so each mount runs the effect twice.

### Correcting the handoff brief

The brief predicted that cycling `#/`, `#/sessions`, `#/workflows`, `#/schedules`, `#/extensions`, `#/skills`, `#/settings` 15 times would print the warning. **It does not, and that matters for anyone re-testing this.** Those seven routes are all children of the shell, so `<Outlet/>` swaps the page while `AppLayout` stays mounted. Measured on `main` at f350cdfc: 105 such navigations left the listener count unchanged at 2. What grows the count is leaving the shell and coming back.

## What changed

- `ui/desktop/src/preload.ts:499-503` — the declared type now returns `() => void`.
- `ui/desktop/src/preload.ts:819-829` — named `const listener`, `ipcRenderer.on(...)`, returns `() => ipcRenderer.removeListener('extension-update-event', listener)`.
- `ui/desktop/src/components/ExtensionUpdateReporter.tsx:24` — captures the disposer; `:52-65` — returns `() => dispose?.()` and replaces the false comment with what is actually true.
- `ui/desktop/src/renderer.tsx:537` — the browser-surface stub returns a no-op disposer. Note this is not a type obligation: that object is assigned through a `Record<string, unknown>` cast and is never checked against `ElectronAPI`. It is runtime hygiene, so the stub cannot become the one host where the reporter's cleanup has nothing to call.
- `ui/desktop/src/components/ExtensionUpdateReporter.listeners.test.tsx` — new.
- `ui/desktop/src/components/sessions/SessionListView.tsx` — removes `selectedSessionId` from the props interface and the destructuring, the scroll-into-view effect, the `sessionRefs` ref, the `setSessionRefs` registrar, the `setSessionRef` prop on the local `SessionItem` row and the `ref` callback that fed it, and both row call sites.
- `ui/desktop/src/components/sessions/SessionsView.tsx:51-56` — the comment explaining why it left the prop unset is rewritten, since there is no prop to leave unset. Its `location.state.selectedSessionId` handover is untouched: that opens a chat, it does not scroll a row.

`element.scrollIntoView` was the ref registry's only reader. The reveal timer from #186 is a `setState` timer and never used it.

**Read `SessionListView.tsx` with `git diff -w`.** The raw diff is ~1200 lines and almost all whitespace: the shorter parameter list lets prettier hug the arrow onto `React.memo(`, de-indenting the component body by two spaces. `git diff -w` shows 61 changed lines, of which three are prettier re-joining lines that now fit.

## Tests

New regression test, failing before the fix:

```
 ❯ src/components/ExtensionUpdateReporter.listeners.test.tsx (2 tests | 2 failed)
     × leaves no listener behind across repeated mounts
     × registers exactly one listener under StrictMode
AssertionError: no live listener after unmount (cycle 1): expected 1 to be +0
AssertionError: expected 2 to be 1
 Test Files  1 failed | 1 passed (2)
      Tests  2 failed | 6 passed (8)
```

After:

```
 ✓ src/components/sessions/SessionListView.test.tsx  (21 tests)
 ✓ src/components/ExtensionUpdateReporter.test.tsx  (6 tests)
 ✓ src/components/ExtensionUpdateReporter.listeners.test.tsx  (2 tests)
 Test Files  17 passed (17)
      Tests  111 passed (111)
```

Full renderer suite, `npm run test:run`, exit 0:

```
 Test Files  435 passed (435)
      Tests  4878 passed | 1 skipped (4879)
```

A first run of the same command reported `434 passed (435), 1 failed`. That failure was `src/utils/artifactCdnAssets.browser.test.ts`, whose two tests both **passed**; its `afterAll` hook timed out closing the Playwright browser after 30 s, on a machine at load 89 from unrelated builds. It references nothing in this diff, passes in isolation on this branch and on `main`, and the re-run above is clean. Unmodified `main` reports `434 passed (434)`; counts line up, since this branch adds one file and two tests.

Other gates: `npm run lint:check` exit 0 (332 contrast assertions, token mirrors OK). `npx prettier --check` exit 0 on all seven changed files, with a deliberately malformed file confirming the check can fail (exit 1).

## Verification

Two sandboxed dev instances, one per tree, driven the same way. Live listeners were counted by adding probe listeners one at a time until Node's `MaxListenersExceededWarning` fires; the warning reports `count: 11`, so app listeners = 11 - probes added.

| tree | shell remounts confirmed | live `extension-update-event` listeners |
|---|---|---|
| `main` f350cdfc | 0 (105 in-shell route navigations) | **2** |
| `main` f350cdfc | 3 | **8** |
| this branch | 5 | **1** |

On `main` the warning fired on the 3rd probe; on this branch, on the 10th.

Two honest caveats about that middle row. Five round trips were driven in both runs, and every one was confirmed to unmount the shell (`[data-route-path]` absent while away). On `main`, only **3** were confirmed re-mounted at the moment the count was sampled — the other two were sampled before the shell came back. That is consistent with what the numbers say: StrictMode double-invokes, so each remount adds 2, and 2 + (3 x 2) = 8. On this branch all 5 round trips were confirmed re-mounted, and the count was still 1. So the branch survived *more* remounts than `main` needed to reach 8.

The protocol also has a ceiling worth stating: Node sets `warned` per (emitter, event name), so a channel warns once. It can measure a count below 11 and not above it. Both figures here are below it, and each was taken on a freshly loaded page whose channel had not warned.

The instrument was validated before use - a fresh control channel warned at exactly 11 on both instances, and the `emit` bridge was shown to dispatch to registered listeners. Two candidate instruments were rejected: counting toast DOM nodes (react-toastify dedupes by a content-derived `toastId`, so N listeners still render one toast, and the app supplies its own class so `.Toastify__toast` matches nothing), and one reading taken from an instance whose React root had gone empty after repeated reloads, which reported a spurious zero. Every measurement now asserts the shell is mounted.

Screenshots after the remount cycling on this branch: Home and Chat history both render normally, 16 session rows with row actions intact.

## Review

An independent adversarial pass over this diff found no defects in the production code, and confirmed by token-level comparison that the large `SessionListView.tsx` diff carries no semantic change beyond the intended removals. Its four findings are addressed in the third commit, except one that was a correction to this description rather than to code:

- A comment in `ExtensionUpdateReporter.test.tsx` claimed those tests never unmount. They do, via the shared `afterEach(cleanup)`. Fixed.
- The StrictMode test asserted only `live.size === 1`, which a harness that had stopped double-invoking would also satisfy. It now pins subscribes and disposes at `{2, 1}`, and was re-checked against the pre-fix effect shape: both tests still fail, now on the totals as well as the live set.
- The behaviour delta below is now written down in the component.
- The `renderer.tsx` wording above is corrected.

**One behaviour really does change.** While the shell is unmounted, nothing listens, so an update event broadcast in that window is dropped rather than queued. Previously a listener left behind by an earlier mount kept firing into the `ToastContainer`, which lives outside the shell, so the toast still appeared. That only worked by accident of the leak; the updater's log still records the failure.

## Follow-ups, not done here

- `SessionsView.tsx:41-49` reads `location.state.selectedSessionId`, and **no producer of that state exists** anywhere in `ui/desktop/src` — `SessionsInsights.tsx` has no navigation code, and the one `navigate('/sessions')` in `App.tsx:247` passes no state. It looks dead for the same reason the prop was, but removing it is out of scope here.
- `preload.ts` exposes five other `on*` subscriptions that do return disposers; whether every renderer consumer actually calls them is a separate sweep.
- The `off()` shim (`preload.ts:6-14`) only warns, so any remaining `off()` caller leaks the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
