### PR TITLE
fix(test): make the workspace-summary cache test deterministic on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "dunce",
  "env-lock",
  "etcetera 0.11.0",
+ "filetime",
  "fs2",
  "futures",
  "git2",

--- a/crates/biorouter/Cargo.toml
+++ b/crates/biorouter/Cargo.toml
@@ -203,6 +203,12 @@ aws-smithy-runtime-api = "=1.9.3"
 # the caller set it is supposed to have. Already resolved at 2.5.0 transitively, so
 # this adds no new package to the lock.
 walkdir = "2.5.0"
+# Test-only: set a directory's own mtime, which is the signal `workspace_summary`
+# caches on. `std::fs` cannot do this portably — a directory can only be opened
+# for write on Windows with `FILE_FLAG_BACKUP_SEMANTICS` — and the timestamp
+# granularity this papers over is exactly what made the cache test flaky there.
+# Already resolved at 0.2.26 transitively, so this adds no new package to the lock.
+filetime = "0.2.26"
 aws-smithy-http-client = { version = "=1.1.5", default-features = false, features = ["test-util"] }
 
 [[example]]

--- a/crates/biorouter/src/agents/workspace_summary.rs
+++ b/crates/biorouter/src/agents/workspace_summary.rs
@@ -111,10 +111,26 @@ struct CacheEntry {
 
 static CACHE: Lazy<Mutex<HashMap<PathBuf, CacheEntry>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
-/// Clear the cache. Test-only; production relies on TTL/mtime invalidation.
+/// The key `working_dir` is cached under. Canonicalized so two spellings of one
+/// directory share an entry; shared with [`forget_cached`] so a test can never
+/// clear a key production would not have written.
+fn cache_key(working_dir: &Path) -> PathBuf {
+    std::fs::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf())
+}
+
+/// Drop one working directory's cached map. Test-only; production relies on
+/// TTL/mtime invalidation.
+///
+/// Scoped to a single key, and deliberately not a whole-map `clear()`: `CACHE`
+/// is process-global, and `cargo test` runs a crate's unit tests in parallel
+/// threads of one process. Emptying it would reach into entries belonging to
+/// whatever else is mid-flight — `collect_moim` caches under its own working
+/// directory on every turn, and has a test of its own that does. Because each
+/// test owns a unique `tempdir` key, keeping the reach this narrow is what lets
+/// the cache tests run unserialized.
 #[cfg(test)]
