### PR TITLE
fix(chat): a failed Stop leaves a usable composer and says so (M2)

### DIFF
--- a/ui/desktop/src/components/conversation/ChatTurnError.test.tsx
+++ b/ui/desktop/src/components/conversation/ChatTurnError.test.tsx
@@ -145,6 +145,57 @@ describe('ChatTurnError', () => {
     });
   });
 
+  /**
+   * M2 — the daemon synthesizes `stream_ended_without_terminal` for any turn
+   * whose writers produced no ending, INCLUDING one the user stopped. Read as
+   * an ordinary internal failure it says "Model turn ended unexpectedly", which
+   * blames the model for an ending the user asked for. The store re-codes the
+   * two stop-shaped endings; the presentation has to name them.
+   */
+  it('names a user-requested ending instead of blaming the model', () => {
+    const presentation = presentChatTurnError(
+      error({
+        message: 'You stopped this turn, so it ended without a result.',
+        code: 'turn_stopped_by_user',
+        scope: 'internal',
+        retryable: false,
+        technicalDetails: 'The stream for this turn ended without a result. Please retry.',
+      })
+    );
+
+    expect(presentation.title).toBe('Turn stopped');
+    expect(presentation.title).not.toBe('Model turn ended unexpectedly');
+    expect(presentation.message).toContain('You stopped this turn');
+  });
+
+  it('names a stop the backend never confirmed', () => {
+    const presentation = presentChatTurnError(
+      error({
+        message:
+          'Biorouter could not stop this turn. It may still be running on the backend. HTTP 504',
+        code: 'stop_not_confirmed',
+        scope: 'internal',
+        retryable: false,
+      })
+    );
+
+    expect(presentation.title).toBe('Stop not confirmed');
+    expect(presentation.message).toContain('may still be running');
+  });
+
+  it('still blames nothing but the model for an ordinary internal failure', () => {
+    expect(
+      presentChatTurnError(
+        error({
+          message: 'The stream for this turn ended without a result. Please retry.',
+          code: 'stream_ended_without_terminal',
+          scope: 'internal',
+          retryable: true,
+        })
+      ).title
+    ).toBe('Model turn ended unexpectedly');
+  });
+
   it('does not duplicate a backend error message that is already in the transcript', () => {
     const turnError = error({ message: 'Authentication failed. Status: 401 Unauthorized' });
     const messages = [

--- a/ui/desktop/src/components/conversation/ChatTurnError.tsx
+++ b/ui/desktop/src/components/conversation/ChatTurnError.tsx
@@ -43,6 +43,16 @@ const BACKEND_CODES = new Set(['session_load_unreachable', 'agent_load_failed', 
 // opened. Distinct copy: the request DID start, so "retry to continue".
 const MIDSTREAM_CODES = new Set(['stream_error', 'stream_interrupted']);
 
+// M2 — the two endings the USER caused. Both arrive as `scope: 'internal'`,
+// which is the scope of a turn that died on its own, so without their own
+// titles they read as "Model turn ended unexpectedly" — the app blaming the
+// model for a Stop the user pressed. The store is what distinguishes them (only
+// it knows a Stop was outstanding); this map is what names them.
+const STOP_TITLES: Record<string, string> = {
+  turn_stopped_by_user: 'Turn stopped',
+  stop_not_confirmed: 'Stop not confirmed',
+};
+
 function isBackendUnreachable(error: ChatTurnErrorData): boolean {
   return (
     (error.scope === 'transport' || isConnectionError(error.message)) &&
@@ -80,7 +90,9 @@ function userFacingMessage(error: ChatTurnErrorData): string {
 
 export function presentChatTurnError(error: ChatTurnErrorData): ChatTurnErrorPresentation {
   let title = 'Model request failed';
-  if (error.providerKind && PROVIDER_TITLES[error.providerKind]) {
+  if (STOP_TITLES[error.code]) {
+    title = STOP_TITLES[error.code];
+  } else if (error.providerKind && PROVIDER_TITLES[error.providerKind]) {
     title = PROVIDER_TITLES[error.providerKind];
   } else if (error.message.includes('insufficient_quota')) {
     title = 'Model quota exceeded';

--- a/ui/desktop/src/hooks/chatStreamStore.test.ts
+++ b/ui/desktop/src/hooks/chatStreamStore.test.ts
@@ -2092,6 +2092,42 @@ describe('ChatStreamRegistry — a Stop the daemon never confirms (M2)', () => {
     await expect(stopped).resolves.toBe(false);
   });
 
+  it('retracts the unconfirmed-stop notice once the turn really does end', async () => {
+    const registry = new ChatStreamRegistry();
+    const controlled = createControlledStream();
+    const cancellation = deferred<unknown>();
+    vi.mocked(resumeAgent).mockResolvedValue({
+      data: { session: session('wedged-retract') },
+    } as never);
+    vi.mocked(reply).mockResolvedValue({ stream: controlled.stream } as never);
+    vi.mocked(cancelTurn).mockReturnValueOnce(cancellation.promise as never);
+
+    const controller = registry.getController('wedged-retract');
+    const submit = controller.handleSubmit('a turn that outlives its Stop');
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledTimes(1));
+
+    // The reverse of the M2 ordering: the cancel fails while the turn is still
+    // genuinely streaming, so the composer keeps Stop and the notice says so.
+    const stopped = controller.stopStreaming();
+    await flush();
+    cancellation.reject({});
+    await expect(stopped).resolves.toBe(false);
+    await flush();
+
+    expect(controller.getSnapshot().turnError?.code).toBe('stop_not_confirmed');
+    expect(controller.getSnapshot().turnError?.message).toMatch(/Press Stop again/);
+    expect(isRunningState(controller.getSnapshot().chatState)).toBe(true);
+
+    // …and then the turn ends anyway. "Press Stop again to retry" now describes
+    // a world that no longer exists.
+    controlled.push({ type: 'Finish', reason: 'done', token_state: tokenState } as MessageEvent);
+    controlled.close();
+    await submit;
+
+    expect(controller.getSnapshot().turnError).toBeUndefined();
+    expect(controller.getSnapshot().chatState).toBe(ChatState.Idle);
+  });
+
   it('still reports an ordinary internal failure as a model failure when no Stop is pending', async () => {
     const registry = new ChatStreamRegistry();
     const controlled = createControlledStream();

--- a/ui/desktop/src/hooks/chatStreamStore.test.ts
+++ b/ui/desktop/src/hooks/chatStreamStore.test.ts
@@ -1920,6 +1920,201 @@ describe('ChatStreamRegistry', () => {
 });
 
 /**
+ * M2 — a Stop the daemon never confirms.
+ *
+ * The #166 battery above pushes its terminal frame AFTER the cancel has
+ * resolved, which is the easy ordering: the Stop gate is already down, so
+ * `finishCurrentStream` lands the turn itself. The wedged-daemon ordering is the
+ * reverse and was never covered — the daemon's synthesized terminal frame
+ * arrives WHILE the cancel is still on the wire, `finishCurrentStream` defers
+ * the Idle transition to the cancel response because `stopGateHolds()`, and the
+ * cancel then comes back a failure and declines to make it. Nothing else ever
+ * does, so the composer keeps its Stop button and never gets Send back.
+ *
+ * `/agent/cancel`'s own failures make this the DEFAULT wedged shape rather than
+ * an exotic one: `CancelTurnFailure::SettlementTimeout` is a bare 504 with no
+ * body, so the generated client throws a literal `{}` (`finalError = finalError
+ * || {}`) and the console warning printed nothing a person could act on.
+ */
+describe('ChatStreamRegistry — a Stop the daemon never confirms (M2)', () => {
+  /** The daemon's synthesized "this turn produced no ending" frame. */
+  function endedWithoutTerminal(): MessageEvent {
+    return {
+      type: 'Error',
+      error: 'The stream for this turn ended without a result. Please retry.',
+      code: 'stream_ended_without_terminal',
+      scope: 'internal',
+      retryable: true,
+    } as MessageEvent;
+  }
+
+  /**
+   * Drive a Stop whose cancel is still on the wire when the daemon's terminal
+   * frame lands, then settle the cancel however the caller asks.
+   */
+  async function stopAgainstAWedgedTurn(
+    sessionId: string,
+    settleCancel: (cancellation: ReturnType<typeof deferred<unknown>>) => void
+  ) {
+    const registry = new ChatStreamRegistry();
+    const controlled = createControlledStream();
+    const cancellation = deferred<unknown>();
+    vi.mocked(resumeAgent).mockResolvedValue({ data: { session: session(sessionId) } } as never);
+    vi.mocked(reply).mockResolvedValue({ stream: controlled.stream } as never);
+    vi.mocked(cancelTurn).mockReturnValueOnce(cancellation.promise as never);
+
+    const controller = registry.getController(sessionId);
+    const submit = controller.handleSubmit('a turn that wedges');
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledTimes(1));
+
+    const stopped = controller.stopStreaming();
+    await flush();
+    expect(cancelTurn).toHaveBeenCalledTimes(1);
+
+    // The terminal frame beats the cancel response — the whole of M2.
+    controlled.push(endedWithoutTerminal());
+    controlled.close();
+    await submit;
+
+    settleCancel(cancellation);
+    await expect(stopped).resolves.toBe(false);
+    await flush();
+
+    return { controller, registry };
+  }
+
+  it('returns the composer to Idle when the cancel fails after the turn already ended', async () => {
+    const { controller } = await stopAgainstAWedgedTurn('wedged-idle', (cancellation) =>
+      // A bare 504 with no body: exactly what the generated client throws.
+      cancellation.reject({})
+    );
+
+    expect(controller.getSnapshot().chatState).toBe(ChatState.Idle);
+    expect(isRunningState(controller.getSnapshot().chatState)).toBe(false);
+  });
+
+  it('lets the user send again rather than stranding the chat with no Send control', async () => {
+    const { controller } = await stopAgainstAWedgedTurn('wedged-resend', (cancellation) =>
+      cancellation.reject({})
+    );
+
+    // The composer draws Send or Stop from `isRunningState(chatState)` — so the
+    // store accepting a submit is NOT the same as the user having a control to
+    // click. Measured in the running app: `textarea.disabled === false` with no
+    // `Send message` button anywhere on screen.
+    expect(isRunningState(controller.getSnapshot().chatState)).toBe(false);
+
+    vi.mocked(reply).mockResolvedValue({
+      stream: (async function* () {
+        yield { type: 'Finish', reason: 'done', token_state: tokenState } as MessageEvent;
+      })(),
+    } as never);
+    await expect(controller.handleSubmit('the chat still works')).resolves.toBe(true);
+    expect(reply).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs the HTTP status of a bodyless cancel rejection instead of an empty object', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // The fields form the generated client returns for an HTTP failure when
+      // it is not asked to throw: the body is `{}` and the status is the only
+      // thing that says WHICH failure this was.
+      await stopAgainstAWedgedTurn('wedged-log', (cancellation) =>
+        cancellation.resolve({ error: {}, response: { status: 504 } })
+      );
+
+      const logged = warn.mock.calls.map((call) => call.map((part) => String(part)).join(' '));
+      const stopLine = logged.find((line) => line.includes('cancel'));
+      expect(stopLine).toBeDefined();
+      expect(stopLine).toContain('504');
+      expect(stopLine).toContain('wedged-log');
+      // `String({})` is `[object Object]`; a raw object argument is exactly what
+      // printed `{}` in the running app.
+      expect(stopLine).not.toContain('[object Object]');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('logs the real error text when the cancel rejects with an Error', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await stopAgainstAWedgedTurn('wedged-log-error', (cancellation) =>
+        cancellation.reject(new Error('network died mid-cancel'))
+      );
+
+      const logged = warn.mock.calls.map((call) => call.map((part) => String(part)).join(' '));
+      expect(logged.some((line) => line.includes('network died mid-cancel'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('tells the user in the chat that the stop was not confirmed', async () => {
+    const { controller } = await stopAgainstAWedgedTurn('wedged-notice', (cancellation) =>
+      cancellation.reject({})
+    );
+
+    const turnError = controller.getSnapshot().turnError;
+    expect(turnError?.code).toBe('stop_not_confirmed');
+    expect(turnError?.message).toMatch(/could not/i);
+    expect(turnError?.message).toMatch(/still be running/i);
+    // Retrying the TURN is not what a user who asked to stop it wants.
+    expect(turnError?.retryable).toBe(false);
+  });
+
+  it('does not blame the model for an ending the user asked for', async () => {
+    const registry = new ChatStreamRegistry();
+    const controlled = createControlledStream();
+    const cancellation = deferred<unknown>();
+    vi.mocked(resumeAgent).mockResolvedValue({
+      data: { session: session('wedged-blame') },
+    } as never);
+    vi.mocked(reply).mockResolvedValue({ stream: controlled.stream } as never);
+    vi.mocked(cancelTurn).mockReturnValueOnce(cancellation.promise as never);
+
+    const controller = registry.getController('wedged-blame');
+    const submit = controller.handleSubmit('a turn that wedges');
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledTimes(1));
+    const stopped = controller.stopStreaming();
+    await flush();
+
+    controlled.push(endedWithoutTerminal());
+    controlled.close();
+    await submit;
+
+    // Sampled BEFORE the cancel answers: this is the card the user actually
+    // stares at while the daemon is wedged.
+    expect(controller.getSnapshot().turnError?.code).toBe('turn_stopped_by_user');
+    expect(controller.getSnapshot().turnError?.retryable).toBe(false);
+
+    cancellation.reject({});
+    await expect(stopped).resolves.toBe(false);
+  });
+
+  it('still reports an ordinary internal failure as a model failure when no Stop is pending', async () => {
+    const registry = new ChatStreamRegistry();
+    const controlled = createControlledStream();
+    vi.mocked(resumeAgent).mockResolvedValue({
+      data: { session: session('unstopped-internal') },
+    } as never);
+    vi.mocked(reply).mockResolvedValue({ stream: controlled.stream } as never);
+
+    const controller = registry.getController('unstopped-internal');
+    const submit = controller.handleSubmit('an ordinary turn');
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledTimes(1));
+
+    controlled.push(endedWithoutTerminal());
+    controlled.close();
+    await submit;
+
+    expect(controller.getSnapshot().turnError?.code).toBe('stream_ended_without_terminal');
+    expect(controller.getSnapshot().turnError?.scope).toBe('internal');
+    expect(controller.getSnapshot().chatState).toBe(ChatState.Idle);
+  });
+});
+
+/**
  * Progressive conversation loading.
  *
  * A resume used to take ~5.1s on a real 355-message session, of which ~4.6s was

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -40,11 +40,7 @@ import {
   NotificationEvent,
   UserAttachment,
 } from '../types/message';
-import {
-  describeRequestFailure,
-  errorMessage,
-  isConnectionError,
-} from '../utils/conversionUtils';
+import { describeRequestFailure, errorMessage, isConnectionError } from '../utils/conversionUtils';
 import { showExtensionLoadResults } from '../utils/extensionErrorUtils';
 import { reasoningEffortForRequest } from '../store/reasoningEffort';
 import { userActionHeaders } from '../utils/userAction';
@@ -3692,11 +3688,7 @@ class ChatStreamController {
    * `console.warn`; `describeRequestFailure` is the only thing that knows a
    * bodyless 504 from a real payload.
    */
-  private noteCancelRejection(
-    turnId: string,
-    error: unknown,
-    status: number | undefined
-  ): boolean {
+  private noteCancelRejection(turnId: string, error: unknown, status: number | undefined): boolean {
     const mismatch = cancelTurnMismatch(error);
     if (mismatch && mismatch.expected_turn_id === turnId) {
       this.rememberRetiredObservedTurn(turnId);

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -40,7 +40,11 @@ import {
   NotificationEvent,
   UserAttachment,
 } from '../types/message';
-import { errorMessage, isConnectionError } from '../utils/conversionUtils';
+import {
+  describeRequestFailure,
+  errorMessage,
+  isConnectionError,
+} from '../utils/conversionUtils';
 import { showExtensionLoadResults } from '../utils/extensionErrorUtils';
 import { reasoningEffortForRequest } from '../store/reasoningEffort';
 import { userActionHeaders } from '../utils/userAction';
@@ -525,6 +529,49 @@ export interface PendingToolCallView {
   partialArgs?: string;
 }
 
+/**
+ * The daemon's synthesized ending for a turn whose writers produced no terminal
+ * frame (`TurnStream::close`, `routes/reply.rs`). It is scope `internal`, so
+ * the card reads "Model turn ended unexpectedly" — which is right for a turn
+ * that died on its own and WRONG for one the user asked to stop, because the
+ * daemon has no idea which of the two it just described.
+ */
+const STREAM_ENDED_WITHOUT_TERMINAL = 'stream_ended_without_terminal';
+
+/** A turn that ended without a result because the user stopped it. */
+export const TURN_STOPPED_BY_USER = 'turn_stopped_by_user';
+
+/** A Stop whose cancel never came back confirmed. */
+export const STOP_NOT_CONFIRMED = 'stop_not_confirmed';
+
+/**
+ * The in-chat notice for a Stop the daemon never confirmed (M2).
+ *
+ * Two facts the user needs and neither of which was on screen before: Biorouter
+ * could not stop the turn, and the turn may still be running over there. The
+ * second half depends on what the renderer was able to do about it — a turn
+ * that had already ended locally leaves a usable chat, one still streaming does
+ * not — so the copy says which case this is rather than hedging across both.
+ *
+ * Not retryable: the failure is the STOP, and a Retry action re-runs the TURN,
+ * which is the opposite of what someone who just pressed Stop is asking for.
+ */
+function stopNotConfirmedError(
+  composerRestored: boolean,
+  detail: string | null
+): ChatTurnErrorData {
+  const message = composerRestored
+    ? 'Biorouter could not confirm that the backend stopped this turn, so it may still be running there. This chat is usable again — anything the stopped turn is still doing will land in it.'
+    : 'Biorouter could not confirm that the backend stopped this turn, so it may still be running there. Press Stop again to retry.';
+  return {
+    message,
+    code: STOP_NOT_CONFIRMED,
+    scope: 'internal',
+    retryable: false,
+    ...(detail ? { technicalDetails: detail } : {}),
+  };
+}
+
 function clientTurnError(
   error: unknown,
   code: string,
@@ -718,6 +765,35 @@ class ChatStreamController {
    * before it submits the replacement.
    */
   private lastSettledStopTurnId: string | null = null;
+  /**
+   * The generation whose terminal frame landed while the Stop gate was still
+   * holding, so `finishCurrentStream` handed the Idle transition to the cancel
+   * response instead of making it itself.
+   *
+   * M2. #166 closed the ordering where the terminal frame arrives AFTER the
+   * cancel resolves — the gate is already down, so the frame lands the turn.
+   * The reverse ordering is what a wedged daemon produces (`/agent/cancel`
+   * parks for its 30 s settlement bound while the turn's stream is already
+   * over) and it strands the composer: the frame deferred the transition, the
+   * cancel then failed and returned without making it, and NOTHING else was
+   * ever going to. The user was left with a Stop button, no Send button and a
+   * spinner over a turn that had already ended.
+   *
+   * Held rather than re-derived because it is the one thing that distinguishes
+   * "the stop failed and the turn is over" (restore the composer) from "the
+   * stop failed and the turn is genuinely still streaming" (do not — the daemon
+   * still owns the session lock, and Stop is the right control to offer).
+   */
+  private stopDeferredFinishTurnId: string | null = null;
+  /**
+   * Why the last exact-generation cancel did not settle, for the in-chat notice.
+   *
+   * `null` covers the two cases that must NOT raise one: a cancel that settled,
+   * and a typed turn mismatch — the mismatch arm resolves the whole state
+   * itself (it adopts the successor and picks the matching `chatState`), so a
+   * notice written over the top of it would be both wrong and destructive.
+   */
+  private lastStopFailure: string | null = null;
   /**
    * The turn this controller is currently rendering — the id it POSTed, or the
    * id it attached to. Held so a re-attach can re-POST the SAME turn (rather
@@ -1947,9 +2023,53 @@ class ChatStreamController {
     return this.snapshot.session != null;
   }
 
+  /**
+   * M2 — do not let the daemon's synthesized ending blame the model for an
+   * ending the USER asked for.
+   *
+   * `TurnStream::close` writes `stream_ended_without_terminal` for any turn
+   * whose writers produced no terminal frame, and a cancelled turn is one of
+   * them: the daemon is describing the SHAPE of the ending, not its cause, and
+   * cannot tell the two apart. Read as an ordinary `scope: internal` failure it
+   * comes out as "Model turn ended unexpectedly" over a Stop the user pressed
+   * themselves.
+   *
+   * Deliberately narrow. Only that one code, and only while this chat has a
+   * Stop outstanding for this exact generation — an ordinary mid-turn internal
+   * failure with no Stop pending keeps the wording it has today, which is the
+   * right wording for it.
+   */
+  private reframeStoppedTurnError(
+    error: ChatTurnErrorData,
+    stopGateHolds: boolean,
+    turnId: string | null
+  ): ChatTurnErrorData {
+    if (error.code !== STREAM_ENDED_WITHOUT_TERMINAL) return error;
+    const stopWasRequested =
+      stopGateHolds ||
+      (!!turnId && (this.stopExpectedTurnId === turnId || this.lastSettledStopTurnId === turnId));
+    if (!stopWasRequested) return error;
+    return {
+      ...error,
+      message: 'You stopped this turn, so it ended without a result.',
+      code: TURN_STOPPED_BY_USER,
+      // Retrying the turn is not what someone who just pressed Stop wants; the
+      // composer they get back is.
+      retryable: false,
+      technicalDetails: error.technicalDetails ?? error.message,
+    };
+  }
+
   private finishCurrentStream = async (error?: ChatTurnErrorData): Promise<void> => {
+    // Sampled at the very top, and once. It reads `activeTurnId`, which
+    // `retireActiveTurn()` below clears — so a check made afterwards answers
+    // the opposite of one made before — and the error rewrite a few lines down
+    // needs the same answer the retirement does.
+    const stopGateHolds = this.stopGateHolds();
+    const stoppedTurnId = this.activeTurnId ?? this.stopExpectedTurnId;
     if (error) {
-      this.updateSnapshot((prev) => ({ ...prev, turnError: error }));
+      const framed = this.reframeStoppedTurnError(error, stopGateHolds, stoppedTurnId);
+      this.updateSnapshot((prev) => ({ ...prev, turnError: framed }));
     }
     // The turn is over: any skeleton whose authoritative request never arrived
     // (cancel, provider abort, a dropped block) must not linger.
@@ -1960,10 +2080,15 @@ class ChatStreamController {
     // reopened tab attaching to a turn that is over, and a stale high-water mark
     // makes the NEXT turn's `seq: 0` look like a duplicate and swallows it.
     //
-    // Sampled once, above the retirement, because `stopGateHolds()` reads
-    // `activeTurnId` and `retireActiveTurn()` clears it.
-    const stopGateHolds = this.stopGateHolds();
-    if (!stopGateHolds) this.retireActiveTurn();
+    if (stopGateHolds) {
+      // M2 — remember that this turn's ending was withheld from the Idle
+      // transition below. If the cancel that owns that transition comes back a
+      // failure, `reportUnconfirmedStop` is the only thing left that can make
+      // it, and it has no other way to know the frame already went by.
+      this.stopDeferredFinishTurnId = stoppedTurnId;
+    } else {
+      this.retireActiveTurn();
+    }
 
     const timeSinceLastInteraction = Date.now() - this.lastInteractionTime;
     if (!error && timeSinceLastInteraction > 60000) {
@@ -3079,6 +3204,10 @@ class ChatStreamController {
     // would cancel a generation that has been dead for several turns.
     this.stopExpectedTurnId = null;
     this.stopContinuationPending = false;
+    // …and with it the deferred ending that generation was owed. A new turn
+    // owns `chatState` from here on; completing an older turn's withheld
+    // transition against it would land this live turn at Idle.
+    this.stopDeferredFinishTurnId = null;
 
     try {
       // The transcript paints before the agent's model + extensions are up, so
@@ -3476,10 +3605,16 @@ class ChatStreamController {
     return this.stopExpectedTurnId === this.activeTurnId;
   }
 
+  /** Where a Stop-path log line says which chat and which generation it means. */
+  private stopLogContext(turnId: string): string {
+    return `session ${this.sessionId}, turn ${turnId}`;
+  }
+
   private requestExactTurnSettlement = async (
     turnId: string,
     continuationPending: boolean
   ): Promise<boolean> => {
+    this.lastStopFailure = null;
     try {
       const body = {
         session_id: this.sessionId,
@@ -3488,17 +3623,30 @@ class ChatStreamController {
         continuation_pending: continuationPending,
         ...(continuationPending ? { continuation_owner_id: getContinuationOwnerId() } : {}),
       };
+      // `throwOnError: false` deliberately. Asked to throw, the generated client
+      // throws the response BODY and drops the `Response` — and `/agent/cancel`
+      // answers its most important failure, the 30 s `SettlementTimeout`, with a
+      // bare 504 and no body at all. So the thrown value was a literal `{}` and
+      // the status, the one piece of information that existed, was gone before
+      // the catch could see it. The fields form keeps both. A rejection is still
+      // possible (a fetch that never reaches a response) and still handled below.
       const result = await cancelTurn({
         body,
         headers: await userActionHeaders(),
-        throwOnError: true,
+        throwOnError: false,
       });
-      const data = result.data;
+      if (result?.error !== undefined) {
+        return this.noteCancelRejection(turnId, result.error, result.response?.status);
+      }
+      const data = result?.data;
       if (data?.settled === true) {
         if (!continuationPending) return true;
         const lease = data.continuation_lease;
         if (!lease) {
-          console.warn('Stop-and-Send response did not include a continuation lease');
+          this.lastStopFailure = 'the Stop-and-Send response carried no continuation lease';
+          console.warn(
+            `Stop-and-Send response did not include a continuation lease (${this.stopLogContext(turnId)})`
+          );
           return false;
         }
         if (this.continuationLease && this.continuationLease !== lease) {
@@ -3519,38 +3667,73 @@ class ChatStreamController {
         }
         return true;
       }
-      console.warn('Cancel response did not confirm that the stopped turn settled');
+      this.lastStopFailure = `the daemon answered the cancel without confirming the turn settled (cancelled=${String(
+        data?.cancelled
+      )}, settled=${String(data?.settled)})`;
+      console.warn(
+        `Cancel response did not confirm that the stopped turn settled (${this.stopLogContext(turnId)}): ${this.lastStopFailure}`
+      );
     } catch (error) {
-      const mismatch = cancelTurnMismatch(error);
-      if (mismatch && mismatch.expected_turn_id === turnId) {
-        this.rememberRetiredObservedTurn(turnId);
-        this.activeStreamId += 1;
-        this.abortController?.abort();
-        this.abortController = null;
-        this.endReplayHold();
-        this.activeTurnId = this.retiredObservedTurnIds.has(mismatch.active_turn_id)
-          ? null
-          : mismatch.active_turn_id;
-        this.reattachesThisTurn = 0;
-        this.stopPending = false;
-        this.stopExpectedTurnId = null;
-        this.stopContinuationPending = false;
-        this.lastSettledStopTurnId = null;
-        this.updateSnapshot((prev) => ({
-          ...prev,
-          chatState: this.activeTurnId ? ChatState.Streaming : ChatState.Idle,
-          turnStartedAt: this.activeTurnId ? (prev.turnStartedAt ?? Date.now()) : undefined,
-          lastMessageAt: this.activeTurnId ? prev.lastMessageAt : undefined,
-        }));
-        console.warn(
-          `Stop targeted retired turn ${turnId}; the active turn is ${mismatch.active_turn_id}`
-        );
-        return false;
-      }
-      console.warn('Failed to cancel running turn on stop:', error);
+      // A rejection now means the fetch never produced a response at all (the
+      // backend is down, the request was aborted). An HTTP failure comes back
+      // through `result.error` above, with its status intact.
+      return this.noteCancelRejection(turnId, error, undefined);
     }
     return false;
   };
+
+  /**
+   * Record and report a cancel that failed, and adopt the successor when the
+   * daemon named one.
+   *
+   * Shared by the two ways a failure can arrive — an HTTP error (`result.error`
+   * plus its status) and a rejected fetch — so neither can drift into logging
+   * less than the other. M2: what it must never do again is hand a raw value to
+   * `console.warn`; `describeRequestFailure` is the only thing that knows a
+   * bodyless 504 from a real payload.
+   */
+  private noteCancelRejection(
+    turnId: string,
+    error: unknown,
+    status: number | undefined
+  ): boolean {
+    const mismatch = cancelTurnMismatch(error);
+    if (mismatch && mismatch.expected_turn_id === turnId) {
+      this.rememberRetiredObservedTurn(turnId);
+      this.activeStreamId += 1;
+      this.abortController?.abort();
+      this.abortController = null;
+      this.endReplayHold();
+      this.activeTurnId = this.retiredObservedTurnIds.has(mismatch.active_turn_id)
+        ? null
+        : mismatch.active_turn_id;
+      this.reattachesThisTurn = 0;
+      this.stopPending = false;
+      this.stopExpectedTurnId = null;
+      this.stopContinuationPending = false;
+      this.lastSettledStopTurnId = null;
+      this.updateSnapshot((prev) => ({
+        ...prev,
+        chatState: this.activeTurnId ? ChatState.Streaming : ChatState.Idle,
+        turnStartedAt: this.activeTurnId ? (prev.turnStartedAt ?? Date.now()) : undefined,
+        lastMessageAt: this.activeTurnId ? prev.lastMessageAt : undefined,
+      }));
+      console.warn(
+        `Stop targeted retired turn ${turnId}; the active turn is ${mismatch.active_turn_id}`
+      );
+      // Deliberately leaves `lastStopFailure` null: this arm has already
+      // resolved the whole state (successor adopted, `chatState` chosen), and
+      // an in-chat "could not stop" notice written over it would be untrue as
+      // well as destructive.
+      return false;
+    }
+    const detail = describeRequestFailure(error, status);
+    this.lastStopFailure = detail;
+    console.warn(
+      `Failed to cancel running turn on stop (${this.stopLogContext(turnId)}): ${detail}`
+    );
+    return false;
+  }
 
   private trackStopOperation(
     operation: Promise<boolean>,
@@ -3596,7 +3779,10 @@ class ChatStreamController {
       // `stopStreaming` and `submitPreparedMessage`.
       this.stopPending = false;
     }
-    if (!settled) return false;
+    if (!settled) {
+      this.reportUnconfirmedStop(stoppedTurnId);
+      return false;
+    }
 
     this.activeStreamId += 1;
     this.abortController?.abort();
@@ -3607,6 +3793,7 @@ class ChatStreamController {
     this.stopPending = false;
     this.stopExpectedTurnId = null;
     this.stopContinuationPending = false;
+    this.stopDeferredFinishTurnId = null;
     this.updateSnapshot((prev) => ({
       ...prev,
       chatState: ChatState.Idle,
@@ -3617,6 +3804,59 @@ class ChatStreamController {
     this.flushNotify();
     return true;
   };
+
+  /**
+   * M2 — finish what the Stop gate deferred, and say out loud that the stop did
+   * not take.
+   *
+   * Two things were missing when a cancel came back a failure, and they are
+   * separate bugs that presented as one dead chat:
+   *
+   *  1. If the turn's terminal frame had ALREADY landed, `finishCurrentStream`
+   *     deferred the Idle transition to this response (`stopGateHolds()`), and
+   *     this response then returned without making it. #166's `finally` frees
+   *     the latch — so a LATER terminal frame lands normally — but the frame
+   *     that mattered has already been and gone. Nothing re-runs it. That is
+   *     the composer with a Stop button, no Send button and a spinner over a
+   *     turn that finished a minute ago.
+   *  2. The failure was silent. The only trace was a `console.warn` the user
+   *     cannot see, so a stop that did not work was indistinguishable from one
+   *     that did.
+   *
+   * The restoration is deliberately NOT unconditional. A cancel that failed
+   * while the turn is genuinely still streaming leaves the daemon holding the
+   * session lock: offering Send there would buy a 409, and Stop is the control
+   * the user actually wants (the retained `stopExpectedTurnId` makes a second
+   * press name the same generation). So only the deferred case is completed,
+   * and the notice says which of the two this was.
+   */
+  private reportUnconfirmedStop(stoppedTurnId: string): void {
+    // Null on the typed-mismatch arm, which has already resolved everything.
+    if (!this.lastStopFailure) return;
+    const detail = this.lastStopFailure;
+    this.lastStopFailure = null;
+
+    const completesDeferredFinish = this.stopDeferredFinishTurnId === stoppedTurnId;
+    if (completesDeferredFinish) {
+      this.stopDeferredFinishTurnId = null;
+      this.endReplayHold();
+      this.retireActiveTurn();
+    }
+    this.updateSnapshot((prev) => ({
+      ...prev,
+      ...(completesDeferredFinish
+        ? {
+            chatState: ChatState.Idle,
+            turnStartedAt: undefined,
+            lastMessageAt: undefined,
+            pendingSteer: undefined,
+          }
+        : {}),
+      turnError: stopNotConfirmedError(completesDeferredFinish, detail),
+    }));
+    // A turn boundary the user is waiting on: paint it now, not a frame late.
+    this.flushNotify();
+  }
 
   private stopAfterObservedLookup = (continuationPending: boolean): Promise<boolean> | null => {
     if (!this.observing || this.activeTurnId) return null;

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -2167,6 +2167,13 @@ class ChatStreamController {
       // microtasks. Keep the composer gated until that response confirms the
       // server-side turn slot has actually been released.
       chatState: stopGateHolds ? prev.chatState : ChatState.Idle,
+      // …and once the turn really has ended, a standing "could not stop, press
+      // Stop again" notice is describing a world that no longer exists. It is
+      // retracted rather than left to age, on the same rule as `pendingSteer`
+      // below: the turn it spoke about is over. Only that one code — a real
+      // turn failure is still the truth about this turn and stays put.
+      turnError:
+        !stopGateHolds && prev.turnError?.code === STOP_NOT_CONFIRMED ? undefined : prev.turnError,
       turnStartedAt: undefined,
       lastMessageAt: undefined,
       // The turn it was aimed at is over; whether or not we saw the echo, there
@@ -3792,6 +3799,8 @@ class ChatStreamController {
       turnStartedAt: undefined,
       lastMessageAt: undefined,
       pendingSteer: undefined,
+      // A retry that succeeded retracts the notice the failed attempt raised.
+      turnError: prev.turnError?.code === STOP_NOT_CONFIRMED ? undefined : prev.turnError,
     }));
     this.flushNotify();
     return true;

--- a/ui/desktop/src/utils/conversionUtils.ts
+++ b/ui/desktop/src/utils/conversionUtils.ts
@@ -80,7 +80,10 @@ export function describeRequestFailure(err: unknown, status?: number): string {
     // else falls through to the whole payload.
     const named = ['error', 'message', 'detail', 'reason', 'code']
       .filter((key) => record[key] != null && record[key] !== '')
-      .map((key) => `${key}=${typeof record[key] === 'string' ? record[key] : JSON.stringify(record[key])}`);
+      .map(
+        (key) =>
+          `${key}=${typeof record[key] === 'string' ? record[key] : JSON.stringify(record[key])}`
+      );
     if (named.length > 0) {
       parts.push(named.join(' '));
       return parts.join(' — ');

--- a/ui/desktop/src/utils/conversionUtils.ts
+++ b/ui/desktop/src/utils/conversionUtils.ts
@@ -38,3 +38,65 @@ export function isConnectionError(err: Error | unknown): boolean {
     msg.includes('err_connection')
   );
 }
+
+/**
+ * A human-readable one-line description of a failed generated-client call.
+ *
+ * The generated client does NOT throw an `Error`. With `throwOnError: true` it
+ * throws the RESPONSE BODY — the parsed JSON when the body is JSON, the raw
+ * text when it is not, and a literal `{}` when there is no body at all
+ * (`finalError = finalError || {}` in `api/client/client.gen.ts`) — and it
+ * discards the `Response`, so the status goes with it.
+ *
+ * That is why `console.warn('…:', error)` printed a bare `{}` on the Stop path
+ * and told the reader nothing: `/agent/cancel` answers several of its failures
+ * with a bare status and no body — `CancelTurnFailure::SettlementTimeout` is a
+ * naked 504, the two continuation-argument refusals are naked 400s — so the
+ * body genuinely IS empty and the status is the only thing that says which
+ * failure this was. Pass it in whenever the call site can still see it.
+ *
+ * Always log the STRING this returns rather than the raw value: a raw object
+ * argument is what produced the empty `{}` in the first place.
+ */
+export function describeRequestFailure(err: unknown, status?: number): string {
+  const parts: string[] = [];
+  if (typeof status === 'number') parts.push(`HTTP ${status}`);
+
+  if (err instanceof Error) {
+    parts.push(err.name && err.name !== 'Error' ? `${err.name}: ${err.message}` : err.message);
+    return parts.join(' — ');
+  }
+
+  if (typeof err === 'string') {
+    parts.push(err.trim() || 'empty response body');
+    return parts.join(' — ');
+  }
+
+  if (err && typeof err === 'object') {
+    const record = err as Record<string, unknown>;
+    // The shapes biorouterd actually returns: a `{ error }` / `{ message }`
+    // envelope, a typed conflict (`{ mismatch, expected_turn_id, … }`), or a
+    // validation `{ detail }`. Named first so they read as prose; anything
+    // else falls through to the whole payload.
+    const named = ['error', 'message', 'detail', 'reason', 'code']
+      .filter((key) => record[key] != null && record[key] !== '')
+      .map((key) => `${key}=${typeof record[key] === 'string' ? record[key] : JSON.stringify(record[key])}`);
+    if (named.length > 0) {
+      parts.push(named.join(' '));
+      return parts.join(' — ');
+    }
+    let serialised: string;
+    try {
+      serialised = JSON.stringify(record);
+    } catch {
+      serialised = '[unserialisable payload]';
+    }
+    // `{}` here is not an error object that lost its fields — it is the
+    // generated client's stand-in for "the response carried no body".
+    parts.push(serialised === '{}' ? 'empty response body' : serialised);
+    return parts.join(' — ');
+  }
+
+  parts.push(err === undefined ? 'no error value' : String(err));
+  return parts.join(' — ');
+}


### PR DESCRIPTION
## The finding

M2 (HIGH) from the 2026-09-10 test drive of merged main. Click Stop on a turn the daemon cannot release (M1 wedges one inside a blocking `opendir`) and the chat dies:

- the renderer logs `Failed to cancel running turn on stop: {}` — an empty object;
- the transcript replaces the spinner with **`Model turn ended unexpectedly`**, blaming the model for an ending the *user* asked for;
- 12 s later and thereafter the `Stop response` button is still there, `Send message` is **absent**, the spinner is still drawn, the running dot is still on the sidebar row and the tab;
- **the chat cannot be used again — there is no Send control to click.**

The cancel cannot succeed while the daemon is wedged (that is M1, fixed separately). This PR is the renderer's response to a cancel that fails, which was to say nothing and leave the composer unusable.

## Pre-existing — with a correction to the brief

The brief I was given said "neither file changed in `f350cdfc..c5392640`". That is right for `ChatTurnError.tsx` and **wrong for `chatStreamStore.tsx`**, which three commits in that range touched (`b85bc98a`, `e4e59740`, `b76584d7`). None of the three touched the Stop path — measured, zero added or removed lines matching `stopPending|stopGateHolds|settleStoppedTurn|requestExactTurnSettlement|Failed to cancel`.

The stronger statement holds instead: **every defect site exists verbatim at `f350cdfc` (v1.90.3, shipped 2026-09-09)** —

```
$ git show f350cdfc:ui/desktop/src/hooks/chatStreamStore.tsx | grep -n ...
1840:    const stopGateHolds = this.stopGateHolds();
3425:      console.warn('Failed to cancel running turn on stop:', error);
3474:    if (!settled) return false;
```

and the `scope: 'internal'` → "Model turn ended unexpectedly" mapping dates to `d2a96723` (2026-07-16). `stopGateHolds` itself arrived with `e2276569` (2026-09-06, the #166 fix), which is an ancestor of v1.90.3.

## What was actually wrong

**1. `{}` was not a spread `Error`.** The generated client's `throwOnError: true` throws the response **body** and discards the `Response` (`api/client/client.gen.ts`: `finalError = finalError || {}` then `throw finalError`). `/agent/cancel` answers its most important failure — `CancelTurnFailure::SettlementTimeout`, the 30 s bound — with a **bare 504 and no body**, and its two continuation-argument refusals with bare 400s. So the thrown value genuinely *is* a literal empty object, and the status, the only information that existed, was gone before the `catch` could see it.

The call now asks for the fields form, so the status survives, and every Stop-path warning goes through a new `describeRequestFailure(err, status)` with the session and generation named. Nothing on that path hands a raw value to `console.warn` any more.

**2. The strand is an ordering #166 never covered.** The #166 battery pushes its terminal frame *after* the cancel resolves — the gate is down, so the frame lands the turn. A wedged daemon produces the reverse: the frame arrives while the cancel is still parked, `finishCurrentStream` hands the Idle transition to the cancel response because `stopGateHolds()`, and the response comes back a failure and returns without making it. #166's `finally` frees the latch for the *next* frame, but the frame that mattered has already been and gone, and nothing re-runs it.

`stopDeferredFinishTurnId` records that deferral so `reportUnconfirmedStop` can complete it — and only then. A cancel that fails while the turn is *genuinely still streaming* leaves the daemon holding the session lock, so that case keeps Stop rather than being handed a Send that would 409. `stopExpectedTurnId` and `stopContinuationPending` are still deliberately retained on failure, so a retry still names the exact generation (#166's invariant, and its tests still pass unchanged).

**3. The failure was silent.** A failed settle now raises an in-chat notice through the existing `turnError` → `ChatTurnError` channel, saying the two things the user needs: Biorouter could not confirm the stop, and the turn may still be running on the backend. The copy differs by case (chat usable again / press Stop again), the real cancel failure sits under Technical details, and it is **not retryable** — the failure is the *stop*, and Retry re-runs the *turn*. It retracts itself once the turn really ends or a retried stop succeeds.

**4. The card no longer blames the model.** `TurnStream::close` writes `stream_ended_without_terminal` for any turn whose writers produced no ending; the daemon is describing the *shape* of the ending and cannot see its cause. The renderer re-codes it to `turn_stopped_by_user` **only** when this chat has a Stop outstanding for that exact generation. An ordinary internal failure with no Stop pending keeps today's wording, pinned by a test.

No Rust changed.

## Evidence

Ten new tests. Five fail on `7ae50acd` (the tests-only commit) and pass on `6a65db41`:

**fail-before** — `npx vitest run src/hooks/chatStreamStore.test.ts src/components/conversation/ChatTurnError.test.tsx`

```
FAIL  chatStreamStore.test.ts > … (M2) > returns the composer to Idle when the cancel fails after the turn already ended
AssertionError: expected 'streaming' to be 'idle'

FAIL  chatStreamStore.test.ts > … (M2) > lets the user send again rather than stranding the chat with no Send control
AssertionError: expected true to be false          [isRunningState(chatState)]

FAIL  chatStreamStore.test.ts > … (M2) > logs the HTTP status of a bodyless cancel rejection instead of an empty object
AssertionError: expected undefined to be defined

FAIL  chatStreamStore.test.ts > … (M2) > tells the user in the chat that the stop was not confirmed
AssertionError: expected 'stream_ended_without_terminal' to be 'stop_not_confirmed'

FAIL  chatStreamStore.test.ts > … (M2) > does not blame the model for an ending the user asked for
AssertionError: expected 'stream_ended_without_terminal' to be 'turn_stopped_by_user'

FAIL  ChatTurnError.test.tsx > ChatTurnError > names a user-requested ending instead of blaming the model
AssertionError: expected 'Model turn ended unexpectedly' to be 'Turn stopped'

FAIL  ChatTurnError.test.tsx > ChatTurnError > names a stop the backend never confirmed
AssertionError: expected 'Model turn ended unexpectedly' to be 'Stop not confirmed'

 Test Files  2 failed (2)
      Tests  7 failed | 93 passed (100)
```

Three of the ten pass before *and* after by design — the two negative guards (an ordinary internal failure still reads as a model failure; a cancel that rejects with a real `Error` already logged its text) and the store-level resend, which passes because the store's submit path was never the thing that was blocked. The user-visible brick was `chatState` alone, which is why the resend test now also asserts `isRunningState(chatState) === false`.

**pass-after**

```
 Test Files  2 passed (2)
      Tests  101 passed (101)
```

**Full suites**

```
$ npm run test:run
 Test Files  1 failed | 439 passed (440)
      Tests  4928 passed | 1 skipped (4929)
```

The one failing *suite* is `src/utils/artifactCdnAssets.browser.test.ts`, whose Playwright `afterAll` hook times out closing the browser under full-suite load. **Pre-existing and unrelated**: the same run against pristine `origin/main` sources gives `1 failed | 439 passed (440)` / `4917 passed` (the 11-test delta is this branch's new tests), and the file passes in isolation on both. No individual test fails on either side.

```
$ npm run lint:check
… OK — all 332 contrast assertions pass
… OK — every semantic colour token used by a utility has a @theme inline mirror
exit 0

$ npm run format:check
exit 1
[warn] src/components/settings/contexts/contexts.test.ts
[warn] src/toasts.autoClose.test.ts
[warn] src/utils/catalogSubscription.test.ts
[warn] src/utils/workdirOutsideHome.test.ts
```

Those four fail on `origin/main` too (verified by piping each file's `origin/main` blob through `prettier --check --stdin-filepath`) and are not touched here. The five files this branch changes are clean:

```
$ npx prettier --check src/hooks/chatStreamStore.tsx src/utils/conversionUtils.ts \
    src/components/conversation/ChatTurnError.tsx src/hooks/chatStreamStore.test.ts \
    src/components/conversation/ChatTurnError.test.tsx
All matched files use Prettier code style!
```

`chatStreamStore.tsx` and `conversionUtils.ts` were prettier-clean on `origin/main`, so `e190342a` re-formats only those two rather than leaving new drift behind.

## Files changed

| File | |
|---|---|
| `ui/desktop/src/hooks/chatStreamStore.tsx` | the deferred-finish marker, `reportUnconfirmedStop`, `noteCancelRejection`, `reframeStoppedTurnError`, the fields-form `cancelTurn` |
| `ui/desktop/src/utils/conversionUtils.ts` | `describeRequestFailure` |
| `ui/desktop/src/components/conversation/ChatTurnError.tsx` | titles for the two stop-shaped endings |
| `ui/desktop/src/hooks/chatStreamStore.test.ts` | 7 tests |
| `ui/desktop/src/components/conversation/ChatTurnError.test.tsx` | 3 tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
