### PR TITLE
fix(session-meta): prune to the union of live watchers; widen the shared-setting guard to crates/*/tests

### DIFF
--- a/crates/biorouter-server/src/routes/session_meta.rs
+++ b/crates/biorouter-server/src/routes/session_meta.rs
@@ -201,4 +201,53 @@ mod tests {
             .join(",");
         assert_eq!(parse_ids(Some(&many)).len(), MAX_IDS);
     }
+
+    /// The claim must be BOUND, and nothing that RUNS can see whether it is.
+    ///
+    /// ⚠ This is the one line carrying the two-window fix, and every
+    /// behavioural test in the workspace passes without it: the row map lives
+    /// in `biorouter`, the poll's claim is taken here, and a route test drives
+    /// neither. Deleting `let _claim = …` restores the defect, and so does
+    /// writing `let _ = …`, which drops the guard on the spot while reading as
+    /// a fix. A source scan is the only instrument that can see either.
+    #[test]
+    fn the_poll_binds_its_watch_claim_for_the_life_of_the_request() {
+        // Production only. This module names the shape it forbids, so a scan
+        // that read its own tests would report itself as its first offender.
+        let (production, _) = include_str!("session_meta.rs")
+            .split_once("#[cfg(test)]")
+            .expect("this route's tests sit at the end, behind one `#[cfg(test)]`");
+        assert!(
+            production.len() > 5000,
+            "the production slice is {} bytes, far too short to be this route — the slice is              wrong and a clean result would mean nothing",
+            production.len()
+        );
+
+        // Comments are stripped for the same reason, and it is not theoretical
+        // here: the call site carries a warning that SPELLS the forbidden
+        // `let _ = …` form, so an unstripped scan sees two claims and fails on
+        // a correct tree. Truncating early can only lose a match, and a lost
+        // match fails the count below rather than passing quietly.
+        let claims: Vec<&str> = production
+            .lines()
+            .filter_map(|line| line.split("//").next())
+            .filter(|code| code.contains(".watch("))
+            .map(str::trim)
+            .collect();
+        assert_eq!(
+            claims.len(),
+            1,
+            "the poll claims its ids exactly once, for the life of the request. Found: {claims:?}"
+        );
+
+        // Whitespace-insensitive, so `let _=` cannot slip past a spelling.
+        let squashed: String = claims[0].chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            squashed.starts_with("let") && !squashed.starts_with("let_="),
+            "the claim must be bound to a NAMED local. `let _ = …` drops the guard \
+             immediately, which prunes the process-global row map against this one caller's \
+             ids again — the defect this endpoint had, wearing a fix. Found: {}",
+            claims[0]
+        );
+    }
 }

--- a/crates/biorouter-server/src/routes/session_meta.rs
+++ b/crates/biorouter-server/src/routes/session_meta.rs
@@ -21,11 +21,18 @@
 //!
 //! # The poll does the reading
 //!
-//! There is no background watcher and no registry of watched ids. The request
-//! carries the ids its client has open, and while parked it re-reads exactly
-//! those rows on a short interval, hands them to
-//! [`SessionMetaEvents::observe`], and returns as soon as the revision moves.
-//! An idle app with no chats open therefore reads nothing at all.
+//! There is no background watcher. The request carries the ids its client has
+//! open, and while parked it re-reads exactly those rows on a short interval,
+//! hands them to [`SessionMetaEvents::observe`], and returns as soon as the
+//! revision moves. An idle app with no chats open therefore reads nothing at
+//! all.
+//!
+//! ⚠ **A poll does register its ids, and that registry is not bookkeeping.**
+//! The row map behind `observe` is process-global while an id list is one
+//! window's, so a poll that pruned that map against its OWN list would evict a
+//! second window's chats — and a re-adopted id is adopted SILENTLY, so the two
+//! windows would thrash and neither would ever be told a row moved. The claim
+//! taken below lives for exactly this request; see [`SessionMetaEvents::watch`].
 //!
 //! ⚠ **`since=0` is a baseline request, not a replay.** A client establishing
 //! itself gets the current revision and no changes; asking for a replay from
@@ -126,6 +133,15 @@ pub async fn session_changes(
             .unwrap_or(MAX_WAIT)
             .min(MAX_WAIT);
 
+    // Claimed for the life of this poll and released when it answers, so the
+    // row map is pruned against the union of every live watcher rather than
+    // against whichever list arrived last.
+    //
+    // ⚠ It must be a NAMED binding. `let _ = events.watch(&ids)` drops the
+    // guard on the spot and reinstates the defect in a shape that reads as a
+    // fix.
+    let _claim = events.watch(&ids);
+
     // Adopt this caller's ids before parking. A chat opened a moment ago has not
     // changed, and reporting its whole row as new would wake every window on
     // connect — the first observation of an id is silent by construction
@@ -142,7 +158,6 @@ pub async fn session_changes(
         {
             events.observe(rows);
         }
-        events.retain_watched(&ids);
 
         let delta = events.since(query.since);
         if !delta.changes.is_empty() || delta.truncated {

--- a/crates/biorouter/src/model.rs
+++ b/crates/biorouter/src/model.rs
@@ -1172,8 +1172,8 @@ mod tests {
     struct Watched {
         key: &'static str,
         verdict: Verdict,
-        /// How many files under `crates/*/src` must still name this key **in
-        /// code**.
+        /// How many files under `crates/*/src` or `crates/*/tests` must still
+        /// name this key **in code**.
         ///
         /// ⚠ A **mention** count, not a match count, and deliberately so: a
         /// `Presence` row is healthy at zero matches, so a floor on matches
@@ -1364,10 +1364,27 @@ mod tests {
     ///    watchable set is the whole config surface, not this table. This table
     ///    is a list of measured hazards, not a closed set. Green here is not a
     ///    proof of hermeticity.
-    /// 3. **`crates/*/tests/`, which is skipped on purpose.** Each file there
-    ///    compiles to its own binary, so a write cannot reach the lib test
-    ///    binary these readers live in. It can still reach the other tests in
-    ///    its own file; that is a smaller, separate hazard the audit records.
+    /// 3. **`crates/*/examples/` and `build.rs`.** Neither is compiled into a
+    ///    test binary, so a write there cannot reach one at all. Eight files,
+    ///    and the only `.rs` in the workspace this walk does not read.
+    ///
+    /// # What it walks
+    ///
+    /// `crates/*/src/**` **and** `crates/*/tests/**`.
+    ///
+    /// ⚠ **The second half was missing, and the omission read as deliberate.**
+    /// The two guards this table replaced walked all of `crates/**`; the table
+    /// walked `crates/*/src/**` and its own documentation explained why
+    /// `tests/` was skipped — so consolidating three instruments into one
+    /// narrowed the coverage by 129 of the workspace's 762 `.rs` files while
+    /// looking like a strict improvement. The reasoning was half right: a
+    /// crate's top-level `tests/` file compiles to its OWN binary, so a write
+    /// there cannot race the lib tests most of these readers live in. It races
+    /// every other test in that binary, which is a smaller hazard and not a
+    /// different one — and it is invisible from anywhere else, which is the
+    /// part that matters. Two unrestored writes of
+    /// `BIOROUTER_ALLOW_PROJECT_HOOKS` sat there while this guard, the audit's
+    /// ledger and the audit's recipe all reported the key as handled.
     #[test]
     fn no_test_parks_a_shared_setting_in_the_process_environment() {
         // CARGO_MANIFEST_DIR is <workspace>/crates/biorouter; go up twice.
@@ -1410,7 +1427,8 @@ mod tests {
             })
             .collect();
 
-        let mut scanned = 0usize;
+        let mut scanned_src = 0usize;
+        let mut scanned_tests = 0usize;
         let mut mentions = vec![0usize; WATCHED.len()];
         let mut offenders: Vec<String> = Vec::new();
 
@@ -1427,18 +1445,26 @@ mod tests {
             if path.extension().and_then(|e| e.to_str()) != Some("rs") {
                 continue;
             }
-            // In scope: `crates/<crate>/src/**`. A `tests/` directory nested
-            // INSIDE `src` is an ordinary module of that crate's lib and stays
-            // in scope; only a crate's top-level `tests/` is its own binary.
+            // In scope: `crates/<crate>/src/**` and `crates/<crate>/tests/**`.
+            // A `tests/` directory nested INSIDE `src` is an ordinary module of
+            // that crate's lib and is already covered by the first arm.
+            //
+            // Counted per scope rather than in one total, because one number
+            // cannot tell "the tests half was walked" from "the src half grew" —
+            // and narrowing back to `src` alone is exactly the regression the
+            // widening exists to prevent.
             let Ok(relative) = path.strip_prefix(&crates) else {
                 continue;
             };
             let mut parts = relative.components();
             let _crate_name = parts.next();
-            if parts.next().map(|c| c.as_os_str()) != Some(std::ffi::OsStr::new("src")) {
-                continue;
+            match parts.next().and_then(|c| c.as_os_str().to_str()) {
+                Some("src") => scanned_src += 1,
+                Some("tests") => scanned_tests += 1,
+                // `examples/` and `build.rs`: not compiled into a test binary,
+                // so a write there cannot reach one.
+                _ => continue,
             }
-            scanned += 1;
             let Ok(source) = std::fs::read_to_string(path) else {
                 continue;
             };
@@ -1496,11 +1522,19 @@ mod tests {
             }
         }
 
-        // A walk that reads nothing agrees with a walk that finds nothing.
+        // A walk that reads nothing agrees with a walk that finds nothing. One
+        // floor per scope: a single total is satisfied by the `src` half alone,
+        // so it would pass on the very narrowing this widening undid.
         assert!(
-            scanned > 400,
-            "the audit only scanned {scanned} files under crates/*/src, which is too few to \
-             have walked the workspace"
+            scanned_src > 400,
+            "the audit only scanned {scanned_src} files under crates/*/src, which is too few \
+             to have walked the workspace"
+        );
+        assert!(
+            scanned_tests > 90,
+            "the audit only scanned {scanned_tests} files under crates/*/tests, which is too \
+             few to have walked them. A write parked there is invisible to every other test in \
+             its own binary, and to every other instrument in this repository"
         );
 
         // PER-KEY non-vacuity. One global floor lets most rows rot silently

