### PR TITLE
Desktop: format:check passes on main — reformat the four test files that failed it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,12 +54,22 @@ just check-everything               # Run all style/lint checks
 ⚠ **Frontend formatting is not enforced anywhere.** `lint:check` resolves to
 `typecheck && eslint && check:themes && check:contrast && check:tokens` — no
 Prettier — and no workflow under `.github/workflows/` invokes Prettier either.
-This line used to claim `lint:check` was an "ESLint + Prettier check"; it never
-was, and the drift is measurable: on 2026-09-02, five files under
-`ui/desktop/src` failed `format:check` on `main`. Run `format:check` yourself
-before pushing frontend changes, and do not wire it into CI without fixing
-those five first — a gate that fails on arrival gets disabled rather than
-obeyed.
+Two things look like they do and do not: `just check-everything` prints
+"Checking UI code formatting..." and then runs `lint:check`; and the
+`lint-staged` block in `ui/desktop/package.json` runs `prettier --write` but
+nothing triggers it — `prepare` runs `husky` from `ui/desktop`, husky 9 exits
+early when the current directory has no `.git` (`npm ci` prints `.git can't be
+found`), and `.githooks/` holds only `commit-msg`. This line used to claim
+`lint:check` was an "ESLint + Prettier check"; it never was, and the drift is
+measurable: five files under `ui/desktop/src` failed `format:check` on `main`
+on 2026-09-02, and four on 2026-09-11. Those four were reformatted that day
+(formatting only), after which `format:check` passed with **0 failing files,
+measured 2026-09-11**. That meets the precondition this note used to set for
+wiring `format:check` into `lint:check` or CI — whether to do it is a
+maintainer's call — but nothing holds the count at zero, so re-measure right
+before wiring it in: a gate that fails on arrival gets disabled rather than
+obeyed. Until then, run `format:check` yourself before pushing frontend
+changes.
 
 ### Build & Release
 

