### PR TITLE
Desktop: a turn states its binding and ratcheted privacy tier from its first frame

### DIFF
--- a/crates/biorouter-cli/src/commands/web.rs
+++ b/crates/biorouter-cli/src/commands/web.rs
@@ -626,14 +626,24 @@ async fn process_message_streaming(
                     Ok(AgentEvent::ModelChange { model, mode }) => {
                         tracing::info!("Model changed to {} in {} mode", model, mode);
                     }
-                    // Issue #56 Gate B's repair arm: this turn ran on the
-                    // provider the session row names. Logged rather than sent:
-                    // the web bridge's frame vocabulary is the transcript, and a
-                    // browser session cannot change its model anyway (SD-1), so
-                    // there is no wrong choice on screen for it to correct.
-                    Ok(AgentEvent::PrivacyProviderPinned { provider, model }) => {
-                        tracing::info!(
-                            "Private chat pinned to its own binding: {provider} / {model}"
+                    // Issue #56 Gate B: what this turn ran on, and how the chat
+                    // is classified. Logged rather than sent: the web bridge's
+                    // frame vocabulary is the transcript, and a browser session
+                    // cannot change its model anyway (SD-1), so there is no wrong
+                    // choice on screen for it to correct.
+                    //
+                    // ⚠ `debug!`, not `info!`. The frame arrives on every turn
+                    // now, so an `info!` line naming a binding nothing can change
+                    // would be one log line per turn, forever, saying what the
+                    // start-up banner already said.
+                    Ok(AgentEvent::PrivacyProviderPinned {
+                        provider,
+                        model,
+                        privacy_tier,
+                        ..
+                    }) => {
+                        tracing::debug!(
+                            "Turn ran on {provider} / {model} (chat classified {privacy_tier:?})"
                         );
                     }
                     // BR-52: the web bridge reads token counts from the session

--- a/crates/biorouter-cli/src/session/mod.rs
+++ b/crates/biorouter-cli/src/session/mod.rs
@@ -1546,19 +1546,27 @@ impl CliSession {
                                 eprintln!("Model changed to {} in {} mode", model, mode);
                             }
                         }
-                        // Issue #56 Gate B's repair arm: the turn ran on the
-                        // provider the session row names rather than on the
-                        // configured one. Its audience is the desktop composer,
-                        // whose model chip is the thing that was saying something
-                        // false; a terminal prints its binding at start-up and
-                        // `builder.rs` refuses, before creating any provider, the
-                        // chats this arm would have had to repair. Reported under
-                        // `--debug` rather than added to `StreamEvent`, whose shape
-                        // is a public contract.
-                        Some(Ok(AgentEvent::PrivacyProviderPinned { provider, model })) => {
+                        // Issue #56 Gate B: what the turn ran on, and how the
+                        // chat is classified. Its audience is the desktop
+                        // composer, whose model chip is the thing that was saying
+                        // something false; a terminal prints its binding at
+                        // start-up and `builder.rs` refuses, before creating any
+                        // provider, the chats Gate B would have had to repair.
+                        // Reported under `--debug` rather than added to
+                        // `StreamEvent`, whose shape is a public contract.
+                        //
+                        // ⚠ The wording no longer claims privacy is the reason.
+                        // The frame arrives on every turn now, so "this chat is
+                        // private, so …" would be false on most of them.
+                        Some(Ok(AgentEvent::PrivacyProviderPinned {
+                            provider,
+                            model,
+                            privacy_tier,
+                            ..
+                        })) => {
                             if self.debug {
                                 eprintln!(
-                                    "This chat is private, so the turn ran on {provider} / {model}"
+                                    "Turn ran on {provider} / {model} (chat classified {privacy_tier:?})"
                                 );
                             }
                         }

--- a/crates/biorouter-cli/src/session/tui/mod.rs
+++ b/crates/biorouter-cli/src/session/tui/mod.rs
@@ -633,10 +633,10 @@ async fn drive_response(
                     Some(Ok(AgentEvent::McpNotification(_))) => {}
                     Some(Ok(AgentEvent::HistoryReplaced(c))) => { session.messages = c; }
                     Some(Ok(AgentEvent::ModelChange { .. })) => {}
-                    // Issue #56 Gate B's repair arm. The TUI shows its binding in
-                    // the status line and reads it from the same session the
-                    // agent does, so it is already displaying the pinned model;
-                    // the arm this frame exists for is the desktop composer's.
+                    // Issue #56 Gate B. The TUI shows its binding in the status
+                    // line and reads it from the same session the agent does, so
+                    // it is already displaying what the frame reports; the arm
+                    // this frame exists for is the desktop composer's.
                     Some(Ok(AgentEvent::PrivacyProviderPinned { .. })) => {}
                     // BR-52: the TUI reads token counts from the session row.
                     Some(Ok(AgentEvent::TokenUsage(_))) => {}

--- a/crates/biorouter-server/src/routes/reply.rs
+++ b/crates/biorouter-server/src/routes/reply.rs
@@ -13,6 +13,7 @@ use axum::{
 use biorouter::agents::{InterruptRefused, PersistedMessage, ReasoningEffort};
 use biorouter::conversation::message::{Message, MessageContent, TokenState};
 use biorouter::conversation::Conversation;
+use biorouter::privacy::SessionClassification;
 use biorouter::session::session_manager::ReplaceOutcome;
 use biorouter::session::SessionManager;
 use bytes::Bytes;
@@ -385,27 +386,38 @@ pub enum MessageEvent {
     MessagesPersisted {
         messages: Vec<PersistedMessage>,
     },
-    /// Issue #56 Gate B, repair arm: the provider and model that actually
-    /// served this turn, sent when the agent had to fall back to the one the
-    /// SESSION ROW names because the chat's classification does not admit the
-    /// bound one.
+    /// Issue #56 Gate B: what this turn is running on — the provider and model
+    /// the agent holds at the seam, plus the chat's classification after the
+    /// turn ratchet has committed.
     ///
     /// Advisory display state, exactly like `ToolCallPending`: never persisted,
     /// never replayed, never shown to the model, and it changes nothing about
-    /// what the privacy gates permit or refuse. Its whole job is that a user who
-    /// switched the app to a public model and then sent into a private chat can
-    /// see that the turn went elsewhere — and that the composer's model chip and
-    /// context gauge can be sized to the window that was really used.
+    /// what the privacy gates permit or refuse. `privacy_tier` here is a REPORT
+    /// of a classification the daemon has already written; reading it is not a
+    /// second write and no gate consults this frame.
     ///
-    /// ⚠ It does NOT carry the selection it displaced, so a client must not
-    /// treat receiving it as "the user's choice was overridden". The frame
-    /// arrives on every repaired bind, including the ordinary ones (a
-    /// rehydrated agent, a legacy row) where it names exactly what the client is
-    /// already showing. Compare it against what you display, and say nothing
-    /// when they agree.
+    /// ⚠ **Sent on every turn that reaches a provider**, not only on a repaired
+    /// bind. It carries the two fields a client cannot compute and that change
+    /// underneath it: the ratcheted `privacy_tier` (measured by #196 as the one
+    /// field that lagged, which is why a chat a turn had just made private
+    /// showed neither the note nor the chip override until a reload) and the
+    /// binding `restore_provider_from_session` took from a row another window,
+    /// the CLI or a schedule may have rewritten.
+    ///
+    /// ⚠ It does NOT carry the selection it may have displaced, so a client must
+    /// not treat receiving it as "the user's choice was overridden" — on the
+    /// overwhelmingly common turn it names exactly what the client is already
+    /// showing. Compare it against what you display, and say nothing when they
+    /// agree. Widening it from the repair arm is safe precisely because that
+    /// comparison, not the frame's arrival, is what earns a word on screen.
     PrivacyProviderPinned {
         provider: String,
         model: String,
+        /// The chat's classification at this turn's seam, after the ratchet.
+        privacy_tier: SessionClassification,
+        /// That classification's provenance on the row (`turn:versa_azure`,
+        /// `mcp:…`, `backfill:…`), or `None` for a row never raised.
+        privacy_reason: Option<String>,
     },
     Ping,
 }

--- a/crates/biorouter-server/src/routes/session_events.rs
+++ b/crates/biorouter-server/src/routes/session_events.rs
@@ -128,12 +128,20 @@ fn map_bus_event_for_turn(
             AgentEvent::MessagesPersisted(messages) => {
                 Some(MessageEvent::MessagesPersisted { messages })
             }
-            // Issue #56 Gate B's repair arm, said out loud. A pass-through: the
-            // frame is advisory display state and the wire enum carries the
-            // identically-shaped variant.
-            AgentEvent::PrivacyProviderPinned { provider, model } => {
-                Some(MessageEvent::PrivacyProviderPinned { provider, model })
-            }
+            // Issue #56 Gate B, said out loud: what the turn runs on and how the
+            // chat is classified. A pass-through — the frame is advisory display
+            // state and the wire enum carries the identically-shaped variant.
+            AgentEvent::PrivacyProviderPinned {
+                provider,
+                model,
+                privacy_tier,
+                privacy_reason,
+            } => Some(MessageEvent::PrivacyProviderPinned {
+                provider,
+                model,
+                privacy_tier,
+                privacy_reason,
+            }),
             // FALLBACK ONLY. The turn runner never publishes a raw
             // `TurnAborted` — it classifies it and publishes `TurnError`
             // instead, precisely so no consumer renders two terminal Error

--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -3522,20 +3522,51 @@ pub enum AgentEvent {
     /// after the rows are durable, so a consumer that stops reading mid-turn
     /// never holds an id for a row that was not written.
     MessagesPersisted(Vec<PersistedMessage>),
-    /// Issue #56 Gate B, repair arm: this turn ran on the provider the SESSION
-    /// ROW names, not on whatever the agent was holding when the turn began,
-    /// because the chat's classification does not admit the bound one.
+    /// Issue #56 Gate B: what this turn is running on — the provider and model
+    /// the agent holds at the seam, and the chat's classification AFTER the
+    /// turn ratchet has committed.
     ///
-    /// The repair itself is old and correct — a private chat must never reach a
-    /// public model, and asking the user to downgrade the chat instead would be
-    /// worse. What was missing is that it happened at all: a user who switches
-    /// the app to a public model, watches the composer's chip change, and then
-    /// sends into a private chat gets an answer from a different model than the
-    /// one on screen, with the context gauge sized to the wrong window.
+    /// # It is sent on every turn, and that is a deliberate widening
+    ///
+    /// It began (#192) as the repair arm's own account of itself: a private
+    /// chat must never reach a public model, so Gate B silently rebinds from the
+    /// row, and a user who had switched the app to a public model, watched the
+    /// composer's chip change, and then sent into a private chat got an answer
+    /// from a different model than the one on screen. The repair was right;
+    /// being invisible was the defect.
+    ///
+    /// It is now emitted on EVERY turn that reaches a provider, because the
+    /// client cannot compute two of these four fields and both of them change
+    /// underneath it:
+    ///
+    /// * `privacy_tier` is raised by the ratchet a few lines below the seam that
+    ///   builds this event. Before this frame carried it, a chat that a turn had
+    ///   just made private kept a `public` classification in the client's cached
+    ///   row for the whole turn, and #196 measured that as the ONE field that
+    ///   lagged — the private-chat note and the chip override are both suppressed
+    ///   by a stale `public`, which is why they used to appear only after a
+    ///   reload.
+    /// * `provider`/`model` are bound from the ROW by
+    ///   `restore_provider_from_session`, so a row rewritten by anything other
+    ///   than this client — a second window, `biorouter session --resume
+    ///   --provider …`, a schedule — makes the turn run somewhere the composer
+    ///   is not naming, with the context gauge sized to the wrong window.
+    ///
+    /// ⚠ **The old restriction to the repair arm was itself a contract, and the
+    /// argument for it has an answer.** It read: the frame must be evidence, not
+    /// decoration, or a client will paint a permanent note. The answer is that
+    /// deciding whether there is anything to SAY was never this event's job and
+    /// still is not (see the ⚠ below): the client compares the frame against
+    /// what it is displaying and says nothing when they agree, which is exactly
+    /// what `bindingDiffersFromSelection` returns on the overwhelmingly common
+    /// turn where they do.
     ///
     /// ⚠ Purely advisory, exactly like [`AgentEvent::ToolCallPending`]. It is
     /// not a `Message`, so it is never persisted, replayed, or shown to the
-    /// model; it changes nothing about what any gate permits or refuses.
+    /// model; it changes nothing about what any gate permits or refuses. In
+    /// particular `privacy_tier` here is a REPORT of the classification the
+    /// ratchet already committed — reading it back is not a second write, and no
+    /// gate consults this frame.
     ///
     /// ⚠ It carries no "requested" binding, and adding one would be a mistake.
     /// The agent's own view of what was displaced is incomplete — an LRU-
@@ -3548,6 +3579,14 @@ pub enum AgentEvent {
         provider: String,
         /// Its model.
         model: String,
+        /// The chat's classification at this turn's seam, AFTER the ratchet —
+        /// the same value stored into `cached_classification` and handed to the
+        /// hooks manager, so the three cannot disagree about one turn.
+        privacy_tier: SessionClassification,
+        /// The provenance string that classification carries on the row
+        /// (`turn:versa_azure`, `mcp:…`, `backfill:…`), or `None` for a row that
+        /// has never been raised.
+        privacy_reason: Option<String>,
     },
 }
 
@@ -6416,25 +6455,39 @@ impl Agent {
         Ok(true)
     }
 
-    /// The binding Gate B's repair arm just installed, as the event that tells
-    /// the turn's readers where it actually went.
+    /// The binding this turn is about to run on, plus the classification the
+    /// ratchet has just committed for it — the event that tells the turn's
+    /// readers where it went and how sensitive the chat now is.
     ///
-    /// ⚠ It states a FACT and judges nothing: "this turn ran on `provider` /
-    /// `model`". It deliberately does not carry the selection it displaced, and
-    /// it is not the place to decide whether the displacement is news. The
-    /// caller that renders it already holds the selection it is showing the
-    /// user, and only that caller can tell "the chip is wrong" from "the chip
-    /// was right all along and a rehydrated agent was quietly repaired to
-    /// match" — the common case (LRU rehydration, a legacy row, any ratchet
-    /// that commits after a legal bind) that must NOT produce a note.
+    /// ⚠ It states FACTS and judges nothing: "this turn ran on `provider` /
+    /// `model`, and the chat is classified `privacy_tier`". It deliberately does
+    /// not carry the selection it may have displaced, and it is not the place to
+    /// decide whether any of that is news. The caller that renders it already
+    /// holds the selection it is showing the user, and only that caller can tell
+    /// "the chip is wrong" from "the chip was right all along" — the common case
+    /// (an ordinary turn, LRU rehydration, a legacy row, any ratchet that
+    /// commits after a legal bind) that must NOT produce a note.
+    ///
+    /// ⚠ `classification` is passed IN rather than re-read, and that is the
+    /// point: it is the same value the caller stored into
+    /// `cached_classification` and handed to the hooks manager, sampled once at
+    /// the seam. A second read here could observe a different row — Gate C's
+    /// dispatch ratchet runs on another task — and this frame would then
+    /// describe a turn that never existed.
     ///
     /// `None` if the binding vanished between the swap and this read, which is
     /// a race no message can usefully describe.
-    async fn pinned_provider_event(&self) -> Option<AgentEvent> {
+    async fn pinned_provider_event(
+        &self,
+        classification: SessionClassification,
+        reason: Option<String>,
+    ) -> Option<AgentEvent> {
         let provider = self.bound_provider_unchecked().await?;
         Some(AgentEvent::PrivacyProviderPinned {
             provider: provider.get_name().to_string(),
             model: provider.get_model_config().model_name,
+            privacy_tier: classification,
+            privacy_reason: reason,
         })
     }
 
@@ -8231,10 +8284,18 @@ impl Agent {
             .await
             .ok();
         let mut privacy_refusal: Option<String> = None;
-        // Set by Gate B's repair arm below, yielded as the turn's own account of
-        // which model actually served it. `None` on every other path, including
-        // the overwhelmingly common one where the bound provider was already
-        // admissible and nothing was repaired.
+        // The turn's own account of what it ran on: the effective binding plus
+        // the POST-ratchet classification, built once below and yielded near the
+        // front of the stream.
+        //
+        // ⚠ It used to be set only by the repair arm. It is now set on every
+        // turn that reaches a provider, because two of the four fields are ones
+        // no client can compute and both change underneath it — the ratchet
+        // raises `privacy_tier` a few lines down, and `restore_provider_from_session`
+        // binds a row this window may not have re-read since another window, the
+        // CLI or a schedule rewrote it. `None` remains for the paths where the
+        // question has no answer: no row, no bound provider, or a refusal (which
+        // returns its own stream before the yield site is ever reached).
         let mut privacy_pinned: Option<AgentEvent> = None;
         // DR-15's master opt-out. ONE read for this seam, used by both halves —
         // the turn barrier below and DR-4's turn ratchet under it — so the two
@@ -8269,9 +8330,12 @@ impl Agent {
                     // then measuring the usage against the wrong model's
                     // window. Nothing about what the gate PERMITS changes here;
                     // the turn is simply made to say where it went.
-                    Ok(true) => {
-                        privacy_pinned = self.pinned_provider_event().await;
-                    }
+                    //
+                    // ⚠ The repair no longer BUILDS the frame here. It is built
+                    // once below, after the ratchet, so the classification it
+                    // reports is the post-ratchet one and a repaired turn and an
+                    // ordinary one cannot report differently shaped facts.
+                    Ok(true) => {}
                     // 3. Otherwise refuse THIS TURN. The row is untouched, so
                     //    the repair card can still offer the one-click fix.
                     _ => privacy_refusal = Some(crate::privacy::refusal::turn_refusal(row)),
@@ -8291,18 +8355,45 @@ impl Agent {
             // "ratchet on the turn" rather than on the bind, which is O5's
             // deliberate trade, and recorded here because it was not.
             let mut classification = row.privacy_tier;
+            // Mirrors the row's `privacy_reason` column so the frame below can
+            // name the provenance the client would otherwise have to refetch.
+            //
+            // ⚠ It is DERIVED, not read back, and the derivation is exact only
+            // because of the `f > row.privacy_tier` guard on the write. The
+            // classification lattice has two values, so a strict increase can
+            // only be `public -> private`; `SessionUpdateBuilder`'s `CASE WHEN`
+            // preserves an existing reason on an already-private row and takes
+            // the new one otherwise, so on a public row it is the `ELSE` arm and
+            // the stored reason is exactly the string passed here. Widen the
+            // lattice or relax that guard and this must become a read-back.
+            let mut classification_reason = row.privacy_reason.clone();
             if privacy_enforced && privacy_refusal.is_none() {
                 if let Some(provider) = self.bound_provider_unchecked().await {
                     let f = crate::privacy::floor(provider.tier());
                     if f > row.privacy_tier {
+                        let reason = format!("turn:{}", provider.get_name());
                         session_manager
                             .update(&session_config.id)
-                            .raise_privacy(f, &format!("turn:{}", provider.get_name()))
+                            .raise_privacy(f, &reason)
                             .apply()
                             .await?;
                         classification = f;
+                        classification_reason = Some(reason);
                     }
                 }
+            }
+            // What this turn runs on, said out loud — after the ratchet, so the
+            // tier it reports is the one the turn actually carries.
+            //
+            // ⚠ Skipped for a refusal. Arm 3 leaves the row alone and returns a
+            // message instead of a turn, and a frame here would claim a turn ran
+            // on a provider when none ran at all. (The refusal returns its own
+            // stream well before the yield site, so this guard is belt and
+            // braces — it is written down because the guard is the statement.)
+            if privacy_refusal.is_none() {
+                privacy_pinned = self
+                    .pinned_provider_event(classification, classification_reason)
+                    .await;
             }
             // ⚠ The POST-ratchet classification, not the row's. A turn that
             // has just raised the session to Private must not leave the cache
@@ -8628,16 +8719,21 @@ impl Agent {
             if let Some(published) = prestream_published {
                 yield published;
             }
-            // Gate B's repair, said out loud. Its position is unconstrained by
-            // #59/#66: the frame names no stored row and carries no message
-            // body, so it can neither arrive ahead of its own content nor claim
-            // an id whose body is still buffered. It goes near the front so a
-            // client that loses the stream mid-turn still learns which model
-            // the turn it half-watched was running on.
+            // What this turn runs on, said out loud. Its position is
+            // unconstrained by #59/#66: the frame names no stored row and
+            // carries no message body, so it can neither arrive ahead of its own
+            // content nor claim an id whose body is still buffered.
+            //
+            // ⚠ Near the front is now load-bearing rather than merely nice. The
+            // composer sizes its context gauge and decides its privacy note from
+            // these fields, so a frame that arrived at the END of the turn would
+            // leave both wrong for exactly as long as the turn takes — which is
+            // the window #196 left open and this closes. A client that loses the
+            // stream mid-turn still learns which model it half-watched.
             //
             // ⚠ Only the ordinary turn path carries it. The slash-command
-            // early-returns above never reach a provider, so "which model
-            // served this turn" has no answer there to report.
+            // early-returns above never reach a provider, so "which model served
+            // this turn" has no answer there to report.
             if let Some(pinned) = privacy_pinned {
                 yield pinned;
             }
@@ -20010,9 +20106,28 @@ mod gate_b_turn_tests {
         events
             .iter()
             .filter_map(|event| match event {
-                Ok(AgentEvent::PrivacyProviderPinned { provider, model }) => {
-                    Some((provider.clone(), model.clone()))
-                }
+                Ok(AgentEvent::PrivacyProviderPinned {
+                    provider, model, ..
+                }) => Some((provider.clone(), model.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Every `PrivacyProviderPinned` the turn reported, as the classification
+    /// and provenance it carried. Separate from [`pinned`] so a test that cares
+    /// about the binding is not rewritten when the tier's shape changes.
+    fn pinned_classification(
+        events: &[Result<AgentEvent>],
+    ) -> Vec<(SessionClassification, Option<String>)> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                Ok(AgentEvent::PrivacyProviderPinned {
+                    privacy_tier,
+                    privacy_reason,
+                    ..
+                }) => Some((*privacy_tier, privacy_reason.clone())),
                 _ => None,
             })
             .collect()
@@ -20106,11 +20221,25 @@ mod gate_b_turn_tests {
     }
 
     #[tokio::test]
-    async fn a_turn_that_needed_no_repair_reports_nothing() {
-        // The frame must be evidence, not decoration. A private chat already on
-        // its own private provider is the overwhelmingly common turn, and a
-        // client that saw this frame on every one of them would either paint a
-        // permanent note or learn to ignore the frame.
+    async fn a_turn_that_needed_no_repair_still_reports_what_it_ran_on() {
+        // ⚠ This assertion is INVERTED from the one that shipped with #192, and
+        // the argument it replaces deserves to be written down rather than
+        // deleted: "the frame must be evidence, not decoration — a private chat
+        // already on its own private provider is the overwhelmingly common turn,
+        // and a client that saw this frame on every one of them would either
+        // paint a permanent note or learn to ignore the frame."
+        //
+        // The answer is that deciding whether there is anything to SAY was never
+        // this frame's job. The contract has always been "compare it against
+        // what you display, and say nothing when they agree", and the client's
+        // `bindingDiffersFromSelection` returns exactly that on this turn — so
+        // no note is painted here whether the frame arrives or not.
+        //
+        // What changed is that the frame now carries the two facts a client
+        // cannot compute: the post-ratchet classification, and the binding
+        // `restore_provider_from_session` took from a row this client may not
+        // have re-read. Withholding those on the common turn is what left the
+        // composer stating a stale tier for the whole of it.
         let (_dir, agent, s) = agent_on(private_provider()).await;
         let sm = manager(&agent);
         let row_provider = private_provider();
@@ -20124,9 +20253,87 @@ mod gate_b_turn_tests {
                 .unwrap(),
         )
         .await;
-        assert!(
-            pinned(&events).is_empty(),
-            "nothing was repaired, so there is nothing to report:\n{}",
+        assert_eq!(
+            pinned(&events),
+            vec![("versa_azure".to_string(), "gpt-5.5".to_string())],
+            "an ordinary turn still states what it ran on, exactly once:\n{}",
+            rendered(&events)
+        );
+        assert_eq!(
+            pinned_classification(&events),
+            vec![(
+                SessionClassification::Private,
+                Some("turn:versa_azure".to_string())
+            )],
+            "and the classification it carries is the row's own:\n{}",
+            rendered(&events)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_turn_that_ratchets_reports_the_classification_it_just_wrote() {
+        // The lag #196 measured, closed at its source. The row is PUBLIC when
+        // the turn starts; the ratchet raises it a few lines below the seam that
+        // builds this frame. A frame carrying the PRE-ratchet tier would leave
+        // the composer suppressing the private-chat note for the whole turn,
+        // which is the reload-to-see-it defect.
+        let (_dir, agent, s) = agent_on(private_provider()).await;
+        let sm = manager(&agent);
+        let row_provider = private_provider();
+        point_row_at(&sm, &s.id, &row_provider).await;
+        // Deliberately NOT ratcheted here: the row is public and the turn is the
+        // thing that privatises it.
+        assert_eq!(
+            sm.get_session(&s.id, false).await.unwrap().privacy_tier,
+            SessionClassification::Public
+        );
+
+        let events = drain(
+            agent
+                .reply(Message::user().with_text("hi"), cfg(&s), None)
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            pinned_classification(&events),
+            vec![(
+                SessionClassification::Private,
+                Some("turn:versa_azure".to_string())
+            )],
+            "the frame must report the POST-ratchet classification and the \
+             provenance the ratchet wrote, not the row's pre-turn `public`:\n{}",
+            rendered(&events)
+        );
+        // And it agrees with what actually landed on the row — the derivation in
+        // Gate B is exact only under the `f > row.privacy_tier` guard, so this
+        // is the assertion that would fail if that guard were relaxed.
+        let row = sm.get_session(&s.id, false).await.unwrap();
+        assert_eq!(row.privacy_tier, SessionClassification::Private);
+        assert_eq!(row.privacy_reason.as_deref(), Some("turn:versa_azure"));
+    }
+
+    #[tokio::test]
+    async fn a_public_turn_on_a_public_chat_reports_public_with_no_reason() {
+        // The negative control for the two above: nothing is repaired, nothing
+        // ratchets, and the frame still states the binding — with the tier the
+        // row genuinely holds and no provenance invented for it.
+        let (_dir, agent, s) = agent_on(public_provider()).await;
+        let sm = manager(&agent);
+        let row_provider = public_provider();
+        point_row_at(&sm, &s.id, &row_provider).await;
+
+        let events = drain(
+            agent
+                .reply(Message::user().with_text("hi"), cfg(&s), None)
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            pinned_classification(&events),
+            vec![(SessionClassification::Public, None)],
+            "a public chat's frame must not invent a provenance:\n{}",
             rendered(&events)
         );
     }

--- a/crates/biorouter/src/agents/subagent_handler.rs
+++ b/crates/biorouter/src/agents/subagent_handler.rs
@@ -1038,11 +1038,11 @@ fn get_agent_messages(
                         AgentEvent::McpNotification(_)
                         | AgentEvent::ModelChange { .. }
                         | AgentEvent::ToolCallPending(_)
-                        // Issue #56 Gate B's repair, addressed to a HUMAN
-                        // reading a composer. A subagent has no composer and its
-                        // parent is not the user, so the parent accumulates
-                        // nothing from it; the tee above still publishes it for
-                        // an observer tab watching the child.
+                        // Issue #56 Gate B, addressed to a HUMAN reading a
+                        // composer. A subagent has no composer and its parent is
+                        // not the user, so the parent accumulates nothing from
+                        // it; the tee above still publishes it for an observer
+                        // tab watching the child.
                         | AgentEvent::PrivacyProviderPinned { .. }
                         // #59: the subagent's own rows are already carried by
                         // the `Message` events above (which now name

--- a/crates/biorouter/tests/privacy_guard_wiring.rs
+++ b/crates/biorouter/tests/privacy_guard_wiring.rs
@@ -628,10 +628,13 @@ const REGISTRY: &[Guard] = &[
         sites: &[
             Site {
                 file: "crates/biorouter/src/agents/agent.rs",
-                counts: c(0, 4, 0),
+                counts: c(0, 5, 0),
                 kind: SiteKind::Unrelated,
                 what: "a LOCAL VARIABLE named `privacy_refusal` in the turn barrier. The second \
-                       standing proof that a name match is not a call site",
+                       standing proof that a name match is not a call site. The count went 4 -> 5 \
+                       when Gate B began stating what every turn runs on: the frame is built only \
+                       for a turn that is not being refused, so the local is read once more. Still \
+                       ZERO calls — the guard function itself gained no caller here",
             },
             Site {
                 file: "crates/biorouter/src/agents/extension_manager.rs",

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -9935,15 +9935,24 @@
           },
           {
             "type": "object",
-            "description": "Issue #56 Gate B, repair arm: the provider and model that actually\nserved this turn, sent when the agent had to fall back to the one the\nSESSION ROW names because the chat's classification does not admit the\nbound one.\n\nAdvisory display state, exactly like `ToolCallPending`: never persisted,\nnever replayed, never shown to the model, and it changes nothing about\nwhat the privacy gates permit or refuse. Its whole job is that a user who\nswitched the app to a public model and then sent into a private chat can\nsee that the turn went elsewhere — and that the composer's model chip and\ncontext gauge can be sized to the window that was really used.\n\n⚠ It does NOT carry the selection it displaced, so a client must not\ntreat receiving it as \"the user's choice was overridden\". The frame\narrives on every repaired bind, including the ordinary ones (a\nrehydrated agent, a legacy row) where it names exactly what the client is\nalready showing. Compare it against what you display, and say nothing\nwhen they agree.",
+            "description": "Issue #56 Gate B: what this turn is running on — the provider and model\nthe agent holds at the seam, plus the chat's classification after the\nturn ratchet has committed.\n\nAdvisory display state, exactly like `ToolCallPending`: never persisted,\nnever replayed, never shown to the model, and it changes nothing about\nwhat the privacy gates permit or refuse. `privacy_tier` here is a REPORT\nof a classification the daemon has already written; reading it is not a\nsecond write and no gate consults this frame.\n\n⚠ **Sent on every turn that reaches a provider**, not only on a repaired\nbind. It carries the two fields a client cannot compute and that change\nunderneath it: the ratcheted `privacy_tier` (measured by #196 as the one\nfield that lagged, which is why a chat a turn had just made private\nshowed neither the note nor the chip override until a reload) and the\nbinding `restore_provider_from_session` took from a row another window,\nthe CLI or a schedule may have rewritten.\n\n⚠ It does NOT carry the selection it may have displaced, so a client must\nnot treat receiving it as \"the user's choice was overridden\" — on the\noverwhelmingly common turn it names exactly what the client is already\nshowing. Compare it against what you display, and say nothing when they\nagree. Widening it from the repair arm is safe precisely because that\ncomparison, not the frame's arrival, is what earns a word on screen.",
             "required": [
               "provider",
               "model",
+              "privacy_tier",
               "type"
             ],
             "properties": {
               "model": {
                 "type": "string"
+              },
+              "privacy_reason": {
+                "type": "string",
+                "description": "That classification's provenance on the row (`turn:versa_azure`,\n`mcp:…`, `backfill:…`), or `None` for a row never raised.",
+                "nullable": true
+              },
+              "privacy_tier": {
+                "$ref": "#/components/schemas/SessionClassification"
               },
               "provider": {
                 "type": "string"

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -2146,6 +2146,12 @@ export type MessageEvent = {
     type: 'MessagesPersisted';
 } | {
     model: string;
+    /**
+     * That classification's provenance on the row (`turn:versa_azure`,
+     * `mcp:…`, `backfill:…`), or `None` for a row never raised.
+     */
+    privacy_reason?: string | null;
+    privacy_tier: SessionClassification;
     provider: string;
     type: 'PrivacyProviderPinned';
 } | {

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -2116,6 +2116,10 @@ function BaseChatContent({
       <PinnedModelNote session={session} reportedByTurn={pinnedModel} className="mx-3 mb-2" />
       <ChatInput
         sessionId={sessionId}
+        // The chat stream's own copy of the row, which the reply stream keeps
+        // current from turn START. `ChatInput` still reads the tier itself for
+        // the callers that thread nothing; this is the fresher of the two.
+        sessionRowPrivacyTier={session?.id === sessionId ? session?.privacy_tier : undefined}
         effectiveModel={effectiveModel}
         handleSubmit={handleFormSubmit}
         chatState={chatState}

--- a/ui/desktop/src/components/ChatInput.privacyTier.test.tsx
+++ b/ui/desktop/src/components/ChatInput.privacyTier.test.tsx
@@ -21,6 +21,10 @@ import { render, screen, waitFor, act } from '@testing-library/react';
  *   3. v1.89.0 F-12 — the daemon RAISES the tier when it starts a turn, after
  *      the bind read and before the turn ends, so a chat that becomes private on
  *      its first message reads `public` for the whole of that turn.
+ *   4. The chat stream now carries the POST-ratchet tier in the reply stream's
+ *      own first frames, so the composer has a fresher answer than any of its
+ *      reads. It must prefer that one — and must still work for the callers
+ *      that thread nothing, which is why the reads above are kept.
  */
 
 // Heavy children that are irrelevant here. The two tier consumers are replaced
@@ -102,11 +106,13 @@ beforeEach(() => {
 function chatInput(
   sessionId: string | null,
   chatState: ChatState = ChatState.Idle,
-  messagesLength = 0
+  messagesLength = 0,
+  sessionRowPrivacyTier?: 'public' | 'private'
 ) {
   return (
     <ChatInput
       sessionId={sessionId}
+      sessionRowPrivacyTier={sessionRowPrivacyTier}
       handleSubmit={vi.fn()}
       chatState={chatState}
       onStop={vi.fn()}
@@ -128,9 +134,10 @@ function chatInput(
 function renderChatInput(
   sessionId: string | null,
   chatState: ChatState = ChatState.Idle,
-  messagesLength = 0
+  messagesLength = 0,
+  sessionRowPrivacyTier?: 'public' | 'private'
 ) {
-  return render(chatInput(sessionId, chatState, messagesLength));
+  return render(chatInput(sessionId, chatState, messagesLength, sessionRowPrivacyTier));
 }
 
 // A promise whose resolution this test controls, so the order responses LAND
@@ -301,5 +308,54 @@ describe('ChatInput session privacy tier (#56)', () => {
     });
 
     expect(screen.getByTestId('tier-probe')).toHaveTextContent('unresolved');
+  });
+});
+
+describe('ChatInput prefers the chat stream`s tier over its own read', () => {
+  /**
+   * F-12's own premise was that "the composer cannot see the ratchet directly —
+   * no event announces it". One does now: the reply stream states the
+   * post-ratchet classification in its first frames and the chat stream patches
+   * its cached row from it. That answer is strictly fresher than this
+   * component's read, which cannot fire until the transcript has grown.
+   */
+  it('takes the row`s tier even while its own read still says public', async () => {
+    getSessionMock.mockResolvedValue({ data: { privacy_tier: 'public' } } as never);
+
+    renderChatInput('chat-stream-wins', ChatState.Idle, 0, 'private');
+
+    // Let the component's own read land, so this is a genuine disagreement
+    // rather than a race the row happened to win.
+    await waitFor(() => expect(getSessionMock).toHaveBeenCalled());
+    expect(screen.getByTestId('tier-probe')).toHaveTextContent('private');
+  });
+
+  /**
+   * The fallback is not decoration. A transcript surface, an observer tab, or
+   * any caller that does not thread the row has only this component's own read
+   * — and `undefined` from the row must mean "I know nothing", never "public".
+   */
+  it('falls back to its own read when the row carries nothing', async () => {
+    getSessionMock.mockResolvedValue({ data: { privacy_tier: 'private' } } as never);
+
+    renderChatInput('chat-no-row', ChatState.Idle, 0, undefined);
+
+    await waitFor(() => expect(screen.getByTestId('tier-probe')).toHaveTextContent('private'));
+  });
+
+  /**
+   * A rebind must not leave the previous chat's row tier asserting about this
+   * one — the same failure mode as the first test in the suite above, on the
+   * new input. `BaseChat` guards it by only passing the row when its id matches
+   * the session, and the composer must honour whatever it is handed.
+   */
+  it('follows the row it is given when the chat rebinds', async () => {
+    getSessionMock.mockResolvedValue({ data: { privacy_tier: 'public' } } as never);
+
+    const { rerender } = renderChatInput('chat-x', ChatState.Idle, 0, 'private');
+    await waitFor(() => expect(screen.getByTestId('tier-probe')).toHaveTextContent('private'));
+
+    rerender(chatInput('chat-y', ChatState.Idle, 0, undefined));
+    await waitFor(() => expect(screen.getByTestId('tier-probe')).toHaveTextContent('public'));
   });
 });

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -269,6 +269,15 @@ interface ModelLimit {
 interface ChatInputProps {
   sessionId: string | null;
   /**
+   * The chat's classification as the chat stream's cached session row holds it.
+   *
+   * Preferred over this component's own read (below) whenever it is present: the
+   * reply stream now states the POST-ratchet classification in its own first
+   * frames, so the row is current from turn START rather than from whenever the
+   * probe happened to fire.
+   */
+  sessionRowPrivacyTier?: SessionClassification;
+  /**
    * Issue #56 / F2 — what THIS chat actually runs on (`BaseChat.chatBinding`):
    * the session row's own provider and model, or the one a turn reported when
    * the privacy barrier had to repair the binding mid-turn.
@@ -350,6 +359,7 @@ interface ChatInputProps {
 
 export default function ChatInput({
   sessionId,
+  sessionRowPrivacyTier,
   effectiveModel,
   handleSubmit,
   chatState = ChatState.Idle,
@@ -485,9 +495,27 @@ export default function ChatInput({
    * an unresolved tier as "judge nothing", because walling a working tool on a
    * failed read is the same defect as hiding it.
    */
-  const [sessionPrivacyTier, setSessionPrivacyTier] = useState<SessionClassification | undefined>(
+  const [ownPrivacyTierRead, setOwnPrivacyTierRead] = useState<SessionClassification | undefined>(
     undefined
   );
+
+  /**
+   * The chat's tier, with the STREAM's answer preferred over this component's
+   * own read.
+   *
+   * ⚠ This is what retires the F-12 probe's premise. That probe exists because
+   * "the composer cannot see the ratchet directly — no event announces it"; the
+   * reply stream now does, in its first frames, so `sessionRowPrivacyTier` is
+   * current from turn START while the probe cannot fire until the transcript
+   * has grown. The probe is KEPT as the fallback: an observer surface, a
+   * transcript view, or any caller that does not thread the row still needs an
+   * answer, and its own read is the only one they have.
+   *
+   * Both sources are the daemon's own answer, so preferring the fresher one
+   * cannot make the composer less restrictive than the truth — the property the
+   * probe's ⚠ turns on.
+   */
+  const sessionPrivacyTier = sessionRowPrivacyTier ?? ownPrivacyTierRead;
   // Which chat `sessionPrivacyTier` is a statement about, and the ordering of the
   // reads that produced it. Refs rather than effect-locals because the reads are
   // now issued from two effects (the bind below and the turn watcher after it)
@@ -509,7 +537,7 @@ export default function ChatInput({
       if (issued !== tierGenerationRef.current) return;
       if (tierSessionRef.current !== sessionId) return;
       if (response.data?.privacy_tier) {
-        setSessionPrivacyTier(response.data.privacy_tier);
+        setOwnPrivacyTierRead(response.data.privacy_tier);
       }
     } catch (error) {
       console.error('[ChatInput] Failed to read the session privacy tier:', error);
@@ -526,7 +554,7 @@ export default function ChatInput({
     // reverse it paints a Private dot on a chat with no such guarantee.
     tierSessionRef.current = sessionId;
     tierGenerationRef.current += 1;
-    setSessionPrivacyTier(undefined);
+    setOwnPrivacyTierRead(undefined);
 
     if (!sessionId) {
       return;

--- a/ui/desktop/src/hooks/chatStreamStore.binding.test.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.binding.test.tsx
@@ -21,6 +21,13 @@
  * the tab — chip `claude-opus-5`, gauge "972.5k of 1M", no note; after
  * `location.reload()` all three were right. A turn writes fields no client can
  * compute, so this half is a re-read rather than an announcement.
+ *
+ * **A turn's START.** The re-read above runs when the turn ENDS, so during a
+ * long turn the composer still held the pre-turn classification — the ratchet
+ * fires at the top of `Agent::reply`. The daemon now states the binding and the
+ * post-ratchet tier in the reply stream's own first frames
+ * (`PrivacyProviderPinned`), so the composer is right from the first token
+ * without a request on the submit path.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageEvent, Session, TokenState } from '../api';
@@ -285,5 +292,164 @@ describe('a turn’s own writes are read back', () => {
     expect(controller.getSnapshot().session?.provider_name).toBe('codex');
     expect(controller.getSnapshot().turnError).toBeUndefined();
     warn.mockRestore();
+  });
+});
+
+describe('a turn states what it runs on, from its first frames', () => {
+  /**
+   * The frame the daemon now sends on every turn. `privacy_tier` is the
+   * POST-ratchet classification, so a chat this turn has just privatised says
+   * `private` here while its row said `public` when the turn began.
+   */
+  function pinFrame(over: Partial<Record<string, unknown>> = {}): MessageEvent {
+    return {
+      type: 'PrivacyProviderPinned',
+      provider: 'versa_azure',
+      model: 'gpt-5.5-2026-04-24',
+      privacy_tier: 'private',
+      privacy_reason: 'turn:versa_azure',
+      ...over,
+    } as MessageEvent;
+  }
+
+  async function runTurn(sid: string, ...frames: MessageEvent[]) {
+    mocks.resumeAgent.mockResolvedValue({ data: { session: boundSession(sid) } });
+    mocks.reply.mockResolvedValue({ stream: streamOf(...frames, finishFrame) });
+    const controller = new ChatStreamRegistry().getController(sid);
+    await controller.loadSession();
+    await controller.handleSubmit('Reply with the single word ready.');
+    return controller;
+  }
+
+  /**
+   * The whole point, and the one field #196 measured as lagging. The post-turn
+   * re-read is deliberately disarmed here (`getSession` resolves `null`, so
+   * `refreshSessionBinding` returns before it patches anything) — so a `private`
+   * classification on the row can ONLY have come from the turn's own frame.
+   */
+  it('adopts the ratcheted classification from the frame, not from a re-read', async () => {
+    const sid = `turn-start-tier-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: null });
+
+    const controller = await runTurn(sid, pinFrame());
+
+    const row = controller.getSnapshot().session;
+    expect(row?.privacy_tier).toBe('private');
+    expect(row?.privacy_reason).toBe('turn:versa_azure');
+    // And the binding half still lands, exactly as #192 shipped it.
+    expect(controller.getSnapshot().pinnedModel).toEqual({
+      provider: 'versa_azure',
+      model: 'gpt-5.5-2026-04-24',
+    });
+  });
+
+  /**
+   * A public turn's frame must not leave a provenance behind. `privacy_reason`
+   * is `None` on a row that has never been raised, and the row is where the
+   * chat-tab dot and the note both read from.
+   */
+  it('clears a provenance the chat no longer has', async () => {
+    const sid = `turn-start-public-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: null });
+    mocks.resumeAgent.mockResolvedValue({
+      data: {
+        session: boundSession(sid, { privacy_tier: 'private', privacy_reason: 'turn:versa_azure' }),
+      },
+    });
+    mocks.reply.mockResolvedValue({
+      stream: streamOf(
+        pinFrame({
+          provider: 'codex',
+          model: 'gpt-6-astra',
+          privacy_tier: 'public',
+          privacy_reason: null,
+        }),
+        finishFrame
+      ),
+    });
+    const controller = new ChatStreamRegistry().getController(sid);
+    await controller.loadSession();
+    await controller.handleSubmit('hi');
+
+    expect(controller.getSnapshot().session?.privacy_tier).toBe('public');
+    expect(controller.getSnapshot().session?.privacy_reason).toBeNull();
+  });
+
+  /**
+   * The frame arrives on EVERY turn now. A fresh session object per turn would
+   * re-render the composer — chip, gauge and note included — once per turn for
+   * no change at all.
+   */
+  it('does not churn the row when the same classification is reported again', async () => {
+    const sid = `turn-start-idempotent-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: null });
+
+    const controller = await runTurn(sid, pinFrame(), pinFrame(), pinFrame());
+    const first = controller.getSnapshot().session;
+
+    mocks.reply.mockResolvedValue({ stream: streamOf(pinFrame(), finishFrame) });
+    await controller.handleSubmit('again');
+
+    expect(controller.getSnapshot().session).toBe(first);
+  });
+
+  /**
+   * A frame from a daemon that predates the tier fields still binds the chip.
+   * `privacy_tier` absent means "this frame knows nothing about the tier", which
+   * must not be read as "public" — that would silently declassify the row this
+   * client is showing.
+   */
+  it('leaves the classification alone when the frame carries none', async () => {
+    const sid = `turn-start-legacy-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: null });
+    mocks.resumeAgent.mockResolvedValue({
+      data: { session: boundSession(sid, { privacy_tier: 'private' }) },
+    });
+    mocks.reply.mockResolvedValue({
+      stream: streamOf(
+        {
+          type: 'PrivacyProviderPinned',
+          provider: 'versa_azure',
+          model: 'gpt-5.5',
+        } as MessageEvent,
+        finishFrame
+      ),
+    });
+    const controller = new ChatStreamRegistry().getController(sid);
+    await controller.loadSession();
+    await controller.handleSubmit('hi');
+
+    expect(controller.getSnapshot().session?.privacy_tier).toBe('private');
+    expect(controller.getSnapshot().pinnedModel?.provider).toBe('versa_azure');
+  });
+
+  /**
+   * ⚠ The regression the widening would otherwise cause, pinned.
+   *
+   * `chatBinding` prefers the turn-reported pin over the row. While the frame
+   * only arrived on a repaired bind that was almost never observable; now that
+   * every turn reports one, a switch made AFTER a turn would be overruled by
+   * that turn's pin and the chip would name the model the user just switched
+   * away from — the exact regression #192 narrowed its rule to avoid.
+   */
+  it('lets a later switch replace the binding a turn reported', async () => {
+    const sid = `turn-start-then-switch-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: null });
+
+    const controller = await runTurn(sid, pinFrame());
+    expect(controller.getSnapshot().pinnedModel?.model).toBe('gpt-5.5-2026-04-24');
+
+    announceSessionBinding({
+      sessionId: sid,
+      provider: 'claude_code',
+      model: 'claude-opus-5',
+      contextLimit: 1_000_000,
+    });
+
+    expect(controller.getSnapshot().pinnedModel).toEqual({
+      provider: 'claude_code',
+      model: 'claude-opus-5',
+    });
+    expect(controller.getSnapshot().session?.provider_name).toBe('claude_code');
   });
 });

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -13,6 +13,7 @@ import {
   reply,
   resumeAgent,
   Session,
+  SessionClassification,
   TokenState,
   updateFromSession,
   updateSessionUserWorkflowValues,
@@ -803,6 +804,18 @@ class ChatStreamController {
     // the announcement already carries.
     subscribeSessionBindingChanges((change) => {
       if (change.sessionId !== sessionId) return;
+      // ⚠ The PIN moves too, and it has to. `chatBinding` prefers the
+      // turn-reported pin over the row, so a switch that patched only the row
+      // would be overruled by the previous turn's pin and the chip would go on
+      // naming the model the user just switched away from — the exact
+      // regression #192 narrowed its rule to avoid. It did not bite while the
+      // frame was rare (only a repaired bind produced one); it bites on every
+      // switch-after-a-turn now that the frame arrives on every turn.
+      //
+      // Replacing rather than clearing is the honest write: an accepted bind is
+      // as authoritative a statement of "what this chat runs on" as a turn's
+      // own report, and it is the LATER one.
+      this.setPinnedModel({ provider: change.provider, model: change.model });
       this.updateSnapshot((prev) => {
         if (!prev.session) return prev;
         if (
@@ -1393,6 +1406,51 @@ class ChatStreamController {
         ? prev
         : { ...prev, pinnedModel: pinned }
     );
+  };
+
+  /**
+   * What the daemon says this turn is running on, applied at turn START.
+   *
+   * `PrivacyProviderPinned` now arrives on every turn and carries four fields.
+   * Two of them are the binding, which becomes {@link ChatSnapshot.pinnedModel}
+   * exactly as before. The other two are the chat's classification AFTER the
+   * privacy ratchet, and they are patched onto the cached session row because
+   * that row is where every reader of the classification looks
+   * (`usePinnedModel` reads `session.privacy_tier`, the chat-tab dot reads the
+   * cached session list).
+   *
+   * ⚠ **The tier is why this frame had to widen.** #196 instrumented which
+   * cached field lagged and measured exactly one: `privacy_tier`, with its
+   * `privacy_reason`. A chat that a turn had just made private kept a `public`
+   * tier in this cache until the turn ENDED and `refreshSessionBinding` re-read
+   * the row — and a stale `public` suppresses the chip override and the
+   * private-chat note together, which is why they used to appear only after a
+   * reload.
+   *
+   * ⚠ **The row is patched, never adopted.** The frame is not a session
+   * payload: it names four fields and this store is the transcript's source of
+   * truth for everything else on that row.
+   */
+  private applyTurnBinding = (event: {
+    provider: string;
+    model: string;
+    privacy_tier?: SessionClassification;
+    privacy_reason?: string | null;
+  }): void => {
+    this.setPinnedModel({ provider: event.provider, model: event.model });
+    if (event.privacy_tier === undefined) return;
+    const tier = event.privacy_tier;
+    const reason = event.privacy_reason ?? null;
+    this.updateSnapshot((prev) => {
+      if (!prev.session) return prev;
+      if (prev.session.privacy_tier === tier && (prev.session.privacy_reason ?? null) === reason) {
+        return prev;
+      }
+      return {
+        ...prev,
+        session: { ...prev.session, privacy_tier: tier, privacy_reason: reason },
+      };
+    });
   };
 
   private clearPendingToolCalls = (): void => {
@@ -2130,7 +2188,7 @@ class ChatStreamController {
           case 'MessagesPersisted':
             break;
           case 'PrivacyProviderPinned':
-            this.setPinnedModel({ provider: event.provider, model: event.model });
+            this.applyTurnBinding(event);
             break;
           case 'ModelChange':
           case 'Ping':

--- a/ui/desktop/src/utils/sessionBindingSync.ts
+++ b/ui/desktop/src/utils/sessionBindingSync.ts
@@ -32,6 +32,13 @@
  * and the bound provider in ways only the daemon knows, so those cannot be
  * announced from here.
  *
+ * ⚠ **A receiver must move the turn-reported PIN as well as the row.** The
+ * daemon reports each turn's own binding (`PrivacyProviderPinned`), and
+ * `privacy/pinnedModel.ts` prefers that pin over the row — so a receiver that
+ * patched only the row would be overruled by the previous turn's pin and would
+ * keep naming the model the user just switched away from. An accepted bind is
+ * the later, equally authoritative statement of the same fact.
+ *
  * ⚠ **Announce only what the daemon accepted.** `updateAgentProvider` can be
  * refused — Gate A returns 409 for a public model on a private chat — and a
  * refused switch leaves the row exactly as it was. The announcement therefore


### PR DESCRIPTION
Handoff 04, part 1 of 2. Round-3 findings **N1**/**N3** left two gaps behind #196, and this closes the second one: *"the privacy ratchet fires at the top of `Agent::reply`, so during a long turn the composer can still show the pre-turn classification; #196 refused to add a request on the submit path."*

## Why

#196 made the renderer's cached session row fresh in the two places a binding changes *in this window*: a per-chat model switch announces itself, and a turn re-reads the row when it **ends**. It also measured, with a `fetch` hook recording every session payload the renderer received, exactly which cached field lagged — one:

| what | `privacy_tier` | `privacy_reason` |
| --- | --- | --- |
| `POST /agent/resume` — what the store cached | `public` | `null` |
| `GET /sessions/…?metadata_only=true` — the post-turn refresh | `private` | `turn:versa_azure` |

The ratchet that writes those two runs at the **top** of `Agent::reply` ([agent.rs:8365](crates/biorouter/src/agents/agent.rs#L8365)), and the re-read that notices runs when the turn is over ([chatStreamStore.tsx:1913](ui/desktop/src/hooks/chatStreamStore.tsx#L1913)). Between them the composer holds a `public` classification for a chat the daemon has already made private — and under #192's rule a stale `public` suppresses the chip override and the private-chat note *together*. On a long turn that is the whole turn.

The binding half has the same shape for a different reason. `restore_provider_from_session` binds whatever the **row** names, so a row rewritten by anything other than this window — a second window, `biorouter session --resume … --provider …`, a schedule — makes the turn run somewhere the composer is not naming, with the gauge sized to the wrong model's window, until the turn ends.

Both are facts the daemon knows at the seam and the client cannot compute. So the daemon says them, in the stream the client is already reading.

## Root cause

Not a missing refresh — a frame that was scoped to the wrong question.

`AgentEvent::PrivacyProviderPinned` (#192) was built **inside Gate B's repair arm** and carried the binding alone ([agent.rs, old line 8272](crates/biorouter/src/agents/agent.rs)). Two consequences:

1. It was withheld on the ~99% of turns that need no repair, which are also the turns whose classification changes.
2. It was built **before** the ratchet a few lines below it, so it could not have carried the post-ratchet tier even where it did fire.

## What changed

### The daemon states what every turn runs on

- **[`agent.rs:8365-8398`](crates/biorouter/src/agents/agent.rs#L8365)** — the frame is built once, **after** the ratchet, for every turn that reaches a provider. The repair arm no longer builds its own (`Ok(true) => {}`), so a repaired turn and an ordinary one cannot report differently shaped facts.
- **[`agent.rs:6480`](crates/biorouter/src/agents/agent.rs#L6480)** `pinned_provider_event(classification, reason)` — the classification is passed **in**, not re-read. It is the same value stored into `cached_classification` and handed to the hooks manager, sampled once at the seam; a second read could observe Gate C's dispatch ratchet on another task and describe a turn that never existed.
- **[`agent.rs:8369`](crates/biorouter/src/agents/agent.rs#L8369)** — `privacy_reason` is **derived, not read back**, and the derivation is exact only because of the `f > row.privacy_tier` guard on the write. The classification lattice has two values, so a strict increase can only be `public → private`; `SessionUpdateBuilder`'s `CASE WHEN` preserves an existing reason on an already-private row and takes the new one otherwise, so on a public row it is the `ELSE` arm and the stored reason is exactly the string passed. That reasoning is written next to the code, and a test asserts the frame agrees with what landed on the row.
- **[`reply.rs:406`](crates/biorouter-server/src/routes/reply.rs#L406)** + **[`session_events.rs:134`](crates/biorouter-server/src/routes/session_events.rs#L134)** — `privacy_tier: SessionClassification` and `privacy_reason: Option<String>` on the wire variant, through the one shared mapper, so `/reply` and the observer feed cannot disagree. Contract regenerated from this worktree and committed.

**Widening the frame is safe because the contract was never "this frame means something is wrong".** It has always read *"compare it against what you display, and say nothing when they agree"* — and `bindingDiffersFromSelection` returns exactly `false` on the common turn, so no note is painted whether the frame arrives or not. The frame decides nothing; the comparison does.

### The three non-desktop consumers say something true

The frame now fires on every turn, so two arms that were correct became wrong prose. `commands/web.rs` logged *"Private chat pinned to its own binding"* at `info!` — one line per turn, forever, about a binding a browser session cannot change (SD-1); now `debug!`, and it no longer claims privacy is the reason. `session/mod.rs`'s `--debug` line said *"This chat is private, so…"*, false on most turns; now it names the classification instead of asserting one.

### The renderer applies it at turn start

- **[`chatStreamStore.tsx:1424` `applyTurnBinding`](ui/desktop/src/hooks/chatStreamStore.tsx#L1424)** — the binding still becomes `pinnedModel`; the two new fields are patched onto the cached row, because that row is where every reader of the classification looks. The row is **patched, never adopted**: the frame names four fields and this store is the transcript's source of truth for the rest.
- A frame carrying no `privacy_tier` leaves the classification alone. Absent means *"this frame knows nothing about the tier"*, which must not be read as `public` — that would silently declassify the row on screen.

### ⚠ The regression the widening would otherwise have caused

`chatBinding` prefers the turn-reported pin **over** the row. While the frame arrived only on a repaired bind that was almost never observable. Now that every turn reports one, a switch made *after* a turn would be overruled by that turn's pin, and the chip would name the model the user just switched away from — the exact regression #192 narrowed its rule to avoid.

So **[the switch announcement moves the pin too](ui/desktop/src/hooks/chatStreamStore.tsx#L820)**. Replacing rather than clearing is the honest write: an accepted bind is as authoritative a statement of *what this chat runs on* as a turn's own report, and it is the later one. The contract is recorded in [`sessionBindingSync.ts`](ui/desktop/src/utils/sessionBindingSync.ts), which is where a second receiver (a cross-window one) will read it.

## Tests

Every line below was run in this worktree after the change, all Rust runs under `BIOROUTER_DISABLE_KEYRING=true`.

| Gate | Result |
| --- | --- |
| `cargo test -p biorouter --lib -- agents::agent::gate` | **33 passed**, 0 failed (baseline 31; +2) |
| `cargo test -p biorouter --lib -- agents::agent::gate_b` | **11 passed** (baseline 9; +2) |
| `cargo test -p biorouter --lib -- privacy::` | **232 passed**, 0 failed |
| `cargo test -p biorouter --lib -- …the_two_chat_side_ratchets_share_one_production_call_site` | **1 passed** |
| `cargo test -p biorouter --lib` | **3734 passed**, 0 failed, 1 ignored |
| `cargo test -p biorouter-server --lib -- routes::reply` | **73 passed**, 0 failed |
| `cargo test -p biorouter-server --lib -- routes::session_events` | **14 passed**, 0 failed |
| `cargo test -p biorouter-server --lib` | **575 passed**, 0 failed |
| `cargo test -p biorouter-cli --lib` (isolated `HOME`, literal `CARGO_HOME`/`RUSTUP_HOME`) | **388 passed**, 0 failed |
| `cargo test -p biorouter --test privacy_capability` | **4 passed** |
| `cargo test -p biorouter --test privacy_guard_wiring` | **3 passed** |
| `cargo fmt --all -- --check` | clean |
| `./scripts/clippy-lint.sh` | ✅ all baseline checks passed, `too_many_lines` ok, no banned TLS crates |
| `just check-openapi-schema` | ✅ OpenAPI schema is up-to-date |
| `cd ui/desktop && npm run test:run` | 434 files, **4884 passed**, 1 skipped (+8 new cases) |
| `npx vitest run` on the brief's seven filters | 10 files, **104 passed** |
| `npx vitest run src/components/ChatInput.privacyTier.test.tsx` | **9 passed** (was 6) |
| `cd ui/desktop && npm run lint:check` | clean — tsc, eslint, 3 themes current, 332 contrast assertions, token mirrors |
| `npx prettier --check` on all 4 changed `ui/desktop/src` files | All matched files use Prettier code style |

### Both halves were falsified before being trusted

- Remove the tier patch from `applyTurnBinding` → **2 of 13** store tests fail (`adopts the ratcheted classification from the frame, not from a re-read`, `clears a provenance the chat no longer has`). The first is disarmed against a false pass: `getSession` resolves `null`, so the post-turn re-read patches nothing and a `private` row can only have come from the frame.
- Remove `setPinnedModel` from the switch subscription → **1 of 13** fails, with exactly the regression in the message: `expected { provider: 'versa_azure' } to deeply equal { provider: 'claude_code' }` — the chip naming the model just switched away from.

### One assertion is inverted, deliberately

`a_turn_that_needed_no_repair_reports_nothing` argued *"the frame must be evidence, not decoration — a client that saw this on every turn would either paint a permanent note or learn to ignore the frame."* That argument is kept verbatim in the test that replaces it, with its answer: deciding whether there is anything to **say** was never this frame's job, and `bindingDiffersFromSelection` already returns `false` here. Two new Rust cases cover what the widening is *for* — `a_turn_that_ratchets_reports_the_classification_it_just_wrote` (row public at the seam, frame says `private` / `turn:versa_azure`, and the row agrees) and `a_public_turn_on_a_public_chat_reports_public_with_no_reason`.

### One privacy census row grew, and it is the benign direction

`privacy_guard_wiring` failed with `privacy_refusal … measured refs: 5, declared 4`. That row already exists as *"a LOCAL VARIABLE named `privacy_refusal` … the second standing proof that a name match is not a call site"*; the fifth reference is the `privacy_refusal.is_none()` guard on building the frame. **`calls` is still 0** — the guard function itself gained no caller — and no call site was added to `privacy::floor(`, `raise_session_privacy(` or `record_session_affiliation(`, whose counts are unchanged.

## Verification

Own seam-built daemon (`cargo build --features biorouter/privacy-test-auth`, staged into this
worktree's `ui/desktop/src/bin/`, `strings … | grep -c TEST-AUTH` = 1), sandboxed instance
`h04-turnstart` (CDP 9351). Screenshots under `~/biorouter-runs/h04-turnstart/shots/`.

### The state, set up to be exactly round 3's N3

Row `20260909_1` = `versa_azure` / `gpt-5.5-2026-04-24` / **`public`**; app-wide selection switched
through Settings → Switch models to **Claude Code / `claude-fable-5-1`** (Public), which left the row
untouched, as the app-wide picker must. Baseline in the running app: **no note**, chip
`gpt-5.5-2026-04-24 (Private model, UCSF). Public chat`.

⚠ One step is a FIXTURE and is named as such: the row's tier was set back to `public` with a direct
`UPDATE`, because the ratchet is monotone and no sequence of app actions can lower it. The *state* it
produces is one production reaches constantly — a chat bound to a private provider that has not yet
run a turn — and everything measured after it is the app's own behaviour.

### (b) The ratcheted tier reaches the composer at turn start

Sampling the note, the chip's accessible name and the running-turn state every animation frame
(~16 ms) across the whole turn, with a `fetch` hook recording every request and its response tier:

| | measured |
| --- | --- |
| turn starts (Stop control appears) | **t = 2030 ms** |
| private-chat note appears | **t = 2206 ms** — 176 ms later |
| still streaming when it appeared | **yes** |
| requests that COMPLETED before the note | **`POST /reply` only** (started 2033, done 2074) |
| any `GET /sessions/…` returning `private` before the note | **none** |
| row afterwards | `versa_azure` / **`private`** / `turn:versa_azure` |

The last two rows are the point. The only thing that had answered before the composer changed its
mind was the reply stream itself, so the classification cannot have come from a session read — and on
`main` a session read is the *only* writer of that field. `02-note-and-chip-mid-turn.png`.

A first run of the same sequence, taken before the composer's own tier reader was wired up, produced
the same timing (turn at 1822 ms, note at 1958 ms) and stayed correct for the whole 38 s the turn ran.

**Independent corroboration, unplanned.** A turn left running across a full page reload came back with
the note showing while every session payload the renderer received said `public` — the daemon logged
`re-POST of a known turn_id: attaching to its stream … from_seq: 0`, so the frames were replayed and
the tier arrived with them. The row and the stream disagreed, and the stream was right about the turn.

### The contradiction this found, and fixed

In that first run the chip's own tooltip still read `(Private model, UCSF). **Public chat**` beside a
note saying the chat is private — two readers of the same fact on two different sources. That is the
second commit: `ChatInput`'s own tier read now yields to the row. After it, note and chip flip in the
**same 16 ms frame** (t = 2206 ms), one transition, no intermediate state.

### (c) A per-chat switch still yields exactly one chip transition

The regression case, on a chat that HAD a live turn-reported pin (`versa_azure` /
`gpt-5.5-2026-04-24`, from the turn above). Per-chat switch through the composer chip → Change Model →
Versa API Azure / `gpt-5.2-2025-12-11`, chip sampled every 16 ms for 5.6 s (540 samples):

- **exactly one transition**, at t = 2531 ms, `gpt-5.5-2026-04-24` → `gpt-5.2-2025-12-11`
- it never returns; the row was rewritten to `gpt-5.2-2025-12-11`

Without the pin moving with the switch, that chip would have reverted — which is what the falsified
store test prints in as many words.

### Not reproduced, and why

The turns themselves never completed: the sandbox's `versa_azure` calls hang without an error
(`Thinking · 1m 48s`, no provider error in the daemon log), and a second send while one is hung is
correctly refused (`Rejected concurrent /reply … turn turn-1 already in flight`). That is a
pre-existing condition of this machine's sandbox, not of this change — every measurement above is
about turn START and none of them needs a completed turn. The one console warning in the whole run,
`Failed to cancel running turn on stop:`, is the Stop click against that hung turn.

**Zero page errors** across the run.

Housekeeping: provider and model restored to `versa_azure` / `gpt-5.5-2026-04-24`; the probe chat
deleted (no session created today remains); instance stopped; the main checkout was never built in and
its `HEAD` is unchanged at `f350cdfc`.

## Out of scope

- **The chat-tab privacy dot and header pill still lag.** They read `getCachedSessionList()` ([ChatGroupsShell.tsx:105-114](ui/desktop/src/components/chatGroups/ChatGroupsShell.tsx#L105)), a different cache that neither this frame nor `refreshSessionBinding` touches — the comment there claiming otherwise is stale. Part 2 of this handoff owns it, together with `updateCachedSessionList`.
- **A row changed in another process** — a second window, the CLI, a schedule — is still stale until this window's next turn or resume. This makes the *turn* honest about it; part 2 adds the change feed that makes the idle window notice.
- **`ui_ask`-style mid-turn switches.** A model switch that lands mid-turn still leaves the frame's report as the older fact until the switch announcement fires; that ordering is the same as `main`'s and is what the announcement-moves-the-pin change makes coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
