### PR TITLE
Route every <config>/skills spelling through skills_root

### DIFF
--- a/crates/biorouter-cli/src/commands/skill.rs
+++ b/crates/biorouter-cli/src/commands/skill.rs
@@ -28,14 +28,21 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
-use biorouter::agents::skills_extension::{Skill, SkillsClient};
+use biorouter::agents::skills_extension::{
+    skills_root as biorouter_skills_root, Skill, SkillsClient,
+};
 use biorouter::config::paths::Paths;
 use console::{style, Color};
 
 const ACCENT: Color = Color::Color256(137);
 
+/// The skills root this CLI installs into and removes from.
+///
+/// A thin wrapper over the library's `skills_root` rather than a second
+/// spelling of the same join: a CLI that removed from a directory the daemon
+/// does not discover would report success and change nothing.
 fn skills_root() -> PathBuf {
-    Paths::config_dir().join("skills")
+    biorouter_skills_root(&Paths::config_dir())
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/crates/biorouter-cli/src/session/completion.rs
+++ b/crates/biorouter-cli/src/session/completion.rs
@@ -83,7 +83,9 @@ fn configured_skill_dirs() -> Vec<PathBuf> {
         dirs.insert(home.join(".claude/skills"));
         dirs.insert(home.join(".config/agents/skills"));
     }
-    dirs.insert(Paths::config_dir().join("skills"));
+    dirs.insert(biorouter::agents::skills_extension::skills_root(
+        &Paths::config_dir(),
+    ));
 
     dirs.into_iter().collect()
 }

--- a/crates/biorouter/src/agents/skill_catalog.rs
+++ b/crates/biorouter/src/agents/skill_catalog.rs
@@ -152,7 +152,7 @@ pub fn roots() -> Vec<SkillRoot> {
     }
 
     roots.push(SkillRoot {
-        path: Paths::config_dir().join("skills"),
+        path: crate::agents::skills_extension::skills_root(&Paths::config_dir()),
         source: SkillSource::new(SkillSourceKind::Biorouter, None),
     });
 

