### PR TITLE
fix(cli): a Windows CLI install can find its daemon and its interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "dashmap",
  "dirs 5.0.1",
  "dotenvy",
+ "dunce",
  "env-lock",
  "etcetera 0.11.0",
  "fs2",

--- a/crates/biorouter-cli/Cargo.toml
+++ b/crates/biorouter-cli/Cargo.toml
@@ -27,7 +27,10 @@ uuid = { version = "1.11", features = ["v4"] }
 dotenvy = "0.15.7"
 # `serve` derives the interface bundle and the daemon from the real path of the
 # running executable, and on Windows `canonicalize` hands back a verbatim
-# `\\?\C:\…` path that must not reach a message or a child's environment.
+# `\\?\C:\…` path that must not reach a message or a child's environment. The
+# stripping itself now lives in `biorouter::system::real_path`, beside the
+# installer that has to spell those paths the same way; what is left here is the
+# Windows-only test that pins the behaviour at the string level.
 dunce = "1"
 bat = "0.25.0"
 pulldown-cmark = { version = "0.13", default-features = false }

--- a/crates/biorouter-cli/src/commands/apps.rs
+++ b/crates/biorouter-cli/src/commands/apps.rs
@@ -239,28 +239,18 @@ pub(crate) async fn daemon_ok(host: &str, port: u16) -> bool {
 }
 
 /// Locate the `biorouterd` binary: prefer the sibling of the running `biorouter`
-/// executable (dev tree and installed app both colocate them), else fall back to
-/// the bare name so the OS resolves it on `PATH`.
+/// executable (dev tree and installed app both colocate them), then the sibling
+/// of the installation this copy came from (a Windows install has nothing else
+/// to go on), else fall back to the bare name so the OS resolves it on `PATH`.
 ///
-/// The path is resolved through symlinks first
-/// ([`crate::commands::exe_path::current_exe_resolved`]): on macOS
-/// `current_exe()` reports the link the user typed, and the CLI is installed as
-/// a symlink, so "the sibling" would otherwise be a sibling of
-/// `~/.local/bin/biorouter`.
+/// The whole rule lives in [`crate::commands::exe_path::biorouterd_for`], which
+/// `serve` also calls — the two commands start the same daemon, and two copies
+/// of "where is it" are two chances to fix only one of them.
 fn biorouterd_path() -> PathBuf {
-    let bin = if cfg!(windows) {
-        "biorouterd.exe"
-    } else {
-        "biorouterd"
-    };
-    if let Some(exe) = crate::commands::exe_path::current_exe_resolved() {
-        if let Some(sibling) = exe.parent().map(|d| d.join(bin)) {
-            if sibling.exists() {
-                return sibling;
-            }
-        }
-    }
-    PathBuf::from(bin)
+    use crate::commands::exe_path;
+    exe_path::current_exe_resolved()
+        .and_then(|exe| exe_path::biorouterd_for(&exe))
+        .unwrap_or_else(|| PathBuf::from(exe_path::daemon_file_name()))
 }
 
 /// The command string we tell users to run when we can't (or won't) start the

--- a/crates/biorouter-cli/src/commands/exe_path.rs
+++ b/crates/biorouter-cli/src/commands/exe_path.rs
@@ -13,7 +13,10 @@
 //!   inside the application bundle.
 //! - **Linux** reads `/proc/self/exe`, which the kernel has already resolved.
 //! - **Windows** returns the real module path from `GetModuleFileNameW`, and the
-//!   installer copies rather than symlinks, so there is no link to follow.
+//!   installer copies rather than symlinks, so there is no link to follow — and
+//!   nothing to find beside the copy either. Resolution alone does not help
+//!   there; the copy has to be told where it came from, which is what
+//!   [`biorouter::system::install_origin`] reads back.
 //!
 //! So the resolution is a no-op on two of the three platforms — which is
 //! precisely why it is unconditional rather than `#[cfg(target_os = "macos")]`.
@@ -38,9 +41,9 @@ use std::path::{Path, PathBuf};
 /// because every caller here treats the result as a *hint* and checks the file
 /// it derives before using it.
 pub fn resolve_exe_path(exe: &Path) -> PathBuf {
-    std::fs::canonicalize(exe)
-        .map(|p| dunce::simplified(&p).to_path_buf())
-        .unwrap_or_else(|_| exe.to_path_buf())
+    // One implementation, in the crate the installer also lives in: the
+    // installer has to spell a path the same way this reads one back.
+    biorouter::system::real_path(exe)
 }
 
 /// [`resolve_exe_path`] applied to the running executable.
