### PR TITLE
Three live readers of the process environment take explicit inputs

### DIFF
--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -3057,6 +3057,20 @@ pub struct AgentConfig {
     pub permission_manager: Arc<PermissionManager>,
     pub scheduler_service: Option<Arc<dyn SchedulerTrait>>,
     pub biorouter_mode: BioRouterMode,
+    /// Whether this agent honours a project's own `.biorouter/hooks.yaml`,
+    /// decided by whoever built the config.
+    ///
+    /// `None` — the production default — resolves it the way it has always been
+    /// resolved: the global config, or `BIOROUTER_ALLOW_PROJECT_HOOKS` in the
+    /// process environment. `Some(_)` states the answer instead.
+    ///
+    /// The field exists because that environment read is a bare
+    /// `std::env::var` in `HooksManager::new_with_managed`, live and unlocked,
+    /// taken by every one of the ~69 places an `Agent` is constructed. A test
+    /// that wanted project hooks on had no way to say so and wrote the variable
+    /// — process-wide, for every other agent in the binary, and in one case
+    /// without ever removing it. See `docs/testing/process-global-state.md`.
+    pub allow_project_hooks: Option<bool>,
 }
 
 impl AgentConfig {
@@ -3071,7 +3085,16 @@ impl AgentConfig {
             permission_manager,
             scheduler_service,
             biorouter_mode,
+            allow_project_hooks: None,
         }
+    }
+
+    /// State the project-hooks decision instead of leaving it to the global
+    /// config and the process environment.
+    #[must_use]
+    pub fn with_project_hooks(mut self, allow: bool) -> Self {
+        self.allow_project_hooks = Some(allow);
+        self
     }
 }
 