--- a/crates/biorouter/src/session_meta.rs
+++ b/crates/biorouter/src/session_meta.rs
@@ -58,10 +58,11 @@
 //! believes a change's fields and never refetches drifts the first time two
 //! changes race. Every consumer here re-reads the row it was told about.
 
-use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
@@ -74,6 +75,19 @@ use tracing::debug;
 /// client watches the handful it has open, and anything past a few is already a
 /// client that has been away long enough to want a fresh read anyway.
 const BUFFER: usize = 32;
+
+/// How long a chat's row survives in [`SessionMetaEvents::last`] after the last
+/// watcher holding its id has gone away.
+///
+/// ⚠ **A grace period, and it is what makes pruning SAFE rather than tidy.** A
+/// client's claim lives for exactly one parked GET, so between two consecutive
+/// polls of the only open window there is an instant with no live watcher at
+/// all. Pruning strictly to the live union at that instant would evict the very
+/// ids that window is about to ask about again — and [`SessionMetaEvents::observe`]
+/// adopts a first-seen id SILENTLY, so a row rewritten in that gap would be
+/// swallowed for good. Five minutes is far longer than any request boundary and
+/// far shorter than a daemon's life.
+const RETENTION: Duration = Duration::from_secs(300);
 
 /// What changed about one chat's row.
 ///
@@ -121,6 +135,15 @@ pub struct SessionMetaRow {
     pub privacy_reason: Option<String>,
 }
 