--- a/crates/biorouter/src/agents/skill_package/install.rs
+++ b/crates/biorouter/src/agents/skill_package/install.rs
@@ -72,7 +72,7 @@ struct RecordComponent {
 
 /// The skills root packages are installed into.
 pub fn install_root() -> PathBuf {
-    Paths::config_dir().join("skills")
+    crate::agents::skills_extension::skills_root(&Paths::config_dir())
 }
 
 /// Write `plan` into `root`, atomically, and refresh the catalog.
@@ -82,7 +82,7 @@ pub fn install_root() -> PathBuf {
 /// installer that quietly picked one of the answers would be the flattening
 /// this module exists to remove.
 pub fn install(plan: &ImportPlan, root: &Path) -> Result<InstalledPackage> {
-    install_in(&Paths::config_dir().join("skills"), plan, root)
+    install_in(&install_root(), plan, root)
 }
 
 /// [`install`] against an explicit seeded root.
@@ -275,7 +275,7 @@ fn common_component_root(components: &[super::PlannedSkill]) -> Option<String> {
 /// Renamed aside first and then deleted, so the directory disappears from the
 /// catalog's view in one step rather than emptying out under a scan in flight.
 pub fn remove(id: &str, root: &Path) -> Result<PackageSummary> {
-    remove_in(&Paths::config_dir().join("skills"), id, root)
+    remove_in(&install_root(), id, root)
 }
 
 /// [`remove`] against an explicit seeded root. See [`install_in`].

--- a/crates/biorouter/src/agents/skills_extension.rs
+++ b/crates/biorouter/src/agents/skills_extension.rs
@@ -376,7 +376,7 @@ pub(crate) fn add_missing_shipped_skills(skills: &mut HashMap<String, Skill>) {
 }
 
 pub fn count_user_skills() -> usize {
-    let skills_dir = Paths::config_dir().join("skills");
+    let skills_dir = skills_root(&Paths::config_dir());
     std::fs::read_dir(skills_dir)
         .into_iter()
         .flatten()
@@ -509,7 +509,7 @@ pub async fn session_skill_inventory_instructions(
 
 pub fn reset_to_builtin_skills() -> Result<usize> {
     let config_dir = Paths::config_dir();
-    let skills_dir = config_dir.join("skills");
+    let skills_dir = skills_root(&config_dir);
     let removed = count_user_skills();
 
     if skills_dir.exists() {
@@ -827,7 +827,7 @@ impl SkillsClient {
     /// by [`skill_catalog::SkillCatalog::scan`] so that *every* view of the
     /// catalog has them — not only the one a client happened to build.
     pub(crate) fn add_missing_shipped_skills(skills: &mut HashMap<String, Skill>) {
-        let root = Paths::config_dir().join("skills");
+        let root = skills_root(&Paths::config_dir());
         // ⚠ The fallback must place each skill where the SEEDER would have, or
         // the two views disagree about the one field the picker keys on: a
         // knowledge skill reconstructed here with `bundle_name: None` would be
@@ -4288,7 +4288,7 @@ Working dir biorouter content
         let temp = TempDir::new().unwrap();
         let _env =
             env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(temp.path().to_str().unwrap()))]);
-        let installed = Paths::config_dir().join("skills");
+        let installed = skills_root(&Paths::config_dir());
         let from_extension = Paths::config_dir().join("extensions/UCSFOMOPAgent/skills");
         fs::create_dir_all(installed.join("my-package")).unwrap();
         fs::create_dir_all(installed.join("about-biorouter")).unwrap();
@@ -5634,9 +5634,7 @@ Working dir biorouter content
         let temp = TempDir::new().unwrap();
         let _env =
             env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(temp.path().to_str().unwrap()))]);
-        let skill_dir = Paths::config_dir()
-            .join("skills")
-            .join("required-procedure");
+        let skill_dir = skills_root(&Paths::config_dir()).join("required-procedure");
         fs::create_dir_all(&skill_dir).unwrap();
         fs::write(
             skill_dir.join("SKILL.md"),
@@ -5697,7 +5695,7 @@ Working dir biorouter content
         let temp = TempDir::new().unwrap();
         let _env =
             env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(temp.path().to_str().unwrap()))]);
-        let bundle = Paths::config_dir().join("skills").join("office-pack");
+        let bundle = skills_root(&Paths::config_dir()).join("office-pack");
         for (name, body) in [("write-docx", "DOCX-BODY"), ("write-xlsx", "XLSX-BODY")] {
             let dir = bundle.join(name);
             fs::create_dir_all(&dir).unwrap();
@@ -5758,6 +5756,141 @@ Working dir biorouter content
         assert!(error.to_string().contains("disabled"), "{error:#}");
 
         skill_catalog::invalidate();
+    }
+    /// **`<config>/skills` is spelled once.**
+    ///
+    /// Three helpers claim to resolve the same path — `skill_catalog::roots()`'s
+    /// `SkillSourceKind::Biorouter` entry, this module's [`skills_root`], and
+    /// `skill_package::install::install_root` — and until this guard only prose
+    /// said so (the doc comments at the top of `skills_root` and inside
+    /// `catalog_item`). Eleven more sites spelled the join themselves, nine of
+    /// them in production. A seeder that writes where the discoverer does not
+    /// look installs nothing, silently, and a CLI that removes from a directory
+    /// the daemon does not discover reports success and changes nothing.
+    ///
+    /// ⚠ **Asserted about SOURCE, not about values, and that is deliberate.**
+    /// `Paths::config_dir` re-reads `BIOROUTER_PATH_ROOT` on every call
+    /// (`config/paths.rs`), so `roots()`, `skills_root(..)` and `install_root()`
+    /// evaluated in a row are three different instants. Pinning them at runtime
+    /// would mean holding `env_lock` — one global mutex over the whole
+    /// environment — to assert a fact the compiler can be shown instead. That
+    /// trade is backwards, and this repository has the flakes to prove it.
+    ///
+    /// ⚠ Whole comment lines are skipped, but a *trailing* comment spelling the
+    /// pattern would be reported. That direction is chosen on purpose: a guard
+    /// that accuses too much gets a line moved, and one that misses too much
+    /// gets believed.
+    #[test]
+    fn the_skills_root_is_spelled_once() {
+        fn rs_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if path.is_dir() {
+                    if name != "target" && name != "node_modules" && name != ".git" {
+                        rs_files(&path, out);
+                    }
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let crates = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        assert!(
+            crates.is_dir(),
+            "the audit walks {}; if that path is wrong it passes for the wrong reason",
+            crates.display()
+        );
+        let mut files = Vec::new();
+        for entry in std::fs::read_dir(crates).unwrap().flatten() {
+            let src = entry.path().join("src");
+            if src.is_dir() {
+                rs_files(&src, &mut files);
+            }
+        }
+        assert!(
+            files.len() > 400,
+            "the audit found only {} .rs files under crates/*/src, too few to have walked \
+             the workspace",
+            files.len()
+        );
+
+        // Comments removed line-wise FIRST, then whitespace squeezed — the other
+        // order would glue a comment's tail onto the next line of code. Squeezing
+        // is what catches the spelling broken across two lines, which one of the
+        // eleven was.
+        // Assembled from two halves on purpose. Spelled whole, this literal is
+        // itself a match once whitespace is squeezed, and the guard reports its
+        // own source as the first offender — the same self-reference that makes
+        // a naive non-vacuity floor pass.
+        let bypass = format!("{}{}", r#"Paths::config_dir()"#, r#".join("skills")"#);
+        let bypass = bypass.as_str();
+        let mut offenders = Vec::new();
+        let mut callers = 0usize;
+        for file in &files {
+            let Ok(source) = std::fs::read_to_string(file) else {
+                continue;
+            };
+            if source.contains("skills_root(") {
+                callers += 1;
+            }
+            let code: String = source
+                .lines()
+                .filter(|line| !line.trim_start().starts_with("//"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let squeezed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+            let hits = squeezed.matches(bypass).count();
+            if hits > 0 {
+                offenders.push(format!(
+                    "{} ({hits})",
+                    file.strip_prefix(crates)
+                        .unwrap_or(file)
+                        .to_string_lossy()
+                        .replace('\\', "/")
+                ));
+            }
+        }
+
+        // Non-vacuity, both halves: the one permitted definition still makes the
+        // join, and the helper is actually reached. Without these, deleting
+        // `skills_root` outright would leave this guard green.
+        // Scoped to `skills_root`'s own BODY, not to the file. Searching the
+        // whole file for the join finds this assertion's own literal and passes
+        // whatever the function does — measured: renaming the join to `skillz`
+        // left the guard green.
+        let body = include_str!("skills_extension.rs")
+            .split("pub fn skills_root(config_dir: &Path) -> PathBuf {")
+            .nth(1)
+            .expect("`skills_root` must exist with this signature")
+            .split("\n}")
+            .next()
+            .expect("`skills_root` must have a block body");
+        assert!(
+            body.contains(".join(\"skills\")"),
+            "`skills_root` no longer makes the join this guard exists to keep unique; \
+             its body is now:{body}"
+        );
+        assert!(
+            callers >= 8,
+            "only {callers} files call `skills_root(`; the helper was expected to be the \
+             single spelling, so a drop here means the sites went back to spelling it \
+             themselves"
+        );
+
+        assert!(
+            offenders.is_empty(),
+            "these files resolve the skills root themselves instead of calling \
+             `skills_extension::skills_root(&Paths::config_dir())`. Two spellings of one \
+             path drift, and the drift is silent — a seeder writes where the discoverer \
+             does not look:\n  {}",
+            offenders.join("\n  ")
+        );
     }
 }
 

--- a/crates/biorouter/src/knowledge/conversation_ingest.rs
+++ b/crates/biorouter/src/knowledge/conversation_ingest.rs
@@ -663,10 +663,11 @@ mod tests {
     }
 
     fn install_edited_soul_skill(body: &str) {
-        let skill_dir = crate::config::paths::Paths::config_dir()
-            .join("skills")
-            .join(crate::agents::skills_extension::KNOWLEDGE_BUNDLE)
-            .join(crate::knowledge::soul::SOUL_SKILL_DIR);
+        let skill_dir = crate::agents::skills_extension::skills_root(
+            &crate::config::paths::Paths::config_dir(),
+        )
+        .join(crate::agents::skills_extension::KNOWLEDGE_BUNDLE)
+        .join(crate::knowledge::soul::SOUL_SKILL_DIR);
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),


### PR DESCRIPTION
## Why

`skills_extension::skills_root(config_dir)` exists and had three callers.
`Paths::config_dir().join("skills")` was spelled **twelve more times** beside it — nine in
production, across two crates — with nothing but a doc comment claiming the two agree.

The consequence is silent in both directions. A seeder that writes where the discoverer does
not look installs nothing and reports success. A CLI that removes from a directory the daemon
does not discover reports success and changes nothing. `skills_extension.rs`'s own comment
already stated the invariant in prose; this makes it checkable.

Named in the follow-up notes as a leftover from #193.

## Root cause

| Site | Kind |
|---|---|
| `crates/biorouter-cli/src/commands/skill.rs:37` | a **second `fn skills_root`**, an independent copy of the same join |
| `crates/biorouter-cli/src/session/completion.rs:86` | production |
| `crates/biorouter/src/agents/skill_catalog.rs:155` | production — `roots()`'s `SkillSourceKind::Biorouter` entry, the one the helper's doc names |
| `crates/biorouter/src/agents/skills_extension.rs:379` | production |
| `crates/biorouter/src/agents/skills_extension.rs:512` | production |
| `crates/biorouter/src/agents/skills_extension.rs:830` | production |
| `crates/biorouter/src/agents/skill_package/install.rs:75` | production — `install_root()`, a third helper for the same value |
| `crates/biorouter/src/agents/skill_package/install.rs:85` | production |
| `crates/biorouter/src/agents/skill_package/install.rs:278` | production |
| `skills_extension.rs:4291`, `:5637`, `:5700`, `knowledge/conversation_ingest.rs:666` | tests |

⚠ **Two corrections to the follow-up note.** It said nine spellings; there are twelve, because
`skills_extension.rs:512` and `conversation_ingest.rs:666` were missed and one more was found
by the guard (below). And it described `skills_extension.rs:830` as a second resolution *inside
`SkillsClient::new`*. It is not — it is `add_missing_shipped_skills`, a separate `pub(crate) fn`
reached from `SkillCatalog::scan`, so the read lands on a later, unowned path. That is worse
than the note claimed: it is the shape `:807` is accepted for *not* being.

## What changed (file:line)

All twelve now call `skills_extension::skills_root(&Paths::config_dir())`. `install_root()`
becomes the helper's one composition and `install`/`remove` call `install_root()` rather than
re-spelling the join. The CLI's own `skills_root` becomes a two-line wrapper over the library's
rather than a second definition — it keeps its name so its two call sites are untouched.

**`SkillsClient::new` (`skills_extension.rs:807`) is deliberately left alone.** PR #193 calls
that synchronous constructor read "the property we want": the root a client seeds into should
be the one that was ambient when it was built. It already routes through `skills_root`.

**The pin is a source property, not a value comparison** —
`skills_extension.rs::tests::the_skills_root_is_spelled_once`. `Paths::config_dir` re-reads
`BIOROUTER_PATH_ROOT` on **every** call (`config/paths.rs:18`), so `roots()`, `skills_root(..)`
and `install_root()` evaluated in a row are three different instants. Pinning them at runtime
would mean holding `env_lock` — one global mutex over the whole environment — to assert
something the compiler can be shown instead. Against 33 locked writers of that variable, that
trade is backwards.

## Writing the guard found three things

Each was measured against a planted probe, not reasoned about.

1. **A twelfth spelling, invisible to a line-wise scan.** `skills_extension.rs:5637` split it
   across two lines:

   ```rust
   let skill_dir = Paths::config_dir()
       .join("skills")
       .join("required-procedure");
   ```

   My own whitespace-insensitive sweep had already declared the tree clean. The guard strips
   comments **line-wise first**, then squeezes whitespace — the other order glues a comment's
   tail onto the next line of code.

2. **The guard was its own first offender.** Its needle, spelled whole, is itself a match once
   whitespace is squeezed. It is now assembled from two halves so the joined spelling never
   appears literally in the file.

3. **The non-vacuity check was self-satisfying.** It searched the whole file for
   `config_dir.join("skills")` — and found the assertion's own literal, so it passed however
   `skills_root` was written. Measured: renaming the join to `skillz` left the guard **green**.
   It now reads `skills_root`'s function *body*.

That third one is the same shape as the first two, and it is the reason this PR states them
rather than quietly fixing them: a guard that cannot see itself is a guard nobody rechecks.

## Tests

**The guard proven to fire**, by planting a probe file and reverting it:

| Probe | Result |
|---|---|
| `Paths::config_dir().join("skills")` on one line | **FIRED** |
| the same, split across two lines | **FIRED** |
| the same, inside a `//` comment | silent (correct) |
| `skills_root`'s join renamed to `skillz` | **FIRED** — `` `skills_root` no longer makes the join this guard exists to keep unique `` |

**Suites:**

```
BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib
test result: ok. 3733 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 29.74s

BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter-server --lib
test result: ok. 575 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.53s

HOME=$(mktemp -d) CARGO_HOME=/Users/wgu/.cargo RUSTUP_HOME=/Users/wgu/.rustup \
  BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter-cli
test result: ok. 388 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.95s
```

3732 on `origin/main`, 3733 here: the one guard added.

**Stress**, `--test-threads=32` over `agents::skills_extension agents::skill_catalog agents::skill_package knowledge::soul`:

| tree | runs | fails | which |
|---|---|---|---|
| this branch | 60 | 2 | `knowledge::soul::…ensure_meditation_schedule_is_idempotent` (ENOENT), `agents::skill_package::pending::…a_parked_plan_comes_back_once_and_only_once` |
| **clean `origin/main`** | 59 | 1 | `agents::skill_package::pending::…a_parked_plan_comes_back_once_and_only_once` |

**Reported rather than glossed over.** This module set is flaky on `main` at a comparable rate,
and the one test that failed on *both* trees is the same. The soul test passed 20/20 when run
alone on this branch, and `knowledge/soul.rs` is not in this diff. The refactor is
value-identical — every changed site resolves to the same path, with the same number of
`Paths::config_dir()` calls — so there is no mechanism by which it could add a race. I do not
claim to have proven the soul failure is unrelated; I claim the evidence points that way and
that both flakes predate this branch.

**Gates:**

```
cargo fmt --all -- --check   → clean
./scripts/clippy-lint.sh     → ✅ All baseline clippy checks passed!
                               ✓ No banned TLS crates found
```

## Verification

Value-identical by construction: every site now calls `config_dir.join("skills")` through one
function instead of writing it inline, and `install`/`remove` make the same single
`Paths::config_dir()` call they made before. After this PR the bypass appears **zero** times
under `crates/*/src`, which is what the new guard asserts on every run.

## Follow-ups

- **Two pre-existing flakes**, both recorded above, neither in this diff:
  `agents::skill_package::pending::tests::a_parked_plan_comes_back_once_and_only_once` (seen on
  `main`) and `knowledge::soul::tests::ensure_meditation_schedule_is_idempotent`.
- `skills_extension.rs:830` (`add_missing_shipped_skills`) resolves the config root on a path
  reached *after* its owner returned. Routing it through the helper fixes the spelling, not the
  ownership — the real fix is a `root: &Path` parameter threaded from `SkillCatalog::scan`,
  which is the shape `knowledge::soul`'s seeders already use. Out of scope here.
- `biorouter-cli/src/session/completion.rs` is a **fourth** skill-root list that ignores
  `skill_catalog::roots()` entirely and reads `HOME` raw rather than `Paths::home_dir()`. Only
  its `<config>/skills` entry is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
