### PR TITLE
fix(cli): --no-wait returns at acceptance, session remove reaches every row, no-TTY refusals

### DIFF
--- a/crates/biorouter-cli/src/cli.rs
+++ b/crates/biorouter-cli/src/cli.rs
@@ -656,7 +656,14 @@ enum SessionCommand {
         text: String,
         #[arg(
             long,
-            help = "Return as soon as the turn starts instead of streaming it"
+            help = "Return as soon as the daemon accepts the turn, printing its turn id, instead \
+                    of streaming it",
+            long_help = "Return as soon as the daemon accepts the turn, printing the session and \
+                         turn id, instead of streaming it. The turn runs on in the daemon: \
+                         `session watch <id>` follows it and `session cancel <id>` stops it. The \
+                         daemon stops a turn once nothing has been attached to its reply stream \
+                         for five minutes (`session watch` does not count), so --no-wait suits \
+                         turns shorter than that."
         )]
         no_wait: bool,
         #[arg(

--- a/crates/biorouter-cli/src/cli.rs
+++ b/crates/biorouter-cli/src/cli.rs
@@ -26,7 +26,9 @@ use crate::commands::schedule::{
     handle_schedule_run_now, handle_schedule_services_status, handle_schedule_services_stop,
     handle_schedule_sessions,
 };
-use crate::commands::session::{handle_session_list, handle_session_remove};
+use crate::commands::session::{
+    handle_session_list, handle_session_remove, RemoveSelector, SessionScope,
+};
 use crate::session::{build_session, SessionBuilderConfig};
 use crate::workflows::extract_from_cli::extract_workflow_info_from_cli;
 use crate::workflows::workflow::{explain_workflow, render_workflow_as_yaml};
@@ -565,11 +567,28 @@ enum SessionCommand {
             help = "Include subagent runs, nested under the session that spawned them. \
                     With this flag --limit counts top-level sessions, not total rows, \
                     and each run is marked live/done (or 'state unknown' when no daemon \
-                    can be reached to ask)"
+                    can be reached to ask). Also lists sessions with no messages"
         )]
         subagents: bool,
+
+        #[arg(
+            long = "include-empty",
+            help = "Include sessions that have not recorded a message yet — what a `biorouter` \
+                    run that exited before its first prompt, `doctor --fix` and `term init` \
+                    leave behind (--subagents already includes them)"
+        )]
+        include_empty: bool,
     },
-    #[command(about = "Remove sessions. Runs interactively if no ID, name, or regex is provided.")]
+    #[command(
+        about = "Remove sessions by id, name or regex, or pick them interactively",
+        long_about = "Remove sessions. --session-id removes that session whatever it is, \
+                      including a subagent run or a session with no messages. --name removes the \
+                      one session carrying that name and refuses when several share it. --regex \
+                      removes every session whose id matches, among those `session list` shows \
+                      unless --include-empty or --subagents widens the search. With none of the \
+                      three, a picker opens. Asks for confirmation first unless --yes; without a \
+                      terminal, --yes is required."
+    )]
     Remove {
         #[command(flatten)]
         identifier: Option<Identifier>,
@@ -579,6 +598,24 @@ enum SessionCommand {
             help = "Regex for removing matched sessions (optional)"
         )]
         regex: Option<String>,
+        #[arg(
+            short = 'y',
+            long,
+            help = "Remove without asking for confirmation (required when not run from a terminal)"
+        )]
+        yes: bool,
+        #[arg(
+            long,
+            help = "With --regex or the picker: also match subagent runs (and sessions with no \
+                    messages)"
+        )]
+        subagents: bool,
+        #[arg(
+            long = "include-empty",
+            help = "With --regex or the picker: also match sessions that have not recorded a \
+                    message yet"
+        )]
+        include_empty: bool,
     },
     #[command(about = "Export a session")]
     Export {
@@ -1789,16 +1826,36 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
             working_dir,
             limit,
             subagents,
+            include_empty,
         } => {
-            handle_session_list(format, ascending, working_dir, limit, subagents).await?;
+            let scope = SessionScope {
+                subagents,
+                include_empty,
+            };
+            handle_session_list(format, ascending, working_dir, limit, scope).await?;
         }
