### PR TITLE
Desktop: settle one spelling convention for user-visible copy, and guard it

### DIFF
--- a/crates/biorouter/src/agents/builtin_skills/about-biorouter/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/about-biorouter/SKILL.md
@@ -154,7 +154,7 @@ page — just stop writing new ones.
   personal details) and is grown automatically by a "Meditation" workflow and a
   daily 3:00 AM "Daily Meditation" scheduled job, guided by the built-in
   `update-soul` skill. Consult it (`kb_search` with `kb_id="soul"`) to
-  personalise answers; it may be hidden, so search it by explicit id.
+  personalize answers; it may be hidden, so search it by explicit id.
 
 ### Models & providers
 

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter-extension/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter-extension/SKILL.md
@@ -67,7 +67,7 @@ rule above, because it is the only one that works everywhere:
 
 A bundle that omits `env_vars`, or leaves `description` blank, installs from the
 terminal and is then rejected by the app the user actually runs — so the CLI's
-laxity is a trap, not a licence. `tools_count` is genuinely optional. Inside an
+laxity is a trap, not a license. `tools_count` is genuinely optional. Inside an
 `env_vars` entry only `key` is required; `required`, `auto_propagate`,
 `description`, `secret` and `default` all default.
 

--- a/crates/biorouter/src/agents/builtin_skills/develop-biorouter/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/develop-biorouter/SKILL.md
@@ -99,7 +99,7 @@ Entry points worth bookmarking: `crates/biorouter-cli/src/main.rs`,
 
 ## Where a new feature goes
 
-Implement non-trivial behaviour **in the `biorouter` crate**, then expose it
+Implement non-trivial behavior **in the `biorouter` crate**, then expose it
 twice:
 
 1. **CLI:** add or extend a subcommand in `crates/biorouter-cli/src/commands/`
@@ -108,7 +108,7 @@ twice:
    `just generate-openapi`, then call the generated client from TypeScript.
 
 Do not reimplement logic in the CLI or the server. Both are thin surfaces over
-the same library, and a behaviour that exists in only one of them is a bug
+the same library, and a behavior that exists in only one of them is a bug
 report waiting to happen.
 
 A new built-in MCP tool belongs in `crates/biorouter-mcp/src/<server>/`. A new
@@ -184,7 +184,7 @@ build.
   passes whether or not the change is present is worse than no test, because it
   reads as coverage. Verify a new test fails before your fix and passes after.
 - **jsdom cannot see layout, Tailwind, or `:has()`.** Anything about geometry,
-  generated utility classes, drag regions or computed colour has to be asserted
+  generated utility classes, drag regions or computed color has to be asserted
   at the source (read the CSS or the token file in the test) or checked in a
   real browser. A component test that reads `getComputedStyle` in jsdom passes
   whether the rule exists or not.