@@ -49,6 +52,50 @@ pub fn resolve_exe_path(exe: &Path) -> PathBuf {
 /// a `PATH` lookup or to a packaged location rather than failing.
 pub fn current_exe_resolved() -> Option<PathBuf> {
     std::env::current_exe().ok().map(|e| resolve_exe_path(&e))
+}
+
+/// The daemon's file name on this platform.
+pub fn daemon_file_name() -> String {
+    format!("biorouterd{}", std::env::consts::EXE_SUFFIX)
+}
+
+/// The `biorouterd` that belongs with the `biorouter` at `exe`.
+///
+/// Two layouts, in order:
+///
+/// 1. **Beside it.** A development tree and a packaged application both put the
+///    two binaries in one directory, so a sibling is the daemon that was built
+///    with this CLI rather than whichever one is earliest on `PATH`.
+/// 2. **Beside the installation it was copied from.** Windows has no symlink to
+///    follow: `biorouter setup-path` copies `biorouter.exe` onto `PATH` and
+///    leaves the rest of the application behind, so the sibling check finds
+///    nothing. The copy records where it came from
+///    ([`biorouter::system::install_origin`]) and the daemon is a sibling
+///    *there*.
+///
+/// `None` when neither holds, so the caller can fall back to a bare name and let
+/// the operating system search `PATH`.
+///
+/// ⚠ `exe` must be the **resolved** path — see [`resolve_exe_path`].
+pub fn biorouterd_for(exe: &Path) -> Option<PathBuf> {
+    biorouterd_beside(exe).or_else(|| biorouterd_at_origin(exe))
+}
+
+/// The daemon sitting in the same directory as `exe`, if it is there.
+///
+/// Split out from [`biorouterd_for`] so a test can hand it a path instead of
+/// being at the mercy of wherever the test binary itself happens to live.
+pub fn biorouterd_beside(exe: &Path) -> Option<PathBuf> {
+    let beside = exe.parent()?.join(daemon_file_name());
+    beside.is_file().then_some(beside)
+}
+
+/// The daemon beside the installation `exe` was copied from, if the copy left a
+/// breadcrumb naming it and the daemon is still there.
+pub fn biorouterd_at_origin(exe: &Path) -> Option<PathBuf> {
+    let origin = biorouter::system::install_origin(exe.parent()?)?;
+    let candidate = origin.join(daemon_file_name());
+    candidate.is_file().then_some(candidate)
 }
 
 #[cfg(test)]
@@ -119,5 +166,102 @@ mod tests {
     fn an_unresolvable_path_is_returned_unchanged() {
         let missing = Path::new("/definitely/not/here/biorouter");
         assert_eq!(resolve_exe_path(missing), missing.to_path_buf());
+    }
+
+    /// A fixture shaped like the shipped Windows application: both binaries in
+    /// `resources/bin`, the interface bundle beside them in `resources/web`.
+    /// Returns the `bin` directory.
+    fn application(root: &Path) -> PathBuf {
+        let bin = root.join("resources").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join(exe_name("biorouter")), b"x").unwrap();
+        std::fs::write(bin.join(daemon_file_name()), b"x").unwrap();
+        let web = root.join("resources").join("web");
+        std::fs::create_dir_all(&web).unwrap();
+        std::fs::write(web.join("index.html"), b"<!doctype html>").unwrap();
+        bin
+    }
+
+    fn exe_name(stem: &str) -> String {
+        format!("{stem}{}", std::env::consts::EXE_SUFFIX)
+    }
+
+    /// A Windows install: `biorouter.exe` copied onto `PATH` on its own, with
+    /// nothing beside it but the breadcrumb naming the application it came from.
+    /// Returns the installed executable.
+    fn windows_style_install(root: &Path, source_bin: &Path) -> PathBuf {
+        let install = root.join("Local").join("Biorouter").join("bin");
+        std::fs::create_dir_all(&install).unwrap();
+        let exe = install.join(exe_name("biorouter"));
+        std::fs::write(&exe, b"x").unwrap();
+        biorouter::system::record_install_origin(source_bin, &install).unwrap();
+        exe
+    }
+
+    /// The Windows half of the defect PR #183 fixed for macOS: there is no
+    /// symlink to resolve, because the install is a copy, so the daemon is not
+    /// anywhere near the executable that has to start it.
+    #[test]
+    fn the_daemon_is_found_through_the_breadcrumb_when_nothing_is_beside_the_copy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_bin = application(&tmp.path().join("Application"));
+        let exe = windows_style_install(tmp.path(), &source_bin);
+
+        assert!(
+            biorouterd_beside(&exe).is_none(),
+            "fixture is wrong: the daemon must not be beside the installed copy, \
+             or this test cannot fail"
+        );
+        assert_eq!(
+            biorouterd_for(&exe).map(|p| std::fs::canonicalize(p).unwrap()),
+            Some(std::fs::canonicalize(source_bin.join(daemon_file_name())).unwrap()),
+            "the daemon must be found beside the application the copy came from"
+        );
+    }
+
+    /// A daemon actually next to the executable is the one that was built with
+    /// it, so it wins over anything a breadcrumb names.
+    #[test]
+    fn a_daemon_beside_the_executable_beats_the_breadcrumb() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_bin = application(&tmp.path().join("Application"));
+        let exe = windows_style_install(tmp.path(), &source_bin);
+        let beside = exe.parent().unwrap().join(daemon_file_name());
+        std::fs::write(&beside, b"x").unwrap();
+
+        assert_eq!(
+            biorouterd_for(&exe).map(|p| std::fs::canonicalize(p).unwrap()),
+            Some(std::fs::canonicalize(&beside).unwrap()),
+            "the sibling must be preferred to the recorded installation"
+        );
+    }
+
+    #[test]
+    fn no_daemon_and_no_breadcrumb_resolves_to_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp.path().join(exe_name("biorouter"));
+        std::fs::write(&exe, b"x").unwrap();
+
+        assert_eq!(
+            biorouterd_for(&exe),
+            None,
+            "with nothing to go on the caller must be allowed to fall back to PATH"
+        );
+    }
+
+    /// The application was uninstalled, or moved, since the CLI was installed.
+    #[test]
+    fn a_breadcrumb_naming_a_deleted_installation_resolves_to_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let application_root = tmp.path().join("Application");
+        let source_bin = application(&application_root);
+        let exe = windows_style_install(tmp.path(), &source_bin);
+        std::fs::remove_dir_all(&application_root).unwrap();
+
+        assert_eq!(
+            biorouterd_for(&exe),
+            None,
+            "a stale breadcrumb must not produce a path to a daemon that is gone"
+        );
     }
 }

--- a/crates/biorouter-cli/src/commands/serve.rs
+++ b/crates/biorouter-cli/src/commands/serve.rs
@@ -26,7 +26,7 @@
 //! session talks to is less capable than the one the desktop application
 //! starts, and anything assuming otherwise is wrong.
 
-use crate::commands::exe_path::current_exe_resolved;
+use crate::commands::exe_path::{biorouterd_for, current_exe_resolved, daemon_file_name};
 use anyhow::{bail, Context, Result};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
@@ -270,26 +270,15 @@ fn wait_until_ready(host: &str, port: u16, child: &mut std::process::Child) -> R
 ///
 /// Beside our own executable first, so a packaged application and a development
 /// tree both pair the two binaries that were built together, rather than
