### PR TITLE
fix(autovisualiser): let render_figure succeed on a model's first call

### DIFF
--- a/crates/biorouter-mcp/src/autovisualiser/mod.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/mod.rs
@@ -371,8 +371,180 @@ pub enum ChartDataValues {
     Points(Vec<ChartPoint>),
 }
 
+/// Move the first present alias onto `to`, if `to` is not already there.
+fn adopt_alias(map: &mut serde_json::Map<String, Value>, aliases: &[&str], to: &str) {
+    if map.contains_key(to) {
+        return;
+    }
+    if let Some(value) = aliases.iter().find_map(|key| map.remove(*key)) {
+        map.insert(to.to_string(), value);
+    }
+}
+
+/// Read a long-form row: `{"label": "a", "value": 1}` and its spellings.
+fn long_form_row(row: &Value) -> Option<(Value, Value)> {
+    let row = row.as_object()?;
+    let label = ["label", "name", "category", "x"]
+        .iter()
+        .find_map(|key| row.get(*key))?;
+    let value = ["value", "y", "count"]
+        .iter()
+        .find_map(|key| row.get(*key))?;
+    Some((label.clone(), value.clone()))
+}
+
+/// Reshape one dataset, lifting anything that belongs to the chart out of it.
+///
+/// Returns the labels the dataset's own points carried, if it turned out to be
+/// holding the category axis (`[{"x": "a", "y": 1}]` with a NON-numeric `x` is
+/// a labelled series written as points, not a scatter).
+fn normalize_chart_dataset(entry: &mut Value, lifted_type: &mut Option<Value>) -> Option<Value> {
+    let map = entry.as_object_mut()?;
+    adopt_alias(map, &["name", "title", "series"], "label");
+    adopt_alias(map, &["values", "y", "points"], "data");
+    // A per-dataset `type` is Chart.js's per-series override, but a model that
+    // wrote it INSTEAD of the chart's own `type` meant the chart's.
+    if let Some(kind) = map.remove("type").or_else(|| map.remove("chart_type")) {
+        lifted_type.get_or_insert(kind);
+    }
+    map.entry("label")
+        .or_insert_with(|| Value::String("Value".to_string()));
+
+    let points = map.get("data")?.as_array()?.clone();
+    if points.is_empty() || !points.iter().all(|p| long_form_row(p).is_some()) {
+        return None;
+    }
+    // Numeric `x` really is a scatter; leave `ChartDataValues::Points` to it.
+    if points
+        .iter()
+        .all(|p| p.get("x").is_some_and(Value::is_number))
+    {
+        return None;
+    }
+    let (labels, values): (Vec<Value>, Vec<Value>) =
+        points.iter().filter_map(long_form_row).unzip();
+    map.insert("data".to_string(), Value::Array(values));
+    Some(Value::Array(labels))
+}
+
+/// Reshape the chart payload a model actually sends into the documented one.
+///
+/// ⚠ Every rule below is a payload MEASURED coming out of Versa GPT-5.5 on the
+/// prompt "render a bar chart of three values a=1, b=2, c=3" — ten rejected
+/// calls over six runs, not a guess at what a model might do. The shapes, by
+/// frequency: the whole series written long-form as `data: [{label, value}]`
+/// with no `datasets` at all (5); `chart_type` for `type` (4); `{x, y}` points
+/// whose `x` is a CATEGORY string rather than a number (3); `name` for a
+/// dataset's `label` and `values` for its `data` (1 each); and `x_label` /
+/// `xLabel` for `xAxisLabel`. That last one was not one of the ten rejections
+/// and could not be: `ChartData` sets no `deny_unknown_fields`, so serde drops
+/// the key and leaves `x_axis_label` at `None`. It is a silent QUALITY loss on a
+/// payload that is otherwise valid — the axis titles the model wrote simply do
+/// not reach the figure — which is why it is fixed here but carries no count.
+///
+/// ⚠ It never GUESSES the chart type. Every measured payload stated it —
+/// under `chart_type`, or inside a dataset — so this moves it rather than
+/// choosing one. A payload that names no type anywhere is still refused, with
+/// the message that names the kind and `describe_figure`: drawing the wrong
+/// chart is worse than one more round trip.
+fn normalize_chart_data(value: Value) -> Value {
+    let mut value = match de_stringified(value) {
+        Value::Object(map) => map,
+        other => return other,
+    };
+
+    adopt_alias(&mut value, &["chart_type", "chartType"], "type");
+    adopt_alias(&mut value, &["series", "dataSets"], "datasets");
+    adopt_alias(
+        &mut value,
+        &["x_axis_label", "xLabel", "x_label", "xaxis_label"],
+        "xAxisLabel",
+    );
+    adopt_alias(
+        &mut value,
+        &["y_axis_label", "yLabel", "y_label", "yaxis_label"],
+        "yAxisLabel",
+    );
+
+    // Long form: one series written as rows, with `data` where `datasets` goes.
+    if !value.contains_key("datasets") {
+        if let Some(rows) = value.get("data").and_then(Value::as_array) {
+            if !rows.is_empty() && rows.iter().all(|row| long_form_row(row).is_some()) {
+                let (labels, values): (Vec<Value>, Vec<Value>) =
+                    rows.iter().filter_map(long_form_row).unzip();
+                let label = value
+                    .get("yAxisLabel")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Value")
+                    .to_string();
+                value.remove("data");
+                value
+                    .entry("labels")
+                    .or_insert_with(|| Value::Array(labels));
+                value.insert(
+                    "datasets".to_string(),
+                    json!([{ "label": label, "data": Value::Array(values) }]),
+                );
+            }
+        }
+    }
+
+    let mut lifted_type = None;
+    let mut lifted_labels = None;
+    if let Some(Value::Array(datasets)) = value.get_mut("datasets") {
+        for entry in datasets.iter_mut() {
+            if let Some(labels) = normalize_chart_dataset(entry, &mut lifted_type) {
+                lifted_labels.get_or_insert(labels);
+            }
+        }
+    }
+    if let Some(kind) = lifted_type {
+        value.entry("type").or_insert(kind);
+    }
+    if let Some(labels) = lifted_labels {
+        value.entry("labels").or_insert(labels);
+    }
+    Value::Object(value)
+}
+
+/// The derived half of [`ChartData`]'s hand-written `Deserialize`.
+#[derive(Deserialize)]
+struct ChartDataRaw {
+    #[serde(rename = "type")]
+    chart_type: ChartType,
+    datasets: Vec<ChartDataset>,
+    #[serde(default)]
+    labels: Option<Vec<String>>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    subtitle: Option<String>,
+    #[serde(default, rename = "xAxisLabel")]
+    x_axis_label: Option<String>,
+    #[serde(default, rename = "yAxisLabel")]
+    y_axis_label: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for ChartData {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::Error as DeError;
+        let raw: ChartDataRaw =
+            serde_json::from_value(normalize_chart_data(Value::deserialize(d)?))
+                .map_err(DeError::custom)?;
+        Ok(ChartData {
+            chart_type: raw.chart_type,
+            datasets: raw.datasets,
+            labels: raw.labels,
+            title: raw.title,
+            subtitle: raw.subtitle,
+            x_axis_label: raw.x_axis_label,
+            y_axis_label: raw.y_axis_label,
+        })
+    }
+}
+
 /// Chart data structure
