### PR TITLE
ci(frontend): run check:tokens, which lint:check has run since 2026-08-07

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -93,8 +93,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: ./scripts/check-openapi-schema.sh
 
-  # ── Static gates: typecheck, lint, theme codegen freshness, WCAG contrast ──
-  # Measured at ~42s CPU (tsc) + ~32s CPU (eslint) + ~1s CPU (the two node
+  # ── Static gates: typecheck, lint, theme codegen, contrast, token mirrors ──
+  # Measured at ~42s CPU (tsc) + ~32s CPU (eslint) + ~1s CPU (the three node
   # scripts). eslint is NOT type-aware here — eslint.config.js declares no
   # parserOptions.project — so it is pure syntactic linting over 656 files.
   static:
@@ -119,8 +119,13 @@ jobs:
       # Each gate is its own step rather than a single `npm run lint:check`, and
       # each runs even if an earlier one failed. `lint:check` chains with && and
       # stops at the first failure, which means a contributor fixes one gate,
-      # pushes, waits, and discovers the next — four round trips instead of one.
+      # pushes, waits, and discovers the next — five round trips instead of one.
       # `!cancelled()` (not `always()`) still honours a cancelled run.
+      #
+      # The price: these steps copy `lint:check` from package.json BY HAND, so a
+      # gate added there runs in no CI job until it also gets a step here.
+      # check:tokens was in lint:check from 2026-08-07 and in no workflow until
+      # its step below was added.
       - name: Typecheck (tsc --noEmit)
         if: ${{ !cancelled() }}
         run: npm run typecheck
@@ -136,6 +141,10 @@ jobs:
       - name: Contrast assertions (WCAG)
         if: ${{ !cancelled() }}
         run: npm run check:contrast
+
+      - name: Token mirrors (@theme inline)
+        if: ${{ !cancelled() }}
+        run: npm run check:tokens
 
   # ── The BAAM registry generator ───────────────────────────────────────────
   # landing/scripts/build-registry.mjs writes three copies of one catalog, and


### PR DESCRIPTION
## What

`npm run check:tokens` has been part of `lint:check` since 2026-08-07 (4ee1e27b), but **no CI workflow runs it**. Frontend's `static` job runs each `lint:check` gate as its own step, so one failure can't hide the next. When `check:tokens` joined `lint:check` it never got a step of its own. On `main` at 7c96d796, `grep -rn 'check:tokens\|check-token-mirrors' .github/workflows/` returns nothing.

This PR adds that step, in the same shape as its neighbours, right after "Contrast assertions (WCAG)":

```yaml
      - name: Token mirrors (@theme inline)
        if: ${{ !cancelled() }}
        run: npm run check:tokens
```

The workflow's default `working-directory` is already `ui/desktop`.

It also adds a short note above the step list saying that these steps copy `lint:check` **by hand**, which is how this gate went missing. And it updates the two comments that counted four gates: the job header and "four round trips instead of one".

## Why this gate matters

`scripts/check-token-mirrors.mjs` fails when a semantic colour token is named by a Tailwind utility (say `ring-border-focus`) but has no `--color-*` entry in `@theme inline`. Without that entry Tailwind generates no utility, so the class silently does nothing. That's invisible in a diff and invisible to jsdom, and it shipped three times before the script existed. Until this step, the script ran only when someone ran `lint:check` by hand.

## Verification

| Check | Result |
| --- | --- |
| `npm ci` in a fresh worktree, hermit Node 24.10.0 / npm 11.6.1, with `ELECTRON_SKIP_BINARY_DOWNLOAD=1` as CI sets it | exit 0 |
| `npm run check:tokens` on 7c96d796 | exit 0: `OK … (341 declared, 91 mirrored, 57 reached from a utility)`, about 0.2s CPU |
| Mutant: a copy of the tree with the `--color-border-focus` mirror deleted | exit 1, naming `--border-focus` and all 8 call sites, so the step can fail |
| Every gate in `lint:check` has a `static` step (workflow YAML parsed and compared against `package.json`) | 5 of 5 |
| The new step in this PR's own Frontend run ([Static checks job](https://github.com/BaranziniLab/biorouter/actions/runs/34632871933/job/103373700249), head f1ff5ae4) | step 9 "Token mirrors (@theme inline)": success. Its log shows `> node scripts/check-token-mirrors.mjs`, then `OK … (341 declared, 91 mirrored, 57 reached from a utility)` |
| AI co-author trailers on the branch (the `no-ai-coauthor` regex) | 0 |

## Not in this PR

- **No Prettier / `format:check` step.** Whether to gate on formatting is a maintainer decision, tracked in the format:check cleanup (#236).
- **A blind spot in the script itself, left unchanged.** `check-token-mirrors.mjs` finds the mirror block with `css.indexOf('@theme inline')`. The first match is a *comment* on line 68 of `main.css`, not the block on line 1257, so every `--color-*` after that comment counts as a mirror. Of the reported 91, only 61 are real mirrors; the other 30 are palette primitives.
  - **Not masking anything today.** Anchoring the slice on the real block still passes, with 61 mirrored and 57 reached.
  - **A real miss.** Moving a mirror out of `@theme inline` into `:root[data-theme='alma-mater']` passes the shipped script, even though Tailwind generates no utility from a selector block. The anchored version fails it.

  This is a separate one-line fix that needs its own mutant test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