@@ -4135,10 +4158,18 @@ impl Agent {
         // Load the managed/enterprise policy once at startup and share it across
         // the hooks manager and the tool inspectors (BR-65).
         let managed = ManagedPolicy::load();
-        let hooks_manager = Arc::new(crate::hooks::HooksManager::new_with_managed(
-            provider.clone(),
-            Arc::clone(&managed),
-        ));
+        let hooks_manager = Arc::new(match config.allow_project_hooks {
+            // Stated by the caller: no environment read at all.
+            Some(allow) => crate::hooks::HooksManager::with_config_and_managed(
+                crate::hooks::config::load_global_config(),
+                allow,
+                provider.clone(),
+                Arc::clone(&managed),
+            ),
+            None => {
+                crate::hooks::HooksManager::new_with_managed(provider.clone(), Arc::clone(&managed))
+            }
+        });
         // BR-43: build the checkpoint manager only when enabled, so the disabled
         // default path never touches disk. Reads `BIOROUTER_CHECKPOINTS` / caps.
         let checkpoint_cfg = CheckpointConfig::from_env();

--- a/crates/biorouter/src/agents/extension_malware_check.rs
+++ b/crates/biorouter/src/agents/extension_malware_check.rs
@@ -46,25 +46,58 @@ impl OsvChecker {
 /// - ends_with("uvx") → PyPI
 ///   unknown commands → skip (fail open)
 pub async fn deny_if_malicious_cmd_args(cmd: &str, args: &[String]) -> Result<(), ExtensionError> {
+    let Some((name, ecosystem, version)) = parse_cmd_args(cmd, args) else {
+        return Ok(());
+    };
+    OsvChecker::new()
+        .map_err(|e| *e)?
+        .deny_if_malicious(&name, ecosystem, version.as_deref())
+        .await
+}
+
+/// [`deny_if_malicious_cmd_args`] against a checker the caller already has.
+///
+/// The endpoint is an **explicit input** here. `OsvChecker::new` resolves
+/// `OSV_ENDPOINT` with a bare `std::env::var`, live and unlocked, and production
+/// reaches it from `ExtensionManager` on every stdio extension launch — so a
+/// test that pointed the checker at a mock server by writing that variable
+/// pointed *every concurrent extension launch in the binary* at the same mock,
+/// and at a dead port once the mock was dropped. The checker fails open on a
+/// request error, so the damage is a silently skipped malware check rather than
+/// a visible failure. See `docs/testing/process-global-state.md`.
+pub async fn deny_if_malicious_cmd_args_with(
+    checker: &OsvChecker,
+    cmd: &str,
+    args: &[String],
+) -> Result<(), ExtensionError> {
+    let Some((name, ecosystem, version)) = parse_cmd_args(cmd, args) else {
+        return Ok(());
+    };
+    checker
+        .deny_if_malicious(&name, ecosystem, version.as_deref())
+        .await
+}
+
+/// The package a command line refers to, or `None` when there is nothing to
+/// check — an unrecognised command, or no package token among the arguments.
+/// Both are "fail open" by design.
+fn parse_cmd_args(cmd: &str, args: &[String]) -> Option<(String, &'static str, Option<String>)> {
     let ecosystem = if cmd.ends_with("uvx") {
         "PyPI"
     } else if cmd.ends_with("npx") {
         "npm"
     } else {
         debug!(%cmd, ?args, "Unknown ecosystem for command; skipping OSV check (fail open).");
-        return Ok(());
+        return None;
     };
 
-    if let Some((name, version)) = parse_first_package_arg(ecosystem, args) {
-        OsvChecker::new()
-            .map_err(|e| *e)?
-            .deny_if_malicious(&name, ecosystem, version.as_deref())
-            .await?;
-    } else {
-        debug!(%cmd, ?args, "No package token found; skipping OSV check.");
+    match parse_first_package_arg(ecosystem, args) {
+        Some((name, version)) => Some((name, ecosystem, version)),
+        None => {
+            debug!(%cmd, ?args, "No package token found; skipping OSV check.");
+            None
+        }
     }
-
-    Ok(())
 }
 
 /// Direct call without command inference.
@@ -286,7 +319,6 @@ fn http_client() -> Result<reqwest::Client, ExtensionError> {
 mod tests {
     use super::*;
     use serde_json::json;
-    use serial_test;
     use tokio;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -294,32 +326,6 @@ mod tests {
     fn checker_for(server: &MockServer) -> OsvChecker {
         let url = Url::parse(&format!("{}/v1/query", server.uri())).unwrap();
         OsvChecker::with_endpoint(url).unwrap()
-    }
-
-    // Helper to temporarily set an environment variable and restore it on drop
-    struct TempEnvVar {
-        key: String,
-        original: Option<String>,
-    }
-
-    impl TempEnvVar {
-        fn set(key: &str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            std::env::set_var(key, value);
-            Self {
-                key: key.to_string(),
-                original,
-            }
-        }
-    }
-
-    impl Drop for TempEnvVar {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(val) => std::env::set_var(&self.key, val),
-                None => std::env::remove_var(&self.key),
-            }
-        }
     }
 
     #[tokio::test]
@@ -364,7 +370,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn cmd_args_pypi_clean() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -376,15 +381,15 @@ mod tests {
             .mount(&server)
             .await;
 
-        // Use env var so OsvChecker::new() picks it up
-        let _env = TempEnvVar::set("OSV_ENDPOINT", &format!("{}/v1/query", server.uri()));
+        // The checker is an argument, so nothing here touches the process
+        // environment that `OsvChecker::new` reads.
+        let checker = checker_for(&server);
         let args = vec!["some_clean_package==1.2.3".to_string()];
-        let res = deny_if_malicious_cmd_args("uvx", &args).await;
+        let res = deny_if_malicious_cmd_args_with(&checker, "uvx", &args).await;
         assert!(res.is_ok());
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn cmd_args_npm_scoped_malicious() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -396,9 +401,9 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _env = TempEnvVar::set("OSV_ENDPOINT", &format!("{}/v1/query", server.uri()));
+        let checker = checker_for(&server);
         let args = vec!["@scope/pkg@2.0.0".to_string()];
-        let res = deny_if_malicious_cmd_args("npx", &args).await;
+        let res = deny_if_malicious_cmd_args_with(&checker, "npx", &args).await;
         assert!(res.is_err());
         let msg = format!("{:?}", res.unwrap_err());
         assert!(msg.contains("Blocked malicious package"));
@@ -406,7 +411,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn cmd_args_skip_flags_then_parse() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -418,13 +422,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let _env = TempEnvVar::set("OSV_ENDPOINT", &format!("{}/v1/query", server.uri()));
+        let checker = checker_for(&server);
         let args = vec![
             "--dry-run".into(),
             "-y".into(),
             "some_clean_package@1.2.3".into(),
         ];
-        let res = deny_if_malicious_cmd_args("npx", &args).await;
+        let res = deny_if_malicious_cmd_args_with(&checker, "npx", &args).await;
         assert!(res.is_ok());
     }
 

--- a/crates/biorouter/src/agents/subagent_tool.rs
+++ b/crates/biorouter/src/agents/subagent_tool.rs
@@ -5646,7 +5646,7 @@ mod tests {
                 Unlock::PermissionMode(mode) => mode,
                 _ => crate::config::BioRouterMode::Auto,
             };
-            let config = AgentConfig::new(sm.clone(), permissions, None, mode);
+            let mut config = AgentConfig::new(sm.clone(), permissions, None, mode);
 
             let mut overrides = ask_overrides(Ask::Public);
             match unlock {
@@ -5660,7 +5660,13 @@ mod tests {
                         format!("hooks: {ALLOW_EVERYTHING}\n"),
                     )
                     .unwrap();
-                    overrides.insert("BIOROUTER_ALLOW_PROJECT_HOOKS".to_string(), "true".into());
+                    // A `with_config_overrides` entry was written here and did
+                    // NOTHING: the task-local is consulted by `Config::get_param`,
+                    // while `HooksManager` reads this flag with a bare
+                    // `std::env::var`. So this arm's unlock was active only when
+                    // another test had leaked the variable, and the test passed
+                    // either way because the refusal holds in both states.
+                    config.allow_project_hooks = Some(true);
                 }
                 Unlock::AlwaysAllowRecord => {}
                 // The wire spelling, not `Debug`: `BioRouterMode` deserializes

--- a/crates/biorouter/src/hooks/mod.rs
+++ b/crates/biorouter/src/hooks/mod.rs
@@ -2325,4 +2325,37 @@ PreToolUse:
             "managed true override should force project hooks on"
         );
     }
+
+    /// A `config::with_config_overrides` entry is **invisible** to this module's
+    /// project-hooks read, and that is not a subtlety — it was a live defect.
+    ///
+    /// `agents/subagent_tool.rs` inserted `BIOROUTER_ALLOW_PROJECT_HOOKS` into an
+    /// override map to unlock project hooks for one arm of a refusal table. The
+    /// task-local is consulted by `Config::get_param` (`config/base.rs`), and
+    /// `HooksManager::new_with_managed` reads the flag with a bare
+    /// `std::env::var` — so the arm was unlocked only when some *other* test had
+    /// leaked the variable into the process, and it passed either way because the
+    /// refusal it asserts holds in both states. The unlock is now stated on
+    /// `AgentConfig::allow_project_hooks` instead.
+    ///
+    /// Written as a before/inside comparison rather than an `is_err()` assertion
+    /// so it does not depend on the ambient environment of the machine running
+    /// it. The other half of the contract — that an override DOES reach a
+    /// `get_param` reader — is `config::base::tests::task_local_override_wins_over_env`.
+    #[tokio::test]
+    async fn a_config_override_never_reaches_the_project_hooks_env_read() {
+        const KEY: &str = "BIOROUTER_ALLOW_PROJECT_HOOKS";
+        let before = std::env::var(KEY).ok();
+        let inside = crate::config::with_config_overrides(
+            std::collections::HashMap::from([(KEY.to_string(), "true".to_string())]),
+            async { std::env::var(KEY).ok() },
+        )
+        .await;
+        assert_eq!(
+            before, inside,
+            "a task-local config override must not change what a bare `std::env::var` \
+             reader sees; if this ever passes by accident, check that nothing in the \
+             binary is writing {KEY}"
+        );
+    }
 }

--- a/crates/biorouter/src/providers/bedrock.rs
+++ b/crates/biorouter/src/providers/bedrock.rs
@@ -1144,7 +1144,11 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn signed_multi_tool_replay_is_exact_in_reply_and_omitted_after_reload() {
-        std::env::set_var("BIOROUTER_ALLOW_PROJECT_HOOKS", "1");
+        // The project-hooks decision is stated on this agent's config below.
+        // It used to be `set_var("BIOROUTER_ALLOW_PROJECT_HOOKS", "1")` with no
+        // matching remove, so the flag stood for every agent constructed in
+        // the binary afterwards — and an unkeyed `#[serial]` fenced it against
+        // only the other unkeyed tests.
         let work = TempDir::new().unwrap();
         let data = TempDir::new().unwrap();
         let permissions = TempDir::new().unwrap();
@@ -1204,12 +1208,15 @@ mod tests {
         .unwrap();
 
         let manager = Arc::new(SessionManager::new(data.path().to_path_buf()));
-        let agent = Agent::with_config(AgentConfig::new(
-            manager.clone(),
-            Arc::new(PermissionManager::new(permissions.path().to_path_buf())),
-            None,
-            BioRouterMode::Auto,
-        ));
+        let agent = Agent::with_config(
+            AgentConfig::new(
+                manager.clone(),
+                Arc::new(PermissionManager::new(permissions.path().to_path_buf())),
+                None,
+                BioRouterMode::Auto,
+            )
+            .with_project_hooks(true),
+        );
         agent
             .add_extension(ExtensionConfig::Builtin {
                 name: "developer".to_string(),

--- a/crates/biorouter/src/providers/formats/anthropic.rs
+++ b/crates/biorouter/src/providers/formats/anthropic.rs
@@ -667,9 +667,30 @@ fn take_ready_tool_contents(
     ready
 }
 
-#[allow(clippy::too_many_lines)]
+/// Decode an Anthropic SSE stream, sampling the tool-call batching kill switch
+/// once, here, at stream construction.
+///
+/// The sample is taken by this wrapper rather than inside the decoder because
+/// the decoder is what tests drive. `tool_call_batching_enabled()` is a bare
+/// `std::env::var` (`providers/base.rs`), so a test that exercised the decoder
+/// read whatever another test had parked in the process environment — and
+/// `env_lock` could not help, because this reader never asked for it. See
+/// `docs/testing/process-global-state.md`.
 pub fn response_to_streaming_message<S>(
+    stream: S,
+) -> impl futures::Stream<Item = anyhow::Result<crate::providers::base::ProviderStreamItem>> + 'static
+where
+    S: futures::Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
+{
+    response_to_streaming_message_batching(stream, tool_call_batching_enabled())
+}
+
+/// [`response_to_streaming_message`] with the batching decision supplied by the
+/// caller instead of resolved from the environment.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn response_to_streaming_message_batching<S>(
     mut stream: S,
+    batch_tool_calls: bool,
 ) -> impl futures::Stream<Item = anyhow::Result<crate::providers::base::ProviderStreamItem>> + 'static
 where
     S: futures::Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
@@ -718,7 +739,6 @@ where
         // text, whichever comes first.
         let mut last_pending_emit: Option<std::time::Instant> = None;
         let mut last_pending_len: usize = 0;
-        let batch_tool_calls = tool_call_batching_enabled();
 
         while let Some(line_result) = stream.next().await {
             let line = line_result?;
@@ -1526,7 +1546,7 @@ mod tests {
             r#"data: {"type":"message_stop"}"#,
         ];
         let response_stream = tokio_stream::iter(lines.into_iter().map(|l| Ok(l.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, true);
         pin!(messages);
 
         let mut thinking_blocks = Vec::new();
@@ -1575,12 +1595,12 @@ mod tests {
     /// arrived in, from a decoded stream. `[2]` means one message carried two
     /// requests (batched); `[1, 1]` means two separate one-request messages
     /// (the pre-§6.2b serial shape).
-    async fn tool_request_message_shape(lines: Vec<&'static str>) -> Vec<usize> {
+    async fn tool_request_message_shape(lines: Vec<&'static str>, batch: bool) -> Vec<usize> {
         use tokio::pin;
         use tokio_stream::StreamExt;
 
         let response_stream = tokio_stream::iter(lines.into_iter().map(|l| Ok(l.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, batch);
         pin!(messages);
 
         let mut shape = Vec::new();
@@ -1620,21 +1640,21 @@ mod tests {
     /// forced serial execution; that shape is what the kill switch restores
     /// (`test_streaming_kill_switch_restores_serial_tool_messages`).
     ///
-    /// ⚠ Same `serial_test` group as the kill-switch test, and this is not
-    /// hygiene: that test sets `BIOROUTER_TOOL_CALL_BATCHING=0` process-wide,
-    /// `serial` only excludes tests carrying the SAME key, and every decoder
-    /// reads the flag at construction. Unannotated, this test read the kill
-    /// switch's env var and asserted `[1, 1] == [2]` — `test (ubuntu-latest)`
-    /// red on a diff nowhere near it, and 7 failures in 8 local runs.
+    /// ⚠ This test states its batching input rather than inheriting it, and the
+    /// argument is what makes that possible. It used to carry
+    /// `#[serial(tool_call_batching_env)]`, which excluded only the two other
+    /// tests holding that key while the flag was read live, unlocked, by every
+    /// decoder in the binary — so it asserted `[1, 1] == [2]` whenever anything
+    /// else wrote the variable. `test (ubuntu-latest)` went red on a diff
+    /// nowhere near it, and 7 of 8 local runs failed.
     #[tokio::test]
-    #[serial_test::serial(tool_call_batching_env)]
     async fn test_streaming_batches_multiple_tool_uses_into_one_message() -> Result<()> {
         use tokio::pin;
         use tokio_stream::StreamExt;
 
         let response_stream =
             tokio_stream::iter(TWO_TOOL_USE_LINES.iter().map(|l| Ok(l.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, true);
         pin!(messages);
 
         let mut items = Vec::new();
@@ -1710,19 +1730,17 @@ mod tests {
     /// batched tools via the after-loop flush — otherwise a whole multi-tool turn
     /// would silently vanish.
     ///
-    /// ⚠ In the kill switch's `serial_test` group for the reason spelled out on
-    /// `test_streaming_batches_multiple_tool_uses_into_one_message`: it decodes
-    /// two `tool_use` blocks, so it reads `BIOROUTER_TOOL_CALL_BATCHING` and
-    /// raced the test that sets it. Any future test that decodes more than one
-    /// tool block belongs here too.
+    /// ⚠ It decodes two `tool_use` blocks, so it is batching-sensitive and states
+    /// its input, for the reason spelled out on
+    /// `test_streaming_batches_multiple_tool_uses_into_one_message`. Any future
+    /// test that decodes more than one tool block must do the same.
     #[tokio::test]
-    #[serial_test::serial(tool_call_batching_env)]
     async fn test_streaming_batches_tools_without_message_delta() -> Result<()> {
         // Drop the trailing message_delta; end with [DONE] instead.
         let mut lines: Vec<&'static str> = TWO_TOOL_USE_LINES[..7].to_vec();
         lines.push(r#"data: [DONE]"#);
 
-        let shape = tool_request_message_shape(lines).await;
+        let shape = tool_request_message_shape(lines, true).await;
         assert_eq!(
             shape,
             vec![2],
@@ -1736,15 +1754,14 @@ mod tests {
     /// serial shape — one assistant message per `tool_use` block (`[1, 1]`). This
     /// is the full rollback lever documented alongside `BIOROUTER_TOOL_WRITE_ORDERING`.
     ///
-    /// Uses `serial_test` because it mutates a process-global env var.
+    /// Injects the decision rather than writing `BIOROUTER_TOOL_CALL_BATCHING`.
+    /// The env write this used to make was read by every OTHER decoder in the
+    /// binary — a live, unlocked `std::env::var` — so `serial_test` could not
+    /// contain it. The env *parsing* is covered separately by
+    /// `providers::base`'s own tests.
     #[tokio::test]
-    #[serial_test::serial(tool_call_batching_env)]
     async fn test_streaming_kill_switch_restores_serial_tool_messages() -> Result<()> {
-        // SAFETY: single-threaded tokio test, serialized against any other test
-        // touching this env var; restored before returning.
-        std::env::set_var("BIOROUTER_TOOL_CALL_BATCHING", "0");
-        let shape = tool_request_message_shape(TWO_TOOL_USE_LINES.to_vec()).await;
-        std::env::remove_var("BIOROUTER_TOOL_CALL_BATCHING");
+        let shape = tool_request_message_shape(TWO_TOOL_USE_LINES.to_vec(), false).await;
 
         assert_eq!(
             shape,
@@ -1772,7 +1789,7 @@ mod tests {
             r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}"#,
         ];
         let response_stream = tokio_stream::iter(lines.into_iter().map(|l| Ok(l.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, true);
         pin!(messages);
 
         let mut items = Vec::new();
@@ -1874,7 +1891,7 @@ mod tests {
             r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}"#,
         ];
         let response_stream = tokio_stream::iter(lines.into_iter().map(|l| Ok(l.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, true);
         pin!(messages);
 
         // Mirror the agent loop: a chunk with no tool requests is pushed
@@ -2113,7 +2130,7 @@ data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"outpu
 data: [DONE]
 "#;
         let response_stream = tokio_stream::iter(lines.lines().map(|line| Ok(line.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, true);
         pin!(messages);
 
         let mut final_usage = None;
@@ -2293,7 +2310,7 @@ data: [DONE]
             r#"data: {"type":"message_stop"}"#,
         ];
         let response_stream = tokio_stream::iter(lines.into_iter().map(|l| Ok(l.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, true);
         pin!(messages);
 
         let mut seen_length = false;
@@ -2326,7 +2343,7 @@ data: [DONE]
             r#"data: {"type":"message_stop"}"#,
         ];
         let response_stream = tokio_stream::iter(lines.into_iter().map(|l| Ok(l.to_string())));
-        let messages = response_to_streaming_message(response_stream);
+        let messages = response_to_streaming_message_batching(response_stream, true);
         pin!(messages);
 
         let mut saw_stop = false;

--- a/crates/biorouter/src/providers/formats/bedrock.rs
+++ b/crates/biorouter/src/providers/formats/bedrock.rs
@@ -1929,7 +1929,7 @@ mod bedrock_stream_tests {
     /// killing the turn.
     #[test]
     fn two_tool_use_blocks_batch_into_one_assistant_message() {
-        let mut decoder = BedrockStreamDecoder::new("m");
+        let mut decoder = BedrockStreamDecoder::with_batching("m", true);
         let items = drain(
             &mut decoder,
             &[
@@ -2010,7 +2010,7 @@ mod bedrock_stream_tests {
     /// so block 2's request was dispatched and persisted ahead of block 1's.
     #[test]
     fn batched_tools_keep_block_order_when_stops_arrive_reversed() {
-        let mut decoder = BedrockStreamDecoder::new("m");
+        let mut decoder = BedrockStreamDecoder::with_batching("m", true);
         let items = drain(
             &mut decoder,
             &[
@@ -2051,7 +2051,7 @@ mod bedrock_stream_tests {
     /// `messageStop` — the `finish()` flush must apply the same index sort.
     #[test]
     fn finish_flush_also_sorts_reversed_stop_order() {
-        let mut decoder = BedrockStreamDecoder::new("m");
+        let mut decoder = BedrockStreamDecoder::with_batching("m", true);
         let during = drain(
             &mut decoder,
             &[
@@ -2124,7 +2124,7 @@ mod bedrock_stream_tests {
     /// silently vanish.
     #[test]
     fn stream_ending_without_message_stop_still_flushes_batched_tools() {
-        let mut decoder = BedrockStreamDecoder::new("m");
+        let mut decoder = BedrockStreamDecoder::with_batching("m", true);
         let during = drain(
             &mut decoder,
             &[

--- a/crates/biorouter/src/providers/formats/google.rs
+++ b/crates/biorouter/src/providers/formats/google.rs
@@ -516,9 +516,30 @@ fn flush_pending_tool_contents(
     )
 }
 
-#[allow(clippy::too_many_lines)]
+/// Decode a Google SSE stream, sampling the tool-call batching kill switch once,
+/// here, at stream construction.
+///
+/// The sample is taken by this wrapper rather than inside the decoder because
+/// the decoder is what tests drive. `tool_call_batching_enabled()` is a bare
+/// `std::env::var` (`providers/base.rs`), so a test that exercised the decoder
+/// read whatever another test had parked in the process environment — and
+/// `env_lock` could not help, because this reader never asked for it. See
+/// `docs/testing/process-global-state.md`.
 pub fn response_to_streaming_message<S>(
+    stream: S,
+) -> impl futures::Stream<Item = anyhow::Result<crate::providers::base::ProviderStreamItem>> + 'static
+where
+    S: futures::Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
+{
+    response_to_streaming_message_batching(stream, tool_call_batching_enabled())
+}
+
+/// [`response_to_streaming_message`] with the batching decision supplied by the
+/// caller instead of resolved from the environment.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn response_to_streaming_message_batching<S>(
     mut stream: S,
+    batch_tool_calls: bool,
 ) -> impl futures::Stream<Item = anyhow::Result<crate::providers::base::ProviderStreamItem>> + 'static
 where
     S: futures::Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
@@ -536,7 +557,6 @@ where
         // dispatches in parallel. Off restores one message per block (serial).
         // Text/thinking parts keep streaming per-part, unchanged. A dropped
         // stream (cancellation) drops this Vec unflushed — never half-delivers.
-        let batch_tool_calls = tool_call_batching_enabled();
         let mut pending_tool_contents: Vec<MessageContent> = Vec::new();
 
         while let Some(line_result) = stream.next().await {
@@ -1398,7 +1418,8 @@ mod tests {
             .map(|l| Ok(l.to_string()))
             .collect();
         let stream = Box::pin(futures::stream::iter(lines));
-        let mut message_stream = std::pin::pin!(response_to_streaming_message(stream));
+        let mut message_stream =
+            std::pin::pin!(response_to_streaming_message_batching(stream, true));
 
         let mut text_parts = Vec::new();
         let mut message_ids: Vec<Option<String>> = Vec::new();
@@ -1443,7 +1464,8 @@ mod tests {
             .map(|l| Ok(l.to_string()))
             .collect();
         let stream = Box::pin(futures::stream::iter(lines));
-        let mut message_stream = std::pin::pin!(response_to_streaming_message(stream));
+        let mut message_stream =
+            std::pin::pin!(response_to_streaming_message_batching(stream, true));
 
         let mut tool_calls = Vec::new();
 
@@ -1483,7 +1505,8 @@ mod tests {
             .map(|l| Ok(l.to_string()))
             .collect();
         let stream = Box::pin(futures::stream::iter(lines));
-        let mut message_stream = std::pin::pin!(response_to_streaming_message(stream));
+        let mut message_stream =
+            std::pin::pin!(response_to_streaming_message_batching(stream, true));
 
         let mut tool_messages: Vec<Message> = Vec::new();
         let mut saw_usage = false;
@@ -1545,7 +1568,8 @@ mod tests {
         let lines: Vec<Result<String, anyhow::Error>> =
             signed_stream.lines().map(|l| Ok(l.to_string())).collect();
         let stream = Box::pin(futures::stream::iter(lines));
-        let mut message_stream = std::pin::pin!(response_to_streaming_message(stream));
+        let mut message_stream =
+            std::pin::pin!(response_to_streaming_message_batching(stream, true));
 
         let mut text_parts = Vec::new();
 
@@ -1572,7 +1596,8 @@ mod tests {
         let lines: Vec<Result<String, anyhow::Error>> =
             error_stream.lines().map(|l| Ok(l.to_string())).collect();
         let stream = Box::pin(futures::stream::iter(lines));
-        let mut message_stream = std::pin::pin!(response_to_streaming_message(stream));
+        let mut message_stream =
+            std::pin::pin!(response_to_streaming_message_batching(stream, true));
 
         let result = message_stream.next().await;
         assert!(result.is_some());
@@ -1598,7 +1623,8 @@ data: [DONE]"#;
         let lines: Vec<Result<String, anyhow::Error>> =
             sse_stream.lines().map(|l| Ok(l.to_string())).collect();
         let stream = Box::pin(futures::stream::iter(lines));
-        let mut message_stream = std::pin::pin!(response_to_streaming_message(stream));
+        let mut message_stream =
+            std::pin::pin!(response_to_streaming_message_batching(stream, true));
 
         let mut text_parts = Vec::new();
 
@@ -1631,7 +1657,8 @@ data: [DONE]"#;
             .map(|l| Ok(l.to_string()))
             .collect();
         let stream = Box::pin(futures::stream::iter(lines));
-        let mut message_stream = std::pin::pin!(response_to_streaming_message(stream));
+        let mut message_stream =
+            std::pin::pin!(response_to_streaming_message_batching(stream, true));
 
         let mut text_parts = Vec::new();
 


### PR DESCRIPTION
## Why

PR #198 fixed one instance of a shape and deferred the general audit. The audit
(BaranziniLab/biorouter#201) found three more, two of them **live**. This PR fixes all three.

The shape: a production reader resolves a process-global with a bare `std::env::var` — live,
unlocked, on a path tests exercise — while a test writes that variable. `env_lock` and
`#[serial]` cannot help, because they serialise only the callers that ask, and the reader
never does.

## Root cause

### 1. `BIOROUTER_TOOL_CALL_BATCHING` — live

`tool_call_batching_enabled()` (`crates/biorouter/src/providers/base.rs:1236`) decides whether
one response's N `tool_use` blocks batch into **one** assistant message (parallel dispatch) or
N messages (serial). It was read from inside the decoder, once per streamed turn:
`formats/anthropic.rs:721`, `formats/google.rs:539`. `formats/bedrock.rs:1108` already had a
`with_batching` test seam, and its own comment says why — the other two never got it.

The writer, `formats/anthropic.rs:1745`, carries `#[serial(tool_call_batching_env)]`. Only
three tests hold that key. **Five batching-sensitive tests hold no key at all**:

| Test | What flips |
|---|---|
| `formats/google.rs:1478` `test_streaming_batches_multiple_function_calls_into_one_message` | asserts one message; unbatched gives two |
| `formats/bedrock.rs:1931` `two_tool_use_blocks_batch_into_one_assistant_message` | same |
| `formats/bedrock.rs:2012` `batched_tools_keep_block_order_when_stops_arrive_reversed` | block order inverts |
| `formats/bedrock.rs:2053` `finish_flush_also_sorts_reversed_stop_order` | drains early |
| `formats/bedrock.rs:2126` `stream_ending_without_message_stop_still_flushes_batched_tools` | drains early |

The google one is a direct twin of the very test that carries the key.

### 2. `OSV_ENDPOINT` — live, and the failure mode is silent

`OsvChecker::new` (`agents/extension_malware_check.rs:18`) reads it, and **production reaches
that from `agents/extension_manager.rs:972` on every stdio extension launch**. Three tests
pointed the checker at a wiremock server by writing the variable under an *unkeyed*
`#[serial]`, which fences them against 30 other tests and leaves them concurrent with the
rest. A concurrent launch then talked to another test's mock — or, once that mock was
dropped, to a dead port. The checker **fails open** on a request error, so the result is a
silently skipped malware check rather than a visible failure.

### 3. `BIOROUTER_ALLOW_PROJECT_HOOKS` — latent, hiding two real defects

`hooks/mod.rs:214` reads it with a bare `env::var`. Sensitivity needs a
`.biorouter/hooks.yaml` in the reading agent's working dir, and there is none in-tree, so
nothing can go red today. Underneath sit two defects that are not hypothetical:

- **A leak with no matching remove.** `providers/bedrock.rs:1147` sets the flag and
  `providers/bedrock.rs` contains no `remove_var` at all, so it stood for every agent
  constructed in the binary afterwards. Its unkeyed `#[serial]` therefore fenced nothing —
  the leak outlives the serial section entirely. The comment above it explains the placement:
  it is the only hook-driven test in the lib rather than in `tests/`, because Windows CI runs
  `--lib --bins`. A safe integration-test idiom was copied into the lib binary and stopped
  being safe on arrival.
- **A dead override.** `agents/subagent_tool.rs:5663` inserted the key into a
  `config::with_config_overrides` map. That task-local is consulted by `Config::get_param`,
  and this reader calls `std::env::var`. **The override was a no-op**, so the
  `ProjectHooksAllow` arm of `the_spawn_refusal_cannot_be_unlocked_by_anything_the_agent_can_write`
  was unlocked only when bedrock's leak happened to fire first. Its coverage was a function of
  test-scheduling order, and it passed either way because the refusal holds in both states.

## What changed (file:line)

**Decoders take the batching decision** — `providers/formats/anthropic.rs`,
`providers/formats/google.rs`. Each public `response_to_streaming_message` becomes a
three-line wrapper that samples `tool_call_batching_enabled()` once at stream construction and
delegates to `response_to_streaming_message_batching(stream, batch)`. **Public arity is
unchanged, so no production caller is touched** (`providers/anthropic.rs:309`,
`providers/claude_code.rs:1155`, `providers/google.rs:212`,
`providers/formats/gcpvertexai.rs:345`/`:347`). In-file tests call the explicit form; the four
batching-sensitive bedrock tests move to the existing `with_batching(_, true)` seam.

**The OSV check takes a checker** — `agents/extension_malware_check.rs`. The command parsing
moves into `parse_cmd_args`, shared by `deny_if_malicious_cmd_args` (which constructs from the
environment, as production does) and the new `deny_if_malicious_cmd_args_with`. The three
tests pass `checker_for(&server)`. The `TempEnvVar` RAII helper is deleted outright.
`unknown_command_is_skipped` deliberately keeps the env-resolving entry point — it must prove
no checker is ever constructed.

**Project hooks become an explicit input** — `agents/agent.rs`. `AgentConfig` gains
`allow_project_hooks: Option<bool>` plus `with_project_hooks(bool)`; `None` keeps today's
resolution, so all ~69 `AgentConfig::new` sites compile unchanged. `Agent::with_config`
branches to `HooksManager::with_config_and_managed`, which already took the flag as a
parameter. `providers/bedrock.rs` and `agents/subagent_tool.rs` use it.

**One new test** — `hooks/mod.rs`, `a_config_override_never_reaches_the_project_hooks_env_read`.
It pins the mechanism the dead override got wrong, as a before/inside comparison rather than
an `is_err()` assertion so it does not depend on the machine's ambient environment.

**Five `#[serial]` attributes removed** (three keyed, two unkeyed). None added.

## Tests

**Fail-before / pass-after, per hazard.** Both use #198's method: take two reads of one
surface with the flip injected between them, at the point a concurrent writer actually lands.

*Batching* — the flip injected into `test_streaming_batches_multiple_tool_uses_into_one_message`:

```
--- pre-fix ---
panicked at crates/biorouter/src/providers/formats/anthropic.rs:1657:9:
assertion `left == right` failed: two tool_use blocks must batch into ONE assistant message, not one per block
  left: 2
 right: 1
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3732 filtered out

--- post-fix, same injection ---
test providers::formats::anthropic::tests::test_streaming_batches_multiple_tool_uses_into_one_message ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3732 filtered out
```

*OSV* — the flip injected into `cmd_args_npm_scoped_malicious` between its own setup and its
call, pointing at a dead port exactly as a dropped mock's port is:

```
--- pre-fix ---
panicked at crates/biorouter/src/agents/extension_malware_check.rs:406:9:
assertion failed: res.is_err()
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3732 filtered out

--- post-fix, same injection ---
test agents::extension_malware_check::tests::cmd_args_npm_scoped_malicious ... ok
```

That pre-fix failure **is** the security consequence: a package the mock reports as `MAL-9999`
is allowed through, because the checker failed open against the dead endpoint.

> A note on method: an earlier attempt injected the flip at the *top* of the OSV test and it
> passed, because the test's own `TempEnvVar::set` came later and overwrote it. The probe was
> measuring nothing. Both injections above are placed where a concurrent writer actually
> lands.

Both probes were removed; neither is in this diff.

**Previously dead arm, now live.** `the_spawn_refusal_cannot_be_unlocked_by_anything_the_agent_can_write`
passes with the `ProjectHooksAllow` unlock genuinely applied for the first time:

```
test agents::subagent_tool::tests::the_spawn_refusal_cannot_be_unlocked_by_anything_the_agent_can_write ... ok
```

**Suites:**

```
BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib
test result: ok. 3733 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 35.40s

BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter-server --lib
test result: ok. 575 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.39s
```

Baseline on `origin/main` in this worktree was `3732 passed`; the delta is the one test added
here, so nothing was lost to a stolen attribute.

**Stress**, 20 runs at `--test-threads=32` over `providers::formats:: agents::extension_malware_check hooks:: agents::subagent_tool`:

| runs | result |
|---|---|
| 1-20 | **20 pass / 0 fail** (410 passed each) |

**Gates:**

```
cargo fmt --all -- --check   → clean
./scripts/clippy-lint.sh     → ✅ All baseline clippy checks passed!
                               ✓ No banned TLS crates found
```

Neither renamed function needed a `too_many_lines` baseline entry: both carry an inline
`#[allow]` that moved with them, and `clippy-baselines/too_many_lines.txt` is unchanged.

## Verification

No user-visible behaviour changes. The claim that production is untouched is structural: the
two public stream entry points keep their arity and sample the same expression they used to
read inline, and `AgentConfig::allow_project_hooks` defaults to `None`, which takes the
pre-existing code path verbatim.

After this PR nothing under `crates/*/src/` writes any of the three keys:

```bash
grep -rn 'set_var("BIOROUTER_TOOL_CALL_BATCHING"\|set_var("BIOROUTER_ALLOW_PROJECT_HOOKS"\|set_var("OSV_ENDPOINT"' crates/ --include='*.rs'
```

returns only two hits in `crates/biorouter/tests/`, plus one comment.

## Follow-ups

- `crates/biorouter/tests/hooks_agent_loop_tests.rs:132` and
  `crates/biorouter/tests/global_memory_consent_agent_loop.rs:141` still set
  `BIOROUTER_ALLOW_PROJECT_HOOKS` without removing it. Each `tests/` file is its own process,
  so they cannot reach the lib binary — but they can reach the other tests in their own file.
  Left alone here; the audit records them.
- The table-driven source-scan guard covering these keys is the next PR, and it needs this
  one merged first: it asserts these keys are unwritten.
- `providers/bedrock.rs:79` and `providers/sagemaker_tgi.rs:52` write every `AWS_*` value and
  secret into the environment of a multi-threaded daemon from **production** code. Same
  mechanism, not a test concern; recorded in the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