@@ -252,7 +252,7 @@ build.
 
 ```
 [ ] source bin/activate-hermit before building anything
-[ ] Behaviour implemented in the biorouter crate, surfaced through the CLI
+[ ] Behavior implemented in the biorouter crate, surfaced through the CLI
     and/or a server route rather than duplicated
 [ ] cargo fmt clean
 [ ] cargo check, then cargo test -p <crate> for what you touched

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-biookf/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-biookf/SKILL.md
@@ -72,7 +72,7 @@ error before calling the source done.
 Work through these in order. Stop at the first one that answers.
 
 **Step 1 — Is it evidence, or is it biology?** Anything that *reports* — a paper, a
-trial, a database, an organisation — is one of the 8 provenance-and-context types
+trial, a database, an organization — is one of the 8 provenance-and-context types
 (`Publication`, `Study`, `Dataset`, `Agent`, `Population`, `GeographicLocation`,
 `Concept`, `Other`). Everything else is one of the 20 biomedical entity types.
 

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-okf/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-okf/SKILL.md
@@ -46,7 +46,7 @@ non-empty string. That freedom is only useful if you are consistent, so:
 
 - look at what the base already uses (`kb_list_pages` shows the directory names);
 - reuse an existing type before coining a new one;
-- coin in the singular, capitalised: `Method`, `Dataset`, `Decision`, `Person`;
+- coin in the singular, capitalized: `Method`, `Dataset`, `Decision`, `Person`;
 - put the page at `knowledge/<lowercased type>/<slug>.md`.
 
 **6 — Validate, then write.** Call `kb_validate_page` with the draft and the path you

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
@@ -160,5 +160,5 @@ on the two surfaces that name a provider: `biorouter kb lint --fix` in the termi
 the "Check for problems" panel in the Knowledge view. It is not reachable as a tool,
 because a tool that sometimes writes could not be classified as reading or writing, and
 that classification is what keeps a private base out of a public chat. Suggest the CLI
-command to the user if the report is long and mechanical; do the judgement calls —
+command to the user if the report is long and mechanical; do the judgment calls —
 contradictions, re-typing, which source wins — yourself either way.

--- a/design.md
+++ b/design.md
@@ -1,6 +1,6 @@
 # Biorouter Design System
 
-**Status:** ✅ **Signed off 2026-07-09** · **Sidebar density addendum 2026-07-15** · **UI cohesion pass 2026-07-16 ([Part 6b](#part-6b--ui-cohesion-pass--2026-07-16))** · **Row density superseded 2026-08-02 (Astryx A-03)** · **Neutrals shared across all three families 2026-08-08 ([§3.1](#31--colour))** · **Version:** 1.87.2 · **Owner:** Baranzini Lab, UCSF
+**Status:** ✅ **Signed off 2026-07-09** · **Sidebar density addendum 2026-07-15** · **UI cohesion pass 2026-07-16 ([Part 6b](#part-6b--ui-cohesion-pass--2026-07-16))** · **Row density superseded 2026-08-02 (Astryx A-03)** · **Neutrals shared across all three families 2026-08-08 ([§3.1](#31--colour))** · **Copy is American English 2026-09-09 ([§3.10](#310--spelling))** · **Version:** 1.87.2 · **Owner:** Baranzini Lab, UCSF
 
 > All 14 open decisions are settled — see [Part 6](#part-6--open-decisions). Recommendations were accepted for
 > D-01 … D-11, D-13, D-14; **D-12 was refined to one fixed density profile — now 36px content rows and 32px sidebar
@@ -773,6 +773,16 @@ Inline `<svg>` literals in view components are forbidden; promote to `components
 #### The logo
 
 `components/icons/Biorouter.tsx` draws the wordmark with gradient stops at `#EC5D2A` (20×) and `#57B9AF` (20×) — an orange and a teal that **exist nowhere else in the system** and are not the token coral `#cf6d47`. `DR-19`. See **[Decision D-02](#d-02--brand-mark-palette)**.
+
+### 3.10 · Spelling
+
+**Decided 2026-09-09.** User-visible copy is **American English** — `behavior`, `color`, `center`, `catalog`, `recognizes`, `canceled`, `judgment`. This governs the desktop renderer's copy and the shipped skill text; it does not govern this repository's contributor prose (`CLAUDE.md`, `docs/`, code comments), which stays as written.
+
+The choice was measured, not assumed. Across the product's user-visible strings: the landing site is 86 American to 6 British, the CLI 76 to 26, the desktop renderer 11 to 9. Two further reasons the American column was kept: the identifiers cannot move — `color`, `center`, `dialog`, `catalog`, `license`, `artifact` are CSS, DOM, API and product identifiers, so a British copy rule would put every label permanently at odds with the symbol beside it, and that seam had already split (the marketplace said "Marketplace catalogue" in one component and "Loading catalog…" in two others); and UCSF and this repository's operator write American English, so it is the convention that gets written by hand rather than remembered.
+
+**Product names are proper nouns and are exempt** — **Auto Visualiser** keeps its British spelling, as do Biorouter, BAAM, Knowledge and every provider and vendor name.
+
+Enforced at the source by `ui/desktop/src/test/uiCopySpelling.test.ts`, which reads user-visible strings out of the AST (JSX text, a `{…}` JSX child, the copy-bearing attributes and properties, toast arguments) rather than grepping — a grep over `src/` is dominated by class strings, web-platform identifiers and comments, and cannot answer a question about copy. Flipping the convention is one word in `spellingVariants.ts`.
 
 ---
 

--- a/docs/desktop-ui/settings-visual-vocabulary.md
+++ b/docs/desktop-ui/settings-visual-vocabulary.md
@@ -1,6 +1,6 @@
 # The settings visual vocabulary
 
-> **What this is.** The ten rules that govern how the desktop Settings view (Models, Chat, App) — and, since 2026-09-07, the chat-history surfaces (`components/sessions/`), the Scheduler (`components/schedule/`) and the four component views Workflows / Extensions / Skills / Built apps — are built, and the primitives they lean on — a living reference for anyone adding or changing a control there.
+> **What this is.** The eleven rules that govern how the desktop Settings view (Models, Chat, App) — and, since 2026-09-07, the chat-history surfaces (`components/sessions/`), the Scheduler (`components/schedule/`) and the four component views Workflows / Extensions / Skills / Built apps — are built, and the primitives they lean on — a living reference for anyone adding or changing a control there.
 > **Status:** Current.
 > **Audience:** contributors working on the desktop renderer.
 
@@ -27,7 +27,7 @@ row computes to nothing there and a render test passes whether the class is pres
 not. Two of the rules are worse than invisible to a render test, because the defect only
 appears in the cascade — see rule 1.
 
-## The ten rules
+## The eleven rules
 
 ### 1. A row's fill never depends on its state
 
@@ -252,6 +252,37 @@ Tab lands on the first control inside, which has its own. The trap, guarded in
 own `:focus-visible` ring is underneath it, so a second rule has to put the suppression back or the
 grey box becomes a ring around the same box. The `prefers-contrast` escape hatch still reaches the
 panel and is deliberately untouched.
+
+### 11. One spelling convention — American English
+
+**Added 2026-09-09.** User-visible copy is American English: `behavior`, `color`, `center`,
+`catalog`, `recognizes`, `canceled`, `judgment`. Unlike rules 1–10 this one is not about
+Settings, and it is not about a shape — it governs every user-visible string the desktop
+renderer ships, plus the shipped skill text under
+`crates/biorouter/src/agents/builtin_skills/`. It is recorded here because rule 9 already
+governs words, and because this is where a contributor looks before writing a label.
+
+**Product names are proper nouns and are exempt.** **Auto Visualiser** keeps its British
+spelling; so do Biorouter, BAAM, Knowledge and every provider and vendor name. So do wire
+values — the daemon's `cancelled` status is a value, not a word.
+
+The convention was measured before it was chosen, because a raw grep cannot decide it: over
+`ui/desktop/src` the counts read `color`/`colour` 126/106 and `center`/`centre` 49/35, and
+almost all of that is Tailwind classes, web-platform identifiers and comments. Counting only
+strings a person reads, the landing site is 86 American to 6 British, the CLI 76 to 26, and
+the renderer 11 to 9. The deciding argument is that the identifiers cannot move — `color`,
+`center`, `dialog`, `catalog`, `license`, `artifact` are CSS, DOM, API and product
+identifiers — so a British copy rule would put every label permanently at odds with the
+symbol beside it. That seam had already split: the marketplace said "Marketplace catalogue"
+in one component and "Loading catalog…" in two others.
+
+⚠ **Its guard is a different file.** Rules 1–8 are enforced by
+`components/settings/settingsVocabulary.test.ts`; this one by
+`ui/desktop/src/test/uiCopySpelling.test.ts`, which reads copy out of the TypeScript AST and
+carries the proper-noun allow-list. Adding a name to that allow-list is a claim that the
+words are a name — not a preference for how a sentence reads.
+
+See [`design.md` §3.10](../../design.md#310--spelling) for the decision record.
 
 ## The two primitives
 

--- a/ui/desktop/src/components/ElicitationRequest.tsx
+++ b/ui/desktop/src/components/ElicitationRequest.tsx
@@ -33,7 +33,7 @@ export default function ElicitationRequest({
   if (isCancelledMessage) {
     return (
       <div className="biorouter-message-content bg-background-muted rounded-2xl px-4 py-2 text-body text-text-default">
-        Information request was cancelled.
+        Information request was canceled.
       </div>
     );
   }

--- a/ui/desktop/src/components/SecretRequestCard.test.tsx
+++ b/ui/desktop/src/components/SecretRequestCard.test.tsx
@@ -155,7 +155,10 @@ describe('SecretRequestCard — issue #117', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
     await waitFor(() => expect(submitSecrets).toHaveBeenCalled());
     expect(submitSecrets.mock.calls[0][0].body).toEqual({ id: 'card-1', cancelled: true });
-    expect(await screen.findByText(/cancelled/i)).toBeInTheDocument();
+    // The two spellings on these two lines are both correct and are not the same
+    // kind of thing: `cancelled` above is the daemon's wire value, `canceled` below
+    // is copy, which is American English (design.md §3.10).
+    expect(await screen.findByText(/canceled/i)).toBeInTheDocument();
   });
 
   /**

--- a/ui/desktop/src/components/SecretRequestCard.tsx
+++ b/ui/desktop/src/components/SecretRequestCard.tsx
@@ -112,7 +112,7 @@ export default function SecretRequestCard({ isCancelledMessage, actionRequiredCo
   if (isCancelledMessage || status.kind === 'cancelled') {
     return (
       <div className="biorouter-message-content bg-background-muted rounded-2xl px-4 py-2 text-body text-text-default">
-        Credential setup was cancelled. Nothing was installed.
+        Credential setup was canceled. Nothing was installed.
       </div>
     );
   }

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -196,7 +196,7 @@ export default function ToolConfirmation({
   // read as a distinct prompt the user is meant to act on.
   return isCancelledMessage ? (
     <div className="biorouter-message-content rounded-2xl border border-border-subtle bg-background-muted px-4 py-3 text-sm text-text-muted">
-      Tool call confirmation was cancelled.
+      Tool call confirmation was canceled.
     </div>
   ) : (
     <>

--- a/ui/desktop/src/components/artifacts/AnnotationOverlay.tsx
+++ b/ui/desktop/src/components/artifacts/AnnotationOverlay.tsx
@@ -263,7 +263,7 @@ export default function AnnotationOverlay({
       {!drag && (
         <div className="pointer-events-none absolute inset-x-0 top-3 flex justify-center">
           <p className="rounded-element bg-black/75 px-2.5 py-1 text-supporting text-white">
-            Drag to select a region · Shift square · Option centre · Space move · Esc cancel
+            Drag to select a region · Shift square · Option center · Space move · Esc cancel
           </p>
         </div>
       )}

--- a/ui/desktop/src/components/baam/registry.ts
+++ b/ui/desktop/src/components/baam/registry.ts
@@ -366,7 +366,7 @@ export function catalogFreshnessLine(load: { live: boolean; fetchedAt?: string }
   if (!load.fetchedAt) return 'showing bundled catalog (offline)';
   const when = new Date(load.fetchedAt);
   if (Number.isNaN(when.getTime())) return 'showing a cached catalog of unknown age';
-  return `catalogue last updated ${when.toLocaleDateString()}`;
+  return `catalog last updated ${when.toLocaleDateString()}`;
 }
 
 /** Case-insensitive match of a query against a skill's searchable fields. */

--- a/ui/desktop/src/components/settings/extensions/ExtensionsSection.privacy.test.tsx
+++ b/ui/desktop/src/components/settings/extensions/ExtensionsSection.privacy.test.tsx
@@ -152,7 +152,7 @@ describe('ExtensionsSection — the pairing state Settings can actually compute'
 
     expect(screen.getByTestId('privacy-badge')).toHaveAttribute('data-privacy', 'public');
     // Not a bare /marketplace/i: the freshness line above the list legitimately
-    // says "Marketplace catalogue", and matching it would make this pass for the
+    // says "Marketplace catalog", and matching it would make this pass for the
     // wrong reason. Both §13.5 marketplace sentences, by name.
     expect(screen.queryByText(/published on the Biorouter marketplace/i)).toBeNull();
     expect(screen.queryByText(/installed from a file/i)).toBeNull();

--- a/ui/desktop/src/components/settings/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings/extensions/ExtensionsSection.tsx
@@ -354,7 +354,7 @@ export default function ExtensionsSection({
             is belongs on the same screen, once. */}
         {catalog && catalogFreshnessLine(catalog) && (
           <p className="text-xs text-text-subtle mb-3">
-            Marketplace catalogue · {catalogFreshnessLine(catalog)}
+            Marketplace catalog · {catalogFreshnessLine(catalog)}
           </p>
         )}
         <ExtensionList

--- a/ui/desktop/src/components/settings/providers/ProviderCatalog.privacy.test.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderCatalog.privacy.test.tsx
@@ -149,9 +149,9 @@ describe('ProviderCatalog — the privacy taxonomy, on screen', () => {
   it('says why an institutional endpoint is private, and why a cloud account is not', () => {
     renderCatalog();
 
-    // §14.5, verbatim: the reason is the recognised endpoint, not the vendor.
+    // §14.5, verbatim: the reason is the recognized endpoint, not the vendor.
     clickTab('institutional');
-    expect(screen.getByText(/recognises this institutional gateway endpoint/i)).toBeInTheDocument();
+    expect(screen.getByText(/recognizes this institutional gateway endpoint/i)).toBeInTheDocument();
 
     // §14.5's note: NOT "a direct cloud account, even if your institution pays
     // for it" — `azure.rs` defaults AZURE_OPENAI_ENDPOINT to the UCSF gateway

--- a/ui/desktop/src/components/settings/providers/ProviderCatalog.test.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderCatalog.test.tsx
@@ -295,7 +295,7 @@ describe('ProviderCatalog — institutions', () => {
     render(<ProviderCatalog providers={[]} mode="settings" configuredProvider={null} />);
     clickTab('institutional');
     const note = screen.getByTestId('other-institutions-note');
-    expect(note).toHaveTextContent(/recognises its endpoint as private/i);
+    expect(note).toHaveTextContent(/recognizes its endpoint as private/i);
     // Case-sensitive on purpose: this used to be `/Add Custom Provider/i`,
     // which kept passing when the control was renamed to sentence case — so
     // it was asserting the words, not that the note names the real label.

--- a/ui/desktop/src/components/settings/providers/ProviderCatalog.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderCatalog.tsx
@@ -545,7 +545,7 @@ export default function ProviderCatalog({
         >
           <h3 className="text-caps text-text-muted mb-1">Other institutions</h3>
           <p className="text-supporting text-text-muted">
-            An institution&apos;s gateway appears here once Biorouter recognises its endpoint as
+            An institution&apos;s gateway appears here once Biorouter recognizes its endpoint as
             private. Anything else can still be added under Public → Add custom provider, and is
             treated as public: Biorouter cannot verify where that endpoint points, so it gets none
             of the private tier&apos;s protections.

--- a/ui/desktop/src/components/settings/providers/providerOrdering.ts
+++ b/ui/desktop/src/components/settings/providers/providerOrdering.ts
@@ -268,7 +268,7 @@ function institutionalSections(providers: ProviderDetails[]): OrderedProviderSec
     sections.push({
       key: 'unaffiliated',
       label: 'Unaffiliated private gateways',
-      note: 'Private because Biorouter recognises the endpoint, but no institution is named for it.',
+      note: 'Private because Biorouter recognizes the endpoint, but no institution is named for it.',
       providers: [...unaffiliated].sort(byDisplayName),
     });
   }
@@ -373,7 +373,7 @@ export function getOrderedProviderGroups(providers: ProviderDetails[]): OrderedP
       key: 'institutional',
       label: 'Private · Institutional',
       tabLabel: 'Institutional',
-      note: 'Private because Biorouter recognises this institutional gateway endpoint.',
+      note: 'Private because Biorouter recognizes this institutional gateway endpoint.',
       accentClassName: 'bg-background-info',
     }),
     withSections({

--- a/ui/desktop/src/test/spellingVariants.ts
+++ b/ui/desktop/src/test/spellingVariants.ts
@@ -1,0 +1,185 @@
+/**
+ * The US/British variant pairs this repository can plausibly disagree about,
+ * with every inflection each pair takes.
+ *
+ * A pair is `[american, british]` and the guard rejects the LEFT one — see
+ * `uiCopySpelling.test.ts` for the convention and why it was chosen.
+ *
+ * Pairs that are a matter of STYLE rather than spelling are deliberately absent
+ * — `toward`/`towards`, `while`/`whilst`, `among`/`amongst` are all current in
+ * British English, so rejecting one of each would be enforcing a preference the
+ * convention does not hold.
+ */
+export type VariantPair = readonly [american: string, british: string];
+
+/**
+ * `-ize`/`-ise` stems. Each yields the verb, its three inflections and — unless
+ * listed in `NO_ATION_NOUN` — its `-ization`/`-isation` noun.
+ *
+ * The `-ize` spelling is not in fact wrong in British English (Oxford uses it),
+ * which is exactly why the stem list matters: this repository's own prose is
+ * consistently `-ise`, and a convention is a choice between two defensible
+ * forms, not a correction of an error.
+ */
+const IZE_STEMS = [
+  'analy',
+  'apologi',
+  'authori',
+  'capitali',
+  'categori',
+  'centrali',
+  'customi',
+  'emphasi',
+  'finali',
+  'formali',
+  'generali',
+  'initiali',
+  'maximi',
+  'minimi',
+  'moderni',
+  'normali',
+  'optimi',
+  'organi',
+  'personali',
+  'prioriti',
+  'randomi',
+  'reali',
+  'recogni',
+  'saniti',
+  'seriali',
+  'speciali',
+  'standardi',
+  'summari',
+  'synchroni',
+  'tokeni',
+  'utili',
+  'visuali',
+] as const;
+
+/**
+ * Stems whose noun is not formed by adding `-ation`: the noun of `analyse` is
+ * `analysis`, of `emphasise` `emphasis`, of `recognise` `recognition`, and of
+ * `apologise` `apology`. Generating `analyzation` would put a non-word in the
+ * guard, where it could only ever produce a confusing failure message.
+ */
+const NO_ATION_NOUN = new Set(['analy', 'apologi', 'emphasi', 'recogni']);
+
+function izePairs(): VariantPair[] {
+  const pairs: VariantPair[] = [];
+  for (const stem of IZE_STEMS) {
+    // `-er` is the agent noun, and it is the form that carries the one product
+    // name this convention cannot touch: **Auto Visualiser**. Generating it is
+    // deliberate — the guard must be able to see `visualiser`, so that the
+    // allow-list exempting the product name is doing real work rather than
+    // describing a case that could never arise.
+    for (const suffix of ['e', 'es', 'ed', 'ing', 'er', 'ers']) {
+      pairs.push([`${stem}z${suffix}`, `${stem}s${suffix}`]);
+    }
+    if (!NO_ATION_NOUN.has(stem)) {
+      pairs.push([`${stem}zation`, `${stem}sation`]);
+      pairs.push([`${stem}zations`, `${stem}sations`]);
+    }
+  }
+  return pairs;
+}
+
+const OTHER_PAIRS: VariantPair[] = [
+  // -or / -our
+  ['behavior', 'behaviour'],
+  ['behaviors', 'behaviours'],
+  ['behavioral', 'behavioural'],
+  ['color', 'colour'],
+  ['colors', 'colours'],
+  ['colored', 'coloured'],
+  ['coloring', 'colouring'],
+  ['colorful', 'colourful'],
+  ['favorite', 'favourite'],
+  ['favorites', 'favourites'],
+  ['favor', 'favour'],
+  ['favored', 'favoured'],
+  ['flavor', 'flavour'],
+  ['flavors', 'flavours'],
+  ['honor', 'honour'],
+  ['honors', 'honours'],
+  ['honored', 'honoured'],
+  ['labor', 'labour'],
+  ['neighbor', 'neighbour'],
+  ['neighbors', 'neighbours'],
+  ['neighboring', 'neighbouring'],
+  // -er / -re
+  ['center', 'centre'],
+  ['centers', 'centres'],
+  ['centered', 'centred'],
+  ['fiber', 'fibre'],
+  ['theater', 'theatre'],
+  // `meter`/`metre` is NOT a pair. British English spells the measuring DEVICE
+  // `meter` and only the unit of length `metre`, so "token meter" in
+  // `ResetPanel` is correct under either convention and listing the pair would
+  // report a dialect disagreement that does not exist.
+  // -se / -ce
+  ['defense', 'defence'],
+  ['defenses', 'defences'],
+  ['license', 'licence'],
+  ['licenses', 'licences'],
+  ['offense', 'offence'],
+  // single / doubled consonant
+  ['canceled', 'cancelled'],
+  ['canceling', 'cancelling'],
+  ['cancelation', 'cancellation'],
+  ['enrollment', 'enrolment'],
+  ['fulfill', 'fulfil'],
+  ['fulfills', 'fulfils'],
+  ['fulfillment', 'fulfilment'],
+  ['installment', 'instalment'],
+  ['labeled', 'labelled'],
+  ['labeling', 'labelling'],
+  ['modeled', 'modelled'],
+  ['modeling', 'modelling'],
+  ['signaled', 'signalled'],
+  ['signaling', 'signalling'],
+  ['skillful', 'skilful'],
+  ['traveled', 'travelled'],
+  ['traveling', 'travelling'],
+  // one-offs
+  ['aging', 'ageing'],
+  ['analog', 'analogue'],
+  ['artifact', 'artefact'],
+  ['artifacts', 'artefacts'],
+  ['catalog', 'catalogue'],
+  ['catalogs', 'catalogues'],
+  ['dialog', 'dialogue'],
+  ['dialogs', 'dialogues'],
+  ['gray', 'grey'],
+  ['grayed', 'greyed'],
+  ['judgment', 'judgement'],
+  ['judgments', 'judgements'],
+  ['program', 'programme'],
+  ['programs', 'programmes'],
+];
+
+export const VARIANT_PAIRS: readonly VariantPair[] = [...izePairs(), ...OTHER_PAIRS];
+
+/**
+ * The convention, in one place: user-visible product copy is **American
+ * English**. Decided 2026-09-09 from a measurement of every user-visible string
+ * in the product — see `uiCopySpelling.test.ts` for the counts and the
+ * trade-off.
+ *
+ * Flipping the convention is deliberately a one-word edit here: `ACCEPTED`
+ * names the column that is kept and `REJECTED_FORMS` is derived from the other,
+ * so nothing downstream encodes which dialect won.
+ */
+export const ACCEPTED_CONVENTION: 'american' | 'british' = 'american';
+
+/** Every variant the convention rejects, mapped to what to write instead. */
+export const REJECTED_FORMS: ReadonlyMap<string, string> = new Map(
+  VARIANT_PAIRS.map(([american, british]) =>
+    ACCEPTED_CONVENTION === 'american' ? [british, american] : [american, british]
+  )
+);
+
+/** Whole-word, case-insensitive occurrences of `word` in `text`. */
+export function variantMatches(text: string, word: string): number {
+  const pattern = new RegExp(`(?<![A-Za-z])${word}(?![A-Za-z])`, 'gi');
+  return (text.match(pattern) ?? []).length;
+}

--- a/ui/desktop/src/test/uiCopySpelling.test.ts
+++ b/ui/desktop/src/test/uiCopySpelling.test.ts
@@ -1,0 +1,289 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { extractUserVisibleStrings, readsAsProse, type CopyString } from './userVisibleCopy';
+import { ACCEPTED_CONVENTION, REJECTED_FORMS, VARIANT_PAIRS } from './spellingVariants';
+
+/**
+ * One spelling convention for the product's user-visible copy, enforced at the
+ * source.
+ *
+ * **The convention: American English.** Decided 2026-09-09 by measuring every
+ * user-visible string in the product rather than by grepping the tree — see
+ * `userVisibleCopy.ts` for why a grep cannot answer this, and
+ * `docs/desktop-ui/settings-visual-vocabulary.md` rule 11 for the rule as
+ * prose. What the measurement found:
+ *
+ * | surface | US | British |
+ * |---|---|---|
+ * | desktop renderer, user-visible strings | 11 | 9 |
+ * | landing site (biorouter.ucsf.edu), visible text | 86 | 6 |
+ * | CLI string literals | 76 | 26 |
+ * | shipped skill text (`builtin_skills/`) | 8 | 9 |
+ *
+ * **The trade-off, recorded because it is real.** The handoff that asked for
+ * this expected British, on the grounds that "the product's own copy uses
+ * British spellings elsewhere". Measured, that is not true of the product's
+ * user-visible copy: the website is 14:1 American and the renderer already
+ * leans American. British forms are concentrated in the repository's
+ * CONTRIBUTOR prose — `CLAUDE.md`, `docs/`, code comments — which this
+ * convention deliberately does not govern, and in one product name. So the
+ * repository stays bilingual, and the line is drawn where a reader changes:
+ * copy a user reads is American, prose a contributor reads is left alone.
+ *
+ * Two further reasons the American column was the one to keep:
+ *
+ * - **The identifiers cannot move.** `color`, `center`, `dialog`, `catalog`,
+ *   `license`, `artifact`, `initialize` are CSS, DOM, API and product
+ *   identifiers. A British copy convention would put every label permanently at
+ *   odds with the symbol beside it, and that seam had already split this
+ *   codebase: the marketplace said "Marketplace catalogue" in one component and
+ *   "Loading catalog…" in two others.
+ * - **UCSF and this repository's operator write American English**, and a
+ *   convention nobody writes by hand is one that rots — the argument
+ *   `CLAUDE.md` already makes about a CI gate that fails on arrival.
+ *
+ * **Auto Visualiser stays British**, along with Biorouter, BAAM and every
+ * provider name: a product name is a proper noun, not a spelling.
+ */
+const SRC = join(__dirname, '..');
+const REPO = join(SRC, '..', '..', '..');
+
+/**
+ * Every tree whose copy this convention governs, each with its own exclusions —
+ * the shape `settingsVocabulary.test.ts` established, for the same reason:
+ * adding a surface is one line, and each surface states its own scope.
+ */
+const ROOTS: { dir: string; outOfScope: string[]; extensions: string[] }[] = [
+  {
+    dir: SRC,
+    // `api/` is generated from the OpenAPI spec and hand-editing it is
+    // forbidden; `bin/` and `web/` are build outputs; `test/` is this guard's
+    // own machinery, where the rejected forms appear as DATA.
+    outOfScope: ['api/', 'bin/', 'web/', 'test/'],
+    extensions: ['.ts', '.tsx'],
+  },
+  // The shipped skill text. It is prose a model reads rather than JSX, so it is
+  // scanned line by line — and it is guarded from here rather than from Rust
+  // because there is no copy guard on that side and this is the only one.
+  {
+    dir: join(REPO, 'crates', 'biorouter', 'src', 'agents', 'builtin_skills'),
+    outOfScope: [],
+    extensions: ['.md'],
+  },
+];
+
+/**
+ * Phrases that keep a rejected spelling, each with the reason it is exempt.
+ *
+ * ⚠ This is for PROPER NOUNS and wire values, not for copy someone would rather
+ * not change. A new entry here is a claim that the words are a name; a sentence
+ * that merely reads better in British English is not one.
+ */
+const ALLOWED_PHRASES: { phrase: string; because: string }[] = [
+  {
+    phrase: 'Auto Visualiser',
+    because:
+      "the built-in server's product name, shown in the capability list and the @-mention picker. " +
+      'Matched case-insensitively: the crate table in `develop-biorouter/SKILL.md` lists the ' +
+      'built-in servers in lower case, and the name is the name in either case.',
+  },
+];
+
+function sourceFiles(): { path: string; rel: string; text: string; markdown: boolean }[] {
+  const found: { path: string; rel: string; text: string; markdown: boolean }[] = [];
+  for (const { dir: root, outOfScope, extensions } of ROOTS) {
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const path = join(dir, entry);
+        if (statSync(path).isDirectory()) {
+          if (!outOfScope.some((prefix) => `${relative(root, path)}/`.startsWith(prefix)))
+            walk(path);
+          continue;
+        }
+        if (!extensions.some((extension) => entry.endsWith(extension))) continue;
+        if (entry.includes('.test.') || entry.endsWith('.d.ts')) continue;
+        if (outOfScope.some((prefix) => relative(root, path).startsWith(prefix))) continue;
+        found.push({
+          path,
+          rel: relative(REPO, path),
+          text: readFileSync(path, 'utf8'),
+          markdown: entry.endsWith('.md'),
+        });
+      }
+    };
+    walk(root);
+  }
+  return found;
+}
+
+const FILES = sourceFiles();
+
+/** Strip the exempt proper nouns before scanning, so the name is invisible to the rule. */
+function withoutAllowedPhrases(text: string): string {
+  let stripped = text;
+  for (const { phrase } of ALLOWED_PHRASES) {
+    stripped = stripped.replace(
+      new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'),
+      ' '
+    );
+  }
+  return stripped;
+}
+
+export interface SpellingOffence {
+  file: string;
+  line: number;
+  found: string;
+  write: string;
+  text: string;
+}
+
+function offences(): SpellingOffence[] {
+  const strings: CopyString[] = [];
+  for (const { rel, text, markdown } of FILES) {
+    if (markdown) {
+      // Markdown is prose end to end. Fenced code and inline code are not, and
+      // an identifier in backticks is exactly the thing that must not be
+      // re-spelled, so both are removed before the lines are read.
+      //
+      // ⚠ A stated gap, not an oversight: a fence with no language tag can hold
+      // prose — `develop-biorouter/SKILL.md`'s change checklist does, and its
+      // "Behaviour implemented in the biorouter crate" line was swept BY HAND
+      // because this loop cannot see it. A regression inside an untagged fence
+      // will not fail this test. The alternative — reading untagged fences as
+      // prose — would put shell transcripts and JSON under a spelling rule,
+      // which is the more damaging way to be wrong.
+      let fenced = false;
+      text.split('\n').forEach((line, index) => {
+        if (/^\s*```/.test(line)) {
+          fenced = !fenced;
+          return;
+        }
+        if (fenced) return;
+        const prose = line.replace(/`[^`]*`/g, ' ');
+        if (prose.trim())
+          strings.push({
+            file: rel,
+            line: index + 1,
+            text: prose,
+            carrier: 'markdown',
+            tier: 'prose',
+          });
+      });
+      continue;
+    }
+    strings.push(...extractUserVisibleStrings(text, rel));
+  }
+
+  const found: SpellingOffence[] = [];
+  for (const string of strings) {
+    const haystack = withoutAllowedPhrases(string.text);
+    for (const [rejected, write] of REJECTED_FORMS) {
+      if (new RegExp(`(?<![A-Za-z])${rejected}(?![A-Za-z])`, 'i').test(haystack)) {
+        found.push({
+          file: string.file,
+          line: string.line,
+          found: rejected,
+          write,
+          text: string.text.replace(/\s+/g, ' ').slice(0, 100),
+        });
+      }
+    }
+  }
+  return found;
+}
+
+describe(`user-visible copy is ${ACCEPTED_CONVENTION} English`, () => {
+  /**
+   * A walker that silently matched nothing would make the rule below vacuous —
+   * and that is not hypothetical here, because one root is reached by a
+   * relative path OUT of `ui/desktop` and would resolve to nothing if this file
+   * ever moved. Both roots are asserted separately for that reason.
+   */
+  it('finds the sources it claims to govern', () => {
+    for (const { dir } of ROOTS) {
+      expect(FILES.filter(({ path }) => path.startsWith(dir)).length).toBeGreaterThan(0);
+    }
+    expect(FILES.length).toBeGreaterThan(400);
+    const covered = new Set(FILES.map(({ rel }) => rel));
+    expect(covered).toContain('ui/desktop/src/components/settings/SettingsView.tsx');
+    expect(covered).toContain(
+      'crates/biorouter/src/agents/builtin_skills/about-biorouter/SKILL.md'
+    );
+  });
+
+  /**
+   * The extractor is what makes the rule mean anything, so its two tiers are
+   * pinned here rather than left to be inferred from a passing sweep.
+   */
+  it('reads copy out of the shapes this app actually writes it in', () => {
+    const source = `
+      export const Example = ({ busy }: { busy: boolean }) => (
+        <Dialog>
+          <p className="text-center items-center">Visible sentence</p>
+          <DialogDescription>{busy ? 'Working on it now' : 'Idle right now'}</DialogDescription>
+          <Button aria-label="Close panel" />
+        </Dialog>
+      );
+      const note = { note: 'A sentence shown to the user.', reason: 'cancelled' };
+      console.error('A developer log line nobody reads');
+      throw new Error('A developer error nobody reads');
+    `;
+    const texts = extractUserVisibleStrings(source, 'Example.tsx').map(({ text }) => text);
+    expect(texts).toContain('Visible sentence');
+    expect(texts).toContain('Working on it now');
+    expect(texts).toContain('Idle right now');
+    expect(texts).toContain('Close panel');
+    expect(texts).toContain('A sentence shown to the user.');
+    // The class list, the wire value, the log and the thrown error are not copy.
+    expect(texts).not.toContain('text-center items-center');
+    expect(texts).not.toContain('cancelled');
+    expect(texts).not.toContain('A developer log line nobody reads');
+    expect(texts).not.toContain('A developer error nobody reads');
+  });
+
+  it('rejects a variant only when it is a whole word', () => {
+    expect(readsAsProse('Colour the row on hover')).toBe(true);
+    expect(readsAsProse('flex items-center gap-2')).toBe(false);
+  });
+
+  /** The rule. */
+  it('has no rejected spelling in any user-visible string', () => {
+    expect(
+      offences().map(
+        ({ file, line, found, write, text }) => `${file}:${line} "${found}" → "${write}" — ${text}`
+      )
+    ).toEqual([]);
+  });
+
+  /**
+   * The allow-list has to be doing work: `visualiser` IS a rejected form, and
+   * the only reason "Auto Visualiser" survives the sweep is the exemption. If
+   * the pair list ever stopped generating that word, this exemption would go
+   * silently inert and a stray "visualiser" in ordinary copy would ship.
+   */
+  it('keeps the product name that the convention would otherwise reject', () => {
+    expect(REJECTED_FORMS.has('visualiser')).toBe(true);
+    for (const { phrase } of ALLOWED_PHRASES) {
+      expect(
+        [...REJECTED_FORMS.keys()].some((word) =>
+          new RegExp(`(?<![A-Za-z])${word}(?![A-Za-z])`, 'i').test(phrase)
+        )
+      ).toBe(true);
+    }
+    expect(
+      offences().filter(({ text }) => ALLOWED_PHRASES.some(({ phrase }) => text.includes(phrase)))
+    ).toEqual([]);
+  });
+
+  it('maps every pair in one direction, with no word rejected and accepted at once', () => {
+    expect(VARIANT_PAIRS.length).toBeGreaterThan(150);
+    const accepted = new Set(
+      VARIANT_PAIRS.map(([american, british]) =>
+        ACCEPTED_CONVENTION === 'american' ? american : british
+      )
+    );
+    expect([...REJECTED_FORMS.keys()].filter((word) => accepted.has(word))).toEqual([]);
+  });
+});

--- a/ui/desktop/src/test/userVisibleCopy.ts
+++ b/ui/desktop/src/test/userVisibleCopy.ts
@@ -1,0 +1,344 @@
+import ts from 'typescript';
+
+/**
+ * Every string the renderer shows a person, pulled out of the source with the
+ * TypeScript parser rather than a regex.
+ *
+ * **Why an AST and not a grep.** A raw grep over `src/` cannot answer a question
+ * about COPY, because each of these words is overwhelmingly more common as
+ * something else. Measured on `main` at f350cdfc: `color`/`colour` 126/106
+ * matches, `center`/`centre` 49/35, `cancelled` 204 — and almost all of those
+ * are Tailwind class strings (`text-center`), CSS properties, web-platform
+ * identifiers (`scrollBehavior`, `role="dialog"`), API enum values
+ * (`status === 'cancelled'`) and prose inside comments. A convention for the
+ * words a user reads cannot be decided — or enforced — from a number dominated
+ * by words no user ever sees.
+ *
+ * **Two tiers, because copy is not written in one shape here.** An earlier
+ * draft of this file read a pure allow-list of carriers (the attributes the
+ * handoff named: `title`, `aria-label`, `placeholder`, `description`). Audited
+ * against the tree, it missed most of the app's sentences: the provider notes
+ * in `providerOrdering.ts`, the greetings array, `formatSupport.ts`'s
+ * suggestions, `artifactFileLinks.ts`'s refusal reasons, and every conditional
+ * sentence written as a `{…}` JSX child. So:
+ *
+ * 1. A **known copy carrier** — JSX text, a `{…}` JSX child, one of
+ *    `COPY_ATTRIBUTES`, one of `COPY_PROPERTIES`, a toast/alert argument —
+ *    contributes its string whatever its length, so a one-word `label` counts.
+ * 2. Any **other** string that reads as a sentence (three or more words, one of
+ *    them four letters or longer, no code punctuation) counts too.
+ *
+ * Both tiers skip `DENIED_*`: class strings, `cn()`/`clsx()`/`cva()`,
+ * `console.*`/`log.*` (developer logs, not copy) and thrown `Error`s
+ * (developer-facing, and a stated non-goal of the copy convention).
+ */
+export interface CopyString {
+  /** Path as the caller supplied it, so a failure names a file a reader can open. */
+  file: string;
+  /** 1-indexed, pointing at the line the literal starts on. */
+  line: number;
+  text: string;
+  /** The carrier this string was written into, for the failure message. */
+  carrier: string;
+  /** Which tier admitted it — `carrier` for tier 1, `prose` for tier 2. */
+  tier: 'carrier' | 'prose';
+}
+
+/**
+ * JSX attributes whose value a person reads — as visible text, as a tooltip, or
+ * through a screen reader.
+ *
+ * `aria-labelledby`/`aria-describedby`/`aria-controls` are deliberately ABSENT:
+ * their values are element ids, not prose, and including them is how a guard
+ * starts failing on an identifier.
+ */
+const COPY_ATTRIBUTES = new Set([
+  'alt',
+  'aria-label',
+  'aria-placeholder',
+  'aria-roledescription',
+  'aria-valuetext',
+  'cancelLabel',
+  'caption',
+  'confirmLabel',
+  'description',
+  'emptyMessage',
+  'emptyText',
+  'errorMessage',
+  'fieldLabel',
+  'heading',
+  'helpText',
+  'helperText',
+  'hint',
+  'label',
+  'message',
+  'placeholder',
+  'secondaryLabel',
+  'subtitle',
+  'title',
+  'tooltip',
+  'tooltipText',
+]);
+
+/**
+ * The same names as object-literal properties, plus the shapes this codebase
+ * actually uses for a sentence it will show: `msg`, `reason`, `suggestion`,
+ * `note`, `warning`. Section descriptors, menu templates, toast option bags and
+ * `dialog.showMessageBox` all carry copy this way rather than as JSX.
+ */
+const COPY_PROPERTIES = new Set([
+  'body',
+  'cancelLabel',
+  'caption',
+  'confirmLabel',
+  'description',
+  'detail',
+  'emptyMessage',
+  'emptyText',
+  'errorMessage',
+  'heading',
+  'helpText',
+  'helperText',
+  'hint',
+  'label',
+  'message',
+  'msg',
+  'note',
+  'placeholder',
+  'reason',
+  'subtitle',
+  'suggestion',
+  'summary',
+  'title',
+  'tooltip',
+  'warning',
+]);
+
+/** Callees whose string arguments are shown verbatim. */
+const COPY_CALLEES = new Set([
+  'alert',
+  'confirm',
+  'notify',
+  'showToast',
+  'toast',
+  'toast.custom',
+  'toast.error',
+  'toast.info',
+  'toast.loading',
+  'toast.message',
+  'toast.success',
+  'toast.warning',
+]);
+
+/** Attributes that carry an identifier, a class list, a URL or a token. */
+const DENIED_ATTRIBUTES = new Set([
+  'aria-controls',
+  'aria-describedby',
+  'aria-labelledby',
+  'aria-owns',
+  'class',
+  'className',
+  'color',
+  'href',
+  'htmlFor',
+  'id',
+  'key',
+  'name',
+  'path',
+  'role',
+  'src',
+  'style',
+  'testId',
+  'to',
+  'type',
+  'value',
+  'variant',
+]);
+
+/**
+ * Calls whose string arguments are never copy: the class-name helpers, and the
+ * developer logs. A log line is prose, and it is prose no user reads — sweeping
+ * 350 of them would bury the copy this guard exists to protect.
+ */
+const DENIED_CALLEES = [
+  /^cn$/,
+  /^clsx$/,
+  /^cva$/,
+  /^twMerge$/,
+  /^console\./,
+  /^log\./,
+  /^logger\./,
+  /^window\.electron\.log/,
+  /logInfo$|logError$|logWarn$/,
+];
+
+function calleeName(node: ts.CallExpression | ts.NewExpression, sf: ts.SourceFile): string {
+  return node.expression.getText(sf).split('\n')[0];
+}
+
+/**
+ * The carrier a literal belongs to: walk up through the wrappers a string can
+ * sit inside (a ternary, a `??` fallback, an array, a template) until something
+ * that names the string's purpose is reached.
+ */
+function carrierOf(
+  literal: ts.Node,
+  sf: ts.SourceFile
+): { name: string; denied: boolean; copy: boolean } {
+  let node: ts.Node | undefined = literal.parent;
+  while (node) {
+    if (
+      ts.isConditionalExpression(node) ||
+      ts.isBinaryExpression(node) ||
+      ts.isParenthesizedExpression(node) ||
+      ts.isArrayLiteralExpression(node) ||
+      ts.isTemplateExpression(node) ||
+      ts.isTemplateSpan(node) ||
+      ts.isAsExpression(node)
+    ) {
+      node = node.parent;
+      continue;
+    }
+    if (ts.isJsxAttribute(node)) {
+      const name = node.name.getText(sf);
+      return {
+        name: `attr:${name}`,
+        denied: DENIED_ATTRIBUTES.has(name),
+        copy: COPY_ATTRIBUTES.has(name),
+      };
+    }
+    if (ts.isJsxExpression(node)) {
+      // An attribute's `{…}` — keep walking so the attribute names it. A CHILD
+      // `{…}` (its parent is the element) is copy in its own right.
+      if (ts.isJsxAttribute(node.parent)) {
+        node = node.parent;
+        continue;
+      }
+      return { name: 'jsx-child', denied: false, copy: true };
+    }
+    if (ts.isPropertyAssignment(node)) {
+      const name =
+        ts.isIdentifier(node.name) || ts.isStringLiteral(node.name) ? node.name.text : '?';
+      return { name: `prop:${name}`, denied: false, copy: COPY_PROPERTIES.has(name) };
+    }
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(node, sf);
+      return {
+        name: `call:${name}`,
+        denied: DENIED_CALLEES.some((pattern) => pattern.test(name)),
+        copy: COPY_CALLEES.has(name),
+      };
+    }
+    if (ts.isNewExpression(node)) {
+      const name = calleeName(node, sf);
+      // A thrown Error is developer-facing; the copy convention is a stated
+      // non-goal for it, and including it would sweep 113 strings no user sees.
+      return { name: `new:${name}`, denied: /Error$/.test(name), copy: false };
+    }
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      return { name: 'import', denied: true, copy: false };
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      return { name: `var:${node.name.text}`, denied: false, copy: false };
+    }
+    if (ts.isReturnStatement(node)) return { name: 'return', denied: false, copy: false };
+    if (
+      ts.isJsxElement(node) ||
+      ts.isJsxFragment(node) ||
+      ts.isBlock(node) ||
+      ts.isSourceFile(node)
+    ) {
+      return { name: ts.SyntaxKind[node.kind], denied: false, copy: false };
+    }
+    node = node.parent;
+  }
+  return { name: 'unknown', denied: false, copy: false };
+}
+
+/**
+ * Reject a "string" that is really an identifier, a token, a path or a class
+ * list.
+ *
+ * The lone-lowercase-word rule is the one that earns its place: this app
+ * carries the daemon's own discriminants in copy-shaped properties —
+ * `reason: 'cancelled'` in `useIngestStream`, `{ kind: 'cancelled' }` in
+ * `SecretRequestCard` — and those are WIRE VALUES that must keep the server's
+ * spelling. Copy shown to a person is capitalised or more than one word, so
+ * dropping a bare lowercase token loses no sentence and stops the guard
+ * demanding that an API value be re-spelled.
+ */
+function looksLikeToken(text: string): boolean {
+  const trimmed = text.trim();
+  if (!/[A-Za-z]{2}/.test(trimmed)) return true;
+  if (!/\s/.test(trimmed) && /[_./:@-]/.test(trimmed)) return true;
+  if (!/\s/.test(trimmed) && trimmed === trimmed.toLowerCase()) return true;
+  return false;
+}
+
+/** Tier 2: does this read as a sentence rather than as code? */
+export function readsAsProse(text: string): boolean {
+  const trimmed = text.trim();
+  if (/[{}<>$=|\\]/.test(trimmed)) return false;
+  if (/^https?:\/\//.test(trimmed)) return false;
+  const words = trimmed.split(/\s+/);
+  if (words.length < 3) return false;
+  if (!words.some((word) => /^[A-Za-z]{4,}$/.test(word))) return false;
+  // A run of Tailwind-ish tokens is multi-word but is not prose.
+  const tokenish = words.filter((word) => /[:/[\]]/.test(word) || /^[a-z]+-[a-z0-9-]+$/.test(word));
+  return tokenish.length < words.length / 2;
+}
+
+export function extractUserVisibleStrings(source: string, file: string): CopyString[] {
+  const isTsx = file.endsWith('.tsx');
+  const sourceFile = ts.createSourceFile(
+    isTsx ? 'source.tsx' : 'source.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    isTsx ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const found: CopyString[] = [];
+  const lineOf = (position: number) => sourceFile.getLineAndCharacterOfPosition(position).line + 1;
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxText(node)) {
+      const text = node.text.trim();
+      if (text && !looksLikeToken(text)) {
+        found.push({
+          file,
+          line: lineOf(node.getStart(sourceFile)),
+          text,
+          carrier: 'jsx-text',
+          tier: 'carrier',
+        });
+      }
+    } else if (
+      ts.isStringLiteral(node) ||
+      ts.isNoSubstitutionTemplateLiteral(node) ||
+      ts.isTemplateHead(node) ||
+      ts.isTemplateMiddle(node) ||
+      ts.isTemplateTail(node)
+    ) {
+      const text = node.text.trim();
+      if (text && !looksLikeToken(text)) {
+        const carrier = carrierOf(node, sourceFile);
+        if (!carrier.denied) {
+          const tier = carrier.copy ? 'carrier' : readsAsProse(text) ? 'prose' : undefined;
+          if (tier) {
+            found.push({
+              file,
+              line: lineOf(node.getStart(sourceFile)),
+              text,
+              carrier: carrier.name,
+              tier,
+            });
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+}


### PR DESCRIPTION
## Why

The Settings subtitle read "Manage models, chat **behavior**, and app preferences." while the
marketplace said "Marketplace **catalogue**" two screens away and "Loading **catalog**…" one screen
after that. Nothing decided which was right, so both kept being written. Round-2 F13 / round-3 N5;
#181 and #191 left spelling alone on purpose.

## Root cause

There was no convention, and no way to acquire one from the tree: **a grep cannot answer this
question.** Over `ui/desktop/src` on `main` at `f350cdfc`, `color`/`colour` is 126/106 matches and
`center`/`centre` 49/35 — almost all of it Tailwind classes (`text-center`), web-platform
identifiers (`scrollBehavior`, `role="dialog"`), API enum values (`status === 'cancelled'`) and
prose in comments. So the measurement was rebuilt on the TypeScript AST, over strings a person
actually reads.

### Counts, measured before deciding

3,596 user-visible strings across 590 renderer files, plus the 8 shipped `SKILL.md` files. Rows with
any hit:

| US form | renderer | skills | UK form | renderer | skills |
|---|---|---|---|---|---|
| analyzing | 1 | 2 | analysing | 0 | 0 |
| authorization | 0 | 2 | authorisation | 0 | 0 |
| capitalized | 0 | 0 | capitalised | 0 | 1 |
| organization | 0 | 0 | organisation | 0 | 1 |
| personalize | 0 | 0 | personalise | 0 | 1 |
| personalized | 1 | 0 | personalised | 0 | 0 |
| recognizes | 0 | 0 | recognises | 3 | 0 |
| visualizes | 0 | 1 | visualises | 0 | 0 |
| visualization | 1 | 0 | visualisation | 0 | 0 |
| behavior | 6 | 0 | behaviour | 0 | 3 |
| behaviors | 1 | 0 | behaviours | 0 | 0 |
| color | 2 | 0 | colour | 0 | 1 |
| colors | 1 | 0 | colours | 0 | 0 |
| center | 0 | 0 | centre | 1 | 0 |
| license | 0 | 0 | licence | 0 | 1 |
| canceled | 0 | 0 | cancelled | 5 | 0 |
| artifact | 12 | 1 | artefact | 0 | 0 |
| artifacts | 4 | 2 | artefacts | 0 | 0 |
| catalog | 8 | 5 | catalogue | 2 | 0 |
| dialog / dialogs | 2 | 0 | dialogue(s) | 0 | 0 |
| gray | 0 | 1 | grey | 0 | 0 |
| judgment | 0 | 2 | judgement | 0 | 1 |

Four rows are not dialect disagreements and were set aside, each for a stated reason:
`artifact`/`catalog`/`dialog` are the product's and the platform's own identifiers; the two `color`
hits are a CSS `color-mix(…)` string; two `cancelled` hits are the daemon's wire value in a
copy-shaped property; and `meter` ("token meter") is the measuring device, spelled `meter` in
British English too — that pair was removed from the list rather than reported.

Net dialect counts, and the two adjacent surfaces measured for comparison:

| surface | American | British |
|---|---|---|
| desktop renderer, user-visible strings | 11 | 9 |
| landing site (biorouter.ucsf.edu), visible text | 86 | 6 |
| CLI string literals | 76 | 26 |
| shipped skill text | 8 | 9 |

### The decision, and its trade-off

**American English**, for user-visible product copy only.

⚠ **This contradicts the handoff's premise, which is wrong.** The brief says "the product's own copy
uses British spellings elsewhere". Measured, that is not true of the product's user-visible copy: the
website is 14:1 American, the CLI 3:1, and the renderer already leans American. The British forms are
concentrated in *contributor* prose — `CLAUDE.md`, `docs/`, code comments — which this convention
deliberately does not govern. The brief's other example was checked and is also wrong: onboarding copy
does not say "personalised" anywhere in `ui/desktop/src`.

Two arguments decided it beyond the counts:

- **The identifiers cannot move.** `color`, `center`, `dialog`, `catalog`, `license`, `artifact`,
  `initialize` are CSS, DOM, API and product identifiers. A British copy rule puts every label
  permanently at odds with the symbol beside it — and that seam had already split, which is the bug
  in the Why above.
- **UCSF and this repository's operator write American English.** A convention nobody writes by hand
  is one that rots, which is the argument `CLAUDE.md` already makes about a CI gate that fails on
  arrival.

The cost, recorded plainly: the repository stays bilingual across the product/contributor line, and
**Auto Visualiser keeps its British spelling** as a proper noun, alongside Biorouter, BAAM, Knowledge
and every provider name. Reversing the decision is one word in `spellingVariants.ts`.

## What changed

**Decision record** — [`design.md`](design.md) §3.10 (new) and a dated line in its Status header;
[`docs/desktop-ui/settings-visual-vocabulary.md`](docs/desktop-ui/settings-visual-vocabulary.md) rule
11. Neither file is reformatted: both already fail `prettier --check` on `main` and still do,
identically (verified by checking `git show origin/main:` copies of each).

**Renderer sweep — 9 strings, before → after**

| file:line | before | after |
|---|---|---|
| [AnnotationOverlay.tsx:266](ui/desktop/src/components/artifacts/AnnotationOverlay.tsx#L266) | Option **centre** | Option **center** |
| [ProviderCatalog.tsx:548](ui/desktop/src/components/settings/providers/ProviderCatalog.tsx#L548) | Biorouter **recognises** its endpoint | **recognizes** |
| [providerOrdering.ts:271](ui/desktop/src/components/settings/providers/providerOrdering.ts#L271) | Biorouter **recognises** the endpoint | **recognizes** |
| [providerOrdering.ts:376](ui/desktop/src/components/settings/providers/providerOrdering.ts#L376) | Biorouter **recognises** this institutional gateway | **recognizes** |
| [ElicitationRequest.tsx:36](ui/desktop/src/components/ElicitationRequest.tsx#L36) | Information request was **cancelled**. | **canceled** |
| [SecretRequestCard.tsx:115](ui/desktop/src/components/SecretRequestCard.tsx#L115) | Credential setup was **cancelled**. | **canceled** |
| [ToolCallConfirmation.tsx:199](ui/desktop/src/components/ToolCallConfirmation.tsx#L199) | Tool call confirmation was **cancelled**. | **canceled** |
| [ExtensionsSection.tsx:357](ui/desktop/src/components/settings/extensions/ExtensionsSection.tsx#L357) | Marketplace **catalogue** · | Marketplace **catalog** · |
| [registry.ts:369](ui/desktop/src/components/baam/registry.ts#L369) | **catalogue** last updated | **catalog** last updated |

**Shipped skill text — 9 words across 6 files**: `behaviour`→`behavior` (×3), `colour`→`color`,
`licence`→`license`, `personalise`→`personalize`, `organisation`→`organization`,
`capitalised`→`capitalized`, `judgement`→`judgment`. No identifier, fenced command or backticked
symbol is touched. `auto visualiser` in the crate table keeps its spelling — it is the product name.

**The guard** — [`ui/desktop/src/test/uiCopySpelling.test.ts`](ui/desktop/src/test/uiCopySpelling.test.ts)
(6 tests), on [`userVisibleCopy.ts`](ui/desktop/src/test/userVisibleCopy.ts) (the AST extractor) and
[`spellingVariants.ts`](ui/desktop/src/test/spellingVariants.ts) (the pair list). It follows
`settingsVocabulary.test.ts`: a `ROOTS` list with per-root exclusions, plus a non-vacuity assertion
per root — one root is reached by a relative path out of `ui/desktop` and would silently resolve to
nothing if this file moved.

Three exclusions in the extractor earn their place, and each is a defect it would otherwise have:
class helpers and `console.*`/`log.*` are not copy; thrown `Error`s are developer-facing; and a lone
lowercase word is dropped because `reason: 'cancelled'` is a wire value in a copy-shaped property —
the guard must not demand an API value be re-spelled. `visualiser` **is** a rejected form, generated
on purpose, so the Auto Visualiser exemption does real work; a test asserts both halves.

## Tests

```
npm run test:run   →  Test Files  435 passed (435)
                      Tests  4882 passed | 1 skipped (4883)
npm run lint:check →  EXIT=0  (tsc, eslint --max-warnings 0, themes --check,
                      "OK — all 332 contrast assertions pass", tokens)
npx prettier --check <14 changed src files>  →  All matched files use Prettier code style!
```

**The guard fails on a planted variant.** With `behavior` → `behaviour` at `SettingsView.tsx:106`:

```
× has no rejected spelling in any user-visible string
+ "ui/desktop/src/components/settings/SettingsView.tsx:106 \"behaviour\" → \"behavior\"
   — Manage models, chat behaviour, and app preferences."
 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

Reverted; `git status` clean before each commit.

Before the sweep the guard reported **exactly the 18 offences** and nothing else — 9 renderer, 9 skill
text — including one my own first grep had missed (`auto visualiser`, lower case, in a crate table).

**Three tests asserted a swept string and are updated**: `ProviderCatalog.test.tsx:298`,
`ProviderCatalog.privacy.test.tsx:154`, `SecretRequestCard.test.tsx:158`.

**Two tests kept passing and were NOT asserting the string**, which is worth naming:

- `ExtensionsSection.privacy.test.tsx` mentions "Marketplace catalogue" only in a comment explaining
  what it deliberately does *not* match. Its assertion never depended on the words; the comment is
  corrected.
- `registry.test.ts:263-268` covers `catalogFreshnessLine` with `/bundled/i` and `.not.toMatch(...)`
  — it never asserts "catalog last updated", so renaming that string moved nothing.

And the one that caught me: `SecretRequestCard.test.tsx` asserts `/cancelled/i` — **the word alone,
not the sentence** — so my grep for the full sentence missed it and the suite failed on the first
run. That is the shape to watch for.

**One flake, not mine.** Run 2 showed `artifactCdnAssets.browser.test.ts` failing with
`Hook timed out in 30000ms` — it launches a real browser, and I was starting the Electron dev GUI at
that moment. Alone: `Test Files 1 passed (1) / Tests 2 passed (2)` in 7.30s. The final run above is
clean.

## Verification

Sandboxed dev instance from this worktree (`launch-dev-gui.sh start … h10-spelling 9351`), stopped
afterwards. Screenshots in `~/biorouter-runs/h10-spelling/shots/`:

- `02-provider-catalog-institutional.png` — **two** of the changed strings live: "Private because
  Biorouter **recognizes** this institutional gateway endpoint." and "…once Biorouter **recognizes**
  its endpoint as private…".
- `03-annotation-hint.png` — "Drag to select a region · Shift square · Option **center** · Space move
  · Esc cancel", read back from the DOM verbatim.
- `01-settings-subtitle.png` — the Settings subtitle the handoff expected to change, shown unchanged:
  under the measured convention "chat behavior" is already correct.

**Not verified in the running app**, with what would do it:

- The two marketplace strings need a non-live registry load. `REGISTRY_URL` is hardcoded in
  `main.ts`, and the renderer cannot stand in for it — `window.electron` is a `contextBridge` object,
  so an override there silently does nothing (measured: the real 129-skill registry still came back).
  Blocking `biorouter.ucsf.edu` for the main process would show them.
- The three "was canceled" strings render only in **saved history**, for a tool request with no
  response (`SessionViewComponents.tsx:230`); live chat always passes `false`. Cancelling a turn
  mid-tool-call and reopening that session in History would show them. `SecretRequestCard.test.tsx`
  does assert the new copy against a real render.
- The third `recognizes` string needs an unaffiliated private gateway configured, which means
  entering a provider credential — not something to do from here.

## Follow-ups

- `landing/docs.html` and the CLI carry a handful of British forms (`colour`, `summarise`,
  `normalise`, `grey`, `modelling`). Both are user-facing and now out of step with a written
  convention; neither is in this brief's scope, and neither has a guard.
- The guard does not read untagged code fences in markdown. One prose line inside one was swept by
  hand; a regression there would not fail CI.
- `ui/desktop/src/components/settings/settingsVocabulary.test.ts` and this guard now walk the tree
  twice with near-identical walkers. Worth sharing one when a third guard appears, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