-        SessionCommand::Remove { identifier, regex } => {
+        SessionCommand::Remove {
+            identifier,
+            regex,
+            yes,
+            subagents,
+            include_empty,
+        } => {
             let (session_id, name) = if let Some(id) = identifier {
                 (id.session_id, id.name)
             } else {
                 (None, None)
             };
-            handle_session_remove(session_id, name, regex).await?;
+            let scope = SessionScope {
+                subagents,
+                include_empty,
+            };
+            handle_session_remove(
+                RemoveSelector::from_flags(session_id, name, regex),
+                scope,
+                yes,
+            )
+            .await?;
         }
         SessionCommand::Export {
             identifier,

--- a/crates/biorouter-cli/src/commands/configure.rs
+++ b/crates/biorouter-cli/src/commands/configure.rs
@@ -29,8 +29,30 @@ use std::collections::HashMap;
 // cursor-selected and cursor-unselected items.
 const MULTISELECT_VISIBILITY_HINT: &str = "<";
 
+/// What `biorouter configure` says when there is no terminal to prompt on
+/// (QA-D F9). It names the non-interactive route to the same end state rather
+/// than only refusing: this is the command every install guide points at, so it
+/// is the one most often run from a script.
+pub(crate) const CONFIGURE_NEEDS_A_TERMINAL: &str =
+    "`biorouter configure` is interactive and needs a terminal; without one, choose a model \
+     with `biorouter models set --provider <provider> --model <model>` (`biorouter models \
+     providers` lists the providers) and pass the provider's API key in its environment \
+     variable, e.g. `OPENAI_API_KEY`.";
+
 pub async fn handle_configure() -> anyhow::Result<()> {
-    let config = Config::global();
+    configure(Config::global(), super::needs_terminal::prompt_can_run()).await
+}
+
+/// [`handle_configure`] over an explicit config, so the refusal can be pinned
+/// against a file a test owns rather than the process-global one.
+///
+/// ⚠ **The terminal check is the first statement**, ahead of the
+/// `config.exists()` branch: both branches open with a cliclack prompt, and a
+/// command that is about to decline must not have read or written anything on
+/// the way there. Under a pipe this used to die inside the first prompt with
+/// cliclack's bare `Error: not connected`.
+async fn configure(config: &Config, terminal: bool) -> anyhow::Result<()> {
+    super::needs_terminal::require(terminal, CONFIGURE_NEEDS_A_TERMINAL)?;
 
     if !config.exists() {
         handle_first_time_setup(config).await
@@ -2258,5 +2280,75 @@ mod privacy_disclosure_tests {
 
         assert!(non_private_model_disclosure(&meta("llamacpp").await).is_none());
         assert!(non_private_model_disclosure(&meta("versa_azure").await).is_none());
+    }
+}
+
+#[cfg(test)]
+mod needs_terminal_tests {
+    use super::{configure, CONFIGURE_NEEDS_A_TERMINAL};
+    use crate::commands::needs_terminal::NeedsTerminal;
+    use biorouter::config::Config;
+    use std::ffi::OsString;
+
+    fn entries(dir: &std::path::Path) -> Vec<OsString> {
+        let mut names: Vec<OsString> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// QA-D F9: under a pipe, `configure` refuses with a sentence that names
+    /// what to run instead — and the configuration is **byte-identical**
+    /// afterwards, with nothing written beside it.
+    ///
+    /// Driven through `configure` itself, the function `handle_configure`
+    /// calls, so moving the check below anything that touches the file fails
+    /// here. The file carries a comment and odd spacing on purpose: a
+    /// parse-and-re-serialise round trip would normalise both, so "identical
+    /// bytes" cannot be satisfied by a write that happened to preserve the keys.
+    #[tokio::test]
+    async fn without_a_terminal_configure_refuses_and_leaves_the_config_byte_identical() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("config.yaml");
+        let original: &[u8] = b"# hand-edited\nBIOROUTER_PROVIDER:   versa_azure\n\
+                                BIOROUTER_MODEL: gpt-5.5-2026-04-24\n";
+        std::fs::write(&config_path, original).unwrap();
+        let config =
+            Config::new_with_file_secrets(&config_path, dir.path().join("secrets.yaml")).unwrap();
+
+        let err = configure(&config, false).await.unwrap_err();
+        let refusal = err
+            .downcast_ref::<NeedsTerminal>()
+            .expect("the refusal must be the typed one main maps to exit 2");
+        assert_eq!(refusal.to_string(), CONFIGURE_NEEDS_A_TERMINAL);
+        assert!(
+            CONFIGURE_NEEDS_A_TERMINAL.contains("biorouter models set --provider"),
+            "the sentence must name the non-interactive route: {CONFIGURE_NEEDS_A_TERMINAL}"
+        );
+
+        assert_eq!(std::fs::read(&config_path).unwrap(), original);
+        assert_eq!(entries(dir.path()), vec![OsString::from("config.yaml")]);
+    }
+
+    /// The first-run branch (no config yet) refuses the same way and creates
+    /// nothing — no config file, no secrets file.
+    #[tokio::test]
+    async fn without_a_terminal_first_run_configure_creates_nothing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = Config::new_with_file_secrets(
+            dir.path().join("config.yaml"),
+            dir.path().join("secrets.yaml"),
+        )
+        .unwrap();
+
+        let err = configure(&config, false).await.unwrap_err();
+        assert!(err.downcast_ref::<NeedsTerminal>().is_some(), "{err:?}");
+        assert!(
+            entries(dir.path()).is_empty(),
+            "a refused first run must leave no file behind: {:?}",
+            entries(dir.path())
+        );
     }
 }

--- a/crates/biorouter-cli/src/commands/mod.rs
+++ b/crates/biorouter-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod extension;
 pub mod info;
 pub mod knowledge;
 pub mod models;
+pub mod needs_terminal;
 pub mod project;
 pub mod schedule;
 pub mod serve;

--- a/crates/biorouter-cli/src/commands/needs_terminal.rs
+++ b/crates/biorouter-cli/src/commands/needs_terminal.rs
@@ -1,0 +1,93 @@
+//! The refusal a command gives when it needs a person at a terminal and was run
+//! without one (QA-D F9).
+//!
+//! `cliclack`'s prompts draw on **stderr** and read keys from stdin, or from
+//! `/dev/tty` when stdin is not one (`console::read_single_key`). So the first
+//! `.interact()` of `biorouter configure`, `biorouter project(s)` or `biorouter
+//! session remove` failed, under a pipe, a cron job or an agent's shell, with
+//! cliclack's bare `Error: not connected` — the `io::ErrorKind` name, which says
+//! neither what happened nor what to run instead. And `configure` is the command
+//! every install guide points at.
+//!
+//! ⚠ **Both streams are checked, not only stdin.** cliclack refuses on its own
+//! when stderr is not a terminal (`PromptInteraction::interact_on`), whatever
+//! stdin is, so a stdin-only check would still let `biorouter configure
+//! 2>install.log` die with the old message. And when stdin is piped but a
+//! controlling terminal exists, cliclack reads the keyboard through `/dev/tty`
+//! and silently ignores what was piped — so `echo y | biorouter session remove
+//! …` would sit waiting for a key the user thinks they already sent. Refusing
+//! both cases with a sentence that names the alternative is the whole fix.
+
+use std::io::IsTerminal;
+
+/// The exit status of the refusal.
+///
+/// 2, the status clap exits with for a usage error, because this is the same
+/// class of failure: the command was run in a way it cannot work, and nothing
+/// was attempted. Distinct from 1 so a script can tell "you need `--yes`" from
+/// "the removal itself failed".
+pub const EXIT_CODE: u8 = 2;
+
+/// A command that needed a person at a terminal was run without one.
+///
+/// A type rather than an `anyhow!` string so `main` can give it its own exit
+/// status and print the sentence alone, without the `Error:` framing every
+/// other failure gets: nothing failed — the command declined to start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NeedsTerminal(String);
+
+impl std::fmt::Display for NeedsTerminal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for NeedsTerminal {}
+
+/// Whether a cliclack prompt can run in this process: stdin and stderr must
+/// both be terminals (see the module doc for why stderr counts too).
+pub fn prompt_can_run() -> bool {
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
+/// `Ok` when a prompt can run, otherwise the refusal carrying `sentence`.
+///
+/// `terminal` is a parameter, not a call to [`prompt_can_run`], so a test can
+/// state the non-terminal case without redirecting its own stdin — and so each
+/// caller samples the terminal once and decides from that one answer.
+pub fn require(terminal: bool, sentence: &str) -> Result<(), NeedsTerminal> {
+    if terminal {
+        Ok(())
+    } else {
+        Err(NeedsTerminal(sentence.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_terminal_passes_and_anything_else_is_refused_with_the_sentence() {
+        assert_eq!(require(true, "unused"), Ok(()));
+
+        let refusal = require(false, "`biorouter x` is interactive.").unwrap_err();
+        assert_eq!(refusal.to_string(), "`biorouter x` is interactive.");
+    }
+
+    /// `main` finds the refusal by downcasting the `anyhow::Error` it is handed,
+    /// so the type must survive the `?` conversion and any `.context()` a caller
+    /// wraps around it. If it did not, the refusal would fall back to exit 1
+    /// with an `Error:` prefix — indistinguishable from a real failure.
+    #[test]
+    fn the_refusal_survives_conversion_into_anyhow_so_main_can_find_it() {
+        let direct: anyhow::Error = require(false, "sentence").unwrap_err().into();
+        assert!(direct.downcast_ref::<NeedsTerminal>().is_some());
+
+        let wrapped = direct.context("while running a command");
+        assert!(
+            wrapped.downcast_ref::<NeedsTerminal>().is_some(),
+            "a context layer must not hide the refusal from main's downcast"
+        );
+    }
+}

--- a/crates/biorouter-cli/src/commands/project.rs
+++ b/crates/biorouter-cli/src/commands/project.rs
@@ -3,8 +3,19 @@ use chrono::DateTime;
 use cliclack::{self, intro, outro};
 use std::path::Path;
 
+use crate::commands::needs_terminal;
 use crate::project_tracker::ProjectTracker;
 use biorouter::utils::safe_truncate;
+
+/// What `biorouter project` and `biorouter projects` say when there is no
+/// terminal to prompt on (QA-D F9). `{command}` is the one the user typed.
+fn needs_a_terminal(command: &str) -> String {
+    format!(
+        "`biorouter {command}` is interactive and needs a terminal; from a script, continue a \
+         chat with `biorouter run --resume --session-id <id> --text \"<prompt>\"` (`biorouter \
+         session list` shows the ids)."
+    )
+}
 
 /// Format a DateTime for display
 fn format_date(date: DateTime<chrono::Utc>) -> String {
@@ -15,8 +26,18 @@ fn format_date(date: DateTime<chrono::Utc>) -> String {
 /// Handle the default project command
 ///
 /// Offers options to resume the most recently accessed project
-#[allow(clippy::too_many_lines)]
 pub fn handle_project_default() -> Result<()> {
+    project_default(needs_terminal::prompt_can_run())
+}
+
+/// [`handle_project_default`] with the terminal answer supplied, so the refusal
+/// is testable without redirecting the test's own stdin.
+#[allow(clippy::too_many_lines)]
+fn project_default(terminal: bool) -> Result<()> {
+    // Before anything else: BOTH paths below need a person — a picker, or (with
+    // no projects yet) an interactive `biorouter session`, which under a pipe
+    // reads EOF and exits having written an empty session row.
+    needs_terminal::require(terminal, &needs_a_terminal("project"))?;
     let tracker = ProjectTracker::load()?;
     let mut projects = tracker.list_projects();
 
@@ -163,15 +184,24 @@ pub fn handle_project_default() -> Result<()> {
 /// Handle the interactive projects command
 ///
 /// Shows a list of projects and lets the user select one to resume
-#[allow(clippy::too_many_lines)]
 pub fn handle_projects_interactive() -> Result<()> {
-    let tracker = ProjectTracker::load()?;
+    projects_interactive(ProjectTracker::load()?, needs_terminal::prompt_can_run())
+}
+
+/// [`handle_projects_interactive`] with the project list and the terminal
+/// answer supplied, so the refusal is testable against a list a test owns.
+#[allow(clippy::too_many_lines)]
+fn projects_interactive(tracker: ProjectTracker, terminal: bool) -> Result<()> {
     let mut projects = tracker.list_projects();
 
     if projects.is_empty() {
         println!("No projects found.");
         return Ok(());
     }
+
+    // Before the picker. "No projects found" above needs no person, so it
+    // still answers under a pipe.
+    needs_terminal::require(terminal, &needs_a_terminal("projects"))?;
 
     // Sort projects by last_accessed (newest first)
     projects.sort_by(|a, b| b.last_accessed.cmp(&a.last_accessed));
@@ -303,4 +333,68 @@ pub fn handle_projects_interactive() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::needs_terminal::NeedsTerminal;
+
+    /// QA-D F9: `biorouter project` refuses under a pipe with a sentence
+    /// naming the scriptable route — and refuses FIRST, before it reads the
+    /// project list, because both of its paths need a person.
+    #[test]
+    fn project_refuses_without_a_terminal_before_it_reads_anything() {
+        let err = project_default(false).unwrap_err();
+        let refusal = err
+            .downcast_ref::<NeedsTerminal>()
+            .expect("the typed refusal main maps to exit 2");
+        let sentence = refusal.to_string();
+        assert!(sentence.contains("`biorouter project`"), "{sentence}");
+        assert!(sentence.contains("is interactive"), "{sentence}");
+        assert!(
+            sentence.contains("biorouter run --resume --session-id"),
+            "the refusal must name what to run instead: {sentence}"
+        );
+    }
+
+    /// `biorouter projects` refuses at its picker, and still answers "No
+    /// projects found." without a terminal — that line needs nobody.
+    #[test]
+    fn projects_refuses_at_the_picker_but_still_reports_an_empty_list() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("projects.json");
+
+        let empty = ProjectTracker::load_from(&file).unwrap();
+        assert!(
+            projects_interactive(empty, false).is_ok(),
+            "an empty list is answered without prompting"
+        );
+
+        let project_dir = dir.path().display().to_string();
+        std::fs::write(
+            &file,
+            serde_json::json!({
+                "projects": {
+                    project_dir.clone(): {
+                        "path": project_dir,
+                        "last_accessed": "2026-09-10T12:00:00Z",
+                        "last_instruction": null,
+                        "last_session_id": "20260910_1"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let one = ProjectTracker::load_from(&file).unwrap();
+        assert_eq!(one.list_projects().len(), 1, "the fixture must load");
+
+        let err = projects_interactive(one, false).unwrap_err();
+        let sentence = err
+            .downcast_ref::<NeedsTerminal>()
+            .expect("the typed refusal main maps to exit 2")
+            .to_string();
+        assert!(sentence.contains("`biorouter projects`"), "{sentence}");
+    }
 }

--- a/crates/biorouter-cli/src/commands/session.rs
+++ b/crates/biorouter-cli/src/commands/session.rs
@@ -1,6 +1,7 @@
 use crate::session::message_to_markdown;
 use anyhow::{Context, Result};
 
+use crate::commands::needs_terminal;
 use crate::commands::session_grouping::{
     group_by_parent, listed_session_types, liveness_label, render_child, Liveness, SessionRow,
 };
@@ -15,23 +16,155 @@ use std::path::PathBuf;
 
 const TRUNCATED_DESC_LENGTH: usize = 60;
 
-async fn remove_sessions(session_manager: &SessionManager, sessions: Vec<Session>) -> Result<()> {
-    println!("The following sessions will be removed:");
-    for session in &sessions {
-        println!("- {} {}", session.id, session.name);
+/// What `session remove` says when it would have to ask before deleting and
+/// there is no terminal to ask on (QA-D F5a / F9).
+pub(crate) const REMOVE_CONFIRMATION_NEEDS_A_TERMINAL: &str =
+    "`biorouter session remove` asks before it deletes anything and needs a terminal to ask on; \
+     to remove without asking, re-run it with --yes.";
+
+/// What `session remove` says when it was given nothing to select by, so it
+/// would open its picker, and there is no terminal to draw one on.
+pub(crate) const REMOVE_PICKER_NEEDS_A_TERMINAL: &str =
+    "`biorouter session remove` with no --session-id, --name or --regex opens a picker, which \
+     needs a terminal; name what to remove with one of those flags and add --yes.";
+
+/// Which rows a listing — and a removal that selects from one — looks through.
+///
+/// The default is what `session list` has always shown: `user` and `scheduled`
+/// sessions that have recorded at least one message.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SessionScope {
+    /// Also subagent runs (`sub_agent` rows). Implies [`Self::include_empty`],
+    /// as `--subagents` always has — see [`fetch_sessions`].
+    pub subagents: bool,
+    /// Also sessions that have not recorded a message yet: what a bare
+    /// `biorouter` that exited before its first prompt, `doctor --fix` and
+    /// `term init` leave behind (QA-D F5b measured 5,313 of 10,855 rows).
+    pub include_empty: bool,
+}
+
+impl SessionScope {
+    /// Every row any listing can show: what a `--name` addresses.
+    const EVERYTHING: Self = Self {
+        subagents: true,
+        include_empty: true,
+    };
+}
+
+/// How `session remove` picks its rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoveSelector {
+    /// `--session-id`: exactly that row, whatever its type and whether or not
+    /// it has recorded a message.
+    Id(String),
+    /// `--name`: the one row carrying that name.
+    Name(String),
+    /// `--regex`: every row in the scope whose id matches.
+    Regex(String),
+    /// Nothing given: an interactive picker over the scope.
+    Pick,
+}
+
+impl RemoveSelector {
+    /// The selector the flags describe, in the precedence the command has
+    /// always applied: an id beats a name beats a regex.
+    pub fn from_flags(
+        session_id: Option<String>,
+        name: Option<String>,
+        regex: Option<String>,
+    ) -> Self {
+        match (session_id, name, regex) {
+            (Some(id), _, _) => Self::Id(id),
+            (None, Some(name), _) => Self::Name(name),
+            (None, None, Some(regex)) => Self::Regex(regex),
+            (None, None, None) => Self::Pick,
+        }
+    }
+}
+
+/// The row `id` names, of any type, with or without messages.
+///
+/// ⚠ **A direct read, not a search of a listing.** This used to look the id up
+/// in `list_sessions()`, which is `user`/`scheduled` only and INNER JOINs
+/// `messages`, so `session remove --session-id` answered "not found" for a
+/// message-less row (QA-D F5b) and for every subagent run (QA-F F9) — rows that
+/// `session export` and `session rename` reached by the same id without
+/// complaint. An id is unambiguous; there is nothing to filter.
+async fn session_by_id(session_manager: &SessionManager, id: &str) -> Result<Session> {
+    match session_manager.get_session(id, false).await {
+        Ok(session) => Ok(session),
+        // The storage layer's own wording for an absent row, matched the way the
+        // daemon's `DELETE /sessions/{id}` matches it. Anything else is a real
+        // store failure and must not be reported as a typo.
+        Err(e) if e.to_string().contains("not found") => {
+            Err(anyhow::anyhow!("Session ID '{}' not found.", id))
+        }
+        Err(e) => Err(e.context(format!("could not read session '{id}'"))),
+    }
+}
+
+/// The ONE row named `name`, among every row a name addresses elsewhere in
+/// the CLI (`resolve_session_by_name`'s set).
+///
+/// ⚠ **A name shared by several rows is refused, never guessed.** This used to
+/// delete the first match. Every session a bare `biorouter` creates reads back
+/// as `New chat` (its stored `CLI Session` is canonicalised on read), and
+/// subagent names are written by the model, so "the first match" is a deletion
+/// of an arbitrary one of them — and with `--yes` nobody would even see which.
+async fn session_by_name(session_manager: &SessionManager, name: &str) -> Result<Session> {
+    let mut matches: Vec<Session> = fetch_sessions(session_manager, SessionScope::EVERYTHING)
+        .await?
+        .into_iter()
+        .filter(|s| s.name == name)
+        .collect();
+    match matches.len() {
+        0 => Err(anyhow::anyhow!("Session with name '{}' not found.", name)),
+        1 => Ok(matches.remove(0)),
+        count => {
+            let ids: Vec<&str> = matches.iter().map(|s| s.id.as_str()).collect();
+            Err(anyhow::anyhow!(
+                "{count} sessions are named '{name}' ({}), so the name does not say which to \
+                 remove; remove one with --session-id <id>.",
+                ids.join(", ")
+            ))
+        }
+    }
+}
+
+/// Delete `sessions`, asking first unless `yes`.
+///
+/// ⚠ **No terminal and no `--yes` is a refusal, checked before anything is
+/// printed or deleted.** This called `cliclack::confirm` unconditionally, which
+/// under a pipe died with cliclack's bare `Error: not connected` even with `y`
+/// piped in (QA-D F5a) — and when a controlling terminal does exist, cliclack
+/// reads the keyboard through `/dev/tty` and ignores the pipe, so `echo y |`
+/// would sit waiting for a key the user thinks they already sent.
+async fn remove_sessions(
+    session_manager: &SessionManager,
+    sessions: Vec<Session>,
+    yes: bool,
+    terminal: bool,
+) -> Result<()> {
+    if !yes {
+        needs_terminal::require(terminal, REMOVE_CONFIRMATION_NEEDS_A_TERMINAL)?;
+
+        println!("The following sessions will be removed:");
+        for session in &sessions {
+            println!("- {} {}", session.id, session.name);
+        }
+
+        let should_delete = confirm("Are you sure you want to delete these sessions?")
+            .initial_value(false)
+            .interact()?;
+        if !should_delete {
+            println!("Skipping deletion of the sessions.");
+            return Ok(());
+        }
     }
 
-    let should_delete = confirm("Are you sure you want to delete these sessions?")
-        .initial_value(false)
-        .interact()?;
-
-    if should_delete {
-        for session in sessions {
-            session_manager.delete_session(&session.id).await?;
-            println!("Session `{}` removed.", session.id);
-        }
-    } else {
-        println!("Skipping deletion of the sessions.");
+    for session in sessions {
+        session_manager.delete_session(&session.id).await?;
+        println!("Session `{}` removed.", session.id);
     }
 
     Ok(())
@@ -76,64 +209,87 @@ fn prompt_interactive_session_removal(sessions: &[Session]) -> Result<Vec<Sessio
 }
 
 pub async fn handle_session_remove(
-    session_id: Option<String>,
-    name: Option<String>,
-    regex_string: Option<String>,
+    selector: RemoveSelector,
+    scope: SessionScope,
+    yes: bool,
 ) -> Result<()> {
-    let session_manager = SessionManager::instance();
-    let all_sessions = match session_manager.list_sessions().await {
-        Ok(sessions) => sessions,
-        Err(e) => {
-            tracing::error!("Failed to retrieve sessions: {:?}", e);
-            return Err(anyhow::anyhow!("Failed to retrieve sessions"));
+    remove_in(
+        &SessionManager::instance(),
+        selector,
+        scope,
+        yes,
+        needs_terminal::prompt_can_run(),
+    )
+    .await
+}
+
+/// [`handle_session_remove`] over an explicit store and terminal answer, so
+/// every rule below is testable against a throwaway database.
+///
+/// Rows are resolved BEFORE the terminal is consulted (the picker aside, which
+/// needs the terminal to resolve anything at all): a script with a mistyped id
+/// is told "not found", not told to add `--yes` and then told "not found".
+async fn remove_in(
+    session_manager: &SessionManager,
+    selector: RemoveSelector,
+    scope: SessionScope,
+    yes: bool,
+    terminal: bool,
+) -> Result<()> {
+    let matched_sessions: Vec<Session> = match selector {
+        RemoveSelector::Id(id) => vec![session_by_id(session_manager, &id).await?],
+        RemoveSelector::Name(name) => vec![session_by_name(session_manager, &name).await?],
+        RemoveSelector::Regex(regex_val) => {
+            let session_regex = Regex::new(&regex_val)
+                .with_context(|| format!("Invalid regex pattern '{}'", regex_val))?;
+
+            let matched: Vec<Session> = fetch_sessions(session_manager, scope)
+                .await?
+                .into_iter()
+                .filter(|session| session_regex.is_match(&session.id))
+                .collect();
+
+            if matched.is_empty() {
+                println!(
+                    "Regex string '{}' does not match any sessions{}",
+                    regex_val,
+                    widen_hint(scope)
+                );
+                return Ok(());
+            }
+            matched
+        }
+        RemoveSelector::Pick => {
+            needs_terminal::require(terminal, REMOVE_PICKER_NEEDS_A_TERMINAL)?;
+            let all_sessions = fetch_sessions(session_manager, scope).await?;
+            if all_sessions.is_empty() {
+                return Err(anyhow::anyhow!("No sessions found."));
+            }
+            prompt_interactive_session_removal(&all_sessions)?
         }
     };
-
-    let matched_sessions: Vec<Session>;
-
-    if let Some(id_val) = session_id {
-        if let Some(session) = all_sessions.iter().find(|s| s.id == id_val) {
-            matched_sessions = vec![session.clone()];
-        } else {
-            return Err(anyhow::anyhow!("Session ID '{}' not found.", id_val));
-        }
-    } else if let Some(name_val) = name {
-        if let Some(session) = all_sessions.iter().find(|s| s.name == name_val) {
-            matched_sessions = vec![session.clone()];
-        } else {
-            return Err(anyhow::anyhow!(
-                "Session with name '{}' not found.",
-                name_val
-            ));
-        }
-    } else if let Some(regex_val) = regex_string {
-        let session_regex = Regex::new(&regex_val)
-            .with_context(|| format!("Invalid regex pattern '{}'", regex_val))?;
-
-        matched_sessions = all_sessions
-            .into_iter()
-            .filter(|session| session_regex.is_match(&session.id))
-            .collect();
-
-        if matched_sessions.is_empty() {
-            println!("Regex string '{}' does not match any sessions", regex_val);
-            return Ok(());
-        }
-    } else {
-        if all_sessions.is_empty() {
-            return Err(anyhow::anyhow!("No sessions found."));
-        }
-        matched_sessions = prompt_interactive_session_removal(&all_sessions)?;
-    }
 
     if matched_sessions.is_empty() {
         return Ok(());
     }
 
-    remove_sessions(&session_manager, matched_sessions).await
+    remove_sessions(session_manager, matched_sessions, yes, terminal).await
 }
 
-/// The rows a listing sees, for a given `--subagents`.
+/// The flags that would widen a selection that found nothing, or nothing when
+/// the scope is already as wide as it goes.
+fn widen_hint(scope: SessionScope) -> &'static str {
+    match (scope.subagents, scope.include_empty) {
+        (true, _) => "",
+        (false, true) => " (--subagents also searches subagent runs)",
+        (false, false) => {
+            " (--include-empty also searches sessions with no messages, --subagents also \
+             searches subagent runs)"
+        }
+    }
+}
+
+/// The rows a listing sees, for a given [`SessionScope`].
 ///
 /// BR-71 Task 38b: `list_sessions()` filters `sub_agent` rows out in SQL, so the
 /// flag has to widen the *query* — a display-only change would show nothing new.
@@ -142,10 +298,14 @@ pub async fn handle_session_remove(
 /// defect has a regression guard:
 /// `the_subagents_flag_widens_the_query_not_just_the_rendering`.
 ///
-/// `subagents == false` is the historical behaviour byte for byte:
+/// The default scope is the historical behaviour byte for byte:
 /// `list_sessions()` IS `list_sessions_by_types(&[User, Scheduled])`.
-async fn fetch_sessions(session_manager: &SessionManager, subagents: bool) -> Result<Vec<Session>> {
-    if subagents {
+async fn fetch_sessions(
+    session_manager: &SessionManager,
+    scope: SessionScope,
+) -> Result<Vec<Session>> {
+    let subagents = scope.subagents;
+    if subagents || scope.include_empty {
         // ⚠ **A subagent that produced nothing was invisible here.** The
         // historical query INNER JOINs `messages`, so a child spawned and ended
         // before its first message is not returned by SQL at all — and this
@@ -155,9 +315,10 @@ async fn fetch_sessions(session_manager: &SessionManager, subagents: bool) -> Re
         // existed, which reads as "no subagent was spawned" rather than "the
         // subagent produced nothing".
         //
-        // Widened only on this branch: without `--subagents` the behaviour is
-        // byte for byte what it was, so the sidebar's deliberate hiding of
-        // message-less rows is untouched.
+        // `--include-empty` reaches the same query for the rows a bare
+        // `biorouter` leaves behind (QA-D F5b). Widened only on these flags:
+        // without either, the behaviour is byte for byte what it was, so the
+        // sidebar's deliberate hiding of message-less rows is untouched.
         return session_manager
             .list_sessions_by_types_including_empty(listed_session_types(subagents))
             .await;
@@ -177,7 +338,7 @@ pub async fn resolve_session_by_name(
     session_manager: &SessionManager,
     name: &str,
 ) -> Result<Option<String>> {
-    let sessions = fetch_sessions(session_manager, true).await?;
+    let sessions = fetch_sessions(session_manager, SessionScope::EVERYTHING).await?;
     Ok(sessions
         .into_iter()
         .find(|s| s.name == name || s.id == name)
@@ -189,10 +350,11 @@ pub async fn handle_session_list(
     ascending: bool,
     working_dir: Option<PathBuf>,
     limit: Option<usize>,
-    subagents: bool,
+    scope: SessionScope,
 ) -> Result<()> {
+    let subagents = scope.subagents;
     let session_manager = SessionManager::instance();
-    let mut sessions = fetch_sessions(&session_manager, subagents).await?;
+    let mut sessions = fetch_sessions(&session_manager, scope).await?;
 
     if let Some(ref pat) = working_dir {
         let pat_lower = pat.to_string_lossy().to_lowercase();
@@ -962,6 +1124,299 @@ mod tests {
     use biorouter::session::session_manager::SessionType;
     use tempfile::TempDir;
 
+    /// `session list --subagents`, which has always implied message-less rows.
+    const SUBAGENTS: SessionScope = SessionScope {
+        subagents: true,
+        include_empty: false,
+    };
+
+    /// `session list --include-empty`.
+    const INCLUDE_EMPTY: SessionScope = SessionScope {
+        subagents: false,
+        include_empty: true,
+    };
+
+    /// One row of each kind `session remove` must reach, in a throwaway store:
+    /// a chat with a message, a chat with NONE (what a bare `biorouter` that
+    /// exited before its first prompt leaves — QA-D F5b), and a subagent run
+    /// (QA-F F9). Returned as `(store, chat, empty, subagent)`.
+    async fn store_with_three_row_kinds(dir: &TempDir) -> (SessionManager, String, String, String) {
+        let sm = SessionManager::new(dir.path().to_path_buf());
+        let chat = sm
+            .create_session(
+                dir.path().to_path_buf(),
+                "Cohort review".to_string(),
+                SessionType::User,
+            )
+            .await
+            .unwrap();
+        sm.add_message(&chat.id, &Message::user().with_text("hello"))
+            .await
+            .unwrap();
+        let empty = sm
+            .create_session(
+                dir.path().to_path_buf(),
+                "CLI Session".to_string(),
+                SessionType::User,
+            )
+            .await
+            .unwrap();
+        let subagent = sm
+            .create_session(
+                dir.path().to_path_buf(),
+                "Subagent: audit the cohort".to_string(),
+                SessionType::SubAgent,
+            )
+            .await
+            .unwrap();
+        sm.add_message(&subagent.id, &Message::user().with_text("audit it"))
+            .await
+            .unwrap();
+        (sm, chat.id, empty.id, subagent.id)
+    }
+
+    async fn exists(sm: &SessionManager, id: &str) -> bool {
+        sm.get_session(id, false).await.is_ok()
+    }
+
+    /// QA-D F5b + QA-F F9: `session remove --session-id` reaches EVERY kind of
+    /// row, and `--yes` removes it with no terminal at all.
+    ///
+    /// The first block is the fixture's own control: the listing the old lookup
+    /// searched really does hide two of the three rows, so a pass below is a
+    /// statement about the new lookup rather than about a fixture that never
+    /// reproduced the defect.
+    #[tokio::test]
+    async fn remove_by_id_reaches_a_message_less_row_and_a_subagent_run() {
+        let dir = TempDir::new().unwrap();
+        let (sm, chat, empty, subagent) = store_with_three_row_kinds(&dir).await;
+
+        let old_view: Vec<String> = fetch_sessions(&sm, SessionScope::default())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(
+            old_view,
+            vec![chat.clone()],
+            "the listing the old lookup searched must hide the empty and subagent rows, or \
+             this test proves nothing"
+        );
+
+        for id in [&empty, &subagent, &chat] {
+            remove_in(
+                &sm,
+                RemoveSelector::Id(id.clone()),
+                SessionScope::default(),
+                true,
+                false,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("remove --session-id {id} --yes failed: {e:#}"));
+            assert!(!exists(&sm, id).await, "{id} is still in the store");
+        }
+    }
+
+    /// Without `--yes` and without a terminal, the refusal is the typed one
+    /// (exit 2, a sentence naming `--yes`) — and NOTHING is deleted.
+    #[tokio::test]
+    async fn without_yes_and_without_a_terminal_remove_refuses_and_deletes_nothing() {
+        let dir = TempDir::new().unwrap();
+        let (sm, chat, empty, subagent) = store_with_three_row_kinds(&dir).await;
+
+        for id in [&chat, &empty, &subagent] {
+            let err = remove_in(
+                &sm,
+                RemoveSelector::Id(id.clone()),
+                SessionScope::default(),
+                false,
+                false,
+            )
+            .await
+            .unwrap_err();
+            let refusal = err
+                .downcast_ref::<needs_terminal::NeedsTerminal>()
+                .unwrap_or_else(|| panic!("not the typed refusal: {err:#}"));
+            assert_eq!(refusal.to_string(), REMOVE_CONFIRMATION_NEEDS_A_TERMINAL);
+            assert!(REMOVE_CONFIRMATION_NEEDS_A_TERMINAL.contains("--yes"));
+            assert!(
+                exists(&sm, id).await,
+                "{id} was deleted by a refused remove"
+            );
+        }
+
+        // The picker cannot run either, and says so before listing anything.
+        let err = remove_in(
+            &sm,
+            RemoveSelector::Pick,
+            SessionScope::default(),
+            true,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<needs_terminal::NeedsTerminal>()
+                .map(ToString::to_string)
+                .as_deref(),
+            Some(REMOVE_PICKER_NEEDS_A_TERMINAL)
+        );
+    }
+
+    /// An id that names no row is "not found" — exit 1, not the terminal
+    /// refusal — even with no terminal: rows are resolved before the terminal
+    /// is consulted, so a script is told about its typo first.
+    #[tokio::test]
+    async fn an_unknown_id_is_not_found_before_the_terminal_is_consulted() {
+        let dir = TempDir::new().unwrap();
+        let (sm, ..) = store_with_three_row_kinds(&dir).await;
+
+        let err = remove_in(
+            &sm,
+            RemoveSelector::Id("20990101_1".to_string()),
+            SessionScope::default(),
+            false,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert!(err
+            .downcast_ref::<needs_terminal::NeedsTerminal>()
+            .is_none());
+        assert_eq!(err.to_string(), "Session ID '20990101_1' not found.");
+    }
+
+    /// `--regex` and the picker select from the scope, and the scope flags
+    /// widen it to the rows `session list` hides.
+    #[tokio::test]
+    async fn regex_removal_selects_from_the_scope_the_flags_describe() {
+        for (scope, expect_removed) in [
+            (SessionScope::default(), [true, false, false]),
+            (INCLUDE_EMPTY, [true, true, false]),
+            (SUBAGENTS, [true, true, true]),
+        ] {
+            let dir = TempDir::new().unwrap();
+            let (sm, chat, empty, subagent) = store_with_three_row_kinds(&dir).await;
+
+            remove_in(
+                &sm,
+                RemoveSelector::Regex(".".to_string()),
+                scope,
+                true,
+                false,
+            )
+            .await
+            .unwrap();
+
+            for (id, removed) in [&chat, &empty, &subagent].into_iter().zip(expect_removed) {
+                assert_eq!(
+                    !exists(&sm, id).await,
+                    removed,
+                    "scope {scope:?}: {id} removed={}",
+                    !exists(&sm, id).await
+                );
+            }
+        }
+    }
+
+    /// `--name` must never guess. Every session a bare `biorouter` creates is
+    /// stored as `CLI Session` and reads back as the default name, `New chat`,
+    /// so a shared name is the ordinary case — and deleting "the first match",
+    /// silently under `--yes`, would delete an arbitrary chat.
+    #[tokio::test]
+    async fn a_name_shared_by_several_sessions_is_refused_and_a_unique_one_is_removed() {
+        use biorouter::session::session_manager::DEFAULT_SESSION_NAME;
+
+        let dir = TempDir::new().unwrap();
+        let (sm, chat, empty, subagent) = store_with_three_row_kinds(&dir).await;
+        let twin = sm
+            .create_session(
+                dir.path().to_path_buf(),
+                "CLI Session".to_string(),
+                SessionType::User,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            sm.get_session(&twin.id, false).await.unwrap().name,
+            DEFAULT_SESSION_NAME,
+            "the fixture assumes a CLI-created row reads back under the default name"
+        );
+
+        let err = remove_in(
+            &sm,
+            RemoveSelector::Name(DEFAULT_SESSION_NAME.to_string()),
+            SessionScope::default(),
+            true,
+            false,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains(&empty) && err.contains(&twin.id),
+            "both candidates must be named: {err}"
+        );
+        assert!(err.contains("--session-id"), "{err}");
+        assert!(exists(&sm, &empty).await && exists(&sm, &twin.id).await);
+
+        // A name held by one row is removed — including a subagent's, which the
+        // old `list_sessions()` lookup could not see at all.
+        remove_in(
+            &sm,
+            RemoveSelector::Name("Subagent: audit the cohort".to_string()),
+            SessionScope::default(),
+            true,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(!exists(&sm, &subagent).await);
+        assert!(exists(&sm, &chat).await, "only the named row goes");
+    }
+
+    /// `session list --include-empty` shows the rows a bare `biorouter` leaves
+    /// behind, and still hides subagent runs unless `--subagents` is given.
+    #[tokio::test]
+    async fn the_include_empty_flag_widens_the_listing_to_message_less_rows() {
+        let dir = TempDir::new().unwrap();
+        let (sm, chat, empty, subagent) = store_with_three_row_kinds(&dir).await;
+
+        let mut listed: Vec<String> = fetch_sessions(&sm, INCLUDE_EMPTY)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        listed.sort();
+        let mut expected = vec![chat, empty];
+        expected.sort();
+        assert_eq!(listed, expected);
+        assert!(!listed.contains(&subagent));
+    }
+
+    #[test]
+    fn remove_flags_map_to_one_selector_in_the_historical_precedence() {
+        let s = |v: &str| Some(v.to_string());
+        assert_eq!(
+            RemoveSelector::from_flags(s("20260910_2"), s("x"), s(".")),
+            RemoveSelector::Id("20260910_2".to_string())
+        );
+        assert_eq!(
+            RemoveSelector::from_flags(None, s("x"), s(".")),
+            RemoveSelector::Name("x".to_string())
+        );
+        assert_eq!(
+            RemoveSelector::from_flags(None, None, s(".")),
+            RemoveSelector::Regex(".".to_string())
+        );
+        assert_eq!(
+            RemoveSelector::from_flags(None, None, None),
+            RemoveSelector::Pick
+        );
+    }
+
     /// Issue #56 — **the export gate is consulted, and it is consulted first.**
     ///
     /// Two assertions, and the second is the one that matters. A gate that ran
@@ -1056,7 +1511,7 @@ mod tests {
             .await
             .unwrap();
 
-        let listed: Vec<String> = fetch_sessions(&sm, true)
+        let listed: Vec<String> = fetch_sessions(&sm, SUBAGENTS)
             .await
             .unwrap()
             .into_iter()
@@ -1071,7 +1526,7 @@ mod tests {
         // …and the default listing is unchanged: it still hides message-less
         // rows, because that is what keeps "Untitled chat" placeholders out of
         // every listing the desktop builds from the same query.
-        let default: Vec<String> = fetch_sessions(&sm, false)
+        let default: Vec<String> = fetch_sessions(&sm, SessionScope::default())
             .await
             .unwrap()
             .into_iter()
@@ -1129,7 +1584,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let (sm, parent_id, child_id) = store_with_a_user_and_a_subagent_session(&dir).await;
 
-        let narrow = fetch_sessions(&sm, false).await.unwrap();
+        let narrow = fetch_sessions(&sm, SessionScope::default()).await.unwrap();
         assert!(
             narrow.iter().any(|s| s.id == parent_id),
             "the default listing still shows user sessions"
@@ -1140,7 +1595,7 @@ mod tests {
              and it lives in the SQL type filter"
         );
 
-        let wide = fetch_sessions(&sm, true).await.unwrap();
+        let wide = fetch_sessions(&sm, SUBAGENTS).await.unwrap();
         assert!(
             wide.iter().any(|s| s.id == child_id),
             "--subagents must widen the query; a rendering-only change shows nothing new"

--- a/crates/biorouter-cli/src/commands/session_watch.rs
+++ b/crates/biorouter-cli/src/commands/session_watch.rs
@@ -513,6 +513,80 @@ pub(crate) enum Render {
     JoinThenLines,
 }
 
+/// How far a streamed response is read before the caller gets it back.
+///
+/// A `bool` (`stop_on_terminal`) until `session send --no-wait` needed a third
+/// answer. With only the bool, `--no-wait` could do nothing but switch the early
+/// exit OFF — so it read until the socket closed, waited at least as long as the
+/// default, and printed strictly more (QA-D F4: 16 s, 779 lines).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Until {
+    /// Until the daemon ends the stream: `watch --follow`, `attach`.
+    Closed,
+    /// Until the turn's terminal frame (`Finish` or `Error`): `watch`, and a
+    /// `send` that waits.
+    Terminal,
+    /// Until the daemon names the turn it accepted — the `turn_id` on the
+    /// stream's opening `TurnStarted` frame — or a terminal frame, whichever
+    /// comes first: `send --no-wait`.
+    Named,
+}
+
+impl Until {
+    /// Whether the read has gone as far as asked, given what it has seen.
+    fn reached(self, seen: &Progress) -> bool {
+        match self {
+            Until::Closed => false,
+            Until::Terminal => seen.ended,
+            Until::Named => seen.ended || seen.turn_id.is_some(),
+        }
+    }
+}
+
+/// What a read has seen so far, carried across socket reads.
+#[derive(Debug, Default)]
+struct Progress {
+    /// `Render::JoinThenLines` has expanded its join snapshot — see
+    /// `stream_frame_lines`.
+    joined: bool,
+    /// The first `turn_id` any frame carried. Every frame of a `/reply` turn log
+    /// carries one; its opening `TurnStarted` is frame 0.
+    turn_id: Option<String>,
+    /// A terminal frame (`Finish` or `Error`) has been seen.
+    ended: bool,
+}
+
+/// What reading one response came to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Streamed {
+    /// The HTTP status the daemon answered with.
+    pub(crate) code: u16,
+    /// The turn the stream belongs to, from the first frame that carried a
+    /// `turn_id` — `None` when none did before the read stopped.
+    pub(crate) turn_id: Option<String>,
+    /// The read saw the turn's terminal frame.
+    pub(crate) ended: bool,
+}
+
+impl Streamed {
+    /// A response known only by its status line.
+    fn status_only(code: u16) -> Self {
+        Self {
+            code,
+            turn_id: None,
+            ended: false,
+        }
+    }
+
+    fn read(code: u16, seen: Progress) -> Self {
+        Self {
+            code,
+            turn_id: seen.turn_id,
+            ended: seen.ended,
+        }
+    }
+}
+
 /// The numeric status from an HTTP status line ("HTTP/1.1 202 Accepted" → 202).
 fn status_code(status_line: &str) -> Option<u16> {
     status_line.split_whitespace().nth(1)?.parse().ok()
@@ -520,10 +594,10 @@ fn status_code(status_line: &str) -> Option<u16> {
 
 /// Stream `request` from the daemon and return the status it answered with.
 ///
-/// On a 200 the body is consumed — rendering per `render` — until the stream
-/// ends, a terminal frame arrives (when `stop_on_terminal`), or the future is
-/// dropped. On any other status it returns at once, so a caller can branch on a
-/// 409 without reading a body it does not want.
+/// On a 200 the body is consumed — rendering per `render` — until `until` is
+/// reached, the stream ends, or the future is dropped. On any other status it
+/// returns at once, so a caller can branch on a 409 without reading a body it
+/// does not want.
 ///
 /// ⚠ Consuming a 200 `/reply` body to its terminal frame is not politeness.
 /// `stream_event` trips the turn's `CancellationToken` the moment its
@@ -536,47 +610,52 @@ fn status_code(status_line: &str) -> Option<u16> {
 /// far too late.
 async fn stream_request(
     request: String,
-    stop_on_terminal: bool,
+    until: Until,
     render: Render,
     status: Option<tokio::sync::oneshot::Sender<u16>>,
-) -> Result<u16> {
-    stream_request_bytes(request.as_bytes(), stop_on_terminal, render, status).await
+) -> Result<Streamed> {
+    stream_request_bytes(request.as_bytes(), until, render, status).await
 }
 
-async fn stream_request_bytes(
-    request: &[u8],
-    stop_on_terminal: bool,
-    render: Render,
-    status: Option<tokio::sync::oneshot::Sender<u16>>,
-) -> Result<u16> {
+/// A connection to the configured daemon, or the actionable "no daemon" error.
+async fn connect_to_daemon() -> Result<tokio::net::TcpStream> {
     let port = configured_port();
     if !daemon_ok(DAEMON_HOST, port).await {
         return Err(anyhow!("{}", no_daemon_at(port)));
     }
-    let mut stream = tokio::net::TcpStream::connect(format!("{DAEMON_HOST}:{port}")).await?;
+    Ok(tokio::net::TcpStream::connect(format!("{DAEMON_HOST}:{port}")).await?)
+}
+
+async fn stream_request_bytes(
+    request: &[u8],
+    until: Until,
+    render: Render,
+    status: Option<tokio::sync::oneshot::Sender<u16>>,
+) -> Result<Streamed> {
+    let mut stream = connect_to_daemon().await?;
     stream.write_all(request).await?;
-    read_response(&mut stream, stop_on_terminal, render, status).await
+    read_response(&mut stream, until, render, status).await
 }
 
 /// Read one HTTP response off `stream` and return the status it carried.
 ///
 /// Generic over the stream so the rules below — a non-200 answered from the
-/// status line alone, a 200 consumed to its terminal frame, and a response that
-/// never completes reported as an ERROR — can be pinned over an in-memory pipe
-/// rather than only against a live daemon.
+/// status line alone, a 200 consumed as far as `until` asks, and a response
+/// that never completes reported as an ERROR — can be pinned over an in-memory
+/// pipe rather than only against a live daemon.
 async fn read_response<S: tokio::io::AsyncRead + Unpin>(
     stream: &mut S,
-    stop_on_terminal: bool,
+    until: Until,
     render: Render,
     status: Option<tokio::sync::oneshot::Sender<u16>>,
-) -> Result<u16> {
+) -> Result<Streamed> {
     let mut status = status;
     let mut raw = Vec::new();
     // Body bytes not yet decodable as whole characters — see `take_complete_utf8`.
     let mut pending: Vec<u8> = Vec::new();
     let mut buffer = String::new();
     let mut headers_done = false;
-    let mut joined = false;
+    let mut seen = Progress::default();
     let mut chunk = [0u8; 8192];
     loop {
         let read = stream.read(&mut chunk).await?;
@@ -605,20 +684,20 @@ async fn read_response<S: tokio::io::AsyncRead + Unpin>(
                 let _ = tx.send(code);
             }
             if code != 200 {
-                return Ok(code);
+                return Ok(Streamed::status_only(code));
             }
             headers_done = true;
             buffer.clear();
             pending.clear();
             let frames = absorb(&mut pending, &mut buffer, &raw[end + 4..]);
-            if print_frames(&frames, stop_on_terminal, render, &mut joined) {
-                return Ok(code);
+            if print_frames(&frames, until, render, &mut seen) {
+                return Ok(Streamed::read(code, seen));
             }
             continue;
         }
         let frames = absorb(&mut pending, &mut buffer, &chunk[..read]);
-        if print_frames(&frames, stop_on_terminal, render, &mut joined) {
-            return Ok(200);
+        if print_frames(&frames, until, render, &mut seen) {
+            return Ok(Streamed::read(200, seen));
         }
     }
     // ⚠ Reaching here without headers means the socket closed part-way through
@@ -633,12 +712,12 @@ async fn read_response<S: tokio::io::AsyncRead + Unpin>(
              so it is not known whether the request was accepted"
         ));
     }
-    Ok(200)
+    Ok(Streamed::read(200, seen))
 }
 
 /// `stream_request` for the callers that treat any non-200 as fatal.
-async fn stream_frames(request: String, stop_on_terminal: bool, render: Render) -> Result<()> {
-    match stream_request(request, stop_on_terminal, render, None).await? {
+async fn stream_frames(request: String, until: Until, render: Render) -> Result<()> {
+    match stream_request(request, until, render, None).await?.code {
         200 => Ok(()),
         code => Err(anyhow!(
             "daemon refused the request: HTTP {code}\n\
@@ -671,28 +750,36 @@ fn stream_frame_lines(frame: &serde_json::Value, render: Render, joined: &mut bo
     }
 }
 
-/// Returns true when a terminal frame was seen and the caller should stop.
+/// Print `frames`, noting in `seen` what they carried, and return true once the
+/// read has gone as far as `until` asks — at which point the rest of the batch
+/// is left unprinted, so `--no-wait` stops at the frame that named its turn
+/// rather than wherever a TCP read happened to end. (Nothing follows a terminal
+/// frame in a turn's log, so for the other two modes this changes nothing.)
 fn print_frames(
     frames: &[serde_json::Value],
-    stop_on_terminal: bool,
+    until: Until,
     render: Render,
-    joined: &mut bool,
+    seen: &mut Progress,
 ) -> bool {
-    let mut done = false;
     for frame in frames {
-        for line in stream_frame_lines(frame, render, joined) {
+        for line in stream_frame_lines(frame, render, &mut seen.joined) {
             println!("{line}");
         }
-        if stop_on_terminal
-            && matches!(
-                frame.get("type").and_then(serde_json::Value::as_str),
-                Some("Finish") | Some("Error")
-            )
-        {
-            done = true;
+        if seen.turn_id.is_none() {
+            seen.turn_id = frame
+                .get("turn_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+        }
+        seen.ended |= matches!(
+            frame.get("type").and_then(serde_json::Value::as_str),
+            Some("Finish") | Some("Error")
+        );
+        if until.reached(seen) {
+            return true;
         }
     }
-    done
+    false
 }
 
 /// The sessions holding a turn right now, read from the daemon (BR-71 Task 38b).
@@ -842,7 +929,11 @@ pub async fn handle_session_watch(session_id: &str, follow: bool) -> Result<()> 
             DAEMON_HOST,
             &auth,
         ),
-        !follow,
+        if follow {
+            Until::Closed
+        } else {
+            Until::Terminal
+        },
         Render::Lines,
     )
     .await
@@ -867,8 +958,93 @@ fn reply_body(session_id: &str, text: &str) -> String {
     .to_string()
 }
 
+/// How long `send --no-wait` waits for the daemon's answer and for the frame
+/// that names the turn.
+///
+/// The name is not slow to arrive: `run_turn_body` publishes `TurnStarted` as
+/// its first act, before the agent is even looked up, so on a healthy daemon it
+/// follows the status line within milliseconds. This bounds only a daemon that
+/// is not healthy, so a flag whose whole point is not blocking cannot block.
+const NO_WAIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// What `session send` came to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SendOutcome {
+    /// The turn's stream was read to its end (the default) — or, under
+    /// `--no-wait`, ended before it named a turn. Its frames are printed.
+    Streamed,
+    /// `--no-wait`: the daemon accepted the turn, which is running without
+    /// this client. `turn_id` is its name, when the daemon had given one by the
+    /// time this returned.
+    Accepted { turn_id: Option<String> },
+    /// 202: the session is a subagent still starting, and the message was kept
+    /// as steering for its first turn (`routes/reply.rs`).
+    Queued,
+}
+
+/// Send one `POST /reply` over `stream` and read the answer as far as `wait`
+/// asks. Generic over the stream so both modes are driven over an in-memory
+/// pipe in tests, through the same function `handle_session_send` calls.
+///
+/// ⚠ **Leaving early does not cancel the turn.** Since the live-turn-stream work
+/// a `/reply` connection is "simply the turn's FIRST observer" and "its
+/// departure means nothing to it" (`routes/reply.rs`), whatever older comments
+/// in this file say about dropping a `/reply` socket. What does end an
+/// unobserved turn is the daemon's orphan reaper, after five minutes with no
+/// `/reply` stream attached — which is why `--no-wait` says so.
+async fn send_turn<S>(
+    stream: &mut S,
+    request: &[u8],
+    wait: bool,
+    deadline: std::time::Duration,
+) -> Result<SendOutcome>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    stream.write_all(request).await?;
+    let streamed = if wait {
+        read_response(stream, Until::Terminal, Render::Lines, None).await?
+    } else {
+        let (status_tx, mut status_rx) = tokio::sync::oneshot::channel();
+        let named = read_response(stream, Until::Named, Render::Lines, Some(status_tx));
+        match tokio::time::timeout(deadline, named).await {
+            Ok(read) => read?,
+            // Out of time. A status line already read IS the acceptance: the turn
+            // lock is taken and the turn spawned before `/reply` answers. With no
+            // status at all the answer is unknown, and "started" would be a guess.
+            Err(_) => match status_rx.try_recv() {
+                Ok(code) => Streamed::status_only(code),
+                Err(_) => {
+                    return Err(anyhow!(
+                        "the daemon did not answer within {deadline:?}, so it is not known \
+                         whether the turn started"
+                    ))
+                }
+            },
+        }
+    };
+    match streamed.code {
+        200 if wait || streamed.ended => Ok(SendOutcome::Streamed),
+        200 => Ok(SendOutcome::Accepted {
+            turn_id: streamed.turn_id,
+        }),
+        202 => Ok(SendOutcome::Queued),
+        code => Err(anyhow!(
+            "daemon refused the request: HTTP {code}\n\
+             (401 usually means BIOROUTER_SERVER__SECRET_KEY does not match the daemon's; \
+              403 means the user-action key does not match the daemon's configured digest)"
+        )),
+    }
+}
+
 /// `biorouter sessions send <id> <text>` — inject a turn and, unless
 /// `--no-wait`, watch it to completion.
+///
+/// ⚠ `--no-wait` used to be passed down as `stop_on_terminal = false`, which
+/// switched OFF the one early exit there was: the flag documented as "return as
+/// soon as the turn starts" read until the socket closed, i.e. waited at least
+/// as long as the default and printed strictly more (QA-D F4). It now returns
+/// at the frame in which the daemon names the turn, and says what it started.
 pub async fn handle_session_send(
     session_id: &str,
     text: &str,
@@ -883,14 +1059,27 @@ pub async fn handle_session_send(
         &reply_body(session_id, text),
     )?;
     // `/reply` streams the turn back, so a send that waits is one request.
-    match stream_request_bytes(request.as_bytes(), wait, Render::Lines, None).await? {
-        200 => Ok(()),
-        code => Err(anyhow!(
-            "daemon refused the request: HTTP {code}\n\
-             (401 usually means BIOROUTER_SERVER__SECRET_KEY does not match the daemon's; \
-              403 means the user-action key does not match the daemon's configured digest)"
-        )),
+    let mut stream = connect_to_daemon().await?;
+    match send_turn(&mut stream, request.as_bytes(), wait, NO_WAIT_DEADLINE).await? {
+        SendOutcome::Streamed => {}
+        SendOutcome::Accepted { turn_id } => {
+            match turn_id {
+                Some(turn_id) => println!("[started] turn {turn_id} in session {session_id}"),
+                None => println!("[started] a turn in session {session_id}"),
+            }
+            eprintln!(
+                "It runs on in the daemon: `biorouter session watch {session_id}` follows it and \
+                 `biorouter session cancel {session_id}` stops it. The daemon stops a turn once \
+                 nothing has been attached to its reply stream for five minutes (`session watch` \
+                 does not count), so --no-wait suits turns shorter than that."
+            );
+        }
+        SendOutcome::Queued => println!(
+            "[queued] session {session_id} is a subagent that is still starting; the message \
+             will be part of its first turn"
+        ),
     }
+    Ok(())
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1141,8 +1330,13 @@ async fn post_reply_quiet(
     // silently kills one.
     window.open();
     let holder = tokio::spawn(async move {
-        let outcome =
-            stream_request_bytes(request.as_bytes(), true, Render::Silent, Some(status_tx)).await;
+        let outcome = stream_request_bytes(
+            request.as_bytes(),
+            Until::Terminal,
+            Render::Silent,
+            Some(status_tx),
+        )
+        .await;
         window.close();
         outcome
     });
@@ -1176,8 +1370,9 @@ async fn post_reply_quiet(
         // read, so the request failed outright. The holder carries the reason.
         Err(_) => match holder.await {
             Ok(Err(err)) => Err(err),
-            Ok(Ok(code)) => Err(anyhow!(
-                "the daemon answered POST /reply with HTTP {code} but never reported it"
+            Ok(Ok(streamed)) => Err(anyhow!(
+                "the daemon answered POST /reply with HTTP {} but never reported it",
+                streamed.code
             )),
             Err(join) => Err(anyhow!("the /reply request could not be run: {join}")),
         },
@@ -1494,7 +1689,7 @@ pub async fn handle_session_attach(
     };
     let observer = stream_request_bytes(
         observer_request.as_bytes(),
-        false,
+        Until::Closed,
         Render::JoinThenLines,
         None,
     );
@@ -1506,7 +1701,7 @@ pub async fn handle_session_attach(
     loop {
         tokio::select! {
             observed = &mut observer => {
-                match observed? {
+                match observed?.code {
                     200 => {
                         eprintln!("the session's event stream ended");
                         return Ok(());
@@ -2166,13 +2361,15 @@ mod tests {
 
     /// Reading a response off an in-memory pipe, so the status/termination rules
     /// below are pinned without a daemon, a port or a race.
-    async fn read_from(script: &'static [u8], stop_on_terminal: bool) -> Result<u16> {
+    async fn read_from(script: &'static [u8], until: Until) -> Result<u16> {
         let (mut client, mut daemon) = tokio::io::duplex(4096);
         tokio::spawn(async move {
             let _ = daemon.write_all(script).await;
             // and the connection closes here.
         });
-        read_response(&mut client, stop_on_terminal, Render::Silent, None).await
+        read_response(&mut client, until, Render::Silent, None)
+            .await
+            .map(|streamed| streamed.code)
     }
 
     /// A response whose headers never arrive is NOT a 200.
@@ -2184,7 +2381,7 @@ mod tests {
     /// inherits the same lie as a silent clean exit.
     #[tokio::test]
     async fn a_response_that_dies_before_its_headers_is_an_error_not_a_200() {
-        let err = read_from(b"HTTP/1.1 200 OK\r\nContent-Type: text/ev", true)
+        let err = read_from(b"HTTP/1.1 200 OK\r\nContent-Type: text/ev", Until::Terminal)
             .await
             .unwrap_err()
             .to_string();
@@ -2194,7 +2391,10 @@ mod tests {
         );
 
         // Nothing at all on the wire is the same failure.
-        let empty = read_from(b"", true).await.unwrap_err().to_string();
+        let empty = read_from(b"", Until::Terminal)
+            .await
+            .unwrap_err()
+            .to_string();
         assert!(empty.contains("closed the connection"), "{empty}");
     }
 
@@ -2208,7 +2408,7 @@ mod tests {
                 b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n\
                   data: {\"type\":\"Ping\"}\n\n\
                   data: {\"type\":\"Finish\",\"reason\":\"stop\"}\n\n",
-                true,
+                Until::Terminal,
             )
             .await
             .unwrap(),
@@ -2219,7 +2419,7 @@ mod tests {
             read_from(
                 b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n\
                   data: {\"type\":\"Ping\"}\n\n",
-                false,
+                Until::Closed,
             )
             .await
             .unwrap(),
@@ -2242,11 +2442,17 @@ mod tests {
         let (status_tx, status_rx) = tokio::sync::oneshot::channel();
         let code = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            read_response(&mut client, true, Render::Silent, Some(status_tx)),
+            read_response(
+                &mut client,
+                Until::Terminal,
+                Render::Silent,
+                Some(status_tx),
+            ),
         )
         .await
         .expect("a 409 must not block on the socket closing")
-        .unwrap();
+        .unwrap()
+        .code;
         assert_eq!(code, 409);
         // The refusal reaches the status channel too. `post_reply_quiet` waits
         // on that channel, so a 409 that only came back as a return value would
@@ -2337,7 +2543,13 @@ mod tests {
         let (mut client, mut daemon) = tokio::io::duplex(4096);
         let (status_tx, status_rx) = tokio::sync::oneshot::channel();
         let holder = tokio::spawn(async move {
-            read_response(&mut client, true, Render::Silent, Some(status_tx)).await
+            read_response(
+                &mut client,
+                Until::Terminal,
+                Render::Silent,
+                Some(status_tx),
+            )
+            .await
         });
 
         daemon
@@ -2359,7 +2571,184 @@ mod tests {
             .write_all(b"data: {\"type\":\"Finish\",\"reason\":\"stop\"}\n\n")
             .await
             .unwrap();
-        assert_eq!(holder.await.unwrap().unwrap(), 200);
+        assert_eq!(holder.await.unwrap().unwrap().code, 200);
+    }
+
+    /// The opening of a real `/reply` turn log, as `attach_response` writes it:
+    /// headers, then `TurnStarted` as frame 0 carrying the server's turn id,
+    /// then the turn's own frames — every logged frame carries `seq` and
+    /// `turn_id`.
+    const TURN_OPENING: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n\
+        data: {\"type\":\"TurnStarted\",\"turn_id\":\"turn-7\",\"seq\":0}\n\n\
+        data: {\"type\":\"Message\",\"seq\":1,\"turn_id\":\"turn-7\",\"message\":{\"role\":\
+        \"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Seven is\"}]}}\n\n";
+
+    const TURN_FINISH: &[u8] =
+        b"data: {\"type\":\"Finish\",\"reason\":\"stop\",\"seq\":2,\"turn_id\":\"turn-7\"}\n\n";
+
+    /// A `session send` over an in-memory pipe, through `send_turn` — the same
+    /// function `handle_session_send` calls. The daemon half is handed back
+    /// OPEN, so a send that returns has returned on its own terms and not
+    /// because the connection closed under it.
+    fn send_over_pipe(
+        wait: bool,
+        deadline: std::time::Duration,
+    ) -> (
+        tokio::task::JoinHandle<Result<SendOutcome>>,
+        tokio::io::DuplexStream,
+    ) {
+        let (mut client, daemon) = tokio::io::duplex(64 * 1024);
+        let send = tokio::spawn(async move {
+            send_turn(&mut client, b"POST /reply HTTP/1.1\r\n\r\n", wait, deadline).await
+        });
+        (send, daemon)
+    }
+
+    /// QA-D F4: `--no-wait` returns as soon as the daemon has accepted the turn
+    /// and named it — while the turn is still streaming, with the connection
+    /// still open — and reports the turn's id.
+    ///
+    /// The regression this pins: `--no-wait` was passed down as "do not stop at
+    /// the terminal frame", so it read until the socket closed. Against this
+    /// pipe, which never closes and never sends a terminal frame, that version
+    /// hangs and the timeout below fails the test.
+    #[tokio::test]
+    async fn no_wait_returns_at_the_frame_that_names_the_turn() {
+        let (send, mut daemon) = send_over_pipe(false, std::time::Duration::from_secs(30));
+
+        let mut request = vec![0u8; 64];
+        let read = daemon.read(&mut request).await.unwrap();
+        assert!(
+            request[..read].starts_with(b"POST /reply"),
+            "the request went out"
+        );
+        daemon.write_all(TURN_OPENING).await.unwrap();
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), send)
+            .await
+            .expect("--no-wait must return without waiting for the turn to finish")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            outcome,
+            SendOutcome::Accepted {
+                turn_id: Some("turn-7".to_string())
+            }
+        );
+        // Held open until here: the turn was still streaming when the client
+        // left, so nothing but the name can have ended the read.
+        drop(daemon);
+    }
+
+    /// The default still waits: the same opening leaves it streaming, and only
+    /// the terminal frame lets it return.
+    #[tokio::test]
+    async fn the_default_send_waits_for_the_terminal_frame() {
+        let (send, mut daemon) = send_over_pipe(true, std::time::Duration::from_secs(30));
+
+        let mut request = vec![0u8; 64];
+        let _ = daemon.read(&mut request).await.unwrap();
+        daemon.write_all(TURN_OPENING).await.unwrap();
+
+        // Only ever a false PASS on a very slow machine, never a false failure:
+        // a send that wrongly returned at the name is done within this window.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(
+            !send.is_finished(),
+            "the default must keep streaming until the turn ends"
+        );
+
+        daemon.write_all(TURN_FINISH).await.unwrap();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), send)
+            .await
+            .expect("the terminal frame must end the default send")
+            .unwrap()
+            .unwrap();
+        assert_eq!(outcome, SendOutcome::Streamed);
+    }
+
+    /// A daemon that accepted the turn but never names it still cannot hold
+    /// `--no-wait`: the status line is the acceptance, so it returns at the
+    /// deadline as a turn started without a known id.
+    #[tokio::test]
+    async fn no_wait_is_bounded_when_the_daemon_never_names_the_turn() {
+        let (send, mut daemon) = send_over_pipe(false, std::time::Duration::from_millis(300));
+        let mut request = vec![0u8; 64];
+        let _ = daemon.read(&mut request).await.unwrap();
+        daemon
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n")
+            .await
+            .unwrap();
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), send)
+            .await
+            .expect("the deadline must bound --no-wait")
+            .unwrap()
+            .unwrap();
+        assert_eq!(outcome, SendOutcome::Accepted { turn_id: None });
+        drop(daemon);
+    }
+
+    /// …but a daemon that has not answered at all is NOT reported as started:
+    /// with no status line nothing is known, and "started" would be a guess.
+    #[tokio::test]
+    async fn no_wait_with_no_answer_at_all_is_an_error_not_a_start() {
+        let (send, daemon) = send_over_pipe(false, std::time::Duration::from_millis(300));
+        let err = tokio::time::timeout(std::time::Duration::from_secs(5), send)
+            .await
+            .expect("the deadline must bound --no-wait")
+            .unwrap()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not known whether the turn started"), "{err}");
+        drop(daemon);
+    }
+
+    /// The other answers `/reply` gives, in both modes: a 409 is still a
+    /// refusal, and a 202 — a subagent still starting kept the message as
+    /// steering for its first turn — is a delivery, not a refusal.
+    #[tokio::test]
+    async fn a_202_is_a_queued_delivery_and_a_409_is_still_a_refusal() {
+        for wait in [true, false] {
+            let (send, mut daemon) = send_over_pipe(wait, std::time::Duration::from_secs(30));
+            let mut request = vec![0u8; 64];
+            let _ = daemon.read(&mut request).await.unwrap();
+            daemon
+                .write_all(b"HTTP/1.1 202 Accepted\r\ncontent-length: 0\r\n\r\n")
+                .await
+                .unwrap();
+            assert_eq!(
+                send.await.unwrap().unwrap(),
+                SendOutcome::Queued,
+                "wait={wait}"
+            );
+
+            let (send, mut daemon) = send_over_pipe(wait, std::time::Duration::from_secs(30));
+            let _ = daemon.read(&mut request).await.unwrap();
+            daemon
+                .write_all(b"HTTP/1.1 409 Conflict\r\n\r\n{}")
+                .await
+                .unwrap();
+            let err = send.await.unwrap().unwrap_err().to_string();
+            assert!(err.contains("HTTP 409"), "wait={wait}: {err}");
+        }
+    }
+
+    /// A stream that ends in an error before it names any turn is not reported
+    /// as a turn that started: the error frame is what the user sees.
+    #[tokio::test]
+    async fn no_wait_does_not_announce_a_turn_the_stream_ended_before_naming() {
+        let (send, mut daemon) = send_over_pipe(false, std::time::Duration::from_secs(30));
+        let mut request = vec![0u8; 64];
+        let _ = daemon.read(&mut request).await.unwrap();
+        daemon
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n\
+                  data: {\"type\":\"Error\",\"code\":\"turn_not_found\",\"error\":\"gone\"}\n\n",
+            )
+            .await
+            .unwrap();
+        assert_eq!(send.await.unwrap().unwrap(), SendOutcome::Streamed);
     }
 
     #[test]

--- a/crates/biorouter-cli/src/commands/skill.rs
+++ b/crates/biorouter-cli/src/commands/skill.rs
@@ -100,14 +100,7 @@ pub async fn handle_install(source: String, force: bool, choice: Option<String>)
     };
 
     let root = skills_root();
-    for plan in &plans {
-        if !force && plan.destination(&root).exists() {
-            bail!(
-                "Already installed at {}. Re-run with --force to replace it.",
-                plan.destination(&root).display()
-            );
-        }
-    }
+    refuse_before_installing(&plans, &root, force)?;
 
     for plan in &plans {
         let installed = skill_package::install(plan, &root)?;
@@ -154,6 +147,39 @@ pub async fn handle_install(source: String, force: bool, choice: Option<String>)
                     style(installed.directory.display()).dim()
                 );
             }
+        }
+    }
+    Ok(())
+}
+
+/// Every refusal an install can know about before it writes anything, for
+/// every plan, so a multi-plan install stops before its first write rather
+/// than halfway through.
+///
+/// ⚠ **The shipped-name refusal comes FIRST, from the installer's own guard.**
+/// This used to check only "already exists", and answered a shipped name with
+/// "Re-run with --force to replace it" — advertising an escape hatch that
+/// `skill_package::install` then refuses (`refuse_shipped`), so following the
+/// advice earned a second refusal (QA-D F10). A shipped name is refused
+/// whatever `--force` says, so the advice must never be offered for one. The
+/// verdict comes from `shipped_refusal`, the same predicate `install` applies,
+/// rather than a copy of the rule here that could drift from it.
+fn refuse_before_installing(
+    plans: &[biorouter::agents::skill_package::ImportPlan],
+    root: &Path,
+    force: bool,
+) -> Result<()> {
+    for plan in plans {
+        if let Some(refusal) =
+            biorouter::agents::skill_package::install::shipped_refusal(plan, root)
+        {
+            bail!(refusal);
+        }
+        if !force && plan.destination(root).exists() {
+            bail!(
+                "Already installed at {}. Re-run with --force to replace it.",
+                plan.destination(root).display()
+            );
         }
     }
     Ok(())
@@ -1439,5 +1465,84 @@ mod tests {
         let set = disabled_set(&config);
         assert!(set.contains("a") && set.contains("b"));
         assert_eq!(disabled_set(&json!({})), HashSet::new());
+    }
+
+    fn plan_named(id: &str) -> biorouter::agents::skill_package::ImportPlan {
+        use biorouter::agents::skill_package::{Evidence, ImportKind, ImportPlan, PlannedSkill};
+        ImportPlan {
+            kind: ImportKind::Single,
+            id: id.to_string(),
+            display_name: id.to_string(),
+            version: None,
+            entry_point: None,
+            groups: Default::default(),
+            components: vec![PlannedSkill {
+                name: id.to_string(),
+                description: "a package that shadows a name".to_string(),
+                directory: id.to_string(),
+                group: None,
+                entry_point: false,
+            }],
+            evidence: Evidence::SingleSkill,
+            ambiguity: None,
+            source: Default::default(),
+            origin: None,
+            shadows: Vec::new(),
+            files: vec![("SKILL.md".to_string(), b"---\nname: x\n---\n".to_vec())],
+        }
+    }
+
+    /// QA-D F10: over a SHIPPED name the pre-install check must never
+    /// recommend `--force` — the installer refuses a shipped name whatever
+    /// `--force` says — and must answer with the installer's own refusal,
+    /// with or without the flag, before anything is written.
+    ///
+    /// Under the process-wide environment lock with the root pinned to a temp
+    /// tree, like every test here that resolves `Paths`: the installer's guard
+    /// reads the seeded root from `Paths`, and an unpinned read could land on
+    /// the developer's real skills directory or race a test that moved it.
+    #[test]
+    fn a_shipped_name_is_never_answered_with_force_advice() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([(
+            "BIOROUTER_PATH_ROOT",
+            Some(tmp.path().to_str().unwrap().to_string()),
+        )]);
+        let root = skills_root();
+        assert!(
+            root.starts_with(tmp.path()),
+            "the fixture resolved to {} — refusing to write there",
+            root.display()
+        );
+        let shipped = "about-biorouter";
+        assert!(
+            biorouter::agents::skills_extension::is_shipped_entry_name(shipped),
+            "the fixture must use a name Biorouter really ships, or this proves nothing"
+        );
+
+        // The state the QA run met: the seeded copy is on disk, so the old
+        // "exists → re-run with --force" branch was reachable.
+        fs::create_dir_all(root.join(shipped)).unwrap();
+        for force in [false, true] {
+            let err = refuse_before_installing(&[plan_named(shipped)], &root, force)
+                .unwrap_err()
+                .to_string();
+            assert!(!err.contains("--force"), "force={force}: {err}");
+            assert!(err.contains("ships with Biorouter"), "force={force}: {err}");
+        }
+
+        // The positive controls: an ordinary name that exists still gets the
+        // advice, and `--force` still lets it through.
+        fs::create_dir_all(root.join("my-own-skill")).unwrap();
+        let err = refuse_before_installing(&[plan_named("my-own-skill")], &root, false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Re-run with --force"), "{err}");
+        refuse_before_installing(&[plan_named("my-own-skill")], &root, true).unwrap();
+
+        // …and the shipped refusal belongs to Biorouter's own root only: the
+        // same name under another root is somebody else's to install over.
+        let elsewhere = tmp.path().join("elsewhere");
+        refuse_before_installing(&[plan_named(shipped)], &elsewhere, false).unwrap();
     }
 }

--- a/crates/biorouter-cli/src/main.rs
+++ b/crates/biorouter-cli/src/main.rs
@@ -1,5 +1,6 @@
 use biorouter::agents::turn_abort::{exit as abort_exit, TurnFailed};
 use biorouter_cli::cli::cli;
+use biorouter_cli::commands::needs_terminal::{self, NeedsTerminal};
 use std::process::ExitCode;
 
 // Tuned jemalloc as the global allocator (default-on `jemalloc` feature). The
@@ -61,6 +62,14 @@ async fn async_main() -> ExitCode {
     match cli().await {
         Ok(()) => ExitCode::from(abort_exit::OK),
         Err(e) => {
+            // A command that needs a person at a terminal and was run without
+            // one declined to start; nothing failed. Its sentence says what to
+            // run instead, so it is printed alone, and it exits 2 — the usage
+            // error status — rather than the generic 1 (QA-D F9).
+            if let Some(refusal) = e.downcast_ref::<NeedsTerminal>() {
+                eprintln!("{refusal}");
+                return ExitCode::from(needs_terminal::EXIT_CODE);
+            }
             eprintln!("Error: {e:?}");
             // A turn that ran but did not complete its work gets its own exit
             // code, so a caller can tell "the provider rejected our key" (75)

--- a/crates/biorouter-cli/tests/non_interactive.rs
+++ b/crates/biorouter-cli/tests/non_interactive.rs
@@ -1,0 +1,248 @@
+//! The real `biorouter` binary, run the way a script runs it: stdin, stdout and
+//! stderr all pipes, against a throwaway `BIOROUTER_PATH_ROOT` (QA-D F5a / F9,
+//! QA-F F9).
+//!
+//! The unit tests beside each command pin the decisions; this pins what only a
+//! separate process can show — the exit status `main` maps the refusal to, that
+//! the sentence (and not cliclack's `Error: not connected`) reaches stderr, and
+//! that the files on disk are untouched afterwards.
+//!
+//! ⚠ Every child gets its own `HOME`, `XDG_CONFIG_HOME` and
+//! `BIOROUTER_PATH_ROOT`, so nothing here can reach the developer's real
+//! configuration or session store, whatever the parent process was started with.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use biorouter::conversation::message::Message;
+use biorouter::session::session_manager::SessionType;
+use biorouter::session::SessionManager;
+
+struct Sandbox {
+    _dir: tempfile::TempDir,
+    home: PathBuf,
+    root: PathBuf,
+}
+
+impl Sandbox {
+    fn new() -> Self {
+        let dir = tempfile::TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        let root = dir.path().join("root");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(root.join("config")).unwrap();
+        std::fs::create_dir_all(root.join("data")).unwrap();
+        Self {
+            _dir: dir,
+            home,
+            root,
+        }
+    }
+
+    fn config_yaml(&self) -> PathBuf {
+        self.root.join("config").join("config.yaml")
+    }
+
+    /// Run `biorouter <args>` with every stream a pipe, `stdin` written and
+    /// closed — `echo … | biorouter …`.
+    fn run(&self, args: &[&str], stdin: &str) -> Output {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_biorouter"))
+            .args(args)
+            .env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", self.home.join(".config"))
+            .env("BIOROUTER_PATH_ROOT", &self.root)
+            .env("BIOROUTER_DISABLE_KEYRING", "true")
+            .env_remove("BIOROUTER_PROVIDER")
+            .env_remove("BIOROUTER_MODEL")
+            .env_remove("BIOROUTER_SERVER__SECRET_KEY")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn the biorouter binary");
+        // Best effort: a command that refuses before reading may already have
+        // exited and closed its end, and that is exactly the case under test.
+        let _ = child.stdin.take().unwrap().write_all(stdin.as_bytes());
+        child.wait_with_output().unwrap()
+    }
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// Every file under `dir` with its bytes, sorted by path.
+fn snapshot(dir: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut files = Vec::new();
+    let mut pending = vec![dir.to_path_buf()];
+    while let Some(next) = pending.pop() {
+        for entry in std::fs::read_dir(&next).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                pending.push(path);
+            } else {
+                let bytes = std::fs::read(&path).unwrap();
+                files.push((path.strip_prefix(dir).unwrap().to_path_buf(), bytes));
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+/// `echo | biorouter configure` exits 2 with the sentence, and the whole
+/// configuration directory is byte-identical afterwards.
+///
+/// The sandbox is started once first. Every `biorouter` process — `--version`
+/// included — runs the privacy master switch's one-time migration at start-up,
+/// which writes `privacy-tiers.json` beside a config that lacks one; a real
+/// install already has it. Snapshotting after that start makes the comparison
+/// about what `configure` does, not about what start-up does once per install.
+#[test]
+fn configure_under_a_pipe_exits_2_with_guidance_and_leaves_config_byte_identical() {
+    let sandbox = Sandbox::new();
+    let original = b"# hand-edited\nBIOROUTER_PROVIDER:   versa_azure\nBIOROUTER_MODEL: gpt-5.5\n";
+    std::fs::write(sandbox.config_yaml(), original).unwrap();
+    let warm = sandbox.run(&["--version"], "");
+    assert_eq!(warm.status.code(), Some(0), "{}", text(&warm.stderr));
+    let before = snapshot(&sandbox.root.join("config"));
+    assert!(
+        before
+            .iter()
+            .any(|(path, _)| path == Path::new("config.yaml")),
+        "{before:?}"
+    );
+
+    let out = sandbox.run(&["configure"], "\n");
+    let stderr = text(&out.stderr);
+
+    assert_eq!(out.status.code(), Some(2), "stderr: {stderr}");
+    assert!(
+        stderr.contains("`biorouter configure` is interactive and needs a terminal"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("biorouter models set --provider"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("not connected"), "{stderr}");
+    assert_eq!(std::fs::read(sandbox.config_yaml()).unwrap(), original);
+    assert_eq!(
+        snapshot(&sandbox.root.join("config")),
+        before,
+        "a refused configure changed the configuration directory"
+    );
+}
+
+/// Both project commands refuse under a pipe with the same exit status.
+#[test]
+fn project_and_projects_under_a_pipe_exit_2_with_guidance() {
+    let sandbox = Sandbox::new();
+    let project_dir = sandbox.home.display().to_string();
+    std::fs::write(
+        sandbox.root.join("data").join("projects.json"),
+        serde_json::json!({
+            "projects": {
+                project_dir.clone(): {
+                    "path": project_dir,
+                    "last_accessed": "2026-09-10T12:00:00Z",
+                    "last_instruction": null,
+                    "last_session_id": null
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    for command in ["project", "projects"] {
+        let out = sandbox.run(&[command], "\n");
+        let stderr = text(&out.stderr);
+        assert_eq!(out.status.code(), Some(2), "{command}: {stderr}");
+        assert!(
+            stderr.contains(&format!("`biorouter {command}` is interactive")),
+            "{command}: {stderr}"
+        );
+        assert!(!stderr.contains("not connected"), "{command}: {stderr}");
+    }
+}
+
+/// A store with a chat that has a message, a message-less chat, and a
+/// subagent run. Returns their ids in that order.
+async fn seed_three_row_kinds(data_dir: &Path) -> (String, String, String) {
+    let sm = SessionManager::new(data_dir.to_path_buf());
+    let chat = sm
+        .create_session(
+            data_dir.to_path_buf(),
+            "Cohort review".into(),
+            SessionType::User,
+        )
+        .await
+        .unwrap();
+    sm.add_message(&chat.id, &Message::user().with_text("hello"))
+        .await
+        .unwrap();
+    let empty = sm
+        .create_session(
+            data_dir.to_path_buf(),
+            "CLI Session".into(),
+            SessionType::User,
+        )
+        .await
+        .unwrap();
+    let subagent = sm
+        .create_session(
+            data_dir.to_path_buf(),
+            "Subagent: audit".into(),
+            SessionType::SubAgent,
+        )
+        .await
+        .unwrap();
+    sm.close().await;
+    (chat.id, empty.id, subagent.id)
+}
+
+async fn exists(data_dir: &Path, id: &str) -> bool {
+    let sm = SessionManager::new(data_dir.to_path_buf());
+    let found = sm.get_session(id, false).await.is_ok();
+    sm.close().await;
+    found
+}
+
+/// `session remove` under a pipe: without `--yes` it exits 2 and deletes
+/// nothing, even with `y` piped in; with `--yes` it removes a message-less row
+/// and a subagent run — the two kinds it used to answer "not found" for.
+#[tokio::test]
+async fn session_remove_under_a_pipe_needs_yes_and_then_reaches_every_row_kind() {
+    let sandbox = Sandbox::new();
+    let data = sandbox.root.join("data");
+    let (chat, empty, subagent) = seed_three_row_kinds(&data).await;
+
+    let out = sandbox.run(&["session", "remove", "--session-id", &empty], "y\n");
+    let stderr = text(&out.stderr);
+    assert_eq!(out.status.code(), Some(2), "{stderr}");
+    assert!(stderr.contains("--yes"), "{stderr}");
+    assert!(!stderr.contains("not connected"), "{stderr}");
+    assert!(
+        exists(&data, &empty).await,
+        "a refused remove deleted the row"
+    );
+
+    for id in [&empty, &subagent] {
+        let out = sandbox.run(&["session", "remove", "--session-id", id, "--yes"], "");
+        let stdout = text(&out.stdout);
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "remove {id}: {stdout}{}",
+            text(&out.stderr)
+        );
+        assert!(
+            stdout.contains(&format!("Session `{id}` removed.")),
+            "{stdout}"
+        );
+        assert!(!exists(&data, id).await, "{id} is still in the store");
+    }
+    assert!(exists(&data, &chat).await, "only the named rows go");
+}

--- a/crates/biorouter/src/agents/skill_package/install.rs
+++ b/crates/biorouter/src/agents/skill_package/install.rs
@@ -75,6 +75,21 @@ pub fn install_root() -> PathBuf {
     crate::agents::skills_extension::skills_root(&Paths::config_dir())
 }
 
+/// Why [`install`] would refuse `plan` into `root` as shadowing something
+/// Biorouter ships — the very verdict it reaches, from the same guard — or
+/// `None`.
+///
+/// For a caller that must decide what to tell the user before it installs
+/// anything. The CLI's "already installed — re-run with `--force`" advice ran
+/// ahead of [`refuse_shipped`], so over a shipped name it recommended a flag
+/// that [`install`] then refused (QA-D F10). Asking this instead of re-deriving
+/// the rule keeps the advice and the guard from disagreeing. Read-only: the
+/// guard itself stays the single choke point on both [`install`] and
+/// [`remove`].
+pub fn shipped_refusal(plan: &ImportPlan, root: &Path) -> Option<String> {
+    refuse_shipped(&install_root(), root, &plan.id)
+}
+
 /// Write `plan` into `root`, atomically, and refresh the catalog.
 ///
 /// Refuses a plan that still carries an unanswered [`ImportPlan::ambiguity`] —

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -55,6 +55,12 @@ Configure biorouter settings - providers, extensions, etc.
 biorouter configure
 ```
 
+`configure` is interactive and needs a terminal. Run from a script, a pipe or
+anywhere else without one, it changes nothing and exits with status `2`, naming
+the non-interactive route instead: choose the model with
+`biorouter models set --provider <provider> --model <model>` and pass the
+provider's API key in its environment variable (for example `OPENAI_API_KEY`).
+
 ### info [options]
 
 Shows biorouter information, including the version, configuration file location, session storage, and logs.
@@ -162,7 +168,8 @@ List all saved sessions.
 - **`--ascending`**: Sort sessions by date in ascending order (oldest first)
 - **`-w, --working_dir <path>`**: Filter sessions by working directory
 - **`-l, --limit <number>`**: Limit the number of results
-- **`--subagents`**: Include subagent runs, nested under the session that spawned them
+- **`--subagents`**: Include subagent runs, nested under the session that spawned them (and sessions that have no messages)
+- **`--include-empty`**: Include sessions that have not recorded a message yet — what a `biorouter` run that exited before its first prompt, `doctor --fix` and `term init` leave behind. They are hidden by default, as they are in the desktop app's History
 
 **Usage:**
 
@@ -224,9 +231,12 @@ Remove one or more saved sessions.
 
 **Options:**
 
-- **`--session-id <session_id>`**: Remove a specific session by its session ID
-- **`-n, --name <name>`**: Remove a specific session by its name
-- **`-r, --regex <pattern>`**: Remove sessions matching a regex pattern
+- **`--session-id <session_id>`**: Remove a specific session by its session ID — any session, including a subagent run or a session with no messages
+- **`-n, --name <name>`**: Remove the one session carrying this name. When several sessions share it (every session a bare `biorouter` creates is listed as `New chat` until it is renamed), nothing is removed and the matching IDs are listed
+- **`-r, --regex <pattern>`**: Remove every session whose ID matches a regex pattern, among the sessions `session list` shows
+- **`--include-empty`**: With `--regex` or the picker, also match sessions that have not recorded a message yet
+- **`--subagents`**: With `--regex` or the picker, also match subagent runs (and sessions with no messages)
+- **`-y, --yes`**: Remove without asking for confirmation. Required when the command is not run from a terminal
 - **`--path <path>`**: Remove a specific session by its file path (legacy)
 
 **Usage:**
@@ -238,6 +248,9 @@ biorouter session remove
 # Remove a specific session by ID
 biorouter session remove --session-id 20251108_3
 
+# The same, from a script: no confirmation prompt
+biorouter session remove --session-id 20251108_3 --yes
+
 # Remove a specific session by name
 biorouter session remove -n my-project
 
@@ -248,7 +261,7 @@ biorouter session remove -r "project-.*"
 biorouter session remove -r ".*migration.*"
 ```
 
-> **Warning.** Session removal is permanent and cannot be undone. biorouter will show which sessions will be removed and ask for confirmation before deleting.
+> **Warning.** Session removal is permanent and cannot be undone. Unless you pass `--yes`, biorouter shows which sessions will be removed and asks for confirmation before deleting. Asking needs a terminal: without one — in a script or a pipe, even with `y` piped in — the command removes nothing and exits with status `2`, asking for `--yes`.
 
 ### session export [options]
 
@@ -341,7 +354,7 @@ Send a prompt into an existing session and stream the resulting turn, without op
 
 **Options:**
 
-- **`--no-wait`**: Return as soon as the turn starts, instead of streaming it to completion
+- **`--no-wait`**: Return as soon as the daemon accepts the turn, printing `[started] turn <turn_id> in session <session_id>`, instead of streaming it to completion
 
 **Usage:**
 
@@ -352,6 +365,12 @@ biorouter session send 20251108_2 "summarize what you have found so far"
 # Kick off a turn and return immediately
 biorouter session send 20251108_2 "run the full test suite" --no-wait
 ```
+
+A turn started with `--no-wait` runs on in the daemon: `biorouter session watch
+<session_id>` follows it and `biorouter session cancel <session_id>` stops it.
+The daemon stops a turn once nothing has been attached to its reply stream for
+five minutes, and `session watch` does not count as attached — so `--no-wait`
+suits turns shorter than that. Leave `--no-wait` off for a longer one.
 
 ### session attach [options]
 
@@ -723,6 +742,10 @@ Choose one of your projects to start working on.
 ```bash
 biorouter projects
 ```
+
+Both `project` and `projects` are interactive and need a terminal. Without one
+they exit with status `2` and point at the scriptable equivalent,
+`biorouter run --resume --session-id <id> --text "<prompt>"`.
 
 ## Interface
 


### PR DESCRIPTION
Fixes four CLI findings from the 2026-09-10 test drive on merged main `7c96d796` (QA-D F4, F5, F9 and the `skill install --force` row of F10), plus the CLI half of QA-F F9 (subagent sessions).

## What changes

**`session send --no-wait` now returns once the turn is accepted (QA-D F4).** `--no-wait` was passed down as "don't stop at the terminal frame", which turned off the only early exit, so it read until the socket closed: at least as long as the default, and more output (16 s, 779 lines). The read now stops when the daemon names the turn (the `turn_id` on the opening `TurnStarted` frame), prints `[started] turn <id> in session <id>`, and exits. The default still waits and streams. Hanging up does not cancel the turn, because a `/reply` connection is only the turn's first observer. One caveat is written into the help and the stderr hint: the daemon's orphan reaper stops a turn after **five minutes with no `/reply` stream attached**, and `session watch` doesn't count as attached. The wait for the name is capped at 10 s. A 202 (a subagent that is still starting kept the message as steering) now reads as `[queued]` instead of "refused: HTTP 202".

**`session remove` finds any row and works from a script (QA-D F5, QA-F F9).**
- `--session-id` reads the row directly instead of searching `list_sessions()`, which only covers user/scheduled sessions and INNER JOINs `messages`. It now finds message-less rows (5,313 of 10,855 in the QA store) and subagent runs, which used to come back "not found".
- New `-y/--yes`. Without it and without a terminal, the command removes nothing and exits 2 with a sentence naming `--yes`. That includes `y` piped in. Rows are resolved first, so a mistyped id still gets "not found".
- `--name` used to delete the first match. It now refuses when several sessions share the name and lists their ids. Every bare-`biorouter` session reads back as `New chat`, so shared names are common.
- `--regex` and the picker search what `session list` shows by default. `--include-empty` and `--subagents` widen that. `session list` also gets `--include-empty`.

**Interactive commands say they're interactive (QA-D F9).** `configure`, `project` and `projects` no longer die with cliclack's `Error: not connected`. When there's no terminal they print one sentence saying the command is interactive and what to run instead (`models set` plus the provider's API-key env var for `configure`, `run --resume --session-id … --text …` for the project commands), and exit **2**. The check looks at stdin **and** stderr, because cliclack draws on stderr and, when a controlling terminal exists, reads keys from `/dev/tty` and ignores whatever was piped. `configure` runs the check before it touches the config.

**`skill install` never suggests `--force` for a shipped name (QA-D F10 row).** The pre-install check now asks the installer's own guard first, through a new read-only `skill_package::install::shipped_refusal`, and replies with that guard's explanation with or without `--force`. `refuse_shipped` itself is unchanged.

## Verification

### Tests
- `HOME=$(mktemp -d) CARGO_HOME=/Users/wgu/.cargo RUSTUP_HOME=/Users/wgu/.rustup BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter-cli`: on HEAD `909423c9`: lib **417 passed** (20 new, none removed), `tests/non_interactive.rs` **3 passed** (new), 0 failed, cargo exit 0.
- `cargo test -p biorouter --lib -- skill_package` (for the `install.rs` addition): **53 passed**, 0 failed.
- `cargo fmt --all -- --check`: clean. `./scripts/clippy-lint.sh`: strict pass with no warnings, `too_many_lines` baseline ok, TLS check ok, exit 0.
- New lib tests (these run in CI): the three row kinds in a throwaway store (a chat with a message, a message-less chat, a subagent run) for id/name/regex/scope. Each fixture first asserts the old lookup really hides two of the three rows. Also: no-`--yes` + no-terminal deletes nothing; `configure` leaves an existing config byte-identical and creates nothing on a first run; both `send` modes over an in-memory pipe that never closes, so the old `--no-wait` fails by timing out; the deadline, no-answer, 202/409 and error-before-name edges; the shipped-name pre-check.
- New `tests/non_interactive.rs` spawns the real binary with every stream piped. CI's `--lib --bins` doesn't run it, which is why the load-bearing assertions are also in lib tests.

### Runtime
Sandbox: `BIOROUTER_PATH_ROOT` cloned from `~/biorouter-runs/seed-config` (versa_azure / gpt-5.5), with my own `biorouterd` from this branch on port 9461 (dev user-action digest on stdin). Output is verbatim.

**F4, `--no-wait`**, on the QA's 600-word prompt:
```
$ printf 'biorouter-dev-user-action\n' | /usr/bin/time -p biorouter session send 20260911_1 "Write a 600-word essay about the number seven." --no-wait --user-action-key-stdin
[started] turn turn-4 in session 20260911_1
It runs on in the daemon: `biorouter session watch 20260911_1` follows it and `biorouter session cancel 20260911_1` stops it. The daemon stops a turn once nothing has been attached to its reply stream for five minutes (`session watch` does not count), so --no-wait suits turns shorter than that.
real 0.20
user 0.01
sys 0.04
exit=0
messages immediately after return: 7
{"session_ids":["20260911_1"]} <- /sessions/running right after return
```
The turn then finished in the background, and the row shows it:
```
turn left /sessions/running after ~4s more: {"session_ids":[]}
78464|assistant|3896|2026-09-11 18:59:36
78463|user|73|2026-09-11 18:59:33
latest assistant reply: words= 607 | ends: 'iners, holding centuries of human attention, imagination, and meaning.'
```
The very first `--no-wait` run took 5.26 s. That was macOS scanning a freshly linked 354 MB debug binary on its first run, not the command: a fresh copy's first `--version` took 6.71 s at ~0 CPU, then 0.02 s. A raw `POST /reply` got its status line and `TurnStarted` frame back in 0.005 s.

**F4, default still waits and streams:**
```
exit=0
real 14.28
user 0.06
sys 0.07
stdout lines:      819
--- first 2 lines:
[assistant] The
[assistant]  number
--- last 2 lines:
[assistant] .
[finished] stop
{"session_ids":[]} <- /sessions/running after the default send returned
```

**F9:**
```
$ echo | biorouter configure
`biorouter configure` is interactive and needs a terminal; without one, choose a model with `biorouter models set --provider <provider> --model <model>` (`biorouter models providers` lists the providers) and pass the provider's API key in its environment variable, e.g. `OPENAI_API_KEY`.
exit=2
config dir byte-identical (5974 files, incl. config.yaml 3d0fa7cc1efca1cb…)
$ echo | biorouter project
`biorouter project` is interactive and needs a terminal; from a script, continue a chat with `biorouter run --resume --session-id <id> --text "<prompt>"` (`biorouter session list` shows the ids).
exit=2
$ echo | biorouter projects
`biorouter projects` is interactive and needs a terminal; from a script, continue a chat with `biorouter run --resume --session-id <id> --text "<prompt>"` (`biorouter session list` shows the ids).
exit=2
```

**F5 / QA-F F9**, on real sandbox rows: `20260805_111` is a `user` row named `CLI Session` with 0 messages, `20260828_7` is a `sub_agent` row with 5 messages.

Before (7c96d796 binary, same sandbox):
```
$ biorouter(7c96d796) session remove --session-id 20260805_111 </dev/null
Error: Session ID '20260805_111' not found.
exit=1
$ biorouter(7c96d796) session remove --session-id 20260828_7 </dev/null
Error: Session ID '20260828_7' not found.
exit=1
```
After (this branch):
```
$ printf 'y\n' | biorouter session remove --session-id 20260805_111
`biorouter session remove` asks before it deletes anything and needs a terminal to ask on; to remove without asking, re-run it with --yes.
exit=2
row still present: 1
$ biorouter session remove --session-id 20260805_111 --yes </dev/null
Session `20260805_111` removed.
exit=0
$ biorouter session remove --session-id 20260828_7 --yes </dev/null
Session `20260828_7` removed.
exit=0
rows left: 0  messages left for 20260828_7: 0
```
```
session list:                 5543
session list --include-empty: 10853
sqlite user+scheduled rows:   10853
```

**F10, `skill install` over the shipped `about-biorouter`:**
```
$ biorouter(7c96d796) skill install shadow.zip
  Error: Already installed at …/config/skills/about-biorouter. Re-run with --force to replace it.
  exit=1
$ biorouter(7c96d796) skill install shadow.zip --force
  Error: `about-biorouter` is the name of something that ships with Biorouter and is rewritten on every start, so this would not last. To turn it off, use Settings -> Chat -> Contexts or `biorouter skill disable about-biorouter`; to install a package of your own, give it another name.
  exit=1
$ biorouter(this branch) skill install shadow.zip
  Error: `about-biorouter` is the name of something that ships with Biorouter and is rewritten on every start, so this would not last. To turn it off, use Settings -> Chat -> Contexts or `biorouter skill disable about-biorouter`; to install a package of your own, give it another name.
  exit=1
$ biorouter(this branch) skill install shadow.zip --force
  (same refusal) exit=1
shipped SKILL.md sha256 before=b70dcbce1a84b0fc after=b70dcbce1a84b0fc unchanged
```

## Notes for review
- **Behaviour change:** `session remove --name` now refuses a name shared by several sessions instead of deleting the first one, and it searches the same rows every other `--name` in the CLI does (user, scheduled and subagent sessions, with or without messages).
- **Not changed:** the other F10 rows (docs route name, token "spent", `mcp` bad-name message, 16 vs 17 routes, flattened-arg help text, `--version` leading space, `cancel` on an unknown id). `session remove` still ignores `--path`, as before.
- **Found, not fixed here:**
  - `session attach`'s Ctrl-C warning ("leaving now CANCELS it") and several comments in `session_watch.rs` still assume that hanging up on `/reply` cancels the turn. That hasn't been true since the live-turn-stream work; the `--no-wait` run above shows the turn finishing. Filed as a separate task.
  - `delete_session` still leaves some per-session side rows behind, which a reissued id then inherits (an existing follow-up). This PR makes more rows deletable from the CLI but doesn't change what a delete removes.
- Runtime housekeeping: stopped my daemon (pid 42587) and confirmed no orphans and port 9461 free. Removed the sandbox. The QA instances (CDP 9371–9376), `setup-path` and `~/.config/biorouter` were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