-/// whichever one is earliest on `PATH`.
+/// whichever one is earliest on `PATH`; then beside the installation this copy
+/// came from, which is the only thing a Windows install has to go on. See
+/// [`crate::commands::exe_path::biorouterd_for`].
 fn resolve_biorouterd() -> Result<PathBuf> {
-    if let Some(found) = current_exe_resolved().and_then(|exe| biorouterd_beside(&exe)) {
+    if let Some(found) = current_exe_resolved().and_then(|exe| biorouterd_for(&exe)) {
         return Ok(found);
     }
     // Fall back to PATH, and let the spawn report a missing binary.
-    Ok(PathBuf::from(format!(
-        "biorouterd{}",
-        std::env::consts::EXE_SUFFIX
-    )))
-}
-
-/// The daemon installed alongside `exe`, if it is there.
-///
-/// Split out from [`resolve_biorouterd`] so a test can hand it a path instead
-/// of being at the mercy of wherever the test binary itself happens to live.
-fn biorouterd_beside(exe: &Path) -> Option<PathBuf> {
-    let name = format!("biorouterd{}", std::env::consts::EXE_SUFFIX);
-    let beside = exe.parent()?.join(name);
-    beside.is_file().then_some(beside)
+    Ok(PathBuf::from(daemon_file_name()))
 }
 
 /// Candidate locations for the built interface, in order.
@@ -304,11 +293,18 @@ fn web_dir_candidates() -> Vec<PathBuf> {
 /// The candidate list for a given executable path.
 ///
 /// ⚠ `exe` must be the **resolved** path, not `current_exe()` — see
-/// [`crate::commands::exe_path`]. Everything below is a sibling of the binary,
-/// so a symlink one directory up from the installation moves every candidate
-/// with it: through `~/.local/bin/biorouter` the two exe-relative entries
-/// became `~/.local/web` and `~/ui/desktop/src/web`, and `serve` reported that
-/// the interface was missing on an installation that ships it.
+/// [`crate::commands::exe_path`]. The exe-relative entries below are siblings of
+/// the binary, so a symlink one directory up from the installation moves every
+/// candidate with it: through `~/.local/bin/biorouter` the two became
+/// `~/.local/web` and `~/ui/desktop/src/web`, and `serve` reported that the
+/// interface was missing on an installation that ships it.
+///
+/// Resolution is not enough on Windows, where the install is a *copy* and the
+/// bundle stays behind in the application. The breadcrumb entry is that case:
+/// the copy records the directory it came from, and the bundle is `../web` of
+/// **that**. It is consulted after the exe-relative entries — a bundle actually
+/// next to the binary is the one to use — and before the Linux package
+/// location, which is a fixed path that has nothing to do with this install.
 fn web_dir_candidates_for(exe: Option<&Path>) -> Vec<PathBuf> {
     let mut out = Vec::new();
     if let Ok(dir) = std::env::var("BIOROUTER_SERVE_UI") {
@@ -328,6 +324,13 @@ fn web_dir_candidates_for(exe: Option<&Path>) -> Vec<PathBuf> {
                 .join("src")
                 .join("web"),
         );
+        // A Windows install: `Resources/web` of the application this copy was
+        // taken from. Pushed even when the recorded directory has since been
+        // deleted, so a stale breadcrumb is named in the failure rather than
+        // leaving the reader to guess why nothing was found.
+        if let Some(origin) = biorouter::system::install_origin(dir) {
+            out.push(origin.join("..").join("web"));
+        }
     }
     // The Linux packages, where the exe-relative rule does not survive: from
     // /usr/bin, `../web` is /usr/web.
@@ -375,6 +378,9 @@ fn normalise(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The sibling rule moved to `exe_path` when `apps` needed it too; the test
+    // that pins it stayed here, with the rest of the `serve` resolution suite.
+    use crate::commands::exe_path::biorouterd_beside;
 
     #[test]
     fn the_default_port_does_not_collide_with_the_daemon_it_starts() {
@@ -557,6 +563,11 @@ mod tests {
     /// A candidate list derived from a verbatim Windows path would be printed
     /// at the user and handed to the daemon in `BIOROUTER_SERVE_UI`. Runs
     /// everywhere; only Windows can fail it.
+    ///
+    /// The breadcrumb is written the way `install_cli` writes it — from the
+    /// parent of a **canonicalised** source path, which on Windows is
+    /// `\\?\C:\…` — so the candidate derived from it is covered by the same
+    /// rule.
     #[test]
     fn the_resolved_candidates_are_never_windows_verbatim_paths() {
         let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
@@ -566,8 +577,26 @@ mod tests {
             .join(format!("biorouter{}", std::env::consts::EXE_SUFFIX));
         std::fs::write(&exe, b"x").unwrap();
 
+        let source_bin = application(&tmp.path().join("Application"));
+        let canonical_source = std::fs::canonicalize(
+            source_bin.join(format!("biorouter{}", std::env::consts::EXE_SUFFIX)),
+        )
+        .unwrap();
+        biorouter::system::record_install_origin(
+            canonical_source.parent().unwrap(),
+            exe.parent().unwrap(),
+        )
+        .unwrap();
+
         let resolved = crate::commands::exe_path::resolve_exe_path(&exe);
-        for candidate in web_dir_candidates_for(Some(&resolved)) {
+        let candidates = web_dir_candidates_for(Some(&resolved));
+        assert_eq!(
+            candidates.len(),
+            4,
+            "the breadcrumb-derived candidate must be present, or this test \
+             covers less than it claims: {candidates:?}"
+        );
+        for candidate in candidates {
             assert!(
                 !normalise(&candidate).to_string_lossy().starts_with(r"\\?\"),
                 "verbatim path in a candidate: {}",
@@ -583,5 +612,172 @@ mod tests {
             normalise(Path::new("/a/b/c/../../ui/desktop/src/web")),
             PathBuf::from("/a/ui/desktop/src/web")
         );
+    }
+
+    /// A fixture shaped like the shipped Windows application: both binaries in
+    /// `resources/bin`, the interface bundle beside them in `resources/web`.
+    /// Returns the `bin` directory.
+    fn application(root: &Path) -> PathBuf {
+        let bin = root.join("resources").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let name = format!("biorouter{}", std::env::consts::EXE_SUFFIX);
+        std::fs::write(bin.join(name), b"x").unwrap();
+        let web = root.join("resources").join("web");
+        std::fs::create_dir_all(&web).unwrap();
+        std::fs::write(web.join("index.html"), b"<!doctype html>").unwrap();
+        bin
+    }
+
+    /// A Windows install: `biorouter.exe` copied onto `PATH` on its own, with
+    /// nothing beside it. Returns the installed executable.
+    fn windows_style_install(root: &Path) -> PathBuf {
+        let install = root.join("Local").join("Biorouter").join("bin");
+        std::fs::create_dir_all(&install).unwrap();
+        let exe = install.join(format!("biorouter{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&exe, b"x").unwrap();
+        exe
+    }
+
+    /// The Windows half of the defect PR #183 fixed for macOS. `install_cli`
+    /// copies `biorouter.exe` into `%LOCALAPPDATA%\Biorouter\bin` and nothing
+    /// else, so there is no link to resolve and no bundle beside the copy — the
+    /// two exe-relative candidates become `%LOCALAPPDATA%\Biorouter\web` and
+    /// `%LOCALAPPDATA%\ui\desktop\src\web`, neither of which can ever exist.
+    #[test]
+    fn a_windows_style_install_finds_the_bundle_through_its_breadcrumb() {
+        let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
+        let tmp = tempfile::tempdir().unwrap();
+        let source_bin = application(&tmp.path().join("Application"));
+        let exe = windows_style_install(tmp.path());
+
+        // Without the breadcrumb the bundle is unreachable — otherwise this
+        // test would pass against the code that shipped the bug.
+        assert!(
+            !web_dir_candidates_for(Some(&exe))
+                .iter()
+                .any(|c| c.join("index.html").is_file()),
+            "fixture is wrong: the bundle must be unreachable before the breadcrumb is written"
+        );
+
+        biorouter::system::record_install_origin(&source_bin, exe.parent().unwrap()).unwrap();
+
+        let candidates = web_dir_candidates_for(Some(&exe));
+        let found = candidates
+            .iter()
+            .find(|c| c.join("index.html").is_file())
+            .unwrap_or_else(|| {
+                panic!("no candidate held the bundle that is on disk: {candidates:?}")
+            });
+        assert_eq!(
+            std::fs::canonicalize(normalise(found)).unwrap(),
+            std::fs::canonicalize(tmp.path().join("Application").join("resources").join("web"))
+                .unwrap(),
+            "the packaged bundle must be found through the breadcrumb"
+        );
+    }
+
+    /// The breadcrumb is a fallback, not an override: a bundle sitting beside
+    /// the binary is this installation's own and must win.
+    #[test]
+    fn the_breadcrumb_is_consulted_after_the_locations_beside_the_binary() {
+        let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
+        let tmp = tempfile::tempdir().unwrap();
+        let source_bin = application(&tmp.path().join("Application"));
+        let exe = windows_style_install(tmp.path());
+        biorouter::system::record_install_origin(&source_bin, exe.parent().unwrap()).unwrap();
+
+        let candidates = web_dir_candidates_for(Some(&exe));
+        // `real_path`, not the fixture's own spelling: on macOS a temp directory
+        // is reached through `/var -> /private/var`, so the recorded origin is
+        // spelled differently while naming the same directory.
+        let derived = normalise(
+            &biorouter::system::real_path(&source_bin)
+                .join("..")
+                .join("web"),
+        );
+        let at = candidates
+            .iter()
+            .position(|c| normalise(c) == derived)
+            .unwrap_or_else(|| {
+                panic!("the breadcrumb-derived candidate {derived:?} must be in {candidates:?}")
+            });
+        assert_eq!(
+            at, 2,
+            "expected the breadcrumb after the two exe-relative entries and before the \
+             Linux package location: {candidates:?}"
+        );
+        assert_eq!(
+            candidates.last(),
+            Some(&PathBuf::from("/usr/share/biorouter/web")),
+            "the fixed package location stays last: {candidates:?}"
+        );
+    }
+
+    /// The application was uninstalled or moved. The stale location has to reach
+    /// the error text — it is the only thing that tells the reader why an
+    /// install that used to work no longer does.
+    #[test]
+    fn a_stale_breadcrumb_is_named_among_the_paths_that_were_tried() {
+        let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
+        let tmp = tempfile::tempdir().unwrap();
+        let application_root = tmp.path().join("Application");
+        let source_bin = application(&application_root);
+        let exe = windows_style_install(tmp.path());
+        biorouter::system::record_install_origin(&source_bin, exe.parent().unwrap()).unwrap();
+        // Read while the directory still exists: once it is gone nothing can
+        // canonicalise it, and on macOS the fixture's own spelling (`/var/…`)
+        // is not the one that was recorded (`/private/var/…`).
+        let recorded = biorouter::system::real_path(&source_bin);
+        std::fs::remove_dir_all(&application_root).unwrap();
+
+        let candidates = web_dir_candidates_for(Some(&exe));
+        assert!(
+            !candidates.iter().any(|c| c.join("index.html").is_file()),
+            "nothing should resolve: the application is gone"
+        );
+        // `resolve_web_dir` prints `normalise(p)` for every candidate, so this
+        // is the string the reader would see.
+        let tried: Vec<String> = candidates
+            .iter()
+            .map(|p| normalise(p).display().to_string())
+            .collect();
+        let expected = normalise(&recorded.join("..").join("web"))
+            .display()
+            .to_string();
+        assert!(
+            tried.contains(&expected),
+            "the stale location must be named in the failure. Tried: {tried:?}"
+        );
+    }
+
+    /// Every state a machine really reaches: a Unix install with no breadcrumb
+    /// at all, and a file that is empty or is not a path.
+    #[test]
+    fn a_missing_or_unusable_breadcrumb_falls_back_without_panicking() {
+        let _env = env_lock::lock_env([("BIOROUTER_SERVE_UI", None::<String>)]);
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = windows_style_install(tmp.path());
+        let install = exe.parent().unwrap().to_path_buf();
+
+        let without = web_dir_candidates_for(Some(&exe));
+        assert_eq!(
+            without.len(),
+            3,
+            "no breadcrumb means the two exe-relative entries plus the package \
+             location: {without:?}"
+        );
+
+        for content in ["", "  \n", "not a path", "./relative/bin"] {
+            std::fs::write(
+                install.join(biorouter::system::INSTALL_ORIGIN_FILE),
+                content,
+            )
+            .unwrap();
+            assert_eq!(
+                web_dir_candidates_for(Some(&exe)),
+                without,
+                "an unusable breadcrumb ({content:?}) must add no candidate"
+            );
+        }
     }
 }

--- a/crates/biorouter-cli/src/commands/serve.rs
+++ b/crates/biorouter-cli/src/commands/serve.rs
@@ -380,6 +380,9 @@ mod tests {
     use super::*;
     // The sibling rule moved to `exe_path` when `apps` needed it too; the test
     // that pins it stayed here, with the rest of the `serve` resolution suite.
+    // `cfg(unix)` for the same reason that test is: it needs a symlink, and an
+    // import only one platform uses is a warning on the other one.
+    #[cfg(unix)]
     use crate::commands::exe_path::biorouterd_beside;
 
     #[test]

--- a/crates/biorouter/Cargo.toml
+++ b/crates/biorouter/Cargo.toml
@@ -27,6 +27,12 @@ anyhow = { workspace = true }
 thiserror = "1.0"
 futures = { workspace = true }
 dirs = "5.0"
+# `system::real_path` canonicalises a path before it is shown to a user, written
+# into the CLI install breadcrumb, or handed to a child process. On Windows
+# `canonicalize` returns a verbatim `\\?\C:\…` path, which is not universally
+# accepted; `dunce::simplified` strips the prefix when the plain form means the
+# same thing and is the identity everywhere else.
+dunce = "1"
 reqwest = { version = "0.12.9", features = [
     "rustls-tls-native-roots",
     "json",

--- a/crates/biorouter/src/system.rs
+++ b/crates/biorouter/src/system.rs
@@ -468,6 +468,137 @@ fn is_writable(dir: &Path) -> bool {
     }
 }
 
+/// The path a file really has, with symlinks followed and Windows' verbatim
+/// prefix stripped.
+///
+/// Falls back to the path as given when it cannot be resolved: a caller that
+/// treats the result as a hint and checks the file it derives is better served
+/// by a guess than by a failure. `biorouter-cli`'s `commands::exe_path` module
+/// carries the full account of why this matters — it is the one that discovered
+/// it — and delegates here so there is a single implementation.
+pub fn real_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path)
+        .map(|p| dunce::simplified(&p).to_path_buf())
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// File name of the breadcrumb an installed copy leaves beside itself, naming
+/// the directory it was installed from.
+///
+/// Defined once, here, and read by `biorouter-cli`'s resolvers rather than
+/// re-spelled there: an installer and a reader that disagree about this string
+/// fail silently, and only on the platform that needs it.
+pub const INSTALL_ORIGIN_FILE: &str = ".biorouter-origin";
+
+/// Record, beside an installed copy of the CLI, the directory it was taken from.
+///
+/// Windows has no symlink to follow. [`install_cli`] *copies* `biorouter.exe`
+/// into a `PATH` directory, so `biorouterd.exe` and the interface bundle that
+/// shipped with it are no longer anywhere near the executable — and neither
+/// `biorouter serve` nor `biorouter apps` could find them. This one line of text
+/// is how the copy gets back to them, and it is rewritten on every install so it
+/// keeps pointing at the application after an update moves it.
+///
+/// A copy is not made instead: `biorouterd.exe` is over 200 MB and the interface
+/// bundle another 12, and a copy taken at install time goes stale the moment the
+/// application updates.
+///
+/// **Writes nothing when the source and the target are the same directory.** The
+/// installed copy is itself on `PATH`, so `biorouter setup-path` can be run
+/// *from* it — at which point the source directory is the install directory, and
+/// a breadcrumb naming its own directory would resolve nothing while destroying
+/// the usable one the application wrote.
+pub fn record_install_origin(source_dir: &Path, target_dir: &Path) -> std::io::Result<()> {
+    if same_dir(source_dir, target_dir) {
+        return Ok(());
+    }
+    let origin = real_path(source_dir);
+    std::fs::write(
+        target_dir.join(INSTALL_ORIGIN_FILE),
+        origin.to_string_lossy().as_bytes(),
+    )
+}
+
+/// The directory an installed copy in `install_dir` was taken from, if it left a
+/// breadcrumb.
+///
+/// Tolerant by construction, because every one of these is a state a real
+/// machine reaches: no file (a Unix install, or a copy from before this
+/// existed), an empty or truncated file (a write interrupted by a crash), an
+/// unreadable one, a leading byte-order mark or trailing newline from a text
+/// editor, or a path that no longer exists.
+///
+/// A recorded directory that has since been deleted is returned anyway rather
+/// than being filtered out here: the caller checks for the file it wants, and
+/// the stale path then appears in the list of places it looked, which is the
+/// only way the reader learns their breadcrumb is out of date.
+pub fn install_origin(install_dir: &Path) -> Option<PathBuf> {
+    let raw = std::fs::read_to_string(install_dir.join(INSTALL_ORIGIN_FILE)).ok()?;
+    let line = raw.trim_start_matches('\u{feff}').lines().next()?.trim();
+    if line.is_empty() {
+        return None;
+    }
+    let path = Path::new(line);
+    // Anything that is not an absolute path is not something we wrote. Resolving
+    // it against the working directory would invent a location rather than
+    // report one.
+    path.is_absolute()
+        .then(|| dunce::simplified(path).to_path_buf())
+}
+
+/// Whether two paths name the same directory, comparing what is on disk when it
+/// can and the spellings when it cannot.
+fn same_dir(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+/// Put `source` at `link`: a symlink on Unix, a copy plus an origin breadcrumb
+/// on Windows.
+///
+/// Split out of [`install_cli`] so the platform difference is one small function
+/// rather than two arms in the middle of a long one.
+fn place_cli(source: &Path, link: &Path, target_dir: &Path) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        let _ = target_dir;
+        std::os::unix::fs::symlink(source, link).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to link {} -> {}: {}",
+                link.display(),
+                source.display(),
+                e
+            )
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::copy(source, link).map(|_| ()).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to copy {} -> {}: {}",
+                source.display(),
+                link.display(),
+                e
+            )
+        })?;
+        // The copy has no siblings, so leave it a note saying where it came
+        // from. A failure here is not a failed install — everything except
+        // `serve` and `apps` works without it — so it is reported, not raised.
+        if let Some(source_dir) = source.parent() {
+            if let Err(e) = record_install_origin(source_dir, target_dir) {
+                tracing::warn!(
+                    "installed the CLI, but could not record where it came from in {}: {e}. \
+                     `biorouter serve` may not be able to find biorouterd or the interface.",
+                    target_dir.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Install (symlink on Unix, copy on Windows) `source` onto a PATH directory so
 /// `biorouter` is callable from any terminal. `source` is normally the running
 /// executable (CLI) or the bundled binary (desktop). Returns where it landed.
@@ -520,24 +651,7 @@ pub fn install_cli(source: &Path) -> anyhow::Result<CliInstall> {
         let _ = std::fs::remove_file(&link);
     }
 
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(&source, &link).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to link {} -> {}: {}",
-            link.display(),
-            source.display(),
-            e
-        )
-    })?;
-    #[cfg(not(unix))]
-    std::fs::copy(&source, &link).map(|_| ()).map_err(|e| {
-        anyhow::anyhow!(
-            "Failed to copy {} -> {}: {}",
-            source.display(),
-            link.display(),
-            e
-        )
-    })?;
+    place_cli(&source, &link, &target_dir)?;
 
     Ok(CliInstall {
         on_path: dir_on_path(&target_dir),
@@ -596,6 +710,231 @@ mod tests {
     fn status_of_rust_resolves() {
         // Should return a status (installed or not) rather than None.
         assert!(status_of("rust").is_some());
+    }
+}
+
+/// The breadcrumb a Windows install leaves so the copied `biorouter.exe` can
+/// still find `biorouterd.exe` and the interface bundle.
+///
+/// None of these are gated on Windows: the reader and the writer are plain path
+/// and string handling, and a rule only one platform ever runs is a rule only
+/// one platform's CI can catch a regression in.
+#[cfg(test)]
+mod install_origin_tests {
+    use super::{install_origin, record_install_origin, INSTALL_ORIGIN_FILE};
+    use std::path::{Path, PathBuf};
+
+    /// A fixture shaped like the shipped Windows application: the two binaries
+    /// in `resources/bin`, the interface bundle beside them in `resources/web`.
+    fn application(root: &Path) -> PathBuf {
+        let bin = root.join("resources").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(
+            bin.join(format!("biorouter{}", std::env::consts::EXE_SUFFIX)),
+            b"x",
+        )
+        .unwrap();
+        std::fs::write(
+            bin.join(format!("biorouterd{}", std::env::consts::EXE_SUFFIX)),
+            b"x",
+        )
+        .unwrap();
+        let web = root.join("resources").join("web");
+        std::fs::create_dir_all(&web).unwrap();
+        std::fs::write(web.join("index.html"), b"<!doctype html>").unwrap();
+        bin
+    }
+
+    #[test]
+    fn an_install_records_the_directory_it_was_copied_from() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_dir = application(&tmp.path().join("Application"));
+        let install_dir = tmp.path().join("Local").join("Biorouter").join("bin");
+        std::fs::create_dir_all(&install_dir).unwrap();
+
+        record_install_origin(&source_dir, &install_dir).unwrap();
+
+        assert_eq!(
+            install_origin(&install_dir).map(|p| std::fs::canonicalize(p).unwrap()),
+            Some(std::fs::canonicalize(&source_dir).unwrap()),
+            "the copy must be able to name the application it came from"
+        );
+    }
+
+    /// Rewritten on every install, because an application update moves the
+    /// directory the previous breadcrumb names.
+    #[test]
+    fn a_second_install_replaces_the_recorded_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = application(&tmp.path().join("Biorouter-1.90.3"));
+        let second = application(&tmp.path().join("Biorouter-1.91.0"));
+        let install_dir = tmp.path().join("Local").join("Biorouter").join("bin");
+        std::fs::create_dir_all(&install_dir).unwrap();
+
+        record_install_origin(&first, &install_dir).unwrap();
+        record_install_origin(&second, &install_dir).unwrap();
+
+        assert_eq!(
+            install_origin(&install_dir).map(|p| std::fs::canonicalize(p).unwrap()),
+            Some(std::fs::canonicalize(&second).unwrap()),
+            "the newest install must win, or an update strands the CLI on the old bundle"
+        );
+    }
+
+    /// The trap that silently destroys a working install: the installed copy is
+    /// itself on `PATH`, so `biorouter setup-path` can be run **from** it. The
+    /// source directory is then the install directory, and a naive writer would
+    /// record the install directory as its own origin — resolving nothing, and
+    /// overwriting the usable breadcrumb the application card wrote.
+    #[test]
+    fn installing_from_the_install_directory_leaves_the_breadcrumb_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let application_bin = application(&tmp.path().join("Application"));
+        let install_dir = tmp.path().join("Local").join("Biorouter").join("bin");
+        std::fs::create_dir_all(&install_dir).unwrap();
+        record_install_origin(&application_bin, &install_dir).unwrap();
+
+        // `biorouter setup-path`, run from the copy on PATH.
+        record_install_origin(&install_dir, &install_dir).unwrap();
+
+        assert_eq!(
+            install_origin(&install_dir).map(|p| std::fs::canonicalize(p).unwrap()),
+            Some(std::fs::canonicalize(&application_bin).unwrap()),
+            "re-installing from the install directory must not overwrite the good breadcrumb"
+        );
+    }
+
+    #[test]
+    fn installing_from_the_install_directory_writes_nothing_at_all() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path().join("Local").join("Biorouter").join("bin");
+        std::fs::create_dir_all(&install_dir).unwrap();
+
+        record_install_origin(&install_dir, &install_dir).unwrap();
+
+        assert!(
+            install_origin(&install_dir).is_none(),
+            "a breadcrumb naming its own directory resolves nothing; none is better"
+        );
+        assert!(
+            !install_dir.join(INSTALL_ORIGIN_FILE).exists(),
+            "no breadcrumb should have been created"
+        );
+    }
+
+    /// A Unix install, or a copy made before this existed.
+    #[test]
+    fn a_missing_breadcrumb_is_none_and_not_a_panic() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(install_origin(tmp.path()).is_none());
+        assert!(install_origin(&tmp.path().join("no-such-directory")).is_none());
+    }
+
+    /// A write interrupted by a crash, or a file a user emptied.
+    #[test]
+    fn an_empty_or_unparseable_breadcrumb_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        for content in ["", "   ", "\n\n", "not a path", "./relative/bin"] {
+            std::fs::write(tmp.path().join(INSTALL_ORIGIN_FILE), content).unwrap();
+            assert!(
+                install_origin(tmp.path()).is_none(),
+                "expected no origin from {content:?}"
+            );
+        }
+    }
+
+    /// A text editor's byte-order mark and trailing newline must not make the
+    /// path unrecognisable.
+    #[test]
+    fn whitespace_and_a_byte_order_mark_are_tolerated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_dir = application(&tmp.path().join("Application"));
+        let install_dir = tmp.path().join("Local");
+        std::fs::create_dir_all(&install_dir).unwrap();
+        std::fs::write(
+            install_dir.join(INSTALL_ORIGIN_FILE),
+            format!("\u{feff}  {}  \r\n", source_dir.display()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            install_origin(&install_dir).map(|p| std::fs::canonicalize(p).unwrap()),
+            Some(std::fs::canonicalize(&source_dir).unwrap())
+        );
+    }
+
+    /// A breadcrumb naming a directory that has since been deleted is returned
+    /// rather than filtered out: the caller checks for the file it wants, and
+    /// the stale path then appears in the list of places it looked. Swallowing
+    /// it here would leave the reader with a failure that names one location
+    /// fewer than were actually tried.
+    #[test]
+    fn a_stale_breadcrumb_is_still_reported() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gone = tmp.path().join("Application").join("resources").join("bin");
+        let install_dir = tmp.path().join("Local");
+        std::fs::create_dir_all(&install_dir).unwrap();
+        std::fs::write(
+            install_dir.join(INSTALL_ORIGIN_FILE),
+            gone.to_string_lossy().as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            install_origin(&install_dir),
+            Some(gone),
+            "a stale breadcrumb must survive to the error message"
+        );
+    }
+
+    /// Runs everywhere and is only capable of failing on Windows, where
+    /// `install_cli` canonicalises its source and `canonicalize` returns
+    /// `\\?\C:\…`. That string would reach `BIOROUTER_SERVE_UI` in a child
+    /// process's environment and the "Tried:" list a user reads.
+    #[test]
+    fn the_recorded_origin_is_never_a_windows_verbatim_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_dir = application(&tmp.path().join("Application"));
+        // Exactly what `install_cli` hands the writer: the parent of a
+        // canonicalised source path.
+        let canonical_source = std::fs::canonicalize(
+            source_dir.join(format!("biorouter{}", std::env::consts::EXE_SUFFIX)),
+        )
+        .unwrap();
+        let install_dir = tmp.path().join("Local");
+        std::fs::create_dir_all(&install_dir).unwrap();
+
+        record_install_origin(canonical_source.parent().unwrap(), &install_dir).unwrap();
+
+        let written = std::fs::read_to_string(install_dir.join(INSTALL_ORIGIN_FILE)).unwrap();
+        assert!(
+            !written.starts_with(r"\\?\"),
+            "a verbatim path was written into the breadcrumb: {written}"
+        );
+        let read_back = install_origin(&install_dir).expect("an origin");
+        assert!(
+            !read_back.to_string_lossy().starts_with(r"\\?\"),
+            "a verbatim path was read back out of the breadcrumb: {}",
+            read_back.display()
+        );
+    }
+
+    #[test]
+    fn a_verbatim_path_already_in_a_breadcrumb_is_stripped_on_the_way_out() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(INSTALL_ORIGIN_FILE),
+            r"\\?\C:\Program Files\Biorouter\resources\bin",
+        )
+        .unwrap();
+
+        // Only Windows recognises that string as an absolute path at all; the
+        // point on every other platform is that it does not panic and does not
+        // resolve to something relative to the working directory.
+        match install_origin(tmp.path()) {
+            Some(p) => assert_eq!(p, Path::new(r"C:\Program Files\Biorouter\resources\bin")),
+            None => assert!(!cfg!(windows), "Windows must read its own absolute paths"),
+        }
     }
 }
 

--- a/crates/biorouter/src/system.rs
+++ b/crates/biorouter/src/system.rs
@@ -928,13 +928,17 @@ mod install_origin_tests {
         )
         .unwrap();
 
-        // Only Windows recognises that string as an absolute path at all; the
-        // point on every other platform is that it does not panic and does not
-        // resolve to something relative to the working directory.
-        match install_origin(tmp.path()) {
-            Some(p) => assert_eq!(p, Path::new(r"C:\Program Files\Biorouter\resources\bin")),
-            None => assert!(!cfg!(windows), "Windows must read its own absolute paths"),
-        }
+        let read_back = install_origin(tmp.path());
+        // Only Windows recognises that string as an absolute path at all. There
+        // it must come back simplified; on every other platform the point is
+        // that it is refused rather than resolved against the working directory.
+        #[cfg(windows)]
+        assert_eq!(
+            read_back,
+            Some(PathBuf::from(r"C:\Program Files\Biorouter\resources\bin"))
+        );
+        #[cfg(not(windows))]
+        assert_eq!(read_back, None);
     }
 }
 

--- a/docs/deployment/browser-access.md
+++ b/docs/deployment/browser-access.md
@@ -204,6 +204,12 @@ child process and watched while it comes up; if it dies, `serve` reports that ra
 the port is healthy. Run `biorouterd agent` by hand to see its own output, and check that the
 configuration it reads is valid.
 
+**`could not start biorouterd`, on Windows.** `serve` starts the daemon that belongs with the CLI
+you ran, and finds it either next to that CLI or next to the application the CLI was installed from
+(see [When the interface cannot be found](#when-the-interface-cannot-be-found) below for how that is
+recorded). If the application has moved or been reinstalled since, run `biorouter setup-path` again
+from inside it — `<application folder>\resources\bin\biorouter.exe setup-path`.
+
 **The tab says the link needs its access token.** The `?t=` part was dropped — from a copy-paste, a
 chat client shortening the link, or a bookmark saved after the redirect. Use the full address as
 printed. If the launch has since restarted, the token has changed; read the new one from the
@@ -225,12 +231,25 @@ finds none:
 1. `BIOROUTER_SERVE_UI`, or `--web-dir`, if either is set.
 2. `web/` beside the installed binaries (a packaged application).
 3. `ui/desktop/src/web/` in a development tree.
-4. `/usr/share/biorouter/web` (where the Linux packages put it).
+4. `web/` beside the application a Windows install was made from.
+5. `/usr/share/biorouter/web` (where the Linux packages put it).
 
-"Beside" means beside the **real** binary. The CLI is installed on `PATH` as a symlink
-(`~/.local/bin/biorouter` → the application bundle), and steps 2 and 3 follow that link before
-deriving anything from it — otherwise they would name directories in your home folder, which is
-what they did in v1.89.5 through v1.90.2.
+"Beside" means beside the **real** binary. On macOS and Linux the CLI is installed on `PATH` as a
+symlink (`~/.local/bin/biorouter` → the application bundle), and steps 2 and 3 follow that link
+before deriving anything from it — otherwise they would name directories in your home folder, which
+is what they did in v1.89.5 through v1.90.2.
+
+Windows has no symlink to follow. `biorouter setup-path` — and the in-app "Biorouter CLI Update"
+card, which runs it — *copies* `biorouter.exe` into `%LOCALAPPDATA%\Biorouter\bin`, leaving
+`biorouterd.exe` and the interface behind inside the application. So the copy also records the
+folder it came from, in a small file named `.biorouter-origin` beside itself, and step 4 reads that
+back. The same record is how `serve` and `biorouter apps` find `biorouterd.exe`. It is rewritten
+every time you install, so updating the application and running `biorouter setup-path` again is what
+points the CLI at the new one.
+
+If you move, rename or uninstall the Biorouter application, the recorded folder is stale — it will
+be named in the list of places `serve` looked. Run `biorouter setup-path` from the application's own
+copy of the CLI to record the new location.
 
 In a development tree, build it first:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -49,7 +49,9 @@ Linux builds are published with each release. Install the desktop app with the `
 
 ### Windows
 
-Windows builds are published with each release. Download `Biorouter-win32-x64-*.zip` from the [releases page](https://github.com/BaranziniLab/biorouter/releases) or the [download page](http://biorouter.ucsf.edu/download), unzip it, and run `Biorouter.exe`. The `biorouter` CLI is bundled inside the app — run `biorouter setup-path` to add it to your `PATH`.
+Windows builds are published with each release. Download `Biorouter-win32-x64-*.zip` from the [releases page](https://github.com/BaranziniLab/biorouter/releases) or the [download page](http://biorouter.ucsf.edu/download), unzip it, and run `Biorouter.exe`. The `biorouter` CLI is bundled inside the app — accept the in-app **Install Biorouter CLI** prompt, or run `biorouter setup-path`, to add it to your `PATH`.
+
+Windows has no symlinks, so this *copies* the CLI into `%LOCALAPPDATA%\Biorouter\bin` and records the folder it came from beside the copy. To upgrade, unzip the new release and run `biorouter setup-path` again from inside it (`<application folder>\resources\bin\biorouter.exe setup-path`) — that refreshes both the copy and the record, so `biorouter serve` keeps finding the daemon and the interface.
 
 ## Configure an LLM provider
 


### PR DESCRIPTION
## Why

On Windows, installing the CLI gives you a `biorouter` that cannot start its own daemon and cannot
find its own interface. `biorouter serve` reports **"could not start biorouterd"**, or lists two
directories that can never exist and gives up. `biorouter apps` fails the same way. Nothing on
macOS or Linux is affected, which is why this survived PR #183.

Follow-up left open by PR #183's investigation.

## Root cause (measured on this tree, 2026-09-09)

`install_cli` (`crates/biorouter/src/system.rs:474` before this change) installs the CLI by
**copying only `biorouter.exe`** into `%LOCALAPPDATA%\Biorouter\bin` — the `#[cfg(not(unix))]` arm
at `:532-533`, target directory from `install_dirs` at `:445-449`. Nothing else is placed beside
that copy, and Windows has no symlink to make instead. So from the installed copy:

- `biorouterd_beside` (`crates/biorouter-cli/src/commands/serve.rs:289`) finds no sibling
  `biorouterd.exe`, and `resolve_biorouterd` (`:274`) falls back to a bare name that is not on
  `PATH` → *"could not start biorouterd"*.
- `web_dir_candidates_for` (`:312`) yields `%LOCALAPPDATA%\Biorouter\web`,
  `%LOCALAPPDATA%\ui\desktop\src\web` and `/usr/share/biorouter/web` — none of which can exist on a
  Windows install → `resolve_web_dir` (`:338`) fails.
- `biorouterd_path` in `crates/biorouter-cli/src/commands/apps.rs:250` carried the *same* sibling
  rule, written a second time, and had the same gap.

Unix is unaffected because the install is a **symlink** and PR #183 routed every resolver through
`crates/biorouter-cli/src/commands/exe_path.rs::resolve_exe_path` (canonicalize + `dunce::simplified`).

Shipped Windows layout, read on disk at
`ui/desktop/out/Biorouter-win32-x64/resources/`:

```
bin/   biorouter.exe (204 MB)  biorouterd.exe (208 MB)  libgcc_s_seh-1.dll
       libstdc++-6.dll  libwinpthread-1.dll  git/  llamacpp/  uv.exe  uvx.exe  ...
web/   index.html  assets/  pdfjs/          (12 MB, a sibling of bin/)
```

**A bare copy of `biorouter.exe` does run.** `objdump -p` on both shipped executables shows neither
imports `libgcc_s_seh-1.dll`, `libstdc++-6.dll` nor `libwinpthread-1.dll`; every import is a system
DLL (`KERNEL32`, `ntdll`, `ws2_32`, `bcrypt`, `crypt32`, `ole32`, `user32`, `shell32`, the
`api-ms-win-*` set …). The copy is not broken — it is *alone*.

The desktop card is the primary install path: `ui/desktop/src/main.ts:4819-4837` (`cli:install`)
runs the **bundled** CLI with `setup-path`, so at install time the source is
`<app>\resources\bin\biorouter.exe` — whose parent directory holds the daemon and whose parent's
parent holds `web`. That is the information the copy loses.

## What changed

**A breadcrumb, not a copy.** Copying would mean 208 MB + 12 MB per install and a copy that goes
stale the moment the application updates. One line of text costs nothing and is rewritten on every
install, so it follows the app.

`crates/biorouter/src/system.rs` — one definition of all three pieces, so the installer and the
readers cannot drift apart:
- `INSTALL_ORIGIN_FILE` (`.biorouter-origin`), `record_install_origin`, `install_origin`, and
  `real_path`.
- `place_cli` is extracted from `install_cli`; only the **call** is `#[cfg(not(unix))]`, so the
  logic is plain path/string handling that every platform's CI compiles and tests. Unix is
  byte-identical: still a symlink, still no breadcrumb.
- `real_path` is the canonicalize + `dunce::simplified` rule PR #183 introduced;
  `exe_path::resolve_exe_path` now delegates to it rather than keeping a second copy. `dunce` is
  added to `crates/biorouter/Cargo.toml` with the same explanatory comment style
  `biorouter-cli` uses.

`crates/biorouter-cli/src/commands/exe_path.rs` — `daemon_file_name`, `biorouterd_beside` and
`biorouterd_for` (sibling → breadcrumb). The sibling rule had been written twice, in `serve` and in
`apps`, and this change needed it in both, so it moved to the module that already owns "where does
this executable really live".

`crates/biorouter-cli/src/commands/serve.rs` — `resolve_biorouterd` calls `biorouterd_for`;
`web_dir_candidates_for` gains the breadcrumb-derived `<origin bin>/../web`.

`crates/biorouter-cli/src/commands/apps.rs` — `biorouterd_path` calls the shared rule (and picks up
`is_file()` in place of `exists()` on the way past).

**Ordering**, as specified: `BIOROUTER_SERVE_UI` → `<exe>/../web` → `<exe>/../../ui/desktop/src/web`
→ breadcrumb → `/usr/share/biorouter/web`; and for the daemon, sibling → breadcrumb → bare-name
`PATH` fallback. The breadcrumb is a fallback, not an override: a bundle or daemon actually beside
the binary is this installation's own.

**A stale breadcrumb still contributes its candidate** rather than being filtered out. The "Tried:"
list is the only thing that tells a user whose application moved why an install that used to work
no longer does.

### Two traps, both guarded and both tested

**The self-referential install.** On Windows the installed copy is itself on `PATH`, so a user can
run `biorouter setup-path` **from it**. The source directory is then the install directory, and a
naive writer records the install directory as its own origin — resolving nothing, *and* destroying
the usable breadcrumb the desktop card wrote. `record_install_origin` compares the two canonicalized
directories and writes nothing when they are the same, leaving any existing breadcrumb intact.

**Verbatim paths.** `install_cli` canonicalizes its source, and on Windows `canonicalize` returns
`\\?\C:\…`. That string would reach `BIOROUTER_SERVE_UI` in the child daemon's environment and the
"Tried:" list a user reads — the exact failure `exe_path.rs` documents. It is stripped on write and
again on read.

**The reader never panics and never guesses:** missing file, empty file, unreadable file, whitespace,
a byte-order mark, a trailing newline, or a non-absolute string all yield `None`; a recorded
directory that no longer exists is returned so the caller's failure can name it.

## Tests

18 new tests — 10 in `crates/biorouter/src/system.rs`, 4 in `commands/exe_path.rs`, 4 in
`commands/serve.rs` — plus one existing test extended. All are string/path level and run on every
platform (`std::env::consts::EXE_SUFFIX`, no `#[cfg(unix)]` gates except where a symlink is needed).

```
$ HOME=$(mktemp -d) CARGO_HOME=/Users/wgu/.cargo RUSTUP_HOME=/Users/wgu/.rustup cargo test -p biorouter-cli --lib -- commands::serve commands::exe_path
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 373 filtered out; finished in 0.21s
```
(15 before this change → 23; +8, all of them new.)

```
$ BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib -- system::
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 3724 filtered out; finished in 0.05s
```
(9 before → 19; +10, all of them new. `install_cli` had zero tests.)

### Fail-before

The new tests call functions that do not exist on the pre-fix tree, so they cannot be compiled
against it. Instead the **production behaviour** was neutered on the finished tree, one seam at a
time, and restored with `git checkout --` afterwards. Exactly what was neutered is stated for each.

**A — the breadcrumb consultation removed from both resolvers**
(`web_dir_candidates_for` no longer pushes the derived candidate; `biorouterd_for` returns
`biorouterd_beside(exe)` only):

```
test result: FAILED. 18 passed; 5 failed; 0 ignored; 0 measured; 373 filtered out; finished in 0.14s

failures:
    commands::exe_path::tests::the_daemon_is_found_through_the_breadcrumb_when_nothing_is_beside_the_copy
    commands::serve::tests::a_stale_breadcrumb_is_named_among_the_paths_that_were_tried
    commands::serve::tests::a_windows_style_install_finds_the_bundle_through_its_breadcrumb
    commands::serve::tests::the_breadcrumb_is_consulted_after_the_locations_beside_the_binary
    commands::serve::tests::the_resolved_candidates_are_never_windows_verbatim_paths
```

The other four new CLI tests are fallback/tolerance guards — they pin that the new code must *not*
change the no-breadcrumb, sibling-wins, stale-breadcrumb and garbage-breadcrumb cases — so they pass
either way, by design.

**B — `record_install_origin` made a no-op** (the installer records nothing):

```
test result: FAILED. 15 passed; 4 failed; 0 ignored; 0 measured; 3724 filtered out; finished in 0.10s

failures:
    system::install_origin_tests::a_second_install_replaces_the_recorded_directory
    system::install_origin_tests::an_install_records_the_directory_it_was_copied_from
    system::install_origin_tests::installing_from_the_install_directory_leaves_the_breadcrumb_alone
    system::install_origin_tests::the_recorded_origin_is_never_a_windows_verbatim_path
```

**C — only the self-referential-install guard removed** (the writer otherwise intact), because that
guard is the one that silently destroys a working install:

```
test result: FAILED. 8 passed; 2 failed; 0 ignored; 0 measured; 3733 filtered out; finished in 0.04s

failures:
    system::install_origin_tests::installing_from_the_install_directory_leaves_the_breadcrumb_alone
    system::install_origin_tests::installing_from_the_install_directory_writes_nothing_at_all
```

## Verification

### Runtime, on macOS — a Windows-shaped install driven end to end

The reader half is platform-neutral, so the exact shape a Windows install produces can be built by
hand on this machine: a real **copy** of the CLI alone in an install directory, a `.biorouter-origin`
beside it, and the application (bundle + daemon) elsewhere. The stand-in daemon is a non-executable
file, so the spawn error names the path that was resolved without ever starting anything.

**A — breadcrumb present.** Past web-dir resolution, past the port pre-flight, failing at the spawn
and naming the breadcrumb-derived daemon. Both halves resolved:

```
Error: could not start /tmp/br-h01/App/resources/bin/biorouterd

Caused by:
    Permission denied (os error 13)
```

**B — same install, breadcrumb removed.** The shipped bug, exactly:

```
Error: could not find the Biorouter web interface. Tried:
  /private/tmp/br-h01/Local/Biorouter/web
  /private/tmp/br-h01/Local/ui/desktop/src/web
  /usr/share/biorouter/web
```

**C — breadcrumb restored, application deleted.** The stale location is named, in position 3:

```
Error: could not find the Biorouter web interface. Tried:
  /private/tmp/br-h01/Local/Biorouter/web
  /private/tmp/br-h01/Local/ui/desktop/src/web
  /tmp/br-h01/App/resources/web
  /usr/share/biorouter/web
```

### macOS regression

The macOS path PR #183 fixed is unchanged — `serve` through a symlink to the debug binary still
fails at the **bind**, never at web-dir resolution:

```
$ ln -s <worktree>/target/debug/biorouter /tmp/br-h01/bin/biorouter
$ /tmp/br-h01/bin/biorouter serve --port 1
Error: cannot bind 127.0.0.1:1: Permission denied (os error 13)
```

The dev-tree candidate `<exe>/../../ui/desktop/src/web` does not exist in a fresh worktree, and the
web directory is resolved *before* `preflight_port`, so it was staged by symlinking the already-built
bundle from the main checkout to that relative path (a real directory of symlinks — `src/web/` is a
directory pattern in `ui/desktop/.gitignore`, so a bare symlink at that path is **not** ignored).
`git status` was clean before every commit; both probe directories were deleted afterwards.

### Gates

```
$ cargo fmt --all -- --check          → clean
$ ./scripts/clippy-lint.sh            → REAL_EXIT=0  (incl. the clippy::too_many_lines baseline)
```

`install_cli` did not grow: `place_cli` was extracted, so the function is shorter than before.

### Windows

**These CI jobs are the only Windows evidence in this PR. No run on real Windows hardware was
performed — no Windows machine was available.**

Locally, the same recipe CI's cross-check uses was run against the final tree:

```
$ . scripts/cross-env.sh && cross_windows "cargo check --workspace --all-targets --locked" /cross-target
REAL_EXIT=0
```

with zero diagnostics naming any changed file. That run also caught the one Windows-only defect in
this branch — an unused test import, because the test that uses it needs a symlink and is
`cfg(unix)` — which is invisible on macOS and Linux.

CI on this PR, all 16 checks green (`cross-build-nightly` skipped by design):

| Job | Conclusion | Duration |
|---|---|---|
| **cross-check (x86_64-pc-windows-gnu)** | **pass** | 9m2s |
| **test (windows-latest)** | **pass** | 15m57s |
| cross-check (x86_64-unknown-linux-gnu) | pass | 7m1s |
| test (macos-latest) | pass | 17m25s |
| test (ubuntu-latest) | pass | 16m0s |
| serve | pass | 9m18s |
| guards | pass | 8s |
| Static checks | pass | 1m22s |
| Generated API contract | pass | 8m15s |
| Unit tests (vitest) | pass | 4m58s |
| Preview panel (Electron) | pass | 1m24s |
| BAAM shelf (browser) | pass | 1m1s |
| Registry generator | pass | 23s |
| no-ai-coauthor | pass | 18s / 20s |

`test (windows-latest)` at 15m57s is in its normal band, not the silent-hang shape that once masked
five real Windows failures.

## Follow-ups

- **`crates/biorouter-cli/src/commands/term.rs:166`** uses a raw `std::env::current_exe()` and is
  deliberately left alone. Measured: `term` never spawns `biorouterd` (no reference to it in the
  file) and never reads the interface bundle, so neither thing the breadcrumb exists for is in play;
  the script it emits wants the **`PATH`-visible** command, and on macOS resolving would bake the
  application-bundle path into a shell profile, which is exactly what breaks on the next update;
  on Windows `current_exe()` is `GetModuleFileNameW`, which never returns a verbatim prefix and
  already reports the installed copy. Resolving there would make it worse, not better.
- The `term` script templates interpolate `{biorouter_bin}` into shell aliases without quoting the
  path itself (`term.rs:39-40`, `:89-90`). A path containing a space would break the alias. Real,
  pre-existing, unrelated.
- `.cross-cache/` — the directory CI's cross-check creates in the repo root — is not in
  `.gitignore`, so a local cross run leaves an untracked 7 GB directory.
- `crates/biorouter/src/system.rs` has a `#[cfg(test)] mod tests` in the middle of the file with
  production code after it. Harmless today, but it is the shape that defeats a source guard slicing
  on the first `#[cfg(test)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