-#[derive(Debug, Serialize, Deserialize, rmcp::schemars::JsonSchema)]
+#[derive(Debug, Serialize, rmcp::schemars::JsonSchema)]
 pub struct ChartData {
     /// Chart type
     #[serde(rename = "type")]

--- a/crates/biorouter-mcp/src/autovisualiser/tests_dashboard.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/tests_dashboard.rs
@@ -460,7 +460,7 @@ fn test_render_figure_call_unwraps_the_shapes_a_model_sends() {
         // `kind` when the fault was the quoting.
         json!("{\"kind\": \"chart\", \"data\": {\"type\": \"bar\"}}"),
     ] {
-        let (kind, data) = render_figure_call(payload.clone())
+        let (kind, data) = render_figure_call(payload.clone(), FigureVocabulary::RenderFigure)
             .unwrap_or_else(|e| panic!("{payload} was refused: {}", e.message));
         assert_eq!(kind, FigureKind::Chart, "{payload}");
         assert_eq!(data["type"], "bar", "{payload}");
@@ -468,7 +468,8 @@ fn test_render_figure_call_unwraps_the_shapes_a_model_sends() {
 
     // A string that is not JSON at all must say so, not fall through to a
     // complaint about a missing `kind`.
-    let err = render_figure_call(json!("kind=chart")).unwrap_err();
+    let err =
+        render_figure_call(json!("kind=chart"), FigureVocabulary::RenderFigure).unwrap_err();
     assert!(
         err.message.contains("did not parse"),
         "{}",
@@ -479,7 +480,8 @@ fn test_render_figure_call_unwraps_the_shapes_a_model_sends() {
     // omitted `tool`, `DashboardFigure` will already have consumed
     // `type`/`name`/`kind` hunting for the TOOL name; and in every case, a chart
     // payload's own `type: "bar"` must not be able to choose the figure.
-    let err = render_figure_call(json!({"type": "chart", "data": {}})).unwrap_err();
+    let err = render_figure_call(json!({"type": "chart", "data": {}}), FigureVocabulary::RenderFigure)
+        .unwrap_err();
     assert!(err.message.contains("needs a `kind`"), "{}", err.message);
 }
 
@@ -1815,4 +1817,301 @@ fn result_text(result: &CallToolResult) -> String {
         .filter_map(|c| c.as_text().map(|t| t.text.clone()))
         .collect::<Vec<_>>()
         .join("")
+}
+
+// ---------------------------------------------------------------------------
+// The first `render_figure` call must land (handoff 07; #150 one layer up)
+// ---------------------------------------------------------------------------
+
+/// The strict door — what `rmcp` itself does with a model's raw arguments.
+///
+/// ⚠ Every other `render_figure` test in this file builds
+/// `RenderFigureParams { kind, data }` in Rust, which skips deserialization
+/// altogether, so none of them can see a payload refused *before* the tool body
+/// runs. `rmcp` calls
+/// `serde_json::from_value::<RenderFigureParams>(Value::Object(arguments))`
+/// (`handler/server/tool.rs`) and turns any failure into a bare
+/// "failed to deserialize parameters: …". This mirrors that call exactly as
+/// `params_from` mirrors it for `render_dashboard`.
+fn figure_params_from(value: Value) -> Result<Parameters<RenderFigureParams>, String> {
+    serde_json::from_value::<RenderFigureParams>(value)
+        .map(Parameters)
+        .map_err(|e| e.to_string())
+}
+
+/// The canonical bar-chart payload, as `describe_figure` reports it.
+fn first_call_chart_data() -> Value {
+    json!({
+        "type": "bar",
+        "labels": ["a", "b", "c"],
+        "datasets": [{"label": "Value", "data": [1.0, 2.0, 3.0]}],
+    })
+}
+
+/// A model's FIRST `render_figure` call must render, not cost a round trip.
+///
+/// Measured on Versa GPT-5.5 in the round-2 and round-3 walkthroughs: "render a
+/// bar chart of three values a=1, b=2, c=3" cost four or five tool-call cards,
+/// two or three of them rejections, before the model called `describe_figure`,
+/// read the schema and succeeded — once even *after* `describe_figure` had
+/// already answered.
+///
+/// The rejections did not come from this crate. The advertised `render_figure`
+/// had a DERIVED `Deserialize`, so `rmcp` refused the arguments with
+/// "missing field `data`" — no kind, no `describe_figure` pointer — before a
+/// line of Auto Visualiser ran, while the lenient `render_figure_call` sat one
+/// door over, wired only to dashboard panels and Agent Drafter's `ui_figure`.
+/// Through the `code_execution` sandbox (default-enabled) the model sees
+/// `data: any` and one line of description, so it cannot read the shape off the
+/// schema either.
+///
+/// Fails the shipped implementation on the flattened, envelope-wrapped and
+/// chart-type-as-kind shapes.
+#[tokio::test]
+async fn render_figure_accepts_the_first_call_shapes_a_model_sends() {
+    let router = AutoVisualiserRouter::new();
+
+    let canonical = router
+        .render_figure(
+            figure_params_from(json!({"kind": "chart", "data": first_call_chart_data()}))
+                .expect("the documented shape must deserialize"),
+        )
+        .await
+        .expect("the documented shape must render");
+    let canonical = decode_html(&canonical);
+
+    for payload in [
+        // (a) Flattened: the payload written straight onto the arguments. The
+        //     shape `rmcp` answered with "missing field `data`".
+        json!({
+            "kind": "chart",
+            "type": "bar",
+            "labels": ["a", "b", "c"],
+            "datasets": [{"label": "Value", "data": [1.0, 2.0, 3.0]}],
+        }),
+        // The envelope keys a model reaches for because that is what a
+        // dashboard panel calls the same object.
+        json!({"kind": "chart", "params": first_call_chart_data()}),
+        json!({"kind": "chart", "arguments": first_call_chart_data()}),
+        json!({"kind": "chart", "args": first_call_chart_data()}),
+        // The `{"tool": …, "params": {…}}` envelope the panel vocabulary uses —
+        // and, before this fix, the shape the missing-`kind` error itself told a
+        // direct caller to send.
+        json!({
+            "tool": "render_figure",
+            "params": {"kind": "chart", "data": first_call_chart_data()},
+        }),
+        // (e) Stringified `data`, and the whole object stringified.
+        json!({"kind": "chart", "data": first_call_chart_data().to_string()}),
+        json!(json!({"kind": "chart", "data": first_call_chart_data()}).to_string()),
+        // (d) A chart TYPE used as the kind. `FigureKind` had no lenient
+        //     `Deserialize` (unlike `ChartType`), so this died at
+        //     "unknown variant `bar`".
+        json!({"kind": "bar", "data": first_call_chart_data()}),
+        json!({"kind": "Bar Chart", "data": first_call_chart_data()}),
+        // …and the same, with the `type` the model already stated as the kind
+        // left out of the payload.
+        json!({
+            "kind": "bar",
+            "data": {
+                "labels": ["a", "b", "c"],
+                "datasets": [{"label": "Value", "data": [1.0, 2.0, 3.0]}],
+            },
+        }),
+        // The kind named by the tool it dispatches to — the spelling
+        // `describe_figure`'s own guidance is written in.
+        json!({"kind": "show_chart", "data": first_call_chart_data()}),
+    ] {
+        let params = figure_params_from(payload.clone())
+            .unwrap_or_else(|e| panic!("{payload} was refused before dispatch: {e}"));
+        let rendered = router
+            .render_figure(params)
+            .await
+            .unwrap_or_else(|e| panic!("{payload} was refused: {}", e.message));
+        assert_eq!(
+            canonical,
+            decode_html(&rendered),
+            "{payload} must draw the SAME figure, not merely draw one"
+        );
+    }
+}
+
+/// A kind a model can plausibly write must resolve; one it cannot must fail with
+/// a message it can act on.
+///
+/// Goes through `serde_json::from_value` rather than a helper so it exercises
+/// the same door `rmcp` uses. Fails the shipped implementation, whose derived
+/// enum `Deserialize` accepted the 32 slugs and nothing else.
+#[test]
+fn figure_kind_resolves_the_names_a_model_writes() {
+    for (written, expected) in [
+        ("chart", FigureKind::Chart),
+        ("Chart", FigureKind::Chart),
+        ("show_chart", FigureKind::Chart),
+        ("bar", FigureKind::Chart),
+        ("bar chart", FigureKind::Chart),
+        ("scatter-plot", FigureKind::Chart),
+        ("pie", FigureKind::Donut),
+        ("render_volcano", FigureKind::Volcano),
+        ("Volcano", FigureKind::Volcano),
+        ("kaplan-meier", FigureKind::KaplanMeier),
+        ("kaplanmeier", FigureKind::KaplanMeier),
+        ("word cloud", FigureKind::Wordcloud),
+        ("ER Diagram", FigureKind::ErDiagram),
+        ("calendar heatmap", FigureKind::CalendarHeatmap),
+    ] {
+        let parsed: FigureKind = serde_json::from_value(json!(written))
+            .unwrap_or_else(|e| panic!("`{written}` must resolve to a kind: {e}"));
+        assert_eq!(parsed, expected, "`{written}`");
+    }
+
+    // A word that names no figure must not be guessed at, and must say where the
+    // list of kinds is.
+    let err = serde_json::from_value::<FigureKind>(json!("wombat")).unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("wombat"), "{message}");
+    assert!(message.contains("describe_figure"), "{message}");
+}
+
+/// A payload that is genuinely wrong must still be reported against a call the
+/// model can make, whichever door refused it.
+///
+/// The kind-and-`describe_figure` phrasing already held for a payload that
+/// reached dispatch (`test_bad_arguments_name_render_figure_and_the_kind`).
+/// What it did NOT hold for was a payload refused during deserialization, which
+/// is where the walkthrough's rejections actually came from.
+#[tokio::test]
+async fn render_figure_refusals_name_render_figure_the_kind_and_describe_figure() {
+    let router = AutoVisualiserRouter::new();
+    let retired: Vec<&str> = FigureKind::ALL.iter().map(|k| k.tool_name()).collect();
+
+    // (c) A chart payload with no `type`, and nothing in the kind to imply one.
+    let message = match figure_params_from(json!({"kind": "chart", "data": {"labels": ["a"]}})) {
+        Err(message) => message,
+        Ok(params) => router
+            .render_figure(params)
+            .await
+            .expect_err("a chart with no `type` must be refused")
+            .message
+            .to_string(),
+    };
+    assert!(message.contains("type"), "must say what is missing: {message}");
+    assert!(message.contains("render_figure"), "{message}");
+    assert!(message.contains("\"chart\""), "must name the kind: {message}");
+    assert!(message.contains("describe_figure"), "{message}");
+    for name in &retired {
+        assert!(
+            !message.contains(name),
+            "the model cannot call `{name}`: {message}"
+        );
+    }
+
+    // No `kind` at all: the example the message offers must be one this door
+    // accepts. It used to hand a direct caller the PANEL spelling
+    // (`{"tool": …, "params": {…}}`), teaching the shape that had just failed.
+    let message =
+        figure_params_from(json!({"data": first_call_chart_data()})).expect_err("no kind");
+    assert!(message.contains("kind"), "{message}");
+    assert!(message.contains("describe_figure"), "{message}");
+    // Brace-matched from the first `{`, char by char: `clippy::string_slice` is
+    // denied repo-wide, and a byte index into a message that carries `…` would
+    // be the exact panic that lint exists for.
+    let example: Value = {
+        let mut depth = 0usize;
+        let mut json = String::new();
+        for ch in message.chars() {
+            if depth == 0 && ch != '{' {
+                continue;
+            }
+            json.push(ch);
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            json.contains("\"kind\""),
+            "the missing-`kind` message must show a shape this door accepts: {message}"
+        );
+        serde_json::from_str(&json)
+            .unwrap_or_else(|e| panic!("the example must be valid JSON ({e}): {json}"))
+    };
+    let params = figure_params_from(example.clone())
+        .unwrap_or_else(|e| panic!("the example the error offers is itself refused: {e}"));
+    router
+        .render_figure(params)
+        .await
+        .unwrap_or_else(|e| panic!("the example the error offers does not render: {}", e.message));
+}
+
+/// Azure and OpenAI reject a request whose `tools[n].function.description`
+/// exceeds 1024 characters with a non-retryable 400 — the same class of failure
+/// as the 128-tool ceiling, and the reason the comment above `render_figure`
+/// says to keep its description short. The limit is real and unhandled:
+/// `providers::utils` classifies that exact 400 (`http_context_classifier_keeps_
+/// tool_description_limits_as_request_failures`) and nothing truncates a
+/// description on the way out.
+///
+/// `per_kind_documentation_stays_out_of_the_declarations` caps the SUM at 4096,
+/// which a single 1500-byte description passes. Nothing pinned the per-tool
+/// limit until now.
+///
+/// ⚠ **`render_dashboard` is already over it**, at 2705 bytes, measured on
+/// `main` at f350cdfc — so this is a RATCHET, not a clean gate. A gate that
+/// fails on arrival gets disabled rather than obeyed. Every other advertised
+/// tool must fit the real cap, and the one that does not may only shrink toward
+/// it; when it fits, delete its entry. Fixing that description is a change to
+/// `render_dashboard`'s call-once guidance and belongs to whoever owns it.
+#[test]
+fn every_advertised_description_fits_the_provider_cap() {
+    /// Tools measured over the cap today, with the size they must not exceed.
+    const KNOWN_OVER_CAP: &[(&str, usize)] = &[("render_dashboard", 2_705)];
+
+    let router = AutoVisualiserRouter::new();
+    for tool in router.tool_router.list_all() {
+        let len = tool.description.as_deref().unwrap_or_default().len();
+        let (cap, note) = match KNOWN_OVER_CAP
+            .iter()
+            .find(|(name, _)| *name == tool.name.as_ref())
+        {
+            Some((_, allowed)) => (
+                *allowed,
+                "it is a known offender and may only shrink; it must never grow",
+            ),
+            None => (
+                1_024,
+                "Azure and OpenAI reject a tool description over 1024 characters \
+                 with a non-retryable 400",
+            ),
+        };
+        assert!(
+            len <= cap,
+            "`{}`'s description is {len} bytes against a budget of {cap}: {note}",
+            tool.name
+        );
+    }
+
+    // An entry that has become unnecessary must be deleted, not left to rot into
+    // a licence for a description that now fits to grow again.
+    for (name, allowed) in KNOWN_OVER_CAP {
+        let len = router
+            .tool_router
+            .list_all()
+            .iter()
+            .find(|tool| tool.name.as_ref() == *name)
+            .and_then(|tool| tool.description.as_deref())
+            .map(str::len)
+            .unwrap_or_else(|| panic!("`{name}` is exempted here but is not advertised"));
+        assert!(
+            len > 1_024,
+            "`{name}` now fits the 1024-byte cap at {len} bytes; remove its \
+             KNOWN_OVER_CAP entry (budget was {allowed})"
+        );
+    }
 }

--- a/crates/biorouter-mcp/src/autovisualiser/tests_dashboard.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/tests_dashboard.rs
@@ -2115,3 +2115,149 @@ fn every_advertised_description_fits_the_provider_cap() {
         );
     }
 }
+
+/// Every chart payload MEASURED coming out of the real model, replayed.
+///
+/// ⚠ These are not invented fixtures. They are the ten `show_chart` payloads
+/// Versa GPT-5.5 was rejected for on the prompt "Use the auto visualiser to
+/// render a bar chart of three values a=1, b=2, c=3, no explanation needed."
+/// over six runs, captured by instrumenting the dispatch table's reject path.
+/// A synthetic matrix would not have produced one of them: the dominant shape
+/// is the whole series written long-form with `data` where `datasets` goes, and
+/// the second is `chart_type` — neither appears anywhere in this repository's
+/// schemas or docs.
+///
+/// Each is compared against the canonical payload it obviously meant, so a
+/// normalization that renders SOMETHING but drops the labels or the axis titles
+/// fails here. The pre-fix tree refuses all six shapes.
+#[tokio::test]
+async fn chart_accepts_the_payloads_the_real_model_sends() {
+    let router = AutoVisualiserRouter::new();
+
+    let rows = json!([
+        {"label": "a", "value": 1}, {"label": "b", "value": 2}, {"label": "c", "value": 3}
+    ]);
+    let points = json!([{"x": "a", "y": 1}, {"x": "b", "y": 2}, {"x": "c", "y": 3}]);
+    let canonical = |title: &str, x: &str, y: &str| {
+        json!({
+            "type": "bar",
+            "labels": ["a", "b", "c"],
+            "datasets": [{"label": y, "data": [1.0, 2.0, 3.0]}],
+            "title": title,
+            "xAxisLabel": x,
+            "yAxisLabel": y,
+        })
+    };
+
+    for (measured, expected) in [
+        // The long-form series, with no `datasets` at all (5 of 10 rejections).
+        (
+            json!({"data": rows, "title": "Values by category", "type": "bar",
+                   "x_label": "Category", "y_label": "Value"}),
+            canonical("Values by category", "Category", "Value"),
+        ),
+        // The same, camelCased. `xLabel` was not itself a rejection: it is an
+        // unknown field, so serde drops it and the chart renders WITHOUT the
+        // axis titles the model wrote. Pinned here because the canonical
+        // payload compared against carries them.
+        (
+            json!({"data": rows, "title": "Values by label", "type": "bar",
+                   "xLabel": "Label", "yLabel": "Value"}),
+            canonical("Values by label", "Label", "Value"),
+        ),
+        // `chart_type` for `type` (4 of 10).
+        (
+            json!({"chart_type": "bar", "labels": ["a", "b", "c"],
+                   "datasets": [{"data": [1, 2, 3], "label": "Value"}],
+                   "title": "Values by label", "x_axis_label": "Label",
+                   "y_axis_label": "Value"}),
+            canonical("Values by label", "Label", "Value"),
+        ),
+        // `name` for `label`, `values` for `data`, and the chart's `type`
+        // written inside the dataset instead of beside it.
+        (
+            json!({"datasets": [{"name": "Value", "type": "bar", "values": points}],
+                   "title": "Values by category", "x_label": "Category",
+                   "y_label": "Value"}),
+            canonical("Values by category", "Category", "Value"),
+        ),
+        // `{x, y}` points whose `x` is a CATEGORY, not a coordinate (3 of 10).
+        (
+            json!({"chart_type": "bar",
+                   "datasets": [{"data": points, "name": "Value"}],
+                   "title": "Values by category", "x_label": "Category",
+                   "y_label": "Value"}),
+            canonical("Values by category", "Category", "Value"),
+        ),
+        (
+            json!({"datasets": [{"chart_type": "bar", "data": points, "name": "Value"}],
+                   "title": "Values by category", "x_label": "Category",
+                   "y_label": "Value"}),
+            canonical("Values by category", "Category", "Value"),
+        ),
+    ] {
+        let want = router
+            .render_figure(
+                figure_params_from(json!({"kind": "chart", "data": expected}))
+                    .expect("the canonical payload must deserialize"),
+            )
+            .await
+            .expect("the canonical payload must render");
+        let got = router
+            .render_figure(
+                figure_params_from(json!({"kind": "chart", "data": measured.clone()}))
+                    .unwrap_or_else(|e| panic!("{measured} was refused before dispatch: {e}")),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("{measured} was refused: {}", e.message));
+        assert_eq!(
+            decode_html(&want),
+            decode_html(&got),
+            "{measured} must draw the figure it meant, labels and axis titles included"
+        );
+    }
+}
+
+/// The leniency must not swallow the two things it could plausibly break.
+#[tokio::test]
+async fn chart_normalization_keeps_scatter_points_and_still_refuses_a_typeless_chart() {
+    let router = AutoVisualiserRouter::new();
+
+    // A real scatter: `{x, y}` with NUMERIC `x` is a coordinate, not a category,
+    // and must stay `ChartDataValues::Points`. A normalization that folded every
+    // `{x, y}` list into labels-plus-numbers would silently turn every scatter
+    // plot in the product into a bar chart.
+    let scatter = json!({
+        "type": "scatter",
+        "datasets": [{"label": "S", "data": [{"x": 1.0, "y": 2.0}, {"x": 2.0, "y": 4.0}]}],
+    });
+    let rendered = router
+        .render_figure(
+            figure_params_from(json!({"kind": "chart", "data": scatter}))
+                .expect("a scatter must deserialize"),
+        )
+        .await
+        .expect("a scatter must render");
+    let html = decode_html(&rendered);
+    assert!(
+        html.contains("\"x\""),
+        "the scatter's points were flattened into labels"
+    );
+
+    // No `type` anywhere. Guessing one would draw a chart the user did not ask
+    // for; the round trip is the cheaper mistake.
+    let message = match figure_params_from(json!({
+        "kind": "chart",
+        "data": {"labels": ["a"], "datasets": [{"label": "V", "data": [1.0]}]},
+    })) {
+        Err(message) => message,
+        Ok(params) => router
+            .render_figure(params)
+            .await
+            .expect_err("a chart naming no type anywhere must be refused")
+            .message
+            .to_string(),
+    };
+    assert!(message.contains("type"), "{message}");
+    assert!(message.contains("describe_figure"), "{message}");
+}

--- a/crates/biorouter-mcp/src/autovisualiser/tools_dashboard.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/tools_dashboard.rs
@@ -441,7 +441,7 @@ impl AutoVisualiserRouter {
         // which is why one unwrap is always enough: `tool_name()` never returns
         // `render_figure`, so this cannot recurse.
         let (name, params) = if name == RENDER_FIGURE {
-            let (kind, data) = render_figure_call(params)?;
+            let (kind, data) = render_figure_call(params, vocab)?;
             (kind.tool_name(), figure_arguments(data))
         } else {
             (name, params)
@@ -902,7 +902,19 @@ macro_rules! figure_kinds {
     ($($variant:ident => ($slug:literal, $tool:literal)),+ $(,)?) => {
         /// Which figure to draw. Enumerated in the schema, so a model cannot
         /// invent a kind and a wrong guess is refused before any work happens.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+        //
+        // ⚠ `Deserialize` is HAND-WRITTEN, below this macro. The derive accepted
+        // the 32 slugs and nothing else, so a model that answered with a chart
+        // type (`"bar"`), the tool name `describe_figure`'s own guidance is
+        // written in (`"show_chart"`) or a capitalised slug (`"Chart"`) was
+        // refused by serde before a line of Auto Visualiser ran — with serde's
+        // "unknown variant" text, which names neither `describe_figure` nor a
+        // kind it could have used instead.
+        //
+        // `Serialize` and `JsonSchema` keep the derive, so the schema the model
+        // is SHOWN is still the strict enum of canonical slugs. The leniency is
+        // what this accepts, never what it advertises.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
         #[derive(rmcp::schemars::JsonSchema)]
         pub enum FigureKind {
             $(
@@ -964,6 +976,77 @@ figure_kinds! {
     Choropleth      => ("choropleth",       "render_choropleth"),
 }
 
+impl FigureKind {
+    /// Resolve a figure name however a model spelled it.
+    ///
+    /// The advertised schema names one spelling per kind, but a model does not
+    /// always answer with it — and through the `code_execution` sandbox it never
+    /// sees the enum at all, only `kind: FigureKind` in a one-line signature.
+    /// Every rung below is a spelling the model was handed somewhere: the slug
+    /// is in the schema, the tool name is in `describe_figure`'s `guidance`
+    /// (it is the underlying tool's own description), and `bar`/`line`/
+    /// `scatter`/`pie` are the words the server instructions use to say what
+    /// `chart` and `donut` are FOR.
+    ///
+    /// ⚠ This resolves the figure's NAME. It is not a licence to guess: a word
+    /// that names no figure still fails, because rendering the wrong figure is
+    /// worse than one more round trip.
+    pub fn from_alias(raw: &str) -> Option<FigureKind> {
+        // Folds case, spaces, dashes and a missing `render_` prefix into the
+        // dispatch table's own spelling — including `chart` → `show_chart`.
+        let tool = normalize_tool_name(raw);
+        if let Some(kind) = Self::ALL.iter().copied().find(|k| k.tool_name() == tool) {
+            return Some(kind);
+        }
+        // Word breaks a model put somewhere else, or nowhere: `kaplanmeier`,
+        // `word cloud`, `ERdiagram`.
+        let squashed = tool.replace('_', "");
+        if let Some(kind) = Self::ALL
+            .iter()
+            .copied()
+            .find(|k| k.tool_name().replace('_', "") == squashed)
+        {
+            return Some(kind);
+        }
+        let word = tool.trim_start_matches("render_").replace('_', "");
+        if implied_chart_type(&word).is_some() {
+            return Some(FigureKind::Chart);
+        }
+        match word.as_str() {
+            // "donut: pie/donut charts for categorical proportions".
+            "pie" | "piechart" | "doughnut" | "doughnutchart" => Some(FigureKind::Donut),
+            _ => None,
+        }
+    }
+}
+
+/// The `ChartData` `type` a kind alias has already named.
+///
+/// `{"kind": "bar"}` states the chart type in the kind, so the payload beside it
+/// usually carries no `type` of its own — and `ChartData::chart_type` is
+/// required. Refusing that call would mean rejecting a model for saying what it
+/// wanted twice rather than once.
+fn implied_chart_type(word: &str) -> Option<&'static str> {
+    match word {
+        "bar" | "barchart" | "column" | "columnchart" => Some("bar"),
+        "line" | "linechart" => Some("line"),
+        "scatter" | "scatterplot" | "scatterchart" => Some("scatter"),
+        _ => None,
+    }
+}
+
+impl<'de> Deserialize<'de> for FigureKind {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::Error as DeError;
+        let raw = String::deserialize(d)?;
+        FigureKind::from_alias(&raw).ok_or_else(|| {
+            DeError::custom(format!(
+                "unknown figure kind {raw:?}; call describe_figure for the list of kinds"
+            ))
+        })
+    }
+}
+
 /// Turn a `render_figure` payload into the arguments the underlying tool takes.
 ///
 /// All thirty-two land on `{"data": …}` — including `donut`, whose
@@ -1002,7 +1085,10 @@ const RENDER_FIGURE: &str = "render_figure";
 /// keys that were meant as the tool. Independently — and this is the one that
 /// bites when `tool` WAS present — a figure's own `type` field (`show_chart`
 /// payloads have one) must not be able to decide which figure gets drawn.
-fn render_figure_call(params: Value) -> Result<(FigureKind, Value), ErrorData> {
+fn render_figure_call(
+    params: Value,
+    vocab: FigureVocabulary,
+) -> Result<(FigureKind, Value), ErrorData> {
     // Some models stringify nested tool-call arguments; `DashboardFigure`
     // accepts that and this used to refuse it, so a stringified panel body
     // failed one level in with a message about `kind` rather than about the
@@ -1025,14 +1111,29 @@ fn render_figure_call(params: Value) -> Result<(FigureKind, Value), ErrorData> {
         }
     };
 
-    let raw_kind = map.remove("kind").ok_or_else(|| {
-        invalid(
-            "`render_figure` needs a `kind` naming the figure to draw, e.g. \
-             {\"tool\": \"render_figure\", \"params\": {\"kind\": \"volcano\", \"data\": {…}}}. \
-             Call describe_figure for the list of kinds."
-                .to_string(),
-        )
-    })?;
+    // A call wrapped the way a dashboard panel writes one:
+    // `{"tool": "render_figure", "params": {"kind": …, "data": …}}`. Descend
+    // before hunting `kind` — and note WHY this shape reaches the declared door
+    // at all: until this change the missing-`kind` error handed every caller the
+    // panel spelling as its worked example, so a direct caller that followed the
+    // advice it was just given failed a second time on the shape the message
+    // recommended.
+    if !map.contains_key("kind") {
+        if let Some(inner) = ["params", "arguments", "args", "data"]
+            .iter()
+            .filter_map(|key| map.get(*key))
+            .find_map(|value| match de_stringified(value.clone()) {
+                Value::Object(inner) if inner.contains_key("kind") => Some(inner),
+                _ => None,
+            })
+        {
+            map = inner;
+        }
+    }
+
+    let raw_kind = map
+        .remove("kind")
+        .ok_or_else(|| invalid(missing_kind_error(vocab)))?;
     let kind: FigureKind = serde_json::from_value(raw_kind.clone()).map_err(|_| {
         invalid(format!(
             "Unknown figure kind {raw_kind}. Call describe_figure for the list of kinds."
@@ -1042,11 +1143,53 @@ fn render_figure_call(params: Value) -> Result<(FigureKind, Value), ErrorData> {
     // An explicit payload key wins; otherwise whatever is left on the object IS
     // the payload, which is how a model that wrote `{"kind": "chart", "type":
     // "bar", "datasets": […]}` still lands on a figure.
-    let data = ["data", "params", "arguments", "args"]
+    let mut data = ["data", "params", "arguments", "args"]
         .iter()
         .find_map(|key| map.remove(*key))
         .unwrap_or(Value::Object(map));
+
+    // `{"kind": "bar", …}` already named the chart type; see `implied_chart_type`.
+    if kind == FigureKind::Chart {
+        if let (Some(implied), Value::Object(fields)) = (
+            raw_kind
+                .as_str()
+                .map(|raw| normalize_tool_name(raw).trim_start_matches("render_").replace('_', ""))
+                .as_deref()
+                .and_then(implied_chart_type),
+            &mut data,
+        ) {
+            fields
+                .entry("type")
+                .or_insert_with(|| Value::String(implied.to_string()));
+        }
+    }
     Ok((kind, data))
+}
+
+/// The example a missing `kind` is answered with, in the caller's own vocabulary.
+///
+/// ⚠ The two are NOT interchangeable, and the wrong one costs the round trip
+/// this message exists to save. `render_figure`'s declared door takes
+/// `{"kind": …, "data": …}` directly; a dashboard panel wraps that same object
+/// as `{"tool": "render_figure", "params": {…}}`. Handing the panel spelling to
+/// a direct caller told it to retry with a shape that door then refused. Both
+/// are accepted now, but the example should still be the one the caller's own
+/// surface documents — a model copies the example it is given.
+fn missing_kind_error(vocab: FigureVocabulary) -> String {
+    let example = match vocab {
+        FigureVocabulary::RenderFigure => {
+            "{\"kind\": \"chart\", \"data\": {\"type\": \"bar\", \
+             \"labels\": [\"a\", \"b\"], \
+             \"datasets\": [{\"label\": \"Value\", \"data\": [1, 2]}]}}"
+        }
+        FigureVocabulary::ToolName => {
+            "{\"tool\": \"render_figure\", \"params\": {\"kind\": \"volcano\", \"data\": {…}}}"
+        }
+    };
+    format!(
+        "`render_figure` needs a `kind` naming the figure to draw, e.g. {example}. \
+         Call describe_figure for the list of kinds."
+    )
 }
 
 /// Which figure names the caller's model can actually emit.
@@ -1133,14 +1276,44 @@ fn unknown_figure_error(vocab: FigureVocabulary, name: &str) -> String {
 }
 
 /// Parameters for `render_figure`.
-#[derive(Debug, Serialize, Deserialize, rmcp::schemars::JsonSchema)]
+#[derive(Debug, Serialize, rmcp::schemars::JsonSchema)]
 pub struct RenderFigureParams {
     /// Which figure to draw.
     pub kind: FigureKind,
     /// The figure's payload. Its shape depends on `kind` — call
     /// `describe_figure` with that kind for the exact schema and a worked
-    /// example.
+    /// example. For `kind: "chart"`: {"type": "bar", "labels": ["a", "b"],
+    /// "datasets": [{"label": "Value", "data": [1, 2]}]}.
     pub data: Value,
+}
+
+/// ⚠ **Hand-written, and this is the fix.** The declared `render_figure` had a
+/// DERIVED `Deserialize`, so `rmcp` refused a model's arguments inside
+/// `Parameters::from_context_part` — `serde_json::from_value::<RenderFigureParams>`
+/// — and answered with its own "failed to deserialize parameters: missing field
+/// `data`". That message names no kind and no `describe_figure`, and it arrives
+/// before any Auto Visualiser code runs, so none of the careful phrasing in
+/// `figure_argument_error` could reach the model.
+///
+/// Meanwhile `render_figure_call` — which unwraps exactly the shapes models are
+/// recorded sending — sat one door over, wired only to dashboard panels and
+/// Agent Drafter's `ui_figure`. Two doors, two behaviours, and the lenient one
+/// was not the door a chat agent uses. Measured on Versa GPT-5.5: "render a bar
+/// chart of three values" cost four or five tool-call cards, two or three of
+/// them rejections, before the model gave in and called `describe_figure`.
+///
+/// This routes the declared door through the same parser, so the two agree.
+/// `render_figure`'s body then calls in as `kind.tool_name()`, which is never
+/// `render_figure`, so `call_figure_tool`'s own unwrap is not re-entered and the
+/// payload is unwrapped exactly once.
+impl<'de> Deserialize<'de> for RenderFigureParams {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::Error as DeError;
+        let (kind, data) =
+            render_figure_call(Value::deserialize(d)?, FigureVocabulary::RenderFigure)
+                .map_err(|e| DeError::custom(e.message))?;
+        Ok(RenderFigureParams { kind, data })
+    }
 }
 
 /// Parameters for `describe_figure`.
@@ -1163,7 +1336,7 @@ impl AutoVisualiserRouter {
     // `describe_figure`, which has no such budget because it is a RESULT.
     #[tool(
         name = "render_figure",
-        description = "Draw one interactive figure. Pick `kind` from the enum, and pass that kind's payload as `data`. The Auto Visualiser instructions in your system prompt list what each kind is for; call describe_figure with a kind to get its exact schema and a worked example. For an answer that needs more than one figure, call render_dashboard once instead of calling this repeatedly."
+        description = "Draw one interactive figure. Pick `kind` from the enum, and pass that kind's payload as `data`. Example: {\"kind\": \"chart\", \"data\": {\"type\": \"bar\", \"labels\": [\"a\", \"b\", \"c\"], \"datasets\": [{\"label\": \"Value\", \"data\": [1, 2, 3]}]}}. The Auto Visualiser instructions in your system prompt list what each kind is for; call describe_figure with a kind to get its exact schema and a worked example. For an answer that needs more than one figure, call render_dashboard once instead of calling this repeatedly."
     )]
     pub async fn render_figure(
         &self,


### PR DESCRIPTION
Handoff 07 — let `render_figure` succeed on a model's first call. Issue #150 class.

## Why

In both runtime walkthroughs the simplest possible request — *"Use the auto visualiser to render a
bar chart of three values a=1, b=2, c=3, no explanation needed."* on Versa GPT-5.5 — cost several
rejected `render_figure` calls before the model gave in, called `describe_figure`, read the schema
and succeeded. The figure rendered, so this was friction, not breakage, but it was two to three
wasted model round trips on every first chart.

Reproduced deterministically here: **6 of 6 pre-fix runs** needed 3–4 `execute_code` cards and
1–2 rejected Auto Visualiser calls.

## Root cause (and how this handoff's brief was wrong)

The brief's correction block said the defect was the **strict deserializer on the advertised
`render_figure`**: `RenderFigureParams` had a derived `Deserialize`, so `rmcp` refused a wrong
shape with a bare `missing field `data`` before any BioRouter code ran, while the lenient
`render_figure_call` sat one door over, wired only to dashboard panels and Agent Drafter's
`ui_figure`.

**That is real, and it is fixed in the first commit — but it is not what the walkthrough failures
were.** I instrumented the dispatch table's reject path
([`tools_dashboard.rs:456`](crates/biorouter-mcp/src/autovisualiser/tools_dashboard.rs#L456)) and
ran the handoff prompt six times against the real provider. All ten rejections were `ChartData`
**payload-shape** errors that reached dispatch with a perfectly good `kind` and `data`:

| count | what the model wrote | error |
|---|---|---|
| 5 | the whole series long-form, `data: [{label, value}]`, no `datasets` key at all | ``missing field `datasets`` |
| 4 | `chart_type` where the schema says `type` | ``missing field `type`` |
| 3 | `{x, y}` points whose `x` is a **category string**, not a coordinate | `data did not match any variant of untagged enum ChartDataValues` |
| 1 | `name` for a dataset's `label` | ``missing field `label`` |
| 1 | `values` for a dataset's `data` | (same call) |

Verbatim, two of them:

```
tool=show_chart err=missing field `datasets` params={"data":{"data":[{"label":"a","value":1},{"label":"b","value":2},{"label":"c","value":3}],"title":"Values by category","type":"bar","x_label":"Category","y_label":"Value"}}
tool=show_chart err=data did not match any variant of untagged enum ChartDataValues params={"data":{"chart_type":"bar","datasets":[{"data":[{"x":"a","y":1},{"x":"b","y":2},{"x":"c","y":3}],"name":"Value"}],"title":"Values for a, b, and c","x_label":"Category","y_label":"Value"}}
```

Two further corrections to the brief:

- **The measured tool-call count is 4, not 2**, matching the corrections block rather than the
  original brief.
- **`describe_figure` was not being skipped.** The model reached it and still failed the next call,
  which is why "make the model read the schema first" was the wrong half. Accepting what the model
  sends is the half that works.
- Two of the four kinds of failure the brief predicted (flattened `data`, a chart type used as the
  kind) **did not occur** in twelve runs. They are still fixed and tested, because they are
  recorded elsewhere in this codebase — but they were not the cost.

## What changed

**1. `RenderFigureParams` gets a hand-written `Deserialize`**
([`tools_dashboard.rs:1309`](crates/biorouter-mcp/src/autovisualiser/tools_dashboard.rs#L1309)),
routed through the existing lenient `render_figure_call`, mirroring `RenderDashboardParams`. The
two doors now agree. Unwrapping happens exactly once: `render_figure` calls in as
`kind.tool_name()`, which is never `render_figure`, so `call_figure_tool`'s own unwrap is not
re-entered.

**2. `FigureKind` gets a hand-written `Deserialize`** mirroring `ChartType`'s. A chart type
(`"bar"`), a tool name (`"show_chart"`), a capitalised slug (`"Chart"`) or a moved word break
(`"kaplanmeier"`, `"word cloud"`) all resolve. `Serialize` and `JsonSchema` keep the derive, so the
advertised schema is still the strict enum of canonical slugs — the leniency is what we accept,
never what we advertise. A word naming no figure is still refused.

**3. `ChartData` gets a hand-written `Deserialize` over `normalize_chart_data`**
([`mod.rs:450`](crates/biorouter-mcp/src/autovisualiser/mod.rs#L450)), mirroring
`RenderMermaidParams`: the leniency lives on the struct, so every door inherits it. Each rule is one
of the measured payloads above. It also adopts `x_label` / `xLabel` for `xAxisLabel`, which is not a
rejection at all — `ChartData` sets no `deny_unknown_fields`, so serde silently dropped it and the
axis titles the model wrote never reached an otherwise valid figure.

**It never guesses the chart type.** Every measured payload stated it, under `chart_type` or inside
a dataset, so this *moves* it. A payload naming no type anywhere is still refused, and a scatter's
numeric `{x, y}` points are not folded into labels. Both are pinned by
`chart_normalization_keeps_scatter_points_and_still_refuses_a_typeless_chart`.

**4. The missing-`kind` error is vocabulary-aware.** It handed *every* caller the dashboard-panel
spelling `{"tool": …, "params": {…}}`, so a direct caller that followed the advice it had just been
given failed a second time on the recommended shape. A test parses the example out of the message
and asserts that door accepts it. That envelope is now accepted too.

**5. `render_figure`'s description carries a one-line worked example.** Through the `code_execution`
sandbox — default-enabled, and the surface these failures actually came through — the model sees
`data: any` plus only the **first non-empty description line**
([`code_execution_extension.rs:406`](crates/biorouter/src/agents/code_execution_extension.rs#L406)),
so the example is the only guidance that survives that transport.

## Tests

```
cargo test -p biorouter-mcp --lib autovisualiser
  baseline  test result: ok. 146 passed; 0 failed; 2 ignored; 0 measured; 1494 filtered out
  final     test result: ok. 152 passed; 0 failed; 2 ignored; 0 measured; 1494 filtered out
cargo test -p biorouter-mcp --lib
  test result: ok. 1641 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
cargo test -p biorouter-mcp --test autovis_cdn_desktop_contract
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
cargo test -p biorouter-mcp --test autovis_dashboard_cdn
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
cargo test -p biorouter-mcp --test ui_example_apps
  test result: ok. 5 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
cargo fmt --all -- --check   clean
./scripts/clippy-lint.sh     All baseline clippy checks passed  (incl. clippy::too_many_lines)
```

The brief estimated "about 147 passed; 1 ignored" from a static count of test attributes. Measured,
the baseline is **146 passed / 2 ignored**.

**Fail-before, verbatim from the pre-fix tree:**

```
---- render_figure_accepts_the_first_call_shapes_a_model_sends stdout ----
{"datasets":[...],"kind":"chart","labels":["a","b","c"],"type":"bar"} was refused before dispatch: missing field `data`

---- figure_kind_resolves_the_names_a_model_writes stdout ----
`Chart` must resolve to a kind: unknown variant `Chart`, expected one of `chart`, `histogram`, ...

---- render_figure_refusals_name_render_figure_the_kind_and_describe_figure stdout ----
missing field `kind`

---- chart_accepts_the_payloads_the_real_model_sends stdout ----
{"data":[{"label":"a","value":1},...],"title":"Values by category","type":"bar","x_label":"Category","y_label":"Value"} was refused: `render_figure` arguments are invalid for kind "chart": missing field `datasets`. Call describe_figure with kind "chart" for the exact schema and a worked example.
```

## Verification — the real provider

`biorouter run -t "<the handoff prompt>" --no-session` on **`versa_azure` / gpt-5.5-2026-04-24**,
`code_execution` enabled (the default), against a sandboxed copy of `~/biorouter-runs/seed-config`.
Same binary source, same sandbox, same prompt; only the patch differs.

| | `execute_code` cards | rejected Auto Visualiser calls | figure rendered |
|---|---|---|---|
| before, 6 runs | 4, 4, 3, 4, 4, 3 | 2, 2, 1, 2, 2, 1 | 6/6 |
| **after, 6 runs** | **1, 1, 1, 1, 1, 1** | **0, 0, 0, 0, 0, 0** | **6/6** |

The pre-fix shape reproduces the walkthrough card-for-card:

```
── 1 tool call execute_code ──   1. autovisualiser/render_figure: Render a bar chart for values a=1, b=2, c=3
── 2 tool calls execute_code ──  1. autovisualiser/describe_figure: Read chart schema
                                2. autovisualiser/render_figure: Render bar chart for a=1, b=2, c=3 (uses 1)
── 1 tool call execute_code ──   1. autovisualiser/describe_figure: Read chart schema
── 1 tool call execute_code ──   1. autovisualiser/render_figure: Render a bar chart for values a=1, b=2, c=3
  ◆ Artifact: Bar Chart
```

The rendered artifact carries the right figure, axis titles included:

```json
{"datasets":[{"data":[1.0,2.0,3.0],"label":"Value"}],"labels":["a","b","c"],
 "title":"Values for a, b, and c","type":"bar","xAxisLabel":"Category","yAxisLabel":"Value"}
```

## Follow-ups (found, deliberately not done)

- ⚠ **`render_dashboard`'s advertised description is 2705 bytes, against a 1024-character
  Azure/OpenAI cap that this repository already knows about and does not handle.**
  `providers::utils` classifies that exact 400 (`http_context_classifier_keeps_tool_description_limits_as_request_failures`,
  [`utils.rs:883`](crates/biorouter/src/providers/utils.rs#L883)) and **nothing truncates a
  description on the way out**. The operator's Versa deployment evidently does not enforce it — every
  run above succeeded — but a deployment that does would 400 every turn, which is exactly the class
  of failure the three-tool consolidation exists to prevent. Rewriting that description is a change
  to `render_dashboard`'s call-once guidance and belongs to whoever owns it. New guard
  `every_advertised_description_fits_the_provider_cap` is therefore a **ratchet**, not a clean gate:
  the known offender is pinned at its current size and may only shrink, everything else must fit
  1024. A gate that fails on arrival gets disabled rather than obeyed.
- The `code_execution` signature renders `data` as `any`
  ([`code_execution_extension.rs:395`](crates/biorouter/src/agents/code_execution_extension.rs#L395)),
  because it is `serde_json::Value`. A per-kind shape in that surface would help more than any
  description text, but it is a `code_execution` change, not an Auto Visualiser one.
- The 31 non-`chart` kinds have had no equivalent measurement. The same class of payload drift
  very likely exists for `network`, `heatmap` and `volcano`; the harness to find out is the
  instrumented reject path described above.

Base `main` at `f350cdfc`. **Not merged** — the operator merges handoffs in the index order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