--- a/ui/desktop/src/components/settings/contexts/contexts.test.ts
+++ b/ui/desktop/src/components/settings/contexts/contexts.test.ts
@@ -202,8 +202,7 @@ describe('the built-in skill list, across every copy', () => {
    * Contexts, and made of different things: five of these nine are reachable
    * only through the bundle.
    */
-  const shippedNames = () =>
-    [...builtinSkills(), ...knowledgeSkills(), soulSkill()].sort();
+  const shippedNames = () => [...builtinSkills(), ...knowledgeSkills(), soulSkill()].sort();
 
   it('CONTEXTS names exactly what Rust offers as a Context', () => {
     expect([...CONTEXT_IDS].sort()).toEqual(rustContextIds());

--- a/ui/desktop/src/toasts.autoClose.test.ts
+++ b/ui/desktop/src/toasts.autoClose.test.ts
@@ -18,10 +18,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const source = readFileSync(
-  resolve(dirname(fileURLToPath(import.meta.url)), 'toasts.tsx'),
-  'utf8'
-);
+const source = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), 'toasts.tsx'), 'utf8');
 
 /** The shared options block every toast in the app is built from. */
 function commonToastOptionsBlock(): string {

--- a/ui/desktop/src/utils/catalogSubscription.test.ts
+++ b/ui/desktop/src/utils/catalogSubscription.test.ts
@@ -224,7 +224,7 @@ describe('reading a delta', () => {
    * made somewhere else that this chat can now opt into; Biorouter's own
    * baseline is never that.
    */
-  it('does not announce Biorouter\'s own bundled extensions', () => {
+  it("does not announce Biorouter's own bundled extensions", () => {
     const d = delta(1, ['developer']);
     d.changes![0].extensions![0].config = {
       name: 'developer',

--- a/ui/desktop/src/utils/workdirOutsideHome.test.ts
+++ b/ui/desktop/src/utils/workdirOutsideHome.test.ts
@@ -53,9 +53,9 @@ describe('a working directory outside the home tree', () => {
   it('is allowed once the session working directory is a root', () => {
     // ⚠ Fails without the fix: `allowedFileRoots()` took no argument, so the
     // folder the user pointed the chat at could never appear in this list.
-    expect(
-      isFilePathAllowedForPreview(file, [outside, ...rootsWithoutWorkingDir], NARROW)
-    ).toBe(true);
+    expect(isFilePathAllowedForPreview(file, [outside, ...rootsWithoutWorkingDir], NARROW)).toBe(
+      true
+    );
   });
 
   it('does not widen to a sensitive path even when it is the working directory', () => {
@@ -142,9 +142,9 @@ describe('a working directory outside the home tree', () => {
 
     it('keeps the home reading when both exist', () => {
       // Precedence: never redirect a path that already works.
-      expect(reinterpretTildeAsAbsolute('~/x', '/home-x', (p) => p === '/home-x' || p === '/x')).toBe(
-        '/home-x'
-      );
+      expect(
+        reinterpretTildeAsAbsolute('~/x', '/home-x', (p) => p === '/home-x' || p === '/x')
+      ).toBe('/home-x');
     });
 
     it('keeps the home reading when neither exists', () => {


### PR DESCRIPTION
Makes `npm run format:check` pass on `main`. The PR is formatting plus one doc note, with no code change.

## The measurement

On `main` at `7c96d796` (hermit Node 24.10.0 / npm 11.6.1, after `npm ci`), `npm run format:check` exits **1** on exactly four files:

- `ui/desktop/src/components/settings/contexts/contexts.test.ts`
- `ui/desktop/src/toasts.autoClose.test.ts`
- `ui/desktop/src/utils/catalogSubscription.test.ts`
- `ui/desktop/src/utils/workdirOutsideHome.test.ts`

With this branch it exits **0** and prints *All matched files use Prettier code style!*

## What changed

**`style(desktop)`** runs `npx prettier --write` on those four paths and nothing else, using the repo's own Prettier (3.8.1, `ui/desktop/.prettierrc.json`). +9 / −13.

- Three files are pure line reflows.
- `catalogSubscription.test.ts` has the only change that isn't whitespace. A test title is re-quoted from `'…Biorouter\'s…'` to `"…Biorouter's…"` to drop the escape, and the string's value is identical.
- I checked this mechanically. I parsed the old and new copy of each file with the repo's TypeScript and compared the syntax trees node by node: literals by decoded value, comment text separately. All four are identical (875 / 181 / 1262 / 670 nodes, 0 parse errors). The checker passed seven controls first. It reports *equal* for a re-quote and two reflows, and *different* for a changed string, a flipped boolean, moved parentheses and a changed comment.

**`docs(claude)`** updates the ⚠ note under *Code Quality* in `CLAUDE.md` with the measured state: five failing files on 2026-09-02, four on 2026-09-11, and **0 after this change (measured 2026-09-11)**. It also names two things that look like Prettier enforcement but aren't. I verified both on this branch:

- `just check-everything` prints *Checking UI code formatting...* and then runs `lint:check`, which has no Prettier in it.
- The `lint-staged` block in `ui/desktop/package.json` runs `prettier --write`, but nothing ever triggers it. `prepare` runs `husky` from `ui/desktop`, where there is no `.git`. Husky 9.1.7 returns early in that case (`index.js:11`), and `npm ci` prints `.git can't be found`. `.githooks/` holds only `commit-msg`.

## You can now add a `format:check` gate; this PR does not

The note used to say not to wire `format:check` into CI until the failing files were fixed, because a gate that fails on arrival gets disabled rather than obeyed. That precondition is now met. This PR deliberately leaves `lint:check`, CI and `just check-everything` untouched, so whether to add the gate is your call. If you do, three things measured here matter:

1. **Nothing holds the count at zero until a gate exists.** Re-run `npm run format:check` on `main` right before wiring it in.
2. **Adding it to `lint:check` does not put it in CI.** The `static` job in `.github/workflows/frontend.yml` runs each gate as its own step, on purpose, so one failure doesn't hide the next. CI needs its own `npm run format:check` step there; the workflow's default `working-directory: ui/desktop` already suits it. `check:tokens` shows what happens otherwise. It joined `lint:check` on 2026-08-07, after `frontend.yml` was written (2026-07-19), and no workflow runs it today.
3. **Run it from `ui/desktop`.** Prettier reads `.prettierignore` from the current directory. From the repo root, the same glob exits 1 on **17** files, including the generated API client (`src/api/**`) and the two generator-owned files that `.prettierignore` excludes on purpose (`src/styles/main.css`, `src/components/baam/registry.fallback.json`). `npm run format:check` already runs from the right place.

## Tests

| Gate | Before | After |
| --- | --- | --- |
| `npm run format:check` | exit 1, 4 files | **exit 0** |
| `npx vitest run` on the four files | 4 files, 39 passed | 4 files, **39 passed** (3 + 10 + 14 + 12, same per-file counts) |
| `npm run lint:check` (tsc, ESLint `--max-warnings 0`, themes, 332 contrast assertions, token mirrors) | not run | **clean** |
| Syntax trees, old vs new (TypeScript parser) | n/a | **identical** for all four files |
| AI co-author trailers on the branch (the `no-ai-coauthor` regex) | n/a | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