+/// One watched chat's row, and when this process last read it.
+///
+/// The timestamp is the second half of the retention rule: an id survives while
+/// a live watcher holds it, and for [`RETENTION`] after the last one lets go.
+struct Tracked {
+    row: SessionMetaRow,
+    seen: Instant,
+}
+
 #[derive(Default)]
 struct Buffer {
     changes: Vec<SessionMetaChanged>,
@@ -140,17 +163,31 @@ pub struct SessionMetaEvents {
     /// does at startup: a client that has just opened a chat has not changed it,
     /// and reporting the whole row as new would make every client refetch on
     /// connect for nothing.
-    last: Mutex<HashMap<String, SessionMetaRow>>,
+    last: Mutex<HashMap<String, Tracked>>,
+    /// The open-chat ids of every LIVE watcher, keyed by its token.
+    ///
+    /// ⚠ **This map is process-global; one caller's id list is not.** Two
+    /// Biorouter windows (tab tear-off is a shipped feature) each mount one
+    /// subscription and poll with DIFFERENT open-chat sets, so pruning
+    /// [`Self::last`] against the ids of whichever poll happened to arrive last
+    /// makes the two windows evict each other in turn: B's prune drops A's
+    /// chats, A's next `observe` re-adopts them SILENTLY and publishes nothing,
+    /// then A's prune drops B's. Neither window ever learns that a row moved.
+    /// The union of every live watcher is the only list that is safe to prune
+    /// against, which is why the registry exists at all.
+    watchers: Mutex<HashMap<u64, Vec<String>>>,
+    /// Hands out the tokens above. Monotonic and never reused, so a guard can
+    /// only ever retire its own claim.
+    next_watcher: AtomicU64,
+    /// How long an id survives after its last watcher goes away — [`RETENTION`]
+    /// in production, and settable so a test can observe an eviction without
+    /// sleeping through it.
+    retention: Duration,
 }
 
 impl Default for SessionMetaEvents {
     fn default() -> Self {
-        Self {
-            revision: AtomicU64::new(0),
-            buffer: Mutex::new(Buffer::default()),
-            notify: Notify::new(),
-            last: Mutex::new(HashMap::new()),
-        }
+        Self::with_retention(RETENTION)
     }
 }
 
@@ -159,6 +196,22 @@ impl SessionMetaEvents {
         static INSTANCE: once_cell::sync::Lazy<Arc<SessionMetaEvents>> =
             once_cell::sync::Lazy::new(|| Arc::new(SessionMetaEvents::default()));
         &INSTANCE
+    }
+
+    /// A feed whose unwatched ids survive `retention` rather than [`RETENTION`].
+    ///
+    /// `Duration::ZERO` prunes strictly to the live union, which is how a test
+    /// asserts that dropping a watcher really does release its ids.
+    pub fn with_retention(retention: Duration) -> Self {
+        Self {
+            revision: AtomicU64::new(0),
+            buffer: Mutex::new(Buffer::default()),
+            notify: Notify::new(),
+            last: Mutex::new(HashMap::new()),
+            watchers: Mutex::new(HashMap::new()),
+            next_watcher: AtomicU64::new(0),
+            retention,
+        }
     }
 
     fn buffer(&self) -> std::sync::MutexGuard<'_, Buffer> {
@@ -243,16 +296,26 @@ impl SessionMetaEvents {
     pub fn observe(&self, rows: Vec<SessionMetaRow>) -> usize {
         let mut moved = Vec::new();
         {
+            let now = Instant::now();
             let mut last = self.last.lock().unwrap_or_else(PoisonError::into_inner);
             for row in rows {
-                match last.get(&row.session_id) {
-                    Some(before) if before == &row => {}
-                    Some(_) => {
-                        last.insert(row.session_id.clone(), row.clone());
-                        moved.push(row);
+                // `entry` rather than `get` + `insert`: the vacant arm writes
+                // through the same borrow, which a `match last.get(..)` cannot
+                // do on stable.
+                match last.entry(row.session_id.clone()) {
+                    Entry::Occupied(mut slot) => {
+                        let tracked = slot.get_mut();
+                        // The stamp is refreshed whether or not the row moved:
+                        // it records that somebody READ this chat, which is what
+                        // `retain_union` prunes on.
+                        tracked.seen = now;
+                        if tracked.row != row {
+                            tracked.row = row.clone();
+                            moved.push(row);
+                        }
                     }
-                    None => {
-                        last.insert(row.session_id.clone(), row);
+                    Entry::Vacant(slot) => {
+                        slot.insert(Tracked { row, seen: now });
                     }
                 }
             }
@@ -264,14 +327,46 @@ impl SessionMetaEvents {
         count
     }
 
-    /// Stop tracking chats nobody is watching any more, so a long-lived daemon's
-    /// map does not grow with every chat ever opened.
-    pub fn retain_watched(&self, watched: &[String]) {
-        let mut last = self.last.lock().unwrap_or_else(PoisonError::into_inner);
-        if last.len() <= watched.len() {
-            return;
+    /// Claim `ids` as watched for as long as the returned guard lives.
+    ///
+    /// One poll, one guard. The claim is what keeps those chats in
+    /// [`Self::last`] while some OTHER caller's poll prunes, and retiring it is
+    /// the only thing that can make them eligible for eviction.
+    ///
+    /// ⚠ **Registering can only ever GROW the union, so it prunes nothing.**
+    /// Pruning belongs on the drop, where a claim disappears.
+    #[must_use = "the ids are watched only for as long as the guard is alive"]
+    pub fn watch(self: &Arc<Self>, ids: &[String]) -> WatchGuard {
+        let token = self.next_watcher.fetch_add(1, Ordering::SeqCst);
+        self.watchers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(token, ids.to_vec());
+        WatchGuard {
+            events: Arc::clone(self),
+            token,
         }
-        last.retain(|id, _| watched.iter().any(|w| w == id));
+    }
+
+    /// Forget the chats that no live watcher holds and nothing has read within
+    /// [`Self::retention`], so a long-lived daemon's map does not grow with
+    /// every chat ever opened.
+    ///
+    /// ⚠ **The union of every live watcher, never one caller's list.** The
+    /// per-caller form this replaced is the two-window defect recorded on
+    /// [`Self::watchers`]; keeping the ids of every watcher is what makes the
+    /// prune agree with the map it prunes.
+    ///
+    /// The watchers lock is released before the rows lock is taken, so there is
+    /// no ordering between the two to remember.
+    fn retain_union(&self) {
+        let union: HashSet<String> = {
+            let watchers = self.watchers.lock().unwrap_or_else(PoisonError::into_inner);
+            watchers.values().flatten().cloned().collect()
+        };
+        let retention = self.retention;
+        let mut last = self.last.lock().unwrap_or_else(PoisonError::into_inner);
+        last.retain(|id, tracked| union.contains(id) || tracked.seen.elapsed() < retention);
     }
 
     /// Park until the revision moves past `since`, or `timeout` elapses.
@@ -296,6 +391,26 @@ impl SessionMetaEvents {
     }
 }
 
+/// One client's claim on the chats it has open, held for the life of its poll.
+///
+/// Dropping it retires the claim and prunes the row map to what is left — see
+/// [`SessionMetaEvents::watch`].
+pub struct WatchGuard {
+    events: Arc<SessionMetaEvents>,
+    token: u64,
+}
+
+impl Drop for WatchGuard {
+    fn drop(&mut self) {
+        self.events
+            .watchers
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&self.token);
+        self.events.retain_union();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -314,8 +429,11 @@ mod tests {
         }
     }
 
-    fn events() -> SessionMetaEvents {
-        SessionMetaEvents::default()
+    /// An `Arc`, because a claim is taken through one — see
+    /// [`SessionMetaEvents::watch`]. Every existing test reaches the inner
+    /// methods through `Deref` and is unchanged by it.
+    fn events() -> Arc<SessionMetaEvents> {
+        Arc::new(SessionMetaEvents::default())
     }
 
     #[test]
@@ -422,22 +540,114 @@ mod tests {
 
     #[test]
     fn a_chat_nobody_watches_stops_being_tracked() {
-        let e = events();
+        // `Duration::ZERO` so the release is observable without sleeping through
+        // the grace period; that the grace exists at all is
+        // `a_row_rewritten_between_two_polls_of_one_window_is_still_reported`.
+        let e = Arc::new(SessionMetaEvents::with_retention(Duration::ZERO));
+        let window_a = e.watch(&["s1".to_string()]);
+        let window_b = e.watch(&["s2".to_string()]);
         e.observe(vec![
             row("s1", "versa_azure", "gpt-5.5", "public"),
             row("s2", "codex", "gpt-6-astra", "public"),
         ]);
-        e.retain_watched(&["s1".to_string()]);
-        // s2 is a stranger again, so re-observing it adopts silently rather than
-        // announcing a change nobody asked about.
+
+        drop(window_b);
+        // s2 was nobody's the moment B retired, so it is a stranger again and
+        // re-observing it adopts silently rather than announcing a change
+        // nobody asked about.
         assert_eq!(e.observe(vec![row("s2", "ollama", "qwen3.6", "public")]), 0);
-        // s1 is still tracked.
+        // s1 is still claimed by A, and B retiring must not have touched it.
         assert_eq!(e.observe(vec![row("s1", "ollama", "qwen3.6", "public")]), 1);
+
+        drop(window_a);
+        assert_eq!(
+            e.observe(vec![row("s1", "codex", "gpt-6-astra", "public")]),
+            0,
+            "the last claim on s1 retired, so s1 is a stranger too"
+        );
+    }
+
+    #[test]
+    fn two_windows_with_different_open_chats_do_not_evict_each_other() {
+        // Two Biorouter windows, each with one subscription and its own open
+        // chats. The per-caller prune this replaced made them thrash: B's prune
+        // dropped s1, A's next `observe` re-adopted s1 as first-seen and
+        // published nothing, then A's prune dropped s2 — so neither window ever
+        // learned that a row had moved. Measured before the fix as
+        // "window A must learn that s1 moved; got 0".
+        let e = events();
+        let window_a = e.watch(&["s1".to_string()]);
+        let window_b = e.watch(&["s2".to_string()]);
+
+        // Each window's first sight of its own chat is silent.
+        assert_eq!(
+            e.observe(vec![row("s1", "versa_azure", "gpt-5.5", "public")]),
+            0
+        );
+        assert_eq!(
+            e.observe(vec![row("s2", "codex", "gpt-6-astra", "public")]),
+            0
+        );
+        // Interleaved rounds: the defect needed one poll from each window to
+        // show, and a single round would have passed against it.
+        for _ in 0..3 {
+            assert_eq!(
+                e.observe(vec![row("s1", "versa_azure", "gpt-5.5", "public")]),
+                0
+            );
+            assert_eq!(
+                e.observe(vec![row("s2", "codex", "gpt-6-astra", "public")]),
+                0
+            );
+        }
+
+        // `biorouter session --resume s1 --provider claude_code` from another
+        // process: only window A's chat moved.
+        assert_eq!(
+            e.observe(vec![row("s1", "claude_code", "claude-opus-5", "public")]),
+            1,
+            "window A must learn that s1 moved"
+        );
+        assert_eq!(
+            e.observe(vec![row("s2", "codex", "gpt-6-astra", "public")]),
+            0,
+            "and window B must not be told about a chat that did not move"
+        );
+
+        let delta = e.since(0);
+        assert_eq!(delta.changes.len(), 1);
+        assert_eq!(delta.changes[0].session_id, "s1");
+        drop((window_a, window_b));
+    }
+
+    #[test]
+    fn a_row_rewritten_between_two_polls_of_one_window_is_still_reported() {
+        // A claim lives for exactly one parked GET, so the ONLY window's ids are
+        // unclaimed for an instant at every request boundary. Pruning strictly
+        // to the live union there would evict them, and `observe` re-adopts a
+        // first-seen id SILENTLY — so a row rewritten in that instant would be
+        // swallowed for good. `RETENTION` is what closes it, and the default
+        // feed is the one production uses.
+        let e = events();
+        let poll_one = e.watch(&["s1".to_string()]);
+        assert_eq!(
+            e.observe(vec![row("s1", "versa_azure", "gpt-5.5", "public")]),
+            0
+        );
+        drop(poll_one);
+
+        let poll_two = e.watch(&["s1".to_string()]);
+        assert_eq!(
+            e.observe(vec![row("s1", "claude_code", "claude-opus-5", "public")]),
+            1,
+            "a row rewritten between two polls of one window must still be reported"
+        );
+        drop(poll_two);
     }
 
     #[tokio::test]
     async fn a_parked_poll_wakes_on_the_change_it_was_waiting_for() {
-        let e = Arc::new(events());
+        let e = events();
         e.observe(vec![row("s1", "versa_azure", "gpt-5.5", "public")]);
         let waiter = Arc::clone(&e);
         let parked = tokio::spawn(async move {

--- a/crates/biorouter/tests/global_memory_consent_agent_loop.rs
+++ b/crates/biorouter/tests/global_memory_consent_agent_loop.rs
@@ -136,9 +136,12 @@ async fn agent_with_hooks(
     provider: Arc<dyn Provider>,
     mode: BioRouterMode,
 ) -> (Agent, String, TempDir) {
-    // SAFETY: only flips the project-hook opt-in the HooksManager reads when it
-    // is constructed, a few lines below.
-    std::env::set_var("BIOROUTER_ALLOW_PROJECT_HOOKS", "1");
+    // The project-hooks decision is STATED on the agent's config below rather
+    // than parked in the process environment. `HooksManager::new_with_managed`
+    // reads `BIOROUTER_ALLOW_PROJECT_HOOKS` with a bare `std::env::var` that no
+    // lock and no task-local override can reach, and this file never removed the
+    // variable — so it stood for every agent built in this binary afterwards.
+    // See `docs/testing/process-global-state.md`.
 
     let work_dir = TempDir::new().unwrap();
     std::fs::create_dir_all(work_dir.path().join(".biorouter")).unwrap();
@@ -155,7 +158,8 @@ async fn agent_with_hooks(
         Arc::new(PermissionManager::new(permission_dir.path().to_path_buf())),
         None,
         mode,
-    );
+    )
+    .with_project_hooks(true);
     let agent = Agent::with_config(config);
 
     let session = session_manager

--- a/crates/biorouter/tests/hooks_agent_loop_tests.rs
+++ b/crates/biorouter/tests/hooks_agent_loop_tests.rs
@@ -127,9 +127,12 @@ async fn agent_with_project_hooks_in_mode(
     provider: Arc<dyn Provider>,
     mode: BioRouterMode,
 ) -> (Agent, String, TempDir) {
-    // SAFETY: tests run single-threaded per process for this env var; it only
-    // flips on the project-hook opt-in the HooksManager reads at construction.
-    std::env::set_var("BIOROUTER_ALLOW_PROJECT_HOOKS", "1");
+    // The project-hooks decision is STATED on the agent's config below rather
+    // than parked in the process environment. `HooksManager::new_with_managed`
+    // reads `BIOROUTER_ALLOW_PROJECT_HOOKS` with a bare `std::env::var` that no
+    // lock and no task-local override can reach, and this file never removed the
+    // variable — so it stood for every agent built in this binary afterwards.
+    // See `docs/testing/process-global-state.md`.
 
     let work_dir = TempDir::new().unwrap();
     std::fs::create_dir_all(work_dir.path().join(".biorouter")).unwrap();
@@ -149,7 +152,8 @@ async fn agent_with_project_hooks_in_mode(
         Arc::new(PermissionManager::new(permission_dir.path().to_path_buf())),
         None,
         mode,
-    );
+    )
+    .with_project_hooks(true);
     let agent = Agent::with_config(config);
 
     let session = session_manager

--- a/docs/testing/process-global-state.md
+++ b/docs/testing/process-global-state.md
@@ -27,7 +27,7 @@ Two remedies exist and **they are not interchangeable**:
 
 - **No new locks.** `env-lock` is a single global mutex over the whole environment. Adding a holder serialises writers against writers, which was never the failure mode, and does nothing about the unlocked readers that are.
 - **No new `#[serial]`.** An *unkeyed* `#[serial]` is worth even less than it looks: it excludes a test from the 31 other unkeyed ones and leaves it concurrent with the rest.
-- **A source-scan guard beats a stress run.** The race needs an interleaving CI produces and a loaded laptop may never show, so twenty green runs are weak evidence. A source scan cannot flake. Give every scan a non-vacuity floor and prove it against a deliberately poisoned probe before trusting it. The standing guard is `model::tests::no_test_parks_a_shared_setting_in_the_process_environment` ([#209](https://github.com/BaranziniLab/biorouter/pull/209)), one table covering nine keys on both principles.
+- **A source-scan guard beats a stress run.** The race needs an interleaving CI produces and a loaded laptop may never show, so twenty green runs are weak evidence. A source scan cannot flake. Give every scan a non-vacuity floor and prove it against a deliberately poisoned probe before trusting it. The standing guard is `model::tests::no_test_parks_a_shared_setting_in_the_process_environment` ([#209](https://github.com/BaranziniLab/biorouter/pull/209)), one table covering nine keys on both principles. It walks `crates/*/src/**` **and** `crates/*/tests/**`. ⚠ The `tests/` half was added later: the two guards that table replaced had walked all of `crates/**`, so consolidating three instruments into one silently dropped 129 of the workspace's 762 `.rs` files, and a consolidation is exactly the kind of change nobody re-measures the coverage of.
 - **Writing the environment is not banned outright.** A key that is *test-private* — namespaced so no production reader can resolve it — and restored on drop is safe without any lock, because there is no reader to race.
 
 ## Why this document exists rather than a fifth per-key guard
@@ -119,8 +119,9 @@ Verdicts: **fixed**, **live** (a reader can observe another test's write today),
 | `TEST_KEY`, `API_KEY`, `PROVIDER`, `PORT`, `ENABLED`, `CONFIG`, `TEST_PRECEDENCE` | none in production today; `get_param` upper-cases, so any `get_param("provider")` would resolve one | 11 unguarded bare `set_var` in 3 `config/base.rs` tests; `TEST_KEY` was never removed at all | **fixed** — [#199](https://github.com/BaranziniLab/biorouter/pull/199): namespaced to `BIOROUTER_TEST_CONFIG_*` and restored on drop |
 | `OSV_ENDPOINT` | `OsvChecker::new` (`agents/extension_malware_check.rs:18`), reached in production from `extension_manager.rs:972` on every Stdio extension install | 3 tests, RAII-restored but unkeyed `#[serial]` | **live** — fixed by [#205](https://github.com/BaranziniLab/biorouter/pull/205) |
 | `BIOROUTER_TOOL_CALL_BATCHING` | `providers/base.rs:1236`, bare `env::var`, once per streamed turn | `formats/anthropic.rs:1745` under `#[serial(tool_call_batching_env)]`, a key only 3 tests hold | **live** — 5 flag-sensitive tests hold no key; fixed by [#205](https://github.com/BaranziniLab/biorouter/pull/205) |
-| `BIOROUTER_ALLOW_PROJECT_HOOKS` | `hooks/mod.rs:214`, bare `env::var` | `providers/bedrock.rs:1147`, **never removed** | **latent** — no `.biorouter/hooks.yaml` in-tree, so no reader is sensitive today; fixed by [#205](https://github.com/BaranziniLab/biorouter/pull/205) |
+| `BIOROUTER_ALLOW_PROJECT_HOOKS` | `hooks/mod.rs:214`, bare `env::var` | three writers, **none of them ever removed**: `providers/bedrock.rs:1147` in the lib, and `tests/hooks_agent_loop_tests.rs:132` + `tests/global_memory_consent_agent_loop.rs:141` in two separate test binaries | **fixed** — the lib writer by [#205](https://github.com/BaranziniLab/biorouter/pull/205), the two `tests/` writers by the row below. ⚠ This row said "no `.biorouter/hooks.yaml` in-tree, so no reader is sensitive today", and that was true only of the lib: **both** test files write one into their own working directory, so each binary's reader is sensitive from its first agent onward. Neither file ever removed the variable, so the opt-in stands for every agent that binary builds afterwards — including `agent_with_memory`, which asks for `hooks: {}` and never wanted the unlock. |
 | `BIOROUTER_ALLOW_PROJECT_HOOKS` override | `hooks/mod.rs:214` | `agents/subagent_tool.rs:5663` via `with_config_overrides` | **live defect, not a race** — the override is a no-op, so that arm does not test its own unlock; fixed by [#205](https://github.com/BaranziniLab/biorouter/pull/205) |
+| `BIOROUTER_ALLOW_PROJECT_HOOKS` in `crates/*/tests` | `hooks/mod.rs:214` | `tests/hooks_agent_loop_tests.rs:132`, `tests/global_memory_consent_agent_loop.rs:141` | **fixed** — both now state the decision on `AgentConfig::with_project_hooks`, the seam [#205](https://github.com/BaranziniLab/biorouter/pull/205) added for exactly this. ⚠ **The interesting part is not the defect, it is that three instruments reported it clean.** The standing guard walked `crates/*/src` only, the row above named one writer, and the writer recipe under [Re-measuring](#re-measuring) grepped `crates/biorouter/src` — so the key read as handled from every angle while both writes stood. Measured: restoring one of the two lines leaves the pre-widening guard green. |
 | `HOME` | `security/policy/command.rs:846`, `policy/target.rs:125` | `knowledge/conversation_ingest.rs:806` | **latent** — `global_memory.rs` is already mitigated by `pinned_store_root()` |
 | `HOME` via `dirs::home_dir()` | `config/search_path.rs:72` and `:109`, both production, inside `SearchPaths::builder()` | the same `conversation_ingest.rs:806` `env_lock` writer | **live** — `a_coding_agent_path_offers_the_node_version_managers` reads `HOME` itself at `:214` to build its expected paths, then the builder reads it again; two instants, and the test holds no lock |
 | `BIOROUTER_PATH_ROOT` (the general case) | ~46 live `Paths::config_dir()` readers | 33 `lock_env` writers | **open** — deferred, see below |
@@ -171,8 +172,15 @@ grep -rn 'Paths::[a-z_]*(' crates/biorouter/src --include='*.rs'
 grep -rn 'env::var\(_os\)\?(\s*"' crates/biorouter/src --include='*.rs'
 ```
 
+⚠ **This one scans all of `crates/`, and the scope is the point.** It read
+`crates/biorouter/src` until 2026-09-09, matching the standing guard's walk — which
+is how two unrestored writers of `BIOROUTER_ALLOW_PROJECT_HOOKS` sat in
+`crates/biorouter/tests/` unreported. A writer in a crate's top-level `tests/`
+cannot reach the lib test binary, but it reaches every other test in its own
+binary, and nothing else in this repository looks there.
+
 ```bash
-grep -rn 'std::env::\(set_var\|remove_var\)' crates/biorouter/src --include='*.rs'
+grep -rn 'std::env::\(set_var\|remove_var\)' crates/ --include='*.rs'
 ```
 
 ```bash


### PR DESCRIPTION
Two review findings from the #201/#205/#209/#211 run: one functional (two Biorouter windows silently stop being told a chat's row moved), one instrument (the guard that was supposed to catch the second class of defect stopped looking at a third of the workspace, and two live offenders were sitting in the part it stopped reading).

## Why

**Finding 1 — the row map was pruned against one window's chats.** `SessionMetaEvents::last` is process-global; the `ids` on a `GET /sessions/changes` is one window's open-chat list. The route called `retain_watched(&ids)` on every 2 s tick of every poll, so the map was pruned against whichever caller's list arrived last. `observe` adopts a first-seen id **silently** by design — the right behaviour for a chat you just opened, and the reason this defect is invisible: B's prune drops A's chats, A's next `observe` re-adopts them and publishes nothing, then A's prune drops B's. Neither window is ever told a row moved. Tab tear-off is a shipped feature, so two windows is the ordinary case, and the endpoint's whole reason to exist — seeing `biorouter session --resume <id> --provider …` from another process — is what stops working.

**Finding 2 — the guard could not see where the offenders were.** `model::tests::no_test_parks_a_shared_setting_in_the_process_environment` (#209) consolidated three per-key instruments into one table. The two it replaced walked all of `crates/**`; the table walked `crates/*/src/**` and documented the omission as deliberate. So a change that reads as a strict improvement narrowed the coverage by 129 of the workspace's 762 `.rs` files. Two unrestored `set_var("BIOROUTER_ALLOW_PROJECT_HOOKS", "1")` writes sat in that blind spot while **three** instruments reported the key handled: the guard walked `src` only, the ledger row named one writer, and the audit's own writer recipe grepped `crates/biorouter/src`.

## Root cause

**Finding 1.** A process-global map pruned against a per-caller list. The two halves disagree about scope, and nothing in the code said so — `retain_watched` took a `&[String]` and had no way to know whose it was. Its `if last.len() <= watched.len() { return; }` early-out made it *look* conservative while doing exactly the wrong thing the moment a second window existed.

**Finding 2.** The stated reason for skipping `tests/` was half right and drew the wrong conclusion. A crate's top-level `tests/` file compiles to its own binary, so a write there cannot race the lib tests most of these readers live in — true. But it races every other test in that binary, which is a smaller hazard, not a different one, and **nothing else in this repository looks there**. Both offending files write a real `.biorouter/hooks.yaml` into their own working directory, so each binary's reader was sensitive from its first agent onward, and neither file ever removed the variable.

## What changed

**Finding 1 — a watcher registry and a claim with a lifetime**

- `crates/biorouter/src/session_meta.rs:178` — `watchers: Mutex<HashMap<u64, Vec<String>>>`, the open-chat ids of every **live** watcher keyed by a monotonic token (`next_watcher`), so a guard can only ever retire its own claim.
- `crates/biorouter/src/session_meta.rs:339` — `watch(self: &Arc<Self>, ids) -> WatchGuard`, `#[must_use]`. Registering only ever *grows* the union, so it prunes nothing; pruning belongs on the drop.
- `crates/biorouter/src/session_meta.rs:398` / `:403` — `WatchGuard` and its `Drop`: retire the claim, then re-prune.
- `crates/biorouter/src/session_meta.rs:362` — `retain_union`, private and reachable only from that drop. Prunes to the union of every live watcher. `retain_watched` is **gone** — zero references anywhere in the repo.
- `crates/biorouter-server/src/routes/session_meta.rs:143` — `let _claim = events.watch(&ids);`, taken before the park loop and released when the request answers. It must be a **named** binding: `let _ = events.watch(&ids)` drops on the spot and reinstates the defect in a shape that reads as a fix. The comment says so at the call site.
- `crates/biorouter-server/src/routes/session_meta.rs:214` — a source scan pinning that line, because **no behavioural test in the workspace can see it**: the row map lives in `biorouter`, the claim is taken in `biorouter-server`, and no test drives the route, so deleting the line leaves every suite green. Both traps this repo has already measured apply and are handled — the scan reads the production slice only (this module's own tests name the shape they forbid) and strips comments (the call site's warning *spells* `let _ = events.watch(&ids)`, so an unstripped scan finds two claims and fails on a correct tree).
- `crates/biorouter/src/session_meta.rs:90` / `:142` / `:205` — the union alone is **not** sufficient, and this is the part that is easy to get wrong. A claim lives for exactly one parked GET, so the only window's ids are unclaimed for an instant at every request boundary, and pruning strictly to the live union there would evict the ids that window is about to ask about again — swallowed for good, because re-adoption is silent. `RETENTION` (5 min) plus a `Tracked { row, seen }` stamp refreshed by every read closes that gap. `with_retention(Duration::ZERO)` lets a test observe an eviction without sleeping through it.

**Finding 2 — widen the walk, and state the decision instead of parking it**

- `crates/biorouter/src/model.rs:1462`–`:1463` — the walk now takes `crates/*/src/**` **and** `crates/*/tests/**`. `examples/` and `build.rs` stay out (8 files, measured); neither is compiled into a test binary, so a write there cannot reach one.
- `crates/biorouter/src/model.rs:1529`–`:1537` — **two** non-vacuity floors, one per scope (`scanned_src > 400`, `scanned_tests > 90`). A single total is satisfied by the `src` half alone, so it would pass on the very narrowing this widening undoes. Measured today: 633 `src`, 121 `tests`, 7 `examples`, 1 `build.rs` = 762.
- `crates/biorouter/src/model.rs:1371` — a `# What it walks` section recording why the second half was missing, so the next consolidation does not re-derive the omission.
- `crates/biorouter/tests/hooks_agent_loop_tests.rs:156` and `crates/biorouter/tests/global_memory_consent_agent_loop.rs:162` — `.with_project_hooks(true)` on `AgentConfig`, the seam #205 added for exactly this, replacing the `set_var`. `HooksManager::new_with_managed` reads the variable with a bare `std::env::var` that no `with_config_overrides` task-local can reach, which is why the remedy is an argument and not an override.
- `docs/testing/process-global-state.md:30` — the guard's stated scope, and the 129/762 measurement.
- `docs/testing/process-global-state.md:122` — the existing row now names all three writers and corrects its own "no `.biorouter/hooks.yaml` in-tree, so no reader is sensitive today", which was true only of the lib.
- `docs/testing/process-global-state.md:124` — a new row for the `crates/*/tests` writers, attributing the `src` readers to #205 and these two to this PR, and recording the measurement that the pre-widening guard stays green with one of them restored.
- `docs/testing/process-global-state.md:183` — the writer recipe under **Re-measuring** now greps `crates/`, not `crates/biorouter/src`.

**Did the widened walk flag anything else?** No. It reads 121 more files and finds no new offender. `crates/*/tests` does hold 12 `BIOROUTER_PATH_ROOT` writer call sites across 11 files (11 on one line, one split across two), and they are **not** silenced: `BIOROUTER_PATH_ROOT` has no row in `WATCHED`, deliberately — the ledger grades it **open — deferred** against ~46 live `Paths::config_dir()` readers and 33 `lock_env` writers, which is a separate piece of work, not something this PR narrowed the walk to avoid. The walk was not scoped down at any point.

**No contract changed.** No route signature, no request/response type, no event type. Verified rather than assumed: `cargo run -p biorouter-server --bin generate_schema` rewrote `ui/desktop/openapi.json` and `git status` came back clean, so the TS client needed no regeneration.

## Tests

`cargo fmt --all -- --check` — exit 0. `./scripts/clippy-lint.sh` — exit 0 (`✅ All baseline clippy checks passed!`); no `too_many_lines` baseline entry was added.

**Finding 1, fail-before.** `git show origin/main:…` for both files, with the new regression ported onto the pre-fix API (each window's own `retain_watched(&ids)` standing in for the guard it does not have):

```
thread 'session_meta::tests::two_windows_with_different_open_chats_do_not_evict_each_other' panicked at crates/biorouter/src/session_meta.rs:626:9:
assertion `left == right` failed: window A must learn that s1 moved
  left: 0
 right: 1

test result: FAILED. 12 passed; 1 failed; 0 ignored; 0 measured; 3758 filtered out; finished in 0.04s
```

Pass-after — `cargo test -p biorouter --lib -- session_meta` (14 tests; three are new: the two-window case, `a_row_rewritten_between_two_polls_of_one_window_is_still_reported` for the retention gap, and `a_chat_nobody_watches_stops_being_tracked` rewritten so dropping a guard is what releases the ids):

```
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 3758 filtered out; finished in 0.04s
```

`cargo test -p biorouter-server --lib -- routes::session_meta`:

```
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 579 filtered out; finished in 0.00s
```

**The call-site guard, proved against two poisoned probes** rather than reasoned about. With `let _ = events.watch(&ids)` — the spelling that compiles, silences `#[must_use]`, and restores the defect:

```
the claim must be bound to a NAMED local. `let _ = …` drops the guard immediately, which prunes the process-global row map against this one caller's ids again — the defect this endpoint had, wearing a fix. Found: let _ = events.watch(&ids);

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 579 filtered out; finished in 0.04s
```

With the line deleted outright:

```
assertion `left == right` failed: the poll claims its ids exactly once, for the life of the request. Found: []
  left: 0
 right: 1

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 579 filtered out; finished in 0.04s
```

**Finding 2, fail-before.** With one of the two `set_var` lines restored, `cargo test -p biorouter --lib -- model::tests::no_test_parks`:

```
these tests park a shared setting in the PROCESS environment, where production code reads it live. `env_lock` does not help: it serialises the callers that ASK for it, and these readers never do.
  biorouter/tests/hooks_agent_loop_tests.rs:137 — BIOROUTER_ALLOW_PROJECT_HOOKS="1": the reader is live and unguarded, so any value changes what a concurrent test observes. Instead, pass the value as an argument — this reader calls `std::env::var`, which no task-local override can reach

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3771 filtered out; finished in 4.11s
```

And the claim the ledger makes, measured rather than reasoned about — the **pre-widening** walk (`tests/` counted but not read) against that same restored line:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3771 filtered out; finished in 3.69s
```

Pass-after, both files restored:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3771 filtered out; finished in 4.11s
```

The two integration binaries whose writers were removed — they exercise real project hooks from a real `.biorouter/hooks.yaml`, so they would fail outright if the seam did not carry the opt-in:

```
cargo test -p biorouter --test hooks_agent_loop_tests
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.73s

cargo test -p biorouter --test global_memory_consent_agent_loop
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s
```

Full suites:

```
cargo test -p biorouter --lib
test result: ok. 3770 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 29.80s

cargo test -p biorouter-server --lib
test result: ok. 581 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.33s
```

## Follow-ups

- **The claim's *lifetime* is still only pinned by inspection.** The new scan proves the guard is bound to a named local, so it lives to the end of the function — but nothing checks that the function is still the whole poll. If the park loop were ever extracted into a helper that took the claim itself, the scan would stay green while the claim's scope shrank. A route-level test that drives a real parked poll would close it, and needs a `SessionManager` fixture this module does not have today.
- **`BIOROUTER_PATH_ROOT` stays open.** The widened walk now *reads* its 12 `crates/*/tests` writers but cannot judge them, because the key has no `WATCHED` row. Adding one means first deciding what a legitimate write looks like against ~46 live `Paths::config_dir()` readers; the ledger already tracks this as deferred.
- **Retention is time-based, so `retain_union` can hold an id for up to 5 minutes after its last watcher.** Bounded and cheap, but a poll-count- or generation-based release would be exact. Only worth it if the map is ever measured to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