-pub fn clear_cache() {
-    CACHE.lock().unwrap().clear();
+pub fn forget_cached(working_dir: &Path) {
+    CACHE.lock().unwrap().remove(&cache_key(working_dir));
 }
 
 fn dir_mtime(dir: &Path) -> Option<SystemTime> {
@@ -142,7 +158,7 @@ pub fn workspace_summary(working_dir: &Path) -> Option<String> {
         "CONTEXT_WORKSPACE_SUMMARY_TTL_SECS",
         DEFAULT_TTL_SECS,
     ));
-    let key = std::fs::canonicalize(working_dir).unwrap_or_else(|_| working_dir.to_path_buf());
+    let key = cache_key(working_dir);
     let current_mtime = dir_mtime(working_dir);
 
     // Fast path: serve a cached map when the directory's mtime is unchanged and
@@ -281,6 +297,7 @@ pub fn build_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use filetime::FileTime;
     use std::fs;
 
     fn cfg() -> SummaryConfig {
@@ -440,24 +457,81 @@ mod tests {
         );
     }
 
+    /// Pin `dir`'s own mtime, and confirm the filesystem kept the value.
+    ///
+    /// Both halves of the cache test below assert what [`workspace_summary`]
+    /// does with [`dir_mtime`], so the timestamp is each half's precondition
+    /// rather than a detail of it. A filesystem that quietly refuses the value
+    /// must fail here, naming the timestamp, instead of downstream where a
+    /// stale map reads as a cache bug — which is how this test used to fail.
+    fn pin_dir_mtime(dir: &Path, at: FileTime) {
+        filetime::set_file_mtime(dir, at).expect("set the directory's mtime");
+        let read_back = FileTime::from_last_modification_time(
+            &fs::metadata(dir).expect("read the directory's metadata"),
+        );
+        assert_eq!(
+            read_back, at,
+            "filesystem kept the directory mtime this test drives invalidation through"
+        );
+    }
+
     #[test]
     fn test_cache_serves_and_invalidates_on_mtime() {
-        clear_cache();
+        // Both halves are steered by two config keys, each resolved from the
+        // environment or `config.yaml`. Assert them up front: a machine that
+        // has turned the feature off — `CONTEXT_WORKSPACE_SUMMARY: false` is
+        // the documented lever for a slow workspace walk — would otherwise
+        // fail below with a message about the file map rather than about its
+        // own configuration.
+        assert!(
+            enabled(),
+            "CONTEXT_WORKSPACE_SUMMARY is off here, so the cache under test never runs"
+        );
+        assert!(
+            config_u64("CONTEXT_WORKSPACE_SUMMARY_TTL_SECS", DEFAULT_TTL_SECS) > 0,
+            "CONTEXT_WORKSPACE_SUMMARY_TTL_SECS is 0 here, which disables caching entirely"
+        );
+
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("one.txt"), "x").unwrap();
 
+        // Fixed timestamps rather than whatever the writes happen to leave
+        // behind: mtime resolution is coarse (the Windows clock ticks roughly
+        // every 15ms, and NTFS updates a directory's own mtime lazily), so two
+        // writes microseconds apart can leave it byte-identical. Taking the
+        // cache's invalidation signal from wall-clock writes is what made this
+        // test flaky on windows-latest while macOS and Ubuntu passed.
+        let before = FileTime::from_unix_time(1_000_000_000, 0);
+        let after = FileTime::from_unix_time(1_000_000_060, 0);
+        pin_dir_mtime(dir.path(), before);
+
         let first = workspace_summary(dir.path()).expect("first summary");
         assert!(first.contains("one.txt"));
+        assert!(
+            !first.contains("two.txt"),
+            "two.txt does not exist yet, so the map cannot name it"
+        );
 
-        // Add a top-level file; the directory mtime changes, so the cache must
-        // invalidate and pick up the new entry even within the TTL.
+        // Half 1 — the cache SERVES. Add a top-level file, then put the mtime
+        // back where the cached entry recorded it: inside the TTL the stale map
+        // must come back unchanged, which is the whole point of caching.
         fs::write(dir.path().join("two.txt"), "y").unwrap();
-        // mtime resolution can be coarse; nudge the directory to be safe.
+        pin_dir_mtime(dir.path(), before);
+        assert_eq!(
+            workspace_summary(dir.path()).expect("cached summary"),
+            first,
+            "an unchanged directory mtime inside the TTL serves the cached map"
+        );
+
+        // Half 2 — the cache INVALIDATES. Move the mtime clearly forward and
+        // the new top-level file must surface, TTL notwithstanding.
+        pin_dir_mtime(dir.path(), after);
         let refreshed = workspace_summary(dir.path()).expect("second summary");
         assert!(
-            refreshed.contains("two.txt") || first.contains("two.txt"),
-            "new top-level file surfaces after mtime change"
+            refreshed.contains("two.txt"),
+            "a changed directory mtime rewalks and surfaces the new file: {refreshed}"
         );
-        clear_cache();
+
+        forget_cached(dir.path());
     }
 }


### PR DESCRIPTION
## The flake

