### PR TITLE
CI: run every tests/*.rs integration binary on ubuntu, offline

### DIFF
--- a/.github/workflows/apps-smoke.yml
+++ b/.github/workflows/apps-smoke.yml
@@ -43,5 +43,12 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-      - name: Run reference apps in Chromium
-        run: cargo test -p biorouter-mcp --test ui_example_apps every_example_passes_the_executing_smoke_harness -- --ignored --nocapture
+      # The whole binary, not just the Chromium harness. Its other tests bundle
+      # every example with esbuild, which is hermetic only where `npm ci` has
+      # put one in ui/desktop/node_modules — here. Anywhere else the bundler
+      # falls back to `npx --yes esbuild`, a download from the npm registry,
+      # which is why rust.yml's no-network integration step leaves this binary
+      # to this job. This line used to filter by name to the Chromium test
+      # alone, so the other five ran in no workflow at all.
+      - name: Run reference apps in Chromium, and the bundling tests
+        run: cargo test -p biorouter-mcp --test ui_example_apps -- --include-ignored --nocapture

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,12 +142,18 @@ jobs:
       # matrix with NO Rust cache (see the cache-on-failure note below), so it
       # pays a cold full-workspace build every run and its debug symbols are
       # what would push the repository over GitHub's 10 GiB cache ceiling once
-      # it finally saves one. Ubuntu is deliberately LEFT OUT — it has a warm
-      # 1.7 GiB cache today and adding the variable would change rust-cache's
-      # CARGO_* environment hash, throwing that cache away to fix a problem
-      # ubuntu does not have.
+      # it finally saves one.
+      #
+      # ⚠ Ubuntu was left out while it had a warm 1.7 GiB cache and no problem
+      # for this to fix. It has one now: the integration-binary step below
+      # links ~117 more executables, and on Linux every one of them EMBEDS the
+      # DWARF of everything it links rather than leaving it in a side file.
+      # Measured 2026-09-11 (run 34628149105) with debug=2: that build took the
+      # runner from 70 GB free to 1.4 GB and died with `No space left on
+      # device` before it finished. The variable changes rust-cache's key, so
+      # ubuntu builds cold (measured: lib + bins 3.7 -> 7.5 min) until main's
+      # first run with it saves the new cache. A one-time price.
       - name: Reduce CI test debuginfo
-        if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
         shell: bash
         run: echo 'CARGO_PROFILE_TEST_DEBUG=0' >> "$GITHUB_ENV"
 
@@ -213,9 +219,12 @@ jobs:
           sudo apt-get install --yes libdbus-1-dev libxcb1-dev pkg-config
 
       # Start narrow (lib + bins on every OS) so the matrix is green on arrival;
-      # widen as it proves stable. This selector leaves out `tests/`, so the
-      # cassette- and key-dependent integration suites (BIOROUTER_RECORD_MCP
-      # fixtures, provider credentials the runners do not have) never run here.
+      # widen as it proves stable. This selector leaves out `tests/`; those
+      # binaries run in their own step below, ubuntu only, with no network.
+      # (They were long assumed to need cassettes and credentials the runners
+      # lack. Measured, they do not: `mcp_integration_test` REPLAYS its
+      # cassettes offline and only records under BIOROUTER_RECORD_MCP, and the
+      # tests that need a real provider or vendor CLI are `#[ignore]`d.)
       #
       # ⚠ It does NOT follow that nothing in this step touches the network. The
       # selector filters by TARGET, not by behaviour, and a test that lives in
@@ -272,10 +281,96 @@ jobs:
       # The cross-platform-sensitive suites BR-70 exists to prove, run on every
       # OS they apply to. The workspace step above already runs the sandbox,
       # developer shell/background and security unit tests through their library
-      # targets. Only the sandbox integration target sits outside --lib/--bins;
+      # targets. The sandbox's integration target is the one `tests/` binary
+      # that runs on every OS (the rest follow in the next step, ubuntu only);
       # name it directly rather than executing those unit tests a second time.
       - name: cargo test (sandbox integration)
         run: cargo test -p biorouter-sandbox --test sandbox --locked --no-fail-fast
+
+      # ── Every other `tests/*.rs` binary, bar a table of exceptions ─────────
+      #
+      # Until this step no workflow ran them. The lib + bins selector above
+      # leaves `tests/` out, and `clippy --all-targets` below only COMPILES
+      # them, which says nothing about whether they pass. So the guards
+      # CLAUDE.md treats as load-bearing (the privacy master-switch binaries,
+      # the keyless-daemon binaries, `privacy_ar15_is_retired`,
+      # `every_test_binary_is_sandboxed`) ran only when someone remembered to.
+      # The cost is on record: from eb594ded until PR #229,
+      # `the_documented_closure_is_the_one_the_code_performs` read the wrong
+      # function, and would have stayed green with the AR-15 gate deleted.
+      #
+      # ⚠ The table is an EXCLUSION list on purpose. An allowlist would rebuild
+      # the gap one file at a time: a new binary would run only if its author
+      # remembered to add it. This way it runs the day it lands, and one that
+      # cannot run hermetically gets a line saying why. A line naming a target
+      # that no longer exists fails the step, so the table cannot outlive what
+      # it excuses.
+      #
+      # ⚠ Never add `--ignored` or `--include-ignored`. The live tests (real
+      # providers, the vendor CLIs, llama.cpp downloads, GitHub fetches) are
+      # `#[ignore]`d inside binaries whose other tests belong here, so the
+      # binary stays in and its live tests stay out.
+      #
+      # ⚠ No network, enforced rather than assumed. The tests run in a network
+      # namespace holding nothing but loopback, so a test that dials out fails
+      # at once with a connection error instead of passing whenever the third
+      # party is up (the lapstone note above is what that looks like).
+      # `setpriv` drops back to the runner user once loopback is up: as root,
+      # every "permission denied" assertion would pass for the wrong reason.
+      # Servers on 127.0.0.1 and ::1 work as usual.
+      #
+      # The table's second entry is the instructive one. `ui_example_apps`
+      # bundles each example with `npx --yes esbuild` when no local esbuild
+      # exists, and this job installs none. Offline it does NOT fail: measured,
+      # npx sits on the unreachable registry until the bundler's 60 s timeout,
+      # then the test passes on the type-stripper fallback without esbuild
+      # ever running. That is a minute spent proving nothing, and a pass that
+      # turns into a failure the day npm's retries give up before the timeout.
+      #
+      # Measured 2026-09-11, one binary at a time on hosted runners (scratch
+      # runs 34628149105 and 34629544896). ubuntu, inside the namespace: all
+      # 119 binaries green, 687 tests passed, 0 failed, 49 ignored. Building
+      # them took 135 s on top of the lib + bins build (14.5 GiB of
+      # executables, with the debuginfo setting above) and the 117 this step
+      # selects spend ~135 s in their tests. macOS was green but for one
+      # log-capture test that failed once in ~70 runs. windows-latest fails
+      # 31 tests in 9 binaries that had never run there, which is why this is
+      # ubuntu only: widening means fixing those first, and `unshare` is
+      # Linux-only, so another OS also needs its own way to stay offline.
+      - name: cargo test (integration binaries, no network)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          BIOROUTER_DISABLE_KEYRING: "true"
+          CARGO_NET_OFFLINE: "true"
+        run: |
+          set -euo pipefail
+          # One line per target, no wrapping: the first word is the name.
+          # target          why it does not run in this step
+          excluded='
+          sandbox           "cargo test (sandbox integration)" above runs it, on every OS
+          ui_example_apps   needs the npm registry (`npx --yes esbuild`); apps-smoke.yml runs it after `npm ci`
+          '
+          all=$(cargo metadata --format-version 1 --no-deps --locked \
+                  | jq -r '.packages[].targets[] | select(.kind == ["test"]) | .name' | sort)
+          # `--test` selects by name across the workspace, so a name two
+          # packages share would run (or be excluded) twice over.
+          dup=$(uniq -d <<<"$all")
+          if [ -n "$dup" ]; then
+            echo "::error::two packages have an integration target named: $dup"; exit 1
+          fi
+          skip=$(awk 'NF { print $1 }' <<<"$excluded" | sort)
+          stale=$(comm -13 <(echo "$all") <(echo "$skip"))
+          if [ -n "$stale" ]; then
+            echo "::error::the exclusion table names targets that no longer exist; delete their lines: $stale"; exit 1
+          fi
+          awk 'NF { t = $1; $1 = ""; printf "not run here: %s --%s\n", t, $0 }' <<<"$excluded"
+          args=()
+          for t in $(comm -23 <(echo "$all") <(echo "$skip")); do args+=(--test "$t"); done
+          echo "running $(( ${#args[@]} / 2 )) integration binaries"
+          sudo -E unshare --net -- sh -c \
+            'ip link set lo up && exec setpriv --reuid="$SUDO_UID" --regid="$SUDO_GID" --init-groups -- "$@"' sh \
+            env HOME="$HOME" PATH="$PATH" \
+            cargo test --workspace --locked --no-fail-fast "${args[@]}"
 
       - name: clippy (host, informational until warnings are burned down)
         if: matrix.os == 'ubuntu-latest'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,15 @@ cd ui/desktop && npm run test:run               # Run frontend unit tests (Vites
 cd ui/desktop && npm run test-e2e               # Run Playwright E2E tests
 ```
 
+**What CI runs.** `rust.yml`'s `test` job runs `--lib --bins` on all three OSes and, on
+ubuntu only, every `tests/*.rs` integration binary **except** the exclusion table inside its
+`cargo test (integration binaries, no network)` step. That step runs in a loopback-only network
+namespace and never passes `--ignored`. So a new integration binary is covered the day it lands,
+and a test that reaches the network fails there rather than passing while the third party is up.
+If a binary genuinely cannot run offline, put its live tests behind `#[ignore]`, or give the binary
+a line in that table saying why. Before 2026-09, `rust.yml` ran only the sandbox's integration
+target, so a green run said nothing about the rest of `tests/`.
+
 ### Code Quality
 
 ```bash


### PR DESCRIPTION
## Summary

No workflow ran the integration binaries under `crates/*/tests/*.rs`. `rust.yml`'s `test` job selects `--lib --bins`, and `clippy --all-targets` only compiles them. So the guards CLAUDE.md treats as load-bearing (the privacy master-switch binaries, `approval_no_user_key` and `knowledge_tier_no_user_key`, `privacy_ar15_is_retired`, `every_test_binary_is_sandboxed`) ran only when someone remembered to run them. From eb594ded until #229, `the_documented_closure_is_the_one_the_code_performs` scanned the wrong function and would have stayed green with the AR-15 gate deleted.

This PR adds a step to the `test` job, **ubuntu only**, that runs **every integration target in the workspace except an exclusion table**. Each table entry gives its reason inline:

| excluded | why |
|---|---|
| `sandbox` | The step before it already runs it, on all three OSes. |
| `ui_example_apps` | Bundles each example with `npx --yes esbuild` when no local esbuild exists, and this job installs none. Offline it passes vacuously: npx waits out the bundler's 60 s timeout, then every example falls back to the type-stripper and esbuild never runs. `apps-smoke.yml` now runs the whole binary after `npm ci`. |

How the step works:
- **Exclusion list, not allowlist.** A new binary runs the day it lands. `new_chat_no_user_key` from #229 is picked up automatically when #229 merges, with no edit here. (Naming it explicitly today would fail: `no test target named new_chat_no_user_key`.) A table entry for a target that no longer exists fails the step, and so does a target name shared by two packages. I planted both failures against the extracted step to check they fire.
- **Never `--ignored`.** The live tests (real providers, vendor CLIs, llama.cpp downloads, GitHub fetches) are `#[ignore]`d inside binaries whose other tests do run, so those binaries stay in and their live tests stay out.
- **No network, enforced.** The tests run under `sudo unshare --net`, which leaves only loopback, then `setpriv` back to the runner user (as root, every "permission denied" assertion would pass for the wrong reason). A test that dials out fails immediately with a connection error. Before trusting it, I ran a positive control on the hosted runner: uid is non-zero inside, `https://example.com` is refused, and a `127.0.0.1` server answers.
- **`--workspace --test <name>`, not `-p <pkg>`.** A `-p` selection changes cargo's feature unification and rebuilt dependencies when I measured it. `--workspace` reuses what the lib+bins step built (0.6 s, nothing rebuilt).
- Keyring off (`BIOROUTER_DISABLE_KEYRING=true`), like the existing step, and `CARGO_NET_OFFLINE=true`.

### A required side change: ubuntu test debuginfo
With ubuntu's default debug=2, building the integration binaries **ran the runner out of disk**: 70 GB free fell to 1.4 GB, then `rustc-LLVM ERROR: IO failure on output stream: No space left on device` ([run 34628149105](https://github.com/BaranziniLab/biorouter/actions/runs/34628149105)). On Linux, every test executable embeds the DWARF of everything it links. I measured that `cargo test` builds **dependencies** with the test profile (flipping only `CARGO_PROFILE_TEST_DEBUG` set cargo recompiling the whole dependency graph: 515 crates in the first 25 s, when I stopped it). So the variable has to be job-wide; set on the new step alone, it would rebuild every dependency. It now applies to ubuntu as well as windows/macOS. With it, the integration executables total 14.5 GiB and the runner keeps 65 GB free.

⚠ **Cost: ubuntu's rust-cache key changes, so ubuntu builds cold until `main` saves a new cache.** That includes this PR's own runs. Measured: the lib+bins build goes from 3.7 to 7.5 min. The workflow comment that deliberately kept ubuntu out ("to fix a problem ubuntu does not have") is rewritten, because ubuntu now has the problem.

## Measurements

Each binary run on its own, with a per-binary timeout, keyring off. Scratch runs: [34628149105](https://github.com/BaranziniLab/biorouter/actions/runs/34628149105) (all OSes, then-current debuginfo settings) and [34629544896](https://github.com/BaranziniLab/biorouter/actions/runs/34629544896) (ubuntu, debuginfo 0, offline).

| | lib+bins build | integration build | executables | binaries green | tests passed / failed / ignored | time in tests |
|---|---|---|---|---|---|---|
| **ubuntu, offline** (debug 0, cold) | 451 s | **135 s** | 14.5 GiB | **119 / 119** | **687 / 0 / 49** | 197 s (137 s for the 117 selected) |
| ubuntu, debug 2 (warm) | 222 s | ❌ disk full | — | — | — | — |
| macOS (cache nearly empty) | 933 s | 430 s | 12.9 GiB | 118 / 119 | 686 / 1 / 49 | 178 s |
| windows (warm) | 463 s | 383 s | 10.3 GiB | 110 / 119 | 645 / 31 / 49 | 241 s |
| local macOS, offline (Seatbelt) | — | — | — | 119 / 119 | 687 / 0 / 49 | 126 s |

Flakiness: I ran the step's exact command locally 6 times (3 at default threads, 3 at `RUST_TEST_THREADS=32`, the stressor that exposed this repo's shared-fake races before). All 117 binaries passed every time, 126–141 s per pass.

On time: the step should add about 5 min to `test (ubuntu-latest)` warm (135 s build plus 137 s of tests plus process startup), against today's 12–19 min and a 40-min cap. macOS (~20 min) sets the workflow's wall clock today.

## Why ubuntu only

- **windows-latest: 31 tests fail in 9 binaries**, none of which had ever run on Windows. They look like real Windows defects, not runner noise:
  - `session_store_dispatch_boundary` (2): *"a script read every conversation on this machine, with no inspector anywhere"*. The #56 session-store guard for `execute_code` does not appear to hold on Windows. **Worth a look on its own.**
  - `code_execution_integration` (6): a Windows path is spliced into JS unescaped (`\b` became a backspace).
  - `hooks_agent_loop_tests` (9), `hooks_integration_tests` (7), `global_memory_consent_agent_loop` (2), `loop_safety_observability_tests` (1): `Tool 'developer__shell' not found`, the same shape as the already-known open Windows bridge failures.
  - `parallel_tool_batch_concurrency_cap`, `_serialization_lever`, `_stress` (4): the tool-concurrency cap did not bound the batch (18 concurrent against a ceiling of 8, and 7 with `BIOROUTER_TOOL_MAX_CONCURRENT=1`).
- **macOS** passed except `output_recovery_agent_loop::private_provider_error_logging_retry_keeps_details_out_of_diagnostics`, which failed once on the CI runner. It passed 7 times locally, 60 more times when hammered (40 at 8/32 threads, 20 throttled with `taskpolicy -b`), and on ubuntu and Windows. My unconfirmed guess is a log-capture race, since it scopes its tracing subscriber to one future with `.with_subscriber()`. It could still flake on ubuntu at a low rate.
- `unshare` is Linux-only. Widening to another OS needs its failures fixed, and its own way to stay offline (Seatbelt works on macOS; I used it for the local run).

## Also in this PR

- `apps-smoke.yml` runs the whole `ui_example_apps` binary (`--include-ignored`) instead of filtering by name to the Chromium test. The binary's other five tests ran in no workflow before.
- Two stale `rust.yml` comments are fixed. One claimed the sandbox target was the only thing outside `--lib/--bins`. The other claimed `tests/` needed cassettes and credentials; in fact `mcp_integration_test` replays its cassettes offline, and credentialed tests are `#[ignore]`d.
- CLAUDE.md's Testing section now says what CI runs.

## Not in this PR

- Fixing the Windows failures above.
- A pre-existing hazard: the `--lib` step's `build_app_bundles_with_available_toolchain` goes through the same `npx --yes esbuild` fallback on runners, so it probably already downloads esbuild from npm on every run. I haven't verified this in a CI log.
- A measurement artifact worth knowing about: locally, `find_esbuild()` walks six parent directories and finds the **main checkout's** `ui/desktop/node_modules/.bin/esbuild` from inside a `.claude/worktrees/*` worktree, so `ui_example_apps` passes locally for a reason CI never has.

## Test plan

- [x] Scratch CI measurement on all three OSes, plus ubuntu offline with debuginfo 0 (links above)
- [x] Local: every binary offline, then the step's exact command 6× (default and 32 threads)
- [x] Step logic, extracted from the YAML with `sudo` stubbed: selects 117 binaries (including all 10 `privacy_*` binaries, both `*_no_user_key` and `every_test_binary_is_sandboxed`); a planted stale entry exits 1; a planted duplicate name exits 1
- [x] This PR's `test (ubuntu-latest)` runs the new step green ([run 34631673813](https://github.com/BaranziniLab/biorouter/actions/runs/34631673813)). From the job log: both exclusions printed, `running 117 integration binaries`, build 2m08s, **117 `test result: ok`, 0 failed**, step total 4m33s. The whole ubuntu job took 22 min on this cold-cache first run (budget 40; lib+bins went from 9.1 to 11.7 min cold).
- [x] `reference-apps` (apps-smoke) runs the whole `ui_example_apps` binary green
- [x] `test (windows-latest)`: the first attempt failed in the **lib** step on `routes::agent::knowledge_selection_tests::applying_a_workflow_hides_a_base_that_lands_mid_call` (git `NotFound` under the Windows temp dir). That's a known Windows flake: it hit renderer-only #175 the same way, and nothing in this diff runs on Windows beyond the unchanged debuginfo setting. The rerun passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