`agents::workspace_summary::tests::test_cache_serves_and_invalidates_on_mtime`
failed once on `test (windows-latest)` — run
[34513035963](https://github.com/BaranziniLab/biorouter/actions/runs/34513035963),
`3693 passed; 1 failed`, panicking at `workspace_summary.rs:457` with *"new
top-level file surfaces after mtime change"*. A rerun of the same commit passed
with no code change; macOS and Ubuntu passed both times; the PR carrying it
(#219) does not touch this file. Both defects were in the test, and both are
visible by reading it.

## Defect 1 — the promised nudge did not exist

The test wrote `two.txt` and immediately re-read, under a comment reading
*"mtime resolution can be coarse; nudge the directory to be safe"* — with no
nudge following it. The Windows clock ticks roughly every 15 ms and NTFS updates
a directory's own mtime lazily, so the two writes could leave `dir_mtime`
byte-identical. The cache then judged its entry fresh and served the stale map,
and neither summary named the new file.

Fixed by **taking the signal rather than hoping for it**: `filetime::set_file_mtime`
pins the directory's mtime to a fixed instant. `std::fs` cannot do this portably
— a directory needs `FILE_FLAG_BACKUP_SEMANTICS` to open for write on Windows,
which is exactly what `filetime` encapsulates. It was already in `Cargo.lock`
transitively, so this adds a dependency *edge* and no new package (the lockfile
diff is one line).

A `pin_dir_mtime` helper reads the timestamp back and asserts the filesystem
kept it, so a platform that quietly refuses the value fails **naming the
timestamp** instead of downstream, where a stale map reads as a cache bug. That
is the general shape of the original bug: an unstated precondition failing
somewhere that blames the thing it precedes.

## Defect 2 — the assertion could not fail

```rust
refreshed.contains("two.txt") || first.contains("two.txt")
```

`first` was captured before `two.txt` existed, so the second disjunct was dead.
It read as tolerating a race and tolerated nothing.

The test's name promises two behaviours, and it now checks both:

- **Half 1 — the cache serves.** Add `two.txt`, restore the mtime to what the
  cached entry recorded, and assert the stale map comes back *unchanged*.
- **Half 2 — the cache invalidates.** Move the mtime clearly forward and assert
  the new file surfaces.

What the dead disjunct gestured at is now a live assertion in the right place:
`assert!(!first.contains("two.txt"))`, pinning the pre-state where it is
actually true.

### Verified by mutation

Since the defect being fixed *was* an assertion that could not fail, both halves
were checked against a broken implementation:

| Mutation | Expected to fail | Result |
|---|---|---|
| `fresh` drops the `dir_mtime` comparison (never invalidates) | half 2 | ✅ *"a changed directory mtime rewalks and surfaces the new file"* |
| `fresh = false` (never serves) | half 1 | ✅ *"an unchanged directory mtime inside the TTL serves the cached map"*, with a diff showing `two.txt` present |

## Is the cache process-global? Yes — but `#[serial]` is not the fix

`CACHE` is a `static Lazy<Mutex<HashMap<..>>>`, and
`test_collect_moim_uses_minute_granularity` (`extension_manager.rs:4278`) does
reach it from a parallel thread through `collect_moim`. But it caches under
`/tmp` while this test caches under its own `tempdir`: **keys never collide, so
no test can corrupt another's entry.**

The entire coupling was the blunt whole-map `clear_cache()` — called only by
this test, and wiping the neighbour's entry on every run. So the blunt tool is
removed rather than serialized around: `clear_cache()` becomes
`forget_cached(working_dir)`, with it and `workspace_summary` deriving the key
through a shared `cache_key()` so the two can never drift.

`#[serial]` would not have helped, for two independent reasons: with keys
already private there is nothing to serialize, and a lone `#[serial]` orders
only against tests that *also* carry the attribute — which the `collect_moim`
neighbour does not. Narrowing the reach is what actually holds.

## Also

The two config keys the test rests on are asserted up front.
`CONTEXT_WORKSPACE_SUMMARY` and `CONTEXT_WORKSPACE_SUMMARY_TTL_SECS` resolve
from the environment or `config.yaml`, and the first is the documented lever for
a slow workspace walk — a developer with it off would otherwise have hit a
cryptic `.expect("first summary")` rather than a message about their own
configuration.

## Deliberately not changed

The same coarse-mtime behaviour means production on Windows can serve a stale
map until the 30 s TTL lapses when a file lands in the same clock tick as the
previous walk. That is within the documented contract — the rendered header says
*"may be truncated or slightly stale"*, and the TTL exists precisely as the
backstop for when mtime is an imperfect signal. It is a weaker signal on Windows
than on Unix, not a defect, so it is left alone.

## Testing

- `cargo test -p biorouter --lib -- agents::workspace_summary` → **11 passed, 0 failed**
- `cargo clippy -p biorouter --lib --tests --all-features` → clean
- `cargo fmt -p biorouter -- --check` → clean
- Both mutation runs above

All with `BIOROUTER_DISABLE_KEYRING=true`.
