### PR TITLE
Schedules: ask before an agent changes one, and keep the daemon in step with schedule.json (QA F1, F2)

### DIFF
--- a/crates/biorouter-cli/src/commands/schedule.rs
+++ b/crates/biorouter-cli/src/commands/schedule.rs
@@ -1,11 +1,33 @@
-use anyhow::{bail, Context, Result};
+//! `biorouter schedule …`.
+//!
+//! ## Which process makes the change
+//!
+//! A running daemon holds the schedule in memory and runs it; the file
+//! (`<data>/schedule.json`) is what every process shares. So a change goes to
+//! the DAEMON whenever this terminal can reach one — the same way `session send`
+//! finds it: `BIOROUTER_SERVER__SECRET_KEY` and `BIOROUTER_PORT` from this
+//! shell, and a daemon answering `/status` there. The daemon then registers,
+//! lists and fires the job at once.
+//!
+//! Only when no daemon can be reached does the command write the file with a
+//! `Scheduler` of its own — and then it says so, and says when the change will
+//! take effect, instead of the "added" it used to print for a job the running
+//! app would not see until a restart (QA 2026-09-10, F2). A running daemon now
+//! notices such a write itself (`Scheduler::spawn_file_watcher`). An agent's
+//! shell is always on this path: the daemon's secret is stripped from every tool
+//! child's environment (issue #57), and that is deliberate.
+
+use anyhow::{anyhow, bail, Context, Result};
 use biorouter::scheduler::{
     get_default_scheduled_workflows_dir, get_default_scheduler_storage_path, ScheduledJob,
-    Scheduler, SchedulerError, RUN_CANCELLED_MARKER,
+    Scheduler, SchedulerError, EXTERNAL_CHANGE_PICKUP, RUN_CANCELLED_MARKER,
 };
 use biorouter::session::SessionManager;
 use std::path::Path;
 use std::sync::Arc;
+
+use super::apps::{configured_port, daemon_ok, DAEMON_HOST};
+use super::session_watch::{daemon_auth, daemon_json_request, DaemonAuth};
 
 fn validate_cron_expression(cron: &str) -> Result<()> {
     // Basic validation and helpful suggestions
@@ -65,19 +87,311 @@ fn validate_cron_expression(cron: &str) -> Result<()> {
     Ok(())
 }
 
+/// Where a `biorouter schedule` change goes.
+pub(crate) enum Reach {
+    /// A running daemon answered on this terminal's port with this terminal's
+    /// key.
+    Daemon { auth: DaemonAuth, port: u16 },
+    /// No daemon could be reached from here; `why` says why.
+    File { why: String },
+}
+
+impl Reach {
+    /// Decided once per command, from this shell's environment.
+    async fn from_environment() -> Self {
+        Self::probe(daemon_auth().await.ok(), configured_port()).await
+    }
+
+    /// The decision, with its inputs passed in rather than read from the
+    /// process environment — so a test can aim it at a fake daemon without
+    /// setting `BIOROUTER_PORT`, which other tests in this binary read.
+    pub(crate) async fn probe(auth: Option<DaemonAuth>, port: u16) -> Self {
+        let Some(auth) = auth else {
+            return Reach::File {
+                why: "BIOROUTER_SERVER__SECRET_KEY is not set".to_string(),
+            };
+        };
+        if daemon_ok(DAEMON_HOST, port).await {
+            Reach::Daemon { auth, port }
+        } else {
+            Reach::File {
+                why: format!("no daemon answered on {DAEMON_HOST}:{port}"),
+            }
+        }
+    }
+}
+
+/// The schedule file this terminal writes when no daemon can be reached, and
+/// the session store a `Scheduler` over it needs.
+pub(crate) struct LocalStore {
+    storage_path: std::path::PathBuf,
+    sessions: Arc<SessionManager>,
+}
+
+impl LocalStore {
+    fn for_this_user() -> Result<Self> {
+        Ok(Self {
+            storage_path: get_default_scheduler_storage_path()
+                .context("Failed to get scheduler storage path")?,
+            sessions: Arc::new(SessionManager::instance()),
+        })
+    }
+
+    async fn scheduler(&self) -> Result<Arc<Scheduler>> {
+        Scheduler::new(self.storage_path.clone(), Arc::clone(&self.sessions))
+            .await
+            .context("Failed to initialize scheduler")
+    }
+
+    /// The store under `BIOROUTER_PATH_ROOT`, without the process-wide
+    /// `SessionManager::instance()` — which resolves its path once per process,
+    /// so a test that initialised it under its own temp root would hand that
+    /// (soon deleted) root to every later test in the binary.
+    #[cfg(test)]
+    fn at_data_dir(data_dir: &Path) -> Self {
+        Self {
+            storage_path: data_dir.join("schedule.json"),
+            sessions: Arc::new(SessionManager::new(data_dir.to_path_buf())),
+        }
+    }
+}
+
+/// How long a schedule request to the daemon may take. Every one of them is a
+/// small read or write; `run_now` is the exception and passes no deadline.
+const REQUEST_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// What a change made straight in the schedule file owes the user: why the
+/// daemon was not used, and when the change actually takes effect.
+///
+/// The pickup time is the daemon's own promise
+/// ([`EXTERNAL_CHANGE_PICKUP`]), not a number written here, so the sentence
+/// cannot drift from what the daemon does.
+fn written_to_the_file(why: &str, done: &str, pickup: &str, tail: &str) -> String {
+    format!(
+        "No running Biorouter could be reached from this terminal ({why}), so {done}. A \
+         Biorouter that is already running — the desktop app included — {pickup} {} \
+         seconds{tail}",
+        EXTERNAL_CHANGE_PICKUP.as_secs()
+    )
+}
+
+/// A daemon that refused this terminal's key. Reported, never worked around:
+/// the user pointed this terminal at that daemon, and writing its file behind
+/// its back would be a second, silent answer to a question it already refused.
+fn key_refused(port: u16, consequence: &str) -> anyhow::Error {
+    anyhow!(
+        "The Biorouter on {DAEMON_HOST}:{port} refused this terminal's key (HTTP 401). \
+         {consequence}. BIOROUTER_SERVER__SECRET_KEY must be the key that daemon was started \
+         with."
+    )
+}
+
+/// The reason in a daemon's error body: `{"message": …}` when it sent one, the
+/// body itself otherwise.
+fn daemon_message(body: &str) -> String {
+    let body = body.trim();
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .and_then(|m| m.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| {
+            if body.is_empty() {
+                "no reason given".to_string()
+            } else {
+                body.to_string()
+            }
+        })
+}
+
+fn stopped_message(schedule_id: &str) -> String {
+    format!(
+        "Schedule '{}' was stopped before it finished, so no work was recorded and its last-run \
+         cursor was not advanced.",
+        schedule_id
+    )
+}
+
+/// `schedule add` through the running daemon, which copies the workflow, parses
+/// the cron and registers the job itself — so its cron engine, its list and the
+/// file agree the moment it answers.
+async fn add_through_daemon(
+    auth: &DaemonAuth,
+    port: u16,
+    schedule_id: &str,
+    cron: &str,
+    workflow_source: &str,
+) -> Result<String> {
+    // The daemon resolves a relative path against ITS working directory.
+    let source = std::path::absolute(workflow_source)
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| workflow_source.to_string());
+    let body = serde_json::json!({
+        "id": schedule_id,
+        "workflow_source": source,
+        "cron": cron,
+    })
+    .to_string();
+    let (status, answer) = daemon_json_request(
+        "POST",
+        "/schedule/create",
+        Some(&body),
+        auth,
+        port,
+        Some(REQUEST_DEADLINE),
+    )
+    .await?;
+    match status {
+        200 => Ok(format!(
+            "Scheduled job '{schedule_id}' added to the running Biorouter on {DAEMON_HOST}:{port}; \
+             it is live now.\n  cron: {cron}\n  workflow: {source} (the daemon keeps its own copy)"
+        )),
+        401 => Err(key_refused(port, "Nothing was scheduled")),
+        409 => bail!("Error: Job with ID '{}' already exists.", schedule_id),
+        _ => bail!(
+            "The running Biorouter on {DAEMON_HOST}:{port} did not add '{schedule_id}' (HTTP \
+             {status}): {}. Nothing was scheduled.",
+            daemon_message(&answer)
+        ),
+    }
+}
+
+async fn remove_through_daemon(auth: &DaemonAuth, port: u16, schedule_id: &str) -> Result<String> {
+    let path = format!("/schedule/delete/{}", urlencoding::encode(schedule_id));
+    let (status, answer) =
+        daemon_json_request("DELETE", &path, None, auth, port, Some(REQUEST_DEADLINE)).await?;
+    match status {
+        200 | 204 => Ok(format!(
+            "Scheduled job '{schedule_id}' removed from the running Biorouter on \
+             {DAEMON_HOST}:{port}; it will not run again."
+        )),
+        401 => Err(key_refused(port, "Nothing was removed")),
+        404 => bail!("Error: Job with ID '{}' not found.", schedule_id),
+        _ => bail!(
+            "The running Biorouter on {DAEMON_HOST}:{port} did not remove '{schedule_id}' (HTTP \
+             {status}): {}. Nothing was removed.",
+            daemon_message(&answer)
+        ),
+    }
+}
+
+async fn list_through_daemon(auth: &DaemonAuth, port: u16) -> Result<String> {
+    #[derive(serde::Deserialize)]
+    struct Listing {
+        jobs: Vec<ScheduledJob>,
+    }
+    let (status, answer) = daemon_json_request(
+        "GET",
+        "/schedule/list",
+        None,
+        auth,
+        port,
+        Some(REQUEST_DEADLINE),
+    )
+    .await?;
+    match status {
+        200 => {
+            let listing: Listing = serde_json::from_str(answer.trim())
+                .context("the daemon's schedule list could not be read")?;
+            Ok(render_schedule_list(
+                &format!("Scheduled Jobs (from the running Biorouter on {DAEMON_HOST}:{port}):"),
+                listing.jobs,
+            ))
+        }
+        401 => Err(key_refused(port, "The schedules could not be listed")),
+        _ => bail!(
+            "The running Biorouter on {DAEMON_HOST}:{port} did not list its schedules (HTTP \
+             {status}): {}",
+            daemon_message(&answer)
+        ),
+    }
+}
+
+/// `run_now` in the daemon, where the desktop's Stop button can reach the run.
+/// No deadline: the route answers when the run ends.
+async fn run_now_through_daemon(auth: &DaemonAuth, port: u16, schedule_id: &str) -> Result<String> {
+    let path = format!("/schedule/{}/run_now", urlencoding::encode(schedule_id));
+    eprintln!(
+        "Running '{schedule_id}' in the Biorouter on {DAEMON_HOST}:{port}. Stopping this command \
+         does not stop the run; stop it from the app."
+    );
+    let (status, answer) = daemon_json_request("POST", &path, None, auth, port, None).await?;
+    match status {
+        200 => {
+            let session_id = serde_json::from_str::<serde_json::Value>(answer.trim())
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("session_id")
+                        .and_then(|id| id.as_str())
+                        .map(str::to_string)
+                })
+                .ok_or_else(|| {
+                    anyhow!("the daemon answered run_now with a body this client could not read")
+                })?;
+            // The sentinel `ScheduleDetailView.tsx` branches on too.
+            if session_id == "CANCELLED" {
+                Ok(stopped_message(schedule_id))
+            } else {
+                Ok(format!(
+                    "Successfully triggered schedule '{schedule_id}' on the running Biorouter on \
+                     {DAEMON_HOST}:{port}. New session ID: {session_id}"
+                ))
+            }
+        }
+        401 => Err(key_refused(port, "Nothing was run")),
+        404 => bail!("Error: Job with ID '{}' not found.", schedule_id),
+        _ => bail!(
+            "Failed to run schedule '{}' now: {}",
+            schedule_id,
+            daemon_message(&answer)
+        ),
+    }
+}
+
 pub async fn handle_schedule_add(
     schedule_id: String,
     cron: String,
     workflow_source_arg: String, // This is expected to be a file path by the Scheduler
 ) -> Result<()> {
     validate_cron_expression(&cron)?;
+    let report = add_schedule(
+        Reach::from_environment().await,
+        LocalStore::for_this_user,
+        &schedule_id,
+        &cron,
+        &workflow_source_arg,
+    )
+    .await?;
+    println!("{report}");
+    Ok(())
+}
+
+/// `schedule add`, minus the printing: what it did, in the words the terminal
+/// prints, or why it could not.
+pub(crate) async fn add_schedule(
+    reach: Reach,
+    local: impl FnOnce() -> Result<LocalStore>,
+    schedule_id: &str,
+    cron: &str,
+    workflow_source_arg: &str,
+) -> Result<String> {
+    let why = match reach {
+        Reach::Daemon { auth, port } => {
+            return add_through_daemon(&auth, port, schedule_id, cron, workflow_source_arg).await
+        }
+        Reach::File { why } => why,
+    };
 
     // The Scheduler's add_scheduled_job will handle copying the workflow from workflow_source_arg
     // to its internal storage and validating the path.
     let job = ScheduledJob {
-        id: schedule_id.clone(),
-        source: workflow_source_arg.clone(), // Pass the original user-provided path
-        cron: cron.clone(),
+        id: schedule_id.to_string(),
+        source: workflow_source_arg.to_string(), // Pass the original user-provided path
+        cron: cron.to_string(),
         last_run: None,
         currently_running: false,
         paused: false,
@@ -91,12 +405,8 @@ pub async fn handle_schedule_add(
         owns_source: None,
     };
 
-    let scheduler_storage_path =
-        get_default_scheduler_storage_path().context("Failed to get scheduler storage path")?;
-    let session_manager = Arc::new(SessionManager::instance());
-    let scheduler = Scheduler::new(scheduler_storage_path, session_manager)
-        .await
-        .context("Failed to initialize scheduler")?;
+    let store = local()?;
+    let scheduler = store.scheduler().await?;
 
     match scheduler.add_scheduled_job(job, true).await {
         Ok(_) => {
@@ -104,17 +414,29 @@ pub async fn handle_schedule_add(
             // We can reconstruct the likely path for display if needed, or adjust success message.
             let scheduled_workflows_dir = get_default_scheduled_workflows_dir()
                 .unwrap_or_else(|_| Path::new("./.biorouter_scheduled_workflows").to_path_buf()); // Fallback for display
-            let extension = Path::new(&workflow_source_arg)
+            let extension = Path::new(workflow_source_arg)
                 .extension()
                 .and_then(|ext| ext.to_str())
                 .unwrap_or("yaml");
             let final_workflow_path =
                 scheduled_workflows_dir.join(format!("{}.{}", schedule_id, extension));
 
-            println!("Scheduled job '{}' added.", schedule_id);
-            println!("  cron: {}", cron);
-            println!("  workflow: {}", final_workflow_path.display());
-            Ok(())
+            // ⚠ Not "added". The shipped command printed exactly that for a job
+            // a running app would not see until it restarted (QA 2026-09-10,
+            // F2). What the user is owed is when it will actually run.
+            Ok(format!(
+                "Scheduled job '{}' written to {}.\n  cron: {}\n  workflow: {}\n{}",
+                schedule_id,
+                store.storage_path.display(),
+                cron,
+                final_workflow_path.display(),
+                written_to_the_file(
+                    &why,
+                    "the job was written to the schedule file directly",
+                    "picks it up from that file within",
+                    "; if none is running, it first runs the next time Biorouter starts."
+                )
+            ))
         }
         Err(e) => {
             // No local file to clean up by the CLI in this revised flow.
@@ -137,23 +459,34 @@ pub async fn handle_schedule_add(
 }
 
 pub async fn handle_schedule_list() -> Result<()> {
-    let scheduler_storage_path =
-        get_default_scheduler_storage_path().context("Failed to get scheduler storage path")?;
-    let session_manager = Arc::new(SessionManager::instance());
-    let scheduler = Scheduler::new(scheduler_storage_path, session_manager)
-        .await
-        .context("Failed to initialize scheduler")?;
-
-    let jobs = scheduler.list_scheduled_jobs().await;
-    if jobs.is_empty() {
-        println!("No scheduled jobs found.");
-    } else {
-        println!("Scheduled Jobs:");
-        for job in jobs {
-            println!("{}", render_schedule_entry(&job));
-        }
-    }
+    let report = list_schedules(Reach::from_environment().await, LocalStore::for_this_user).await?;
+    println!("{report}");
     Ok(())
+}
+
+/// `schedule list`, minus the printing. From the daemon when one is reachable —
+/// what it lists is what will fire — and from the file otherwise.
+pub(crate) async fn list_schedules(
+    reach: Reach,
+    local: impl FnOnce() -> Result<LocalStore>,
+) -> Result<String> {
+    if let Reach::Daemon { auth, port } = reach {
+        return list_through_daemon(&auth, port).await;
+    }
+    let scheduler = local()?.scheduler().await?;
+    Ok(render_schedule_list(
+        "Scheduled Jobs:",
+        scheduler.list_scheduled_jobs().await,
+    ))
+}
+
+fn render_schedule_list(heading: &str, jobs: Vec<ScheduledJob>) -> String {
+    if jobs.is_empty() {
+        return "No scheduled jobs found.".to_string();
+    }
+    let mut lines = vec![heading.to_string()];
+    lines.extend(jobs.iter().map(render_schedule_entry));
+    lines.join("\n")
 }
 
 /// One schedule's block in `biorouter schedule list`.
@@ -192,21 +525,43 @@ fn render_schedule_entry(job: &ScheduledJob) -> String {
 }
 
 pub async fn handle_schedule_remove(schedule_id: String) -> Result<()> {
-    let scheduler_storage_path =
-        get_default_scheduler_storage_path().context("Failed to get scheduler storage path")?;
-    let session_manager = Arc::new(SessionManager::instance());
-    let scheduler = Scheduler::new(scheduler_storage_path, session_manager)
-        .await
-        .context("Failed to initialize scheduler")?;
+    let report = remove_schedule(
+        Reach::from_environment().await,
+        LocalStore::for_this_user,
+        &schedule_id,
+    )
+    .await?;
+    println!("{report}");
+    Ok(())
+}
 
-    match scheduler.remove_scheduled_job(&schedule_id, true).await {
-        Ok(_) => {
-            println!(
-                "Scheduled job '{}' and its associated workflow removed.",
-                schedule_id
-            );
-            Ok(())
+/// `schedule remove`, minus the printing.
+pub(crate) async fn remove_schedule(
+    reach: Reach,
+    local: impl FnOnce() -> Result<LocalStore>,
+    schedule_id: &str,
+) -> Result<String> {
+    let why = match reach {
+        Reach::Daemon { auth, port } => {
+            return remove_through_daemon(&auth, port, schedule_id).await
         }
+        Reach::File { why } => why,
+    };
+    let store = local()?;
+    let scheduler = store.scheduler().await?;
+
+    match scheduler.remove_scheduled_job(schedule_id, true).await {
+        Ok(_) => Ok(format!(
+            "Scheduled job '{}' and its associated workflow removed from {}.\n{}",
+            schedule_id,
+            store.storage_path.display(),
+            written_to_the_file(
+                &why,
+                "the change was made in the schedule file directly",
+                "stops scheduling it within",
+                "; a run it has already started finishes first."
+            )
+        )),
         Err(e) => match e {
             SchedulerError::JobNotFound(job_id) => {
                 bail!("Error: Job with ID '{}' not found.", job_id);
@@ -257,18 +612,35 @@ pub async fn handle_schedule_sessions(schedule_id: String, limit: Option<usize>)
 }
 
 pub async fn handle_schedule_run_now(schedule_id: String) -> Result<()> {
-    let scheduler_storage_path =
-        get_default_scheduler_storage_path().context("Failed to get scheduler storage path")?;
-    let session_manager = Arc::new(SessionManager::instance());
-    let scheduler = Scheduler::new(scheduler_storage_path, session_manager)
-        .await
-        .context("Failed to initialize scheduler")?;
-
-    println!(
-        "{}",
-        run_now_message(&schedule_id, scheduler.run_now(&schedule_id).await)?
-    );
+    let report = run_schedule_now(
+        Reach::from_environment().await,
+        LocalStore::for_this_user,
+        &schedule_id,
+    )
+    .await?;
+    println!("{report}");
     Ok(())
+}
+
+/// `schedule run-now`, minus the printing. In the daemon when one is reachable;
+/// otherwise in this terminal's own process, as it always ran.
+pub(crate) async fn run_schedule_now(
+    reach: Reach,
+    local: impl FnOnce() -> Result<LocalStore>,
+    schedule_id: &str,
+) -> Result<String> {
+    let why = match reach {
+        Reach::Daemon { auth, port } => {
+            return run_now_through_daemon(&auth, port, schedule_id).await
+        }
+        Reach::File { why } => why,
+    };
+    eprintln!(
+        "No running Biorouter could be reached from this terminal ({why}), so '{schedule_id}' \
+         runs here, in this terminal."
+    );
+    let scheduler = local()?.scheduler().await?;
+    run_now_message(schedule_id, scheduler.run_now(schedule_id).await)
 }
 
 /// What the terminal prints for a finished `schedule run-now`, or the error it
@@ -295,11 +667,7 @@ fn run_now_message(schedule_id: &str, result: Result<String, SchedulerError>) ->
         Err(SchedulerError::AnyhowError(ref err))
             if err.to_string().contains(RUN_CANCELLED_MARKER) =>
         {
-            Ok(format!(
-                "Schedule '{}' was stopped before it finished, so no work was recorded and its \
-                 last-run cursor was not advanced.",
-                schedule_id
-            ))
+            Ok(stopped_message(schedule_id))
         }
         // `{}` and not `{:?}`: `SchedulerError`'s `Display` is the whole point of
         // the carefully-worded messages behind it — the privacy barrier's
@@ -503,5 +871,341 @@ mod tests {
         )
         .expect_err("a missing schedule is an error exit");
         assert!(format!("{error}").contains("not found"), "{error}");
+    }
+
+    // -- F2: reaching the daemon ------------------------------------------------
+
+    /// A daemon that answers `/status` the way `biorouterd` does and replies to
+    /// every other request with `reply`, recording each one it was sent.
+    struct FakeDaemon {
+        port: u16,
+        requests: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl FakeDaemon {
+        fn requests(&self) -> Vec<String> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    async fn fake_daemon(reply: fn(&str) -> (u16, String)) -> FakeDaemon {
+        use tokio::io::AsyncWriteExt;
+        let listener = tokio::net::TcpListener::bind((DAEMON_HOST, 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen = Arc::clone(&requests);
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let seen = Arc::clone(&seen);
+                tokio::spawn(async move {
+                    let request = read_request(&mut socket).await;
+                    let (status, body) = if request.starts_with("GET /status ") {
+                        (200, "ok".to_string())
+                    } else {
+                        seen.lock().unwrap().push(request.clone());
+                        reply(&request)
+                    };
+                    let response = format!(
+                        "HTTP/1.1 {status} Fake\r\nContent-Type: application/json\r\n\
+                         Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+        FakeDaemon { port, requests }
+    }
+
+    /// One request off the socket: its head, then as many body bytes as its
+    /// `Content-Length` promises.
+    async fn read_request(socket: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt;
+        let mut raw = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            let read = socket.read(&mut chunk).await.unwrap_or(0);
+            if read == 0 {
+                break;
+            }
+            raw.extend_from_slice(&chunk[..read]);
+            if let Some(end) = raw.windows(4).position(|w| w == b"\r\n\r\n") {
+                let head = String::from_utf8_lossy(&raw[..end]).to_ascii_lowercase();
+                let length = head
+                    .lines()
+                    .find_map(|line| line.strip_prefix("content-length:"))
+                    .and_then(|value| value.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                if raw.len() >= end + 4 + length {
+                    break;
+                }
+            }
+        }
+        String::from_utf8_lossy(&raw).into_owned()
+    }
+
+    /// A loopback port nothing is listening on.
+    async fn unused_port() -> u16 {
+        let listener = tokio::net::TcpListener::bind((DAEMON_HOST, 0))
+            .await
+            .unwrap();
+        listener.local_addr().unwrap().port()
+    }
+
+    fn body_of(request: &str) -> serde_json::Value {
+        serde_json::from_str(request.split("\r\n\r\n").nth(1).unwrap_or_default())
+            .unwrap_or_else(|e| panic!("the request body is not JSON ({e}): {request}"))
+    }
+
+    fn local_store_is_off_limits() -> Result<LocalStore> {
+        panic!(
+            "a daemon was reachable, so this terminal must not write the schedule file behind \
+             its back — the daemon owns it"
+        )
+    }
+
+    const CREATED: &str =
+        r#"{"id":"qaf-probe","source":"/tmp/probe.yaml","cron":"0 2 * * *","last_run":null}"#;
+
+    /// QA 2026-09-10, F2, the half the CLI owns: `schedule add` built its own
+    /// `Scheduler` over the file even when a daemon was running and reachable,
+    /// so the daemon never registered the job. When a daemon answers on this
+    /// terminal's port with this terminal's key, it makes the change itself —
+    /// the one way its cron engine, its list and the file agree at once — and
+    /// this terminal never touches the file.
+    ///
+    /// Fails the shipped command, which wrote the file and sent nothing.
+    #[tokio::test]
+    async fn a_schedule_added_while_a_daemon_runs_is_registered_with_that_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflow = dir.path().join("probe.yaml");
+        std::fs::write(
+            &workflow,
+            "title: Probe\ndescription: d\nprompt: echo probe\n",
+        )
+        .unwrap();
+        let daemon = fake_daemon(|request| {
+            if request.starts_with("POST /schedule/create ") {
+                (200, CREATED.to_string())
+            } else {
+                (404, "{}".to_string())
+            }
+        })
+        .await;
+
+        let reach = Reach::probe(Some(DaemonAuth::for_test("s3cret", "")), daemon.port).await;
+        assert!(
+            matches!(reach, Reach::Daemon { .. }),
+            "a daemon that answers /status is reachable"
+        );
+        let report = add_schedule(
+            reach,
+            local_store_is_off_limits,
+            "qaf-probe",
+            "0 2 * * *",
+            &workflow.to_string_lossy(),
+        )
+        .await
+        .expect("the daemon accepted it");
+
+        let requests = daemon.requests();
+        assert_eq!(requests.len(), 1, "{requests:?}");
+        let request = &requests[0];
+        assert!(
+            request.starts_with("POST /schedule/create HTTP/1.1\r\n"),
+            "{request}"
+        );
+        assert!(request.contains("X-Secret-Key: s3cret\r\n"), "{request}");
+        let body = body_of(request);
+        assert_eq!(body["id"], "qaf-probe");
+        assert_eq!(body["cron"], "0 2 * * *");
+        assert_eq!(
+            body["workflow_source"],
+            serde_json::Value::String(workflow.to_string_lossy().into_owned()),
+            "the daemon runs in another directory, so the path it is given must be absolute"
+        );
+        assert!(report.contains("running Biorouter"), "{report}");
+        assert!(report.contains(&daemon.port.to_string()), "{report}");
+    }
+
+    /// The daemon's refusal is the answer. A key the daemon rejects is a
+    /// configuration mistake to report — not a reason to go round the daemon and
+    /// write its file anyway.
+    #[tokio::test]
+    async fn a_daemon_that_refuses_this_terminals_key_is_reported_not_worked_around() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflow = dir.path().join("probe.yaml");
+        std::fs::write(
+            &workflow,
+            "title: Probe\ndescription: d\nprompt: echo probe\n",
+        )
+        .unwrap();
+        let daemon = fake_daemon(|_| (401, String::new())).await;
+
+        let reach = Reach::probe(Some(DaemonAuth::for_test("wrong", "")), daemon.port).await;
+        let error = add_schedule(
+            reach,
+            local_store_is_off_limits,
+            "qaf-probe",
+            "0 2 * * *",
+            &workflow.to_string_lossy(),
+        )
+        .await
+        .expect_err("a refused key is not a scheduled job");
+        let text = format!("{error:#}");
+        assert!(text.contains("401"), "{text}");
+        assert!(text.contains("BIOROUTER_SERVER__SECRET_KEY"), "{text}");
+        assert!(text.contains("Nothing was scheduled"), "{text}");
+    }
+
+    /// With no daemon to reach, the job goes into the file — and the terminal
+    /// says what that means rather than "added". The shipped command printed
+    /// `Scheduled job '…' added.` and nothing else, for a job the running app
+    /// would not see until it restarted.
+    ///
+    /// Fails the shipped command: its report says nothing about when the job
+    /// will run.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn a_schedule_added_with_no_daemon_says_exactly_when_it_will_run() {
+        let root = tempfile::tempdir().unwrap();
+        let _env = env_lock::lock_env([(
+            "BIOROUTER_PATH_ROOT",
+            Some(root.path().to_string_lossy().into_owned()),
+        )]);
+        let data_dir = root.path().join("data");
+        let workflow = root.path().join("probe.yaml");
+        std::fs::write(
+            &workflow,
+            "title: Probe\ndescription: d\nprompt: echo probe\n",
+        )
+        .unwrap();
+        let port = unused_port().await;
+
+        let reach = Reach::probe(Some(DaemonAuth::for_test("s3cret", "")), port).await;
+        let report = add_schedule(
+            reach,
+            || Ok(LocalStore::at_data_dir(&data_dir)),
+            "qaf-probe",
+            "0 2 * * *",
+            &workflow.to_string_lossy(),
+        )
+        .await
+        .expect("with no daemon the job still goes into the file");
+
+        let on_disk: Vec<ScheduledJob> =
+            serde_json::from_str(&std::fs::read_to_string(data_dir.join("schedule.json")).unwrap())
+                .unwrap();
+        assert_eq!(on_disk.len(), 1);
+        assert_eq!(on_disk[0].id, "qaf-probe");
+
+        assert!(
+            report.contains(&format!("no daemon answered on {DAEMON_HOST}:{port}")),
+            "the report must say why the daemon was not used: {report}"
+        );
+        assert!(
+            report.contains("picks it up from that file within"),
+            "the report must say when a running Biorouter will see it: {report}"
+        );
+        assert!(
+            report.contains("next time Biorouter starts"),
+            "the report must say what happens when none is running: {report}"
+        );
+    }
+
+    /// With no key in this shell there is nothing to probe with, and the report
+    /// names that — the case an agent's shell is always in, since the daemon's
+    /// secret is stripped from every tool's environment (issue #57).
+    #[tokio::test]
+    async fn without_a_key_there_is_no_daemon_to_reach_and_the_report_says_so() {
+        let daemon = fake_daemon(|_| (500, String::new())).await;
+        match Reach::probe(None, daemon.port).await {
+            Reach::File { why } => assert!(why.contains("BIOROUTER_SERVER__SECRET_KEY"), "{why}"),
+            Reach::Daemon { .. } => panic!("without a key the daemon cannot be asked anything"),
+        }
+        assert!(
+            daemon.requests().is_empty(),
+            "nothing may be sent without a key"
+        );
+    }
+
+    /// `schedule remove` reaches the daemon the same way, so the job stops
+    /// being listed and stops firing at once.
+    ///
+    /// Fails the shipped command, which removed it from the file only.
+    #[tokio::test]
+    async fn a_schedule_removed_while_a_daemon_runs_is_removed_by_that_daemon() {
+        let daemon = fake_daemon(|request| {
+            if request.starts_with("DELETE /schedule/delete/qaf-probe ") {
+                (204, String::new())
+            } else {
+                (404, "{}".to_string())
+            }
+        })
+        .await;
+        let reach = Reach::probe(Some(DaemonAuth::for_test("s3cret", "")), daemon.port).await;
+        let report = remove_schedule(reach, local_store_is_off_limits, "qaf-probe")
+            .await
+            .expect("the daemon removed it");
+        assert_eq!(daemon.requests().len(), 1, "{:?}", daemon.requests());
+        assert!(report.contains("running Biorouter"), "{report}");
+    }
+
+    /// A delete the daemon reports as 404 is "not found", in the same words the
+    /// file path has always used.
+    #[tokio::test]
+    async fn a_schedule_the_daemon_does_not_have_is_not_found() {
+        let daemon = fake_daemon(|_| (404, String::new())).await;
+        let reach = Reach::probe(Some(DaemonAuth::for_test("s3cret", "")), daemon.port).await;
+        let error = remove_schedule(reach, local_store_is_off_limits, "nightly")
+            .await
+            .expect_err("404 is not a removal");
+        assert!(format!("{error}").contains("not found"), "{error}");
+    }
+
+    /// `schedule list` asks the daemon too: what it lists is what will fire.
+    ///
+    /// Fails the shipped command, which read the file with a scheduler of its
+    /// own.
+    #[tokio::test]
+    async fn schedules_are_listed_by_the_daemon_that_runs_them() {
+        let daemon = fake_daemon(|request| {
+            if request.starts_with("GET /schedule/list ") {
+                (200, format!(r#"{{"jobs":[{CREATED}]}}"#))
+            } else {
+                (404, "{}".to_string())
+            }
+        })
+        .await;
+        let reach = Reach::probe(Some(DaemonAuth::for_test("s3cret", "")), daemon.port).await;
+        let listing = list_schedules(reach, local_store_is_off_limits)
+            .await
+            .expect("the daemon listed them");
+        assert!(listing.contains("qaf-probe"), "{listing}");
+        assert!(listing.contains("running Biorouter"), "{listing}");
+    }
+
+    /// `schedule run-now` runs the job IN the daemon when there is one — where
+    /// the desktop's Stop button can reach it — rather than in this terminal.
+    ///
+    /// Fails the shipped command, which ran it here.
+    #[tokio::test]
+    async fn run_now_runs_in_the_daemon_that_holds_the_schedule() {
+        let daemon = fake_daemon(|request| {
+            if request.starts_with("POST /schedule/qaf-probe/run_now ") {
+                (200, r#"{"session_id":"20260911_42"}"#.to_string())
+            } else {
+                (404, "{}".to_string())
+            }
+        })
+        .await;
+        let reach = Reach::probe(Some(DaemonAuth::for_test("s3cret", "")), daemon.port).await;
+        let report = run_schedule_now(reach, local_store_is_off_limits, "qaf-probe")
+            .await
+            .expect("the daemon ran it");
+        assert!(report.contains("20260911_42"), "{report}");
     }
 }

--- a/crates/biorouter-cli/src/commands/session_watch.rs
+++ b/crates/biorouter-cli/src/commands/session_watch.rs
@@ -832,6 +832,93 @@ async fn post_json(path: &str, body: &str, auth: &DaemonAuth) -> Result<(u16, St
     Ok((code, body.to_string()))
 }
 
+/// One request to a JSON route that takes the secret key and nothing more — the
+/// schedule routes — returning the status and the body.
+///
+/// Unlike [`post_json`] it carries no user-action proof, and it takes the port
+/// rather than reading `BIOROUTER_PORT` itself: the caller has already probed
+/// that port, and a request must go to the daemon the probe found.
+///
+/// `deadline` is `None` only for a request whose answer genuinely takes as long
+/// as it takes — `POST /schedule/{id}/run_now` answers when the run ends.
+pub(crate) async fn daemon_json_request(
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+    auth: &DaemonAuth,
+    port: u16,
+    deadline: Option<std::time::Duration>,
+) -> Result<(u16, String)> {
+    let body = body.unwrap_or("");
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {DAEMON_HOST}\r\n{}\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\
+         Accept: application/json\r\nConnection: close\r\n\r\n{body}",
+        auth.headers(),
+        body.len()
+    );
+    let exchange = async {
+        let mut stream = tokio::net::TcpStream::connect(format!("{DAEMON_HOST}:{port}")).await?;
+        stream.write_all(request.as_bytes()).await?;
+        let mut raw = Vec::new();
+        stream.read_to_end(&mut raw).await?;
+        Ok::<Vec<u8>, std::io::Error>(raw)
+    };
+    let raw = match deadline {
+        Some(limit) => tokio::time::timeout(limit, exchange)
+            .await
+            .map_err(|_| anyhow!("the daemon did not answer {method} {path} within {limit:?}"))??,
+        None => exchange.await?,
+    };
+
+    // Split on BYTES: a chunk size counts bytes, and a lossy decode first could
+    // move them.
+    let end = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .ok_or_else(|| {
+            anyhow!(
+                "the daemon closed the connection before sending a complete response to {method} \
+             {path}, so it is not known whether the request was carried out"
+            )
+        })?;
+    let head = String::from_utf8_lossy(&raw[..end]).into_owned();
+    let status = head.lines().next().unwrap_or_default();
+    let code = status_code(status)
+        .ok_or_else(|| anyhow!("daemon sent a response carrying no status code: {status}"))?;
+    let body = &raw[end + 4..];
+    let body = if head
+        .to_ascii_lowercase()
+        .contains("transfer-encoding: chunked")
+    {
+        dechunk(body)
+    } else {
+        body.to_vec()
+    };
+    Ok((code, String::from_utf8_lossy(&body).into_owned()))
+}
+
+/// An HTTP/1.1 chunked body, joined. Malformed framing ends the body where it
+/// breaks rather than inventing bytes.
+fn dechunk(mut rest: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    while let Some(line_end) = rest.windows(2).position(|w| w == b"\r\n") {
+        let Some(size) = std::str::from_utf8(&rest[..line_end])
+            .ok()
+            .and_then(|line| usize::from_str_radix(line.trim(), 16).ok())
+        else {
+            break;
+        };
+        let data = &rest[line_end + 2..];
+        if size == 0 || data.len() < size {
+            break;
+        }
+        out.extend_from_slice(&data[..size]);
+        rest = data[size..].strip_prefix(b"\r\n").unwrap_or(&data[size..]);
+    }
+    out
+}
+
 /// `biorouter sessions watch <id>` — read-only observation of a live session.
 pub async fn handle_session_watch(session_id: &str, follow: bool) -> Result<()> {
     let auth = daemon_auth().await?;

--- a/crates/biorouter-server/src/commands/agent.rs
+++ b/crates/biorouter-server/src/commands/agent.rs
@@ -217,6 +217,14 @@ pub async fn run() -> Result<()> {
     // and without it a running app needs a restart to notice them.
     biorouter::catalog::spawn_config_watcher();
 
+    // QA 2026-09-10, F2 — the same problem for `schedule.json`. A schedule
+    // another process writes (`biorouter schedule add` when it cannot reach this
+    // daemon, which from an agent's shell it never can; a terminal session's
+    // `/loop`) used to stay invisible here until a restart: absent from the
+    // Scheduler page and `manage_schedule list`, undeletable through either, and
+    // never fired — after the CLI had printed "Scheduled job added".
+    app_state.agent_manager.watch_schedule_file();
+
     // `into_make_service_with_connect_info` is what puts the real peer address
     // in request extensions, so the auth throttle can key on it instead of the
     // client-supplied `x-forwarded-for` header.

--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -7142,8 +7142,16 @@ impl Agent {
             // for the same reason: the value the call is granted must be fixed
             // before the call runs, not re-read while it runs.
             let cap = crate::privacy::CallCapability::sample(&self.provider).await;
+            // The turn's token, so a Stop releases an approval card nobody has
+            // answered rather than leaving the turn parked on it.
             let result = self
-                .handle_schedule_management(arguments, request_id.clone(), &session.id, cap)
+                .handle_schedule_management(
+                    arguments,
+                    request_id.clone(),
+                    &session.id,
+                    cap,
+                    cancellation_token.clone(),
+                )
                 .await;
             let wrapped_result = result.map(|content| CallToolResult {
                 content,

--- a/crates/biorouter/src/agents/mod.rs
+++ b/crates/biorouter/src/agents/mod.rs
@@ -31,6 +31,10 @@ pub mod mcp_client;
 pub mod mcp_pool;
 pub mod mistakes;
 pub mod moim;
+// The one approval card `platform__manage_workflow` and `platform__manage_schedule`
+// park before they change the user's setup — shared so the two cannot disagree
+// about whether to ask (QA 2026-09-10, F1).
+pub(crate) mod platform_approval;
 pub mod platform_tools;
 // BR-47: auto post-edit diagnostics — the config gate, write-detection, and
 // corrective-context formatting for the edit->check->fix reflection loop.
@@ -45,7 +49,7 @@ mod recurring;
 pub(crate) mod reply_parts;
 pub mod resource_refs;
 pub mod retry;
-mod schedule_tool;
+pub(crate) mod schedule_tool;
 mod session_blob_tool;
 // The session-row write for `enabled_extensions.v0`, plus the classifier that
 // says which catalog tools require it. `pub` because `agents::agent` is

--- a/crates/biorouter/src/agents/platform_approval.rs
+++ b/crates/biorouter/src/agents/platform_approval.rs
@@ -1,0 +1,122 @@
+//! The approval card a `platform__*` management tool parks before it changes the
+//! user's own setup — and the one place that card is built.
+//!
+//! Two tools raise it: `platform__manage_workflow` (save, delete, import,
+//! schedule) and `platform__manage_schedule` (create, run_now, pause, unpause,
+//! delete, kill). They used to disagree. The workflow tool asked before writing a
+//! YAML file, while the schedule tool created a standing daily agent run with no
+//! card at all — the cheaper-to-undo action gated and the more consequential one
+//! not (QA 2026-09-10, finding F1). One function is what stops the two drifting
+//! apart again: the card's shape, its proof requirement and the way its answer is
+//! read cannot differ between tools that both call it.
+//!
+//! ## Why the card appears in every permission mode
+//!
+//! It is parked by the handler itself, through [`PendingUserActions`], not raised
+//! by the permission inspector, so the permission mode never decides whether it
+//! appears. Autonomous mode — where the inspector asks nothing — still gets it,
+//! and that is the point: an agent in Autonomous mode is the one best placed to
+//! set up a standing run nobody asked for. `requires_user_proof` means only a
+//! surface that can prove a person clicked may allow it, so a model cannot
+//! approve its own schedule over daemon HTTP. A user who wants the change says
+//! yes; an agent never gets it done on its own.
+
+use std::time::Duration;
+
+use rmcp::model::{ErrorCode, ErrorData};
+use serde_json::Value;
+use tokio_util::sync::CancellationToken;
+
+use crate::pending_user_action::{
+    PendingUserActions, ToolApprovalRequest, UserActionOutcome, UserActionRequest,
+};
+use crate::permission::tool_risk::ToolRisk;
+
+/// How long a platform-tool change waits for the user to answer its card.
+const PLATFORM_MUTATION_APPROVAL_TTL: Duration = Duration::from_secs(300);
+
+/// What the card asks about.
+pub(crate) struct PlatformApproval<'a> {
+    /// The tool the card names — `Run Manage Schedule?` is read off this.
+    pub tool_name: &'a str,
+    /// The verb, for the refusal text the model reads.
+    pub action: &'a str,
+    /// The chat the card is shown in.
+    pub session_id: &'a str,
+    /// The sentence at the top of the card. It carries the decision, so it says
+    /// what will happen in words rather than restating the arguments.
+    pub summary: &'a str,
+    /// What the card shows under the sentence. Not necessarily the call's own
+    /// arguments: a caller whose raw arguments are opaque (a base64 link, a bare
+    /// path) passes the thing they stand for instead.
+    pub arguments: &'a Value,
+    pub risk: ToolRisk,
+}
+
+fn refused(message: String) -> ErrorData {
+    ErrorData::new(ErrorCode::INVALID_PARAMS, message, None)
+}
+
+/// Park an approval card the user must actually answer, and return only once
+/// they have allowed the change.
+///
+/// Every outcome other than an allow — a denial, a timeout, a Stop, a card that
+/// could not be shown — is an error that says nothing was changed, because the
+/// caller has not changed anything yet and must not.
+pub(crate) async fn require_platform_approval(
+    approval: PlatformApproval<'_>,
+    cancellation_token: Option<&CancellationToken>,
+) -> Result<(), ErrorData> {
+    let PlatformApproval {
+        tool_name,
+        action,
+        session_id,
+        summary,
+        arguments,
+        risk,
+    } = approval;
+
+    if session_id.is_empty() {
+        return Err(refused(format!(
+            "`{action}` needs an active conversation so Biorouter can show its approval card"
+        )));
+    }
+
+    let approval_arguments = arguments
+        .as_object()
+        .cloned()
+        .unwrap_or_else(serde_json::Map::new);
+    let request = UserActionRequest::ToolApproval(ToolApprovalRequest {
+        tool_name: tool_name.to_string(),
+        arguments: approval_arguments.clone(),
+        prompt: Some(summary.to_string()),
+        risk: Some(risk),
+        preview: crate::conversation::tool_preview::ToolPreview::for_tool_call(
+            tool_name,
+            &approval_arguments,
+        ),
+        requires_user_proof: true,
+    });
+
+    let parked = PendingUserActions::global().park(Some(session_id), None, request);
+    let outcome = parked
+        .wait(PLATFORM_MUTATION_APPROVAL_TTL, cancellation_token)
+        .await;
+
+    match outcome {
+        UserActionOutcome::Approved { .. }
+            if !cancellation_token.is_some_and(CancellationToken::is_cancelled) =>
+        {
+            Ok(())
+        }
+        UserActionOutcome::Approved { .. } => Err(refused(format!(
+            "`{action}` was cancelled after approval and before anything changed"
+        ))),
+        UserActionOutcome::Denied { .. } => Err(refused(format!(
+            "The user declined the `{action}`. Nothing was changed."
+        ))),
+        other => Err(refused(format!(
+            "`{action}` was not approved ({other:?}). Nothing was changed."
+        ))),
+    }
+}

--- a/crates/biorouter/src/agents/platform_tools.rs
+++ b/crates/biorouter/src/agents/platform_tools.rs
@@ -129,8 +129,9 @@ pub struct PlatformToolGates {
     pub bug_report: bool,
     /// `pending_user_action::user_proof_available()` again — the SAME
     /// process-global, sampled in the same breath as [`Self::bug_report`], for
-    /// a different decision: it narrows `platform__manage_workflow`'s action
-    /// list rather than deciding whether a tool is offered at all.
+    /// a different decision: it narrows `platform__manage_workflow`'s and
+    /// `platform__manage_schedule`'s action lists rather than deciding whether a
+    /// tool is offered at all.
     ///
     /// It is a field rather than a read inside [`Self::tools`] because this
     /// struct's whole contract is that a gate is sampled ONCE by
@@ -164,7 +165,7 @@ impl PlatformToolGates {
         }
         let mut tools = Vec::new();
         if self.scheduler {
-            tools.push(manage_schedule_tool());
+            tools.push(manage_schedule_tool(self.can_ask_a_person));
         }
         if self.knowledge {
             tools.push(ingest_conversation_tool());
@@ -523,9 +524,34 @@ pub fn report_bug_tool() -> Tool {
     })
 }
 
-pub fn manage_schedule_tool() -> Tool {
-    Tool::new(
-        PLATFORM_MANAGE_SCHEDULE_TOOL_NAME.to_string(),
+/// Manage the user's scheduled jobs.
+///
+/// ⚠ Like [`manage_workflow_tool`], the `enum` is DERIVED from
+/// [`crate::agents::schedule_tool::available_actions`] rather than written out
+/// here, and for the same two reasons: a schema listing an action the handler
+/// refuses advertises a verb that always fails, and on a `biorouter serve`
+/// daemon — where `can_ask_a_person` is false forever — the six actions that
+/// need an approval can never get one, so they are absent and the description
+/// says why (SD-8).
+pub fn manage_schedule_tool(can_ask_a_person: bool) -> Tool {
+    let action_values: Vec<serde_json::Value> =
+        crate::agents::schedule_tool::available_actions(can_ask_a_person)
+            .iter()
+            .map(|action| serde_json::Value::String((*action).to_string()))
+            .collect();
+
+    let approval_note = if can_ask_a_person {
+        "Creating, running, pausing, resuming, deleting and stopping a job ask the user to \
+         approve it first, and the approval tells them when the job runs, what it runs and how."
+    } else {
+        "This Biorouter cannot ask the user to approve anything (it is a browser session), so \
+         creating, running, pausing, resuming, deleting and stopping jobs are not available here. \
+         Reading still works; tell the user to make changes in the desktop app or with the \
+         `biorouter` command."
+    };
+
+    let description = format!(
+        "{}\n{approval_note}",
         indoc! {r#"
             Manage biorouter's internal scheduled workflow execution.
 
@@ -541,14 +567,18 @@ pub fn manage_schedule_tool() -> Tool {
             - "sessions": List execution history for a biorouter scheduled job
             - "session_content": Get the full content (messages) of a specific session
         "#}
-        .to_string(),
+    );
+
+    Tool::new(
+        PLATFORM_MANAGE_SCHEDULE_TOOL_NAME.to_string(),
+        description,
         object!({
             "type": "object",
             "required": ["action"],
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["list", "create", "run_now", "pause", "unpause", "delete", "kill", "inspect", "sessions", "session_content"]
+                    "enum": action_values
                 },
                 "job_id": {"type": "string", "description": "Job identifier for operations on existing jobs"},
                 "workflow_path": {"type": "string", "description": "Path to workflow file for create action"},
@@ -560,7 +590,9 @@ pub fn manage_schedule_tool() -> Tool {
     ).annotate(ToolAnnotations {
         title: Some("Manage scheduled workflows".to_string()),
         read_only_hint: Some(false),
-        destructive_hint: Some(true), // Can kill jobs
+        // `delete` and `kill` are destructive; without a person to ask neither
+        // is offered, so the hint follows the most dangerous action on offer.
+        destructive_hint: Some(can_ask_a_person),
         idempotent_hint: Some(false),
         open_world_hint: Some(false),
     })

--- a/crates/biorouter/src/agents/schedule_tool.rs
+++ b/crates/biorouter/src/agents/schedule_tool.rs
@@ -2,16 +2,326 @@
 //!
 //! This module contains all the handlers for the schedule management platform tool,
 //! including job creation, execution, monitoring, and session management.
+//!
+//! ## Approval posture
+//!
+//! A schedule is a standing agent run: once it exists, a new session starts on
+//! its cron with nobody watching and does whatever its workflow says. That is at
+//! least as consequential as writing the workflow file it runs — yet `create`,
+//! `delete` and `kill` went straight to the scheduler while
+//! `platform__manage_workflow` asked before saving that file (QA 2026-09-10,
+//! finding F1: in one Autonomous turn the model asked permission to write a YAML
+//! file and then, without a card, set up a daily 02:00 run with `developer`).
+//!
+//! So every action that changes what the scheduler will do —
+//! [`MUTATING_ACTIONS`] — now parks the workflow tool's own proof-backed card
+//! ([`super::platform_approval`]), in every permission mode, and the card says in
+//! words when the job runs, what it runs and how. The reads —
+//! [`READ_ONLY_ACTIONS`] — park nothing. On a daemon that can never obtain a
+//! person's proof (`biorouter serve`), the mutating actions are absent from the
+//! schema and refused here (SD-8), exactly as the workflow tool's are.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::mcp_utils::ToolResult;
 use chrono::Utc;
 use rmcp::model::{Content, ErrorCode, ErrorData};
+use tokio_util::sync::CancellationToken;
 
+use super::platform_approval::{require_platform_approval, PlatformApproval};
+use super::platform_tools::PLATFORM_MANAGE_SCHEDULE_TOOL_NAME;
 use super::Agent;
+use crate::permission::tool_risk::ToolRisk;
+use crate::scheduler::ScheduledJob;
 use crate::scheduler_trait::SchedulerTrait;
 use crate::workflow::Workflow;
+
+/// The actions that change what the scheduler will do, and therefore need a
+/// person: each one starts, stops, silences, re-arms or removes a standing run.
+pub const MUTATING_ACTIONS: &[&str] = &["create", "run_now", "pause", "unpause", "delete", "kill"];
+
+/// The actions that only read.
+pub const READ_ONLY_ACTIONS: &[&str] = &["list", "inspect", "sessions", "session_content"];
+
+/// Every action the model may be offered, given whether a person is reachable.
+///
+/// The schema's `enum` is derived from this rather than written out beside it,
+/// for the reason `workflow_tool::available_actions` gives: a schema listing a
+/// verb the handler refuses advertises a call that always fails.
+pub fn available_actions(can_ask_a_person: bool) -> Vec<&'static str> {
+    let mut actions: Vec<&'static str> = READ_ONLY_ACTIONS.to_vec();
+    if can_ask_a_person {
+        actions.extend_from_slice(MUTATING_ACTIONS);
+    }
+    actions
+}
+
+/// What a mutating action meets on a daemon that cannot ask anyone.
+fn refusal_without_a_person(action: &str) -> ErrorData {
+    invalid(format!(
+        "`{action}` changes the user's scheduled jobs, so it needs their approval — and this \
+         Biorouter is running in a mode that cannot ask anyone (a browser session started by \
+         `biorouter serve` has no way to prove a person acted). Read-only actions still work \
+         here: {}. To make this change, the user has to do it in the Biorouter desktop app or \
+         with the `biorouter` command line.",
+        READ_ONLY_ACTIONS.join(", ")
+    ))
+}
+
+fn invalid(message: impl Into<String>) -> ErrorData {
+    ErrorData::new(ErrorCode::INVALID_PARAMS, message.into(), None)
+}
+
+fn job_id_argument(arguments: &serde_json::Value) -> Result<String, ErrorData> {
+    arguments
+        .get("job_id")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| invalid("Missing 'job_id' parameter"))
+}
+
+/// Read a workflow file the way a scheduled run will: JSON by extension,
+/// otherwise YAML.
+fn read_workflow(path: &Path) -> Result<Workflow, String> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("Cannot read workflow file: {e}"))?;
+    if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+        serde_json::from_str::<Workflow>(&content)
+            .map_err(|e| format!("Invalid JSON workflow: {e}"))
+    } else {
+        serde_yaml::from_str::<Workflow>(&content)
+            .map_err(|e| format!("Invalid YAML workflow: {e}"))
+    }
+}
+
+/// The name a card gives the workflow a schedule runs: its title, or — for a
+/// file that no longer reads — its path, which is still true.
+fn workflow_label(source: &str) -> String {
+    match read_workflow(Path::new(source)) {
+        Ok(workflow) if !workflow.title.trim().is_empty() => workflow.title.trim().to_string(),
+        _ => source.to_string(),
+    }
+}
+
+/// The permission mode a scheduled run inherits, in the words Settings uses.
+///
+/// A scheduled run builds its agent with `Agent::new()`, which reads the global
+/// mode at the moment it runs — so this is "currently", not a promise.
+fn permission_mode_label() -> &'static str {
+    use crate::config::BioRouterMode;
+    match crate::config::Config::global()
+        .get_biorouter_mode()
+        .unwrap_or(BioRouterMode::Auto)
+    {
+        BioRouterMode::Auto => "Autonomous",
+        BioRouterMode::Approve => "Manual",
+        BioRouterMode::SmartApprove => "Smart",
+        BioRouterMode::Chat => "Chat only",
+    }
+}
+
+/// A cron expression in words, for a person deciding whether to allow it.
+///
+/// Deliberately partial. It names the shapes people actually write — a time
+/// every day, on certain weekdays or on one day of the month, and "every N
+/// seconds/minutes/hours" — and QUOTES anything else rather than guessing: a
+/// wrong sentence on an approval card is worse than none, and the card carries
+/// the raw expression beside it either way.
+///
+/// Clock times are this computer's local time because that is how the engine
+/// reads them (`Job::new_async_tz(.., Local)` in `scheduler.rs`), and day-of-week
+/// numbers follow the engine's parser (`croner`): 0 and 7 are Sunday.
+pub(crate) fn describe_cron(expression: &str) -> String {
+    let quoted = || format!("on the cron schedule `{}`", expression.trim());
+    let fields: Vec<&str> = expression.split_whitespace().collect();
+    let (second, minute, hour, day, month, weekday) = match fields.as_slice() {
+        [minute, hour, day, month, weekday] => ("0", *minute, *hour, *day, *month, *weekday),
+        [second, minute, hour, day, month, weekday] => {
+            (*second, *minute, *hour, *day, *month, *weekday)
+        }
+        _ => return quoted(),
+    };
+    let any = |field: &str| field == "*" || field == "?";
+    let number = |field: &str, max: u32| field.parse::<u32>().ok().filter(|n| *n <= max);
+    let step = |field: &str| {
+        field
+            .strip_prefix("*/")
+            .and_then(|n| n.parse::<u32>().ok())
+            .filter(|n| *n > 0)
+    };
+    let every = |n: u32, unit: &str| {
+        if n == 1 {
+            format!("every {unit}")
+        } else {
+            format!("every {n} {unit}s")
+        }
+    };
+    if !any(month) {
+        return quoted();
+    }
+
+    // A clock time: second, minute and hour all fixed.
+    if let (Some(s), Some(m), Some(h)) = (number(second, 59), number(minute, 59), number(hour, 23))
+    {
+        let time = if s == 0 {
+            format!("{h:02}:{m:02}")
+        } else {
+            format!("{h:02}:{m:02}:{s:02}")
+        };
+        let clock = format!("at {time}, this computer's local time");
+        return match (any(day), any(weekday)) {
+            (true, true) => format!("every day {clock}"),
+            (true, false) => match weekdays(weekday) {
+                Some(days) => format!("every {days} {clock}"),
+                None => quoted(),
+            },
+            (false, true) => match number(day, 31).filter(|d| *d >= 1) {
+                Some(d) => format!("on the {} of every month {clock}", ordinal(d)),
+                None => quoted(),
+            },
+            (false, false) => quoted(),
+        };
+    }
+
+    // An interval: nothing coarser than the field that steps is restricted.
+    if !(any(day) && any(weekday)) {
+        return quoted();
+    }
+    match (second, minute, hour) {
+        ("*", "*", "*") => "every second".to_string(),
+        (s, "*", "*") if step(s).is_some() => every(step(s).unwrap_or(1), "second"),
+        ("0", "*", "*") => "every minute".to_string(),
+        ("0", m, "*") if step(m).is_some() => every(step(m).unwrap_or(1), "minute"),
+        ("0", m, h) if number(m, 59).is_some() && (any(h) || step(h).is_some()) => {
+            let m = number(m, 59).unwrap_or(0);
+            let hours = if any(h) {
+                "every hour".to_string()
+            } else {
+                every(step(h).unwrap_or(1), "hour")
+            };
+            if m == 0 {
+                format!("{hours}, on the hour")
+            } else {
+                format!("{hours}, at {m} minutes past")
+            }
+        }
+        _ => quoted(),
+    }
+}
+
+/// `1-5` → "Monday to Friday", `1,3,5` → "Monday, Wednesday and Friday". `None`
+/// for anything this does not recognise (`L`, `#`, steps, a wrapping range) — the
+/// caller then quotes the expression rather than naming the wrong days.
+fn weekdays(field: &str) -> Option<String> {
+    const NAMES: [&str; 7] = [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+    ];
+    // 0..=7 as the engine numbers them — 0 and 7 are both Sunday — or a
+    // three-letter name.
+    let day = |token: &str| -> Option<usize> {
+        const ABBREVIATIONS: [&str; 7] = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+        let upper = token.to_ascii_uppercase();
+        ABBREVIATIONS
+            .iter()
+            .position(|abbreviation| *abbreviation == upper)
+            .or_else(|| token.parse::<usize>().ok().filter(|n| *n <= 7))
+    };
+    let mut parts = Vec::new();
+    for item in field.split(',') {
+        match item.split_once('-') {
+            Some((from, to)) => {
+                let (from, to) = (day(from)?, day(to)?);
+                // A range that wraps past Saturday (`5-1`), or runs Sunday to
+                // Sunday (`0-7`), is not named; the caller quotes it instead.
+                if from >= to || from % 7 == to % 7 {
+                    return None;
+                }
+                parts.push(format!("{} to {}", NAMES[from % 7], NAMES[to % 7]));
+            }
+            None => parts.push(NAMES[day(item)? % 7].to_string()),
+        }
+    }
+    Some(match parts.as_slice() {
+        [] => return None,
+        [only] => only.clone(),
+        [init @ .., last] => format!("{} and {last}", init.join(", ")),
+    })
+}
+
+fn ordinal(n: u32) -> String {
+    let suffix = match (n % 10, n % 100) {
+        (_, 11..=13) => "th",
+        (1, _) => "st",
+        (2, _) => "nd",
+        (3, _) => "rd",
+        _ => "th",
+    };
+    format!("{n}{suffix}")
+}
+
+/// The sentence on a by-id action's card, and how risky the action is.
+///
+/// Each one says what will happen to the user's standing run in their terms,
+/// not the tool's. `delete` is graded like the workflow tool's delete; the rest
+/// are ordinary changes.
+fn job_change_summary(
+    action: &str,
+    job: &ScheduledJob,
+    workflow: &str,
+    when: &str,
+    mode: &str,
+) -> (String, ToolRisk) {
+    let id = &job.id;
+    match action {
+        "run_now" => (
+            format!(
+                "Run the schedule '{id}' once, right now: the workflow '{workflow}' starts in a \
+                 new background session that nobody watches, under your permission mode \
+                 (currently {mode}). Its regular schedule ({when}) is unchanged."
+            ),
+            ToolRisk::Medium,
+        ),
+        "pause" => (
+            format!(
+                "Pause the schedule '{id}', which runs the workflow '{workflow}' {when}. It will \
+                 not run again until it is resumed."
+            ),
+            ToolRisk::Medium,
+        ),
+        "unpause" => (
+            format!(
+                "Resume the schedule '{id}': the workflow '{workflow}' will run automatically \
+                 again {when}, each time in a new background session that nobody watches, under \
+                 your permission mode (currently {mode})."
+            ),
+            ToolRisk::Medium,
+        ),
+        "delete" => (
+            format!(
+                "Delete the schedule '{id}', which runs the workflow '{workflow}' {when}. It will \
+                 never run again."
+            ),
+            ToolRisk::High,
+        ),
+        _ => (
+            format!(
+                "Stop the run of the schedule '{id}' (the workflow '{workflow}') that is in \
+                 progress now. What it has already done stays done; the run is recorded as \
+                 stopped, not finished."
+            ),
+            ToolRisk::Medium,
+        ),
+    }
+}
 
 impl Agent {
     /// Handle schedule management tool calls.
@@ -20,19 +330,23 @@ impl Agent {
     /// from `dispatch_tool_call`'s own `session` argument. `create` records it on
     /// the job so a scheduled run resolves the *creating chat's* model rather
     /// than the global default (issue #56, R5) — see
-    /// `scheduler::resolve_scheduled_provider`.
+    /// `scheduler::resolve_scheduled_provider`. It is also the chat every
+    /// approval card below is shown in.
     /// `cap` is the caller's admitted capability, sampled by `dispatch_tool_call`
     /// in the schedule branch. Two of the actions below read another chat's
     /// content — `session_content` returns a whole transcript, `sessions` returns
     /// LLM-generated titles and working directories — so this tool needs the same
     /// capability its `workspace_*` siblings take. It shipped with none at all,
     /// which is why the parameter looks bolted on: it is.
+    /// `cancellation_token` is the turn's, so a Stop releases a card nobody has
+    /// answered instead of leaving the turn parked for the card's whole lifetime.
     pub async fn handle_schedule_management(
         &self,
         arguments: serde_json::Value,
         _request_id: String,
         creator_session_id: &str,
         cap: crate::privacy::CallCapability,
+        cancellation_token: Option<CancellationToken>,
     ) -> ToolResult<Vec<Content>> {
         let scheduler = self.config.scheduler_service.clone().ok_or_else(|| {
             ErrorData::new(
@@ -51,28 +365,123 @@ impl Agent {
                     "Missing 'action' parameter".to_string(),
                     None,
                 )
-            })?;
+            })?
+            .to_string();
 
-        match action {
+        // Sampled ONCE per call, as the workflow tool does: two reads of a
+        // daemon-level fact can disagree, and the second is the one a change
+        // would run behind.
+        let can_ask_a_person = crate::pending_user_action::user_proof_available();
+        if MUTATING_ACTIONS.contains(&action.as_str()) && !can_ask_a_person {
+            return Err(refusal_without_a_person(&action));
+        }
+
+        let cancel = cancellation_token.as_ref();
+        match action.as_str() {
             "list" => self.handle_list_jobs(scheduler).await,
             "create" => {
-                self.handle_create_job(scheduler, arguments, creator_session_id)
+                self.handle_create_job(scheduler, arguments, creator_session_id, cancel)
                     .await
             }
-            "run_now" => self.handle_run_now(scheduler, arguments).await,
-            "pause" => self.handle_pause_job(scheduler, arguments).await,
-            "unpause" => self.handle_unpause_job(scheduler, arguments).await,
-            "delete" => self.handle_delete_job(scheduler, arguments).await,
-            "kill" => self.handle_kill_job(scheduler, arguments).await,
+            "run_now" => {
+                self.handle_run_now(scheduler, arguments, creator_session_id, cancel)
+                    .await
+            }
+            "pause" => {
+                self.handle_pause_job(scheduler, arguments, creator_session_id, cancel)
+                    .await
+            }
+            "unpause" => {
+                self.handle_unpause_job(scheduler, arguments, creator_session_id, cancel)
+                    .await
+            }
+            "delete" => {
+                self.handle_delete_job(scheduler, arguments, creator_session_id, cancel)
+                    .await
+            }
+            "kill" => {
+                self.handle_kill_job(scheduler, arguments, creator_session_id, cancel)
+                    .await
+            }
             "inspect" => self.handle_inspect_job(scheduler, arguments).await,
             "sessions" => self.handle_list_sessions(scheduler, arguments, cap).await,
             "session_content" => self.handle_session_content(arguments, cap).await,
-            _ => Err(ErrorData::new(
-                ErrorCode::INTERNAL_ERROR,
-                format!("Unknown action: {}", action),
+            other => Err(ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                format!(
+                    "Unknown action '{other}'. Available actions: {}",
+                    available_actions(can_ask_a_person).join(", ")
+                ),
                 None,
             )),
         }
+    }
+
+    /// Find the schedule a by-id action names, say in words what the action will
+    /// do to it, and park the card. Returns once the user has allowed it.
+    ///
+    /// ⚠ The lookup comes BEFORE the card, and so do the refusals the scheduler
+    /// would make anyway: a card for a schedule that does not exist, or a Stop for
+    /// a run that is not running, spends the user's attention on something that
+    /// cannot happen.
+    async fn ask_about_job(
+        &self,
+        scheduler: &Arc<dyn SchedulerTrait>,
+        action: &str,
+        job_id: &str,
+        session_id: &str,
+        cancellation_token: Option<&CancellationToken>,
+    ) -> Result<(), ErrorData> {
+        let job = scheduler
+            .list_scheduled_jobs()
+            .await
+            .into_iter()
+            .find(|job| job.id == job_id)
+            .ok_or_else(|| {
+                invalid(format!(
+                    "There is no schedule with the id '{job_id}'. Use action \"list\" to see the \
+                     schedules that exist."
+                ))
+            })?;
+        if action == "kill" && !job.currently_running {
+            return Err(invalid(format!(
+                "The schedule '{job_id}' is not running right now, so there is nothing to stop. \
+                 Nothing was changed."
+            )));
+        }
+        if action == "pause" && job.currently_running {
+            return Err(invalid(format!(
+                "The schedule '{job_id}' is running right now and cannot be paused mid-run; stop \
+                 it with action \"kill\" or wait for the run to finish. Nothing was changed."
+            )));
+        }
+
+        let workflow = workflow_label(&job.source);
+        let when = describe_cron(&job.cron);
+        let (summary, risk) =
+            job_change_summary(action, &job, &workflow, &when, permission_mode_label());
+        let card = serde_json::json!({
+            "action": action,
+            "job_id": job.id,
+            "schedule": when,
+            "cron_expression": job.cron,
+            "paused": job.paused,
+            "running_now": job.currently_running,
+            "workflow": workflow,
+            "workflow_path": job.source,
+        });
+        require_platform_approval(
+            PlatformApproval {
+                tool_name: PLATFORM_MANAGE_SCHEDULE_TOOL_NAME,
+                action,
+                session_id,
+                summary: &summary,
+                arguments: &card,
+                risk,
+            },
+            cancellation_token,
+        )
+        .await
     }
 
     async fn handle_list_jobs(
@@ -98,6 +507,7 @@ impl Agent {
         scheduler: Arc<dyn SchedulerTrait>,
         arguments: serde_json::Value,
         creator_session_id: &str,
+        cancellation_token: Option<&CancellationToken>,
     ) -> ToolResult<Vec<Content>> {
         let workflow_path = arguments
             .get("workflow_path")
@@ -121,49 +531,68 @@ impl Agent {
                 )
             })?;
 
-        // Get the execution_mode parameter, defaulting to "background" if not provided
-        let execution_mode = arguments
-            .get("execution_mode")
-            .and_then(|v| v.as_str())
-            .unwrap_or("background");
-
-        if !std::path::Path::new(workflow_path).exists() {
+        // Everything below is checked BEFORE the card: an approval for a schedule
+        // that cannot be created spends the user's attention on nothing.
+        if !Path::new(workflow_path).exists() {
             return Err(ErrorData::new(
                 ErrorCode::INTERNAL_ERROR,
                 format!("Workflow file not found: {}", workflow_path),
                 None,
             ));
         }
+        let workflow = read_workflow(Path::new(workflow_path))
+            .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e, None))?;
 
-        // Validate it's a valid workflow by trying to parse it
-        match std::fs::read_to_string(workflow_path) {
-            Ok(content) => {
-                if workflow_path.ends_with(".json") {
-                    serde_json::from_str::<Workflow>(&content).map_err(|e| {
-                        ErrorData::new(
-                            ErrorCode::INTERNAL_ERROR,
-                            format!("Invalid JSON workflow: {}", e),
-                            None,
-                        )
-                    })?;
-                } else {
-                    serde_yaml::from_str::<Workflow>(&content).map_err(|e| {
-                        ErrorData::new(
-                            ErrorCode::INTERNAL_ERROR,
-                            format!("Invalid YAML workflow: {}", e),
-                            None,
-                        )
-                    })?;
-                }
-            }
-            Err(e) => {
-                return Err(ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    format!("Cannot read workflow file: {}", e),
-                    None,
-                ))
-            }
+        // The card is the user's one look at what will run unattended on this
+        // schedule, and hidden characters are exactly what a card cannot show —
+        // the same sweep that stops `platform__manage_workflow` saving one.
+        if workflow.check_for_security_warnings() {
+            return Err(invalid(format!(
+                "The workflow at {workflow_path} contains hidden Unicode characters that could \
+                 carry instructions the user cannot see. It has not been scheduled. Tell the user \
+                 the file is suspicious."
+            )));
         }
+
+        crate::scheduler::normalize_cron(cron_expression)
+            .map_err(|e| invalid(format!("That schedule cannot be created: {e}")))?;
+
+        // ⚠ Always "background", whatever `execution_mode` the call carried. The
+        // scheduler has no other mode, and the success message used to echo the
+        // argument back — so a card or a result naming a mode the run will not
+        // use would be the one untrue sentence in the exchange.
+        let when = describe_cron(cron_expression);
+        let title = workflow.title.trim();
+        let summary = format!(
+            "Run the workflow '{title}' automatically {when}, in background mode: every run is a \
+             new session that nobody watches, on this chat's model, under your permission mode \
+             (currently {}).",
+            permission_mode_label()
+        );
+        // The card shows the WHOLE workflow, not only its path: the path is a
+        // pointer at a file anything with a shell could have written a moment
+        // ago, and what the user is agreeing to is what that file tells an
+        // unattended agent to do.
+        let card = serde_json::json!({
+            "action": "create",
+            "schedule": when,
+            "cron_expression": cron_expression,
+            "execution_mode": "background",
+            "workflow_path": workflow_path,
+            "workflow": workflow,
+        });
+        require_platform_approval(
+            PlatformApproval {
+                tool_name: PLATFORM_MANAGE_SCHEDULE_TOOL_NAME,
+                action: "create",
+                session_id: creator_session_id,
+                summary: &summary,
+                arguments: &card,
+                risk: ToolRisk::Medium,
+            },
+            cancellation_token,
+        )
+        .await?;
 
         // Generate unique job ID
         let job_id = format!("agent_created_{}", Utc::now().timestamp());
@@ -197,8 +626,8 @@ impl Agent {
 
         match scheduler.add_scheduled_job(job, true).await {
             Ok(()) => Ok(vec![Content::text(format!(
-                "Successfully created scheduled job '{}' for workflow '{}' with cron expression '{}' in {} mode",
-                job_id, workflow_path, cron_expression, execution_mode
+                "Successfully created scheduled job '{}' for workflow '{}' with cron expression '{}' in background mode",
+                job_id, workflow_path, cron_expression
             ))]),
             Err(e) => Err(ErrorData::new(
                 ErrorCode::INTERNAL_ERROR,
@@ -213,19 +642,20 @@ impl Agent {
         &self,
         scheduler: Arc<dyn SchedulerTrait>,
         arguments: serde_json::Value,
+        session_id: &str,
+        cancellation_token: Option<&CancellationToken>,
     ) -> ToolResult<Vec<Content>> {
-        let job_id = arguments
-            .get("job_id")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INVALID_PARAMS,
-                    "Missing 'job_id' parameter".to_string(),
-                    None,
-                )
-            })?;
+        let job_id = job_id_argument(&arguments)?;
+        self.ask_about_job(
+            &scheduler,
+            "run_now",
+            &job_id,
+            session_id,
+            cancellation_token,
+        )
+        .await?;
 
-        match scheduler.run_now(job_id).await {
+        match scheduler.run_now(&job_id).await {
             Ok(session_id) => Ok(vec![Content::text(format!(
                 "Successfully started job '{}'. Session ID: {}",
                 job_id, session_id
@@ -243,19 +673,14 @@ impl Agent {
         &self,
         scheduler: Arc<dyn SchedulerTrait>,
         arguments: serde_json::Value,
+        session_id: &str,
+        cancellation_token: Option<&CancellationToken>,
     ) -> ToolResult<Vec<Content>> {
-        let job_id = arguments
-            .get("job_id")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Missing 'job_id' parameter".to_string(),
-                    None,
-                )
-            })?;
+        let job_id = job_id_argument(&arguments)?;
+        self.ask_about_job(&scheduler, "pause", &job_id, session_id, cancellation_token)
+            .await?;
 
-        match scheduler.pause_schedule(job_id).await {
+        match scheduler.pause_schedule(&job_id).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully paused job '{}'",
                 job_id
@@ -273,19 +698,20 @@ impl Agent {
         &self,
         scheduler: Arc<dyn SchedulerTrait>,
         arguments: serde_json::Value,
+        session_id: &str,
+        cancellation_token: Option<&CancellationToken>,
     ) -> ToolResult<Vec<Content>> {
-        let job_id = arguments
-            .get("job_id")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Missing 'job_id' parameter".to_string(),
-                    None,
-                )
-            })?;
+        let job_id = job_id_argument(&arguments)?;
+        self.ask_about_job(
+            &scheduler,
+            "unpause",
+            &job_id,
+            session_id,
+            cancellation_token,
+        )
+        .await?;
 
-        match scheduler.unpause_schedule(job_id).await {
+        match scheduler.unpause_schedule(&job_id).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully unpaused job '{}'",
                 job_id
@@ -303,19 +729,20 @@ impl Agent {
         &self,
         scheduler: Arc<dyn SchedulerTrait>,
         arguments: serde_json::Value,
+        session_id: &str,
+        cancellation_token: Option<&CancellationToken>,
     ) -> ToolResult<Vec<Content>> {
-        let job_id = arguments
-            .get("job_id")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Missing 'job_id' parameter".to_string(),
-                    None,
-                )
-            })?;
+        let job_id = job_id_argument(&arguments)?;
+        self.ask_about_job(
+            &scheduler,
+            "delete",
+            &job_id,
+            session_id,
+            cancellation_token,
+        )
+        .await?;
 
-        match scheduler.remove_scheduled_job(job_id, true).await {
+        match scheduler.remove_scheduled_job(&job_id, true).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully deleted job '{}'",
                 job_id
@@ -333,19 +760,14 @@ impl Agent {
         &self,
         scheduler: Arc<dyn SchedulerTrait>,
         arguments: serde_json::Value,
+        session_id: &str,
+        cancellation_token: Option<&CancellationToken>,
     ) -> ToolResult<Vec<Content>> {
-        let job_id = arguments
-            .get("job_id")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Missing 'job_id' parameter".to_string(),
-                    None,
-                )
-            })?;
+        let job_id = job_id_argument(&arguments)?;
+        self.ask_about_job(&scheduler, "kill", &job_id, session_id, cancellation_token)
+            .await?;
 
-        match scheduler.kill_running_job(job_id).await {
+        match scheduler.kill_running_job(&job_id).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully killed running job '{}'",
                 job_id
@@ -364,18 +786,9 @@ impl Agent {
         scheduler: Arc<dyn SchedulerTrait>,
         arguments: serde_json::Value,
     ) -> ToolResult<Vec<Content>> {
-        let job_id = arguments
-            .get("job_id")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Missing 'job_id' parameter".to_string(),
-                    None,
-                )
-            })?;
+        let job_id = job_id_argument(&arguments)?;
 
-        match scheduler.get_running_job_info(job_id).await {
+        match scheduler.get_running_job_info(&job_id).await {
             Ok(Some((session_id, start_time))) => {
                 let duration = Utc::now().signed_duration_since(start_time);
                 Ok(vec![Content::text(format!(
@@ -538,5 +951,759 @@ impl Agent {
             "Session '{}' Content:\n\nSession:\n{}",
             session_id, metadata_json
         ))])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::platform_tools::PLATFORM_MANAGE_SCHEDULE_TOOL_NAME;
+    use crate::agents::AgentConfig;
+    use crate::config::permission::PermissionManager;
+    use crate::config::BioRouterMode;
+    use crate::conversation::message::{ActionRequiredData, MessageContent};
+    use crate::pending_user_action::{
+        DecisionAuthority, PendingUserActions, ResolveOutcome, UserActionOutcome,
+    };
+    use crate::permission::Permission;
+    use crate::scheduler::{ScheduledJob, SchedulerError};
+    use crate::session::session_manager::{Session, SessionType};
+    use crate::session::SessionManager;
+    use rmcp::model::{CallToolRequestParams, JsonObject};
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
+
+    /// A scheduler that does nothing but remember what it was asked to do.
+    #[derive(Default)]
+    struct RecordingScheduler {
+        jobs: tokio::sync::Mutex<Vec<ScheduledJob>>,
+        calls: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl RecordingScheduler {
+        fn record(&self, call: String) {
+            self.calls.lock().unwrap().push(call);
+        }
+
+        /// Every call that would have CHANGED something. Reads are left out:
+        /// looking a job up before asking about it is the point, not a leak.
+        fn mutations(&self) -> Vec<String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|call| {
+                    !["list", "inspect", "sessions"]
+                        .iter()
+                        .any(|read| call.starts_with(read))
+                })
+                .cloned()
+                .collect()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SchedulerTrait for RecordingScheduler {
+        async fn add_scheduled_job(
+            &self,
+            job: ScheduledJob,
+            _copy_workflow: bool,
+        ) -> Result<(), SchedulerError> {
+            self.record(format!("add {}", job.id));
+            self.jobs.lock().await.push(job);
+            Ok(())
+        }
+
+        async fn schedule_workflow(
+            &self,
+            _workflow_path: PathBuf,
+            _cron_schedule: Option<String>,
+        ) -> Result<(), SchedulerError> {
+            self.record("schedule_workflow".to_string());
+            Ok(())
+        }
+
+        async fn list_scheduled_jobs(&self) -> Vec<ScheduledJob> {
+            self.record("list".to_string());
+            self.jobs.lock().await.clone()
+        }
+
+        async fn remove_scheduled_job(
+            &self,
+            id: &str,
+            _remove_owned_workflow: bool,
+        ) -> Result<(), SchedulerError> {
+            self.record(format!("remove {id}"));
+            self.jobs.lock().await.retain(|job| job.id != id);
+            Ok(())
+        }
+
+        async fn pause_schedule(&self, id: &str) -> Result<(), SchedulerError> {
+            self.record(format!("pause {id}"));
+            Ok(())
+        }
+
+        async fn unpause_schedule(&self, id: &str) -> Result<(), SchedulerError> {
+            self.record(format!("unpause {id}"));
+            Ok(())
+        }
+
+        async fn run_now(&self, id: &str) -> Result<String, SchedulerError> {
+            self.record(format!("run_now {id}"));
+            Ok("scheduled-run-session".to_string())
+        }
+
+        async fn sessions(
+            &self,
+            sched_id: &str,
+            _limit: usize,
+        ) -> Result<Vec<(String, Session)>, SchedulerError> {
+            self.record(format!("sessions {sched_id}"));
+            Ok(Vec::new())
+        }
+
+        async fn update_schedule(
+            &self,
+            sched_id: &str,
+            _new_cron: String,
+        ) -> Result<(), SchedulerError> {
+            self.record(format!("update {sched_id}"));
+            Ok(())
+        }
+
+        async fn kill_running_job(&self, sched_id: &str) -> Result<(), SchedulerError> {
+            self.record(format!("kill {sched_id}"));
+            Ok(())
+        }
+
+        async fn get_running_job_info(
+            &self,
+            sched_id: &str,
+        ) -> Result<Option<(String, chrono::DateTime<Utc>)>, SchedulerError> {
+            self.record(format!("inspect {sched_id}"));
+            Ok(None)
+        }
+    }
+
+    struct Fixture {
+        _dir: tempfile::TempDir,
+        agent: Arc<Agent>,
+        scheduler: Arc<RecordingScheduler>,
+        session: Session,
+        workflow: PathBuf,
+    }
+
+    fn job(id: &str, source: &Path) -> ScheduledJob {
+        ScheduledJob {
+            id: id.to_string(),
+            source: source.to_string_lossy().into_owned(),
+            cron: "0 0 2 * * *".to_string(),
+            last_run: None,
+            currently_running: false,
+            paused: false,
+            current_session_id: None,
+            process_start_time: None,
+            run_count: 0,
+            max_runs: None,
+            creator_session_id: None,
+            last_error: None,
+            owns_source: None,
+        }
+    }
+
+    /// An agent over a recording scheduler, a chat to call from, and a workflow
+    /// file on disk. `jobs` lets a test start with schedules already in place.
+    ///
+    /// ⚠ The session id is minted here, not by `create_session`. Test databases
+    /// each number their sessions from `YYYYMMDD_1`, so every test's first chat
+    /// has the SAME id — and the approval registry these tests read is
+    /// process-global and keyed by it. Two tests would answer each other's cards.
+    async fn fixture(jobs: impl FnOnce(&Path) -> Vec<ScheduledJob>) -> Fixture {
+        let dir = tempfile::tempdir().unwrap();
+        let workflow = dir.path().join("nightly-probe.yaml");
+        std::fs::write(
+            &workflow,
+            "title: Nightly probe\ndescription: Echoes a marker\nprompt: echo the probe marker\n",
+        )
+        .unwrap();
+        let scheduler = Arc::new(RecordingScheduler::default());
+        *scheduler.jobs.lock().await = jobs(&workflow);
+        let session_manager = Arc::new(SessionManager::new(dir.path().to_path_buf()));
+        let agent = Arc::new(Agent::with_config(AgentConfig::new(
+            session_manager,
+            Arc::new(PermissionManager::new(dir.path().to_path_buf())),
+            Some(scheduler.clone()),
+            BioRouterMode::Auto,
+        )));
+        let session = Session {
+            id: format!("schedule-tool-{}", uuid::Uuid::new_v4()),
+            session_type: SessionType::User,
+            working_dir: dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        Fixture {
+            _dir: dir,
+            agent,
+            scheduler,
+            session,
+            workflow,
+        }
+    }
+
+    /// Call the tool exactly as a chat does — through `dispatch_tool_call` — and
+    /// hand back its text or its error, so a test can print either.
+    fn spawn_call(
+        fx: &Fixture,
+        arguments: serde_json::Value,
+        cancel: Option<CancellationToken>,
+    ) -> tokio::task::JoinHandle<Result<String, String>> {
+        let agent = Arc::clone(&fx.agent);
+        let session = fx.session.clone();
+        tokio::spawn(async move {
+            let call = CallToolRequestParams {
+                task: None,
+                meta: None,
+                name: PLATFORM_MANAGE_SCHEDULE_TOOL_NAME.into(),
+                arguments: arguments.as_object().cloned(),
+            };
+            let (_, dispatched) = agent
+                .dispatch_tool_call(call, "req-schedule".to_string(), cancel, &session)
+                .await;
+            let result = dispatched
+                .map_err(|e| e.message.to_string())?
+                .result
+                .await
+                .map_err(|e| e.message.to_string())?;
+            Ok(result
+                .content
+                .iter()
+                .filter_map(|content| content.as_text().map(|text| text.text.clone()))
+                .collect::<Vec<_>>()
+                .join("\n"))
+        })
+    }
+
+    struct Card {
+        id: String,
+        tool_name: String,
+        prompt: String,
+        arguments: JsonObject,
+    }
+
+    /// The approval card parked for `session_id`, or a panic that says what the
+    /// handler did INSTEAD of asking. From the registry alone an early return and
+    /// a slow handler look identical, so on a timeout the handler is asked.
+    async fn approval_card(
+        session_id: &str,
+        running: tokio::task::JoinHandle<Result<String, String>>,
+    ) -> (Card, tokio::task::JoinHandle<Result<String, String>>) {
+        let found = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                for message in PendingUserActions::global().pending_cards_for_session(session_id) {
+                    for content in message.content {
+                        if let MessageContent::ActionRequired(action) = content {
+                            if let ActionRequiredData::ToolConfirmation {
+                                id,
+                                tool_name,
+                                arguments,
+                                prompt,
+                                ..
+                            } = action.data
+                            {
+                                return Card {
+                                    id,
+                                    tool_name,
+                                    prompt: prompt.unwrap_or_default(),
+                                    arguments,
+                                };
+                            }
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        match found {
+            Ok(card) => (card, running),
+            Err(_) => {
+                let outcome = tokio::time::timeout(Duration::from_secs(5), running).await;
+                panic!(
+                    "no approval card was raised within 10s. The call's own outcome was: \
+                     {outcome:#?}\n(an Ok(Ok(..)) here means it went straight through without \
+                     asking anyone)"
+                );
+            }
+        }
+    }
+
+    fn answer(session_id: &str, card: &Card, outcome: UserActionOutcome) {
+        assert_eq!(
+            PendingUserActions::global().resolve_in_session(
+                session_id,
+                &card.id,
+                outcome,
+                DecisionAuthority::for_test_proven(),
+            ),
+            ResolveOutcome::Delivered
+        );
+    }
+
+    fn deny(session_id: &str, card: &Card) {
+        answer(
+            session_id,
+            card,
+            UserActionOutcome::Denied {
+                permission: Permission::DenyOnce,
+            },
+        );
+    }
+
+    fn approve(session_id: &str, card: &Card) {
+        answer(
+            session_id,
+            card,
+            UserActionOutcome::Approved {
+                permission: Permission::AllowOnce,
+            },
+        );
+    }
+
+    /// F1 (QA 2026-09-10): `create` put a daily agent run on the user's machine
+    /// with no card at all, while saving a workflow FILE through the sibling tool
+    /// asked first. The card has to exist, has to be proof-backed like the
+    /// workflow tool's, has to say in words when the job runs, what it runs and
+    /// how — and nothing may be scheduled while it is unanswered.
+    ///
+    /// Fails the shipped handler, which went straight to `add_scheduled_job`.
+    #[tokio::test]
+    async fn create_asks_first_and_the_card_says_when_what_and_how() {
+        let fx = fixture(|_| Vec::new()).await;
+        let running = spawn_call(
+            &fx,
+            serde_json::json!({
+                "action": "create",
+                "workflow_path": fx.workflow.to_string_lossy(),
+                "cron_expression": "0 2 * * *",
+            }),
+            None,
+        );
+
+        let (card, running) = approval_card(&fx.session.id, running).await;
+        assert_eq!(card.tool_name, PLATFORM_MANAGE_SCHEDULE_TOOL_NAME);
+        assert!(
+            PendingUserActions::global().requires_user_proof_in_session(&fx.session.id, &card.id),
+            "like the workflow tool's, this card must not be answerable by a model"
+        );
+        for needle in ["every day at 02:00", "Nightly probe", "background"] {
+            assert!(
+                card.prompt.contains(needle),
+                "the card must say `{needle}`: {}",
+                card.prompt
+            );
+        }
+        assert_eq!(
+            card.arguments
+                .get("cron_expression")
+                .and_then(|v| v.as_str()),
+            Some("0 2 * * *"),
+            "the card must still show the exact expression it is asking about"
+        );
+        assert!(
+            fx.scheduler.mutations().is_empty(),
+            "nothing may be scheduled while the card is unanswered: {:?}",
+            fx.scheduler.mutations()
+        );
+
+        deny(&fx.session.id, &card);
+        let refused = running
+            .await
+            .unwrap()
+            .expect_err("a declined create is not a success");
+        assert!(refused.contains("declined"), "{refused}");
+        assert!(
+            fx.scheduler.mutations().is_empty(),
+            "a declined create scheduled something: {:?}",
+            fx.scheduler.mutations()
+        );
+    }
+
+    /// Issue #56 (R5), moved here from `tests/agent.rs` when the approval
+    /// arrived: an integration test cannot grant a proof-backed card, and this
+    /// one's whole assertion sits behind that card. A schedule the agent makes
+    /// from a chat must remember that chat, so its runs resolve the chat's
+    /// model rather than the global default.
+    ///
+    /// The id comes from `dispatch_tool_call`'s own `session` argument, NOT from
+    /// `session_context::current_session_id()`, which is scoped around scheduled
+    /// and subagent runs only and reads `None` on the ordinary chat path.
+    #[tokio::test]
+    async fn an_approved_create_schedules_it_for_the_chat_that_asked() {
+        let fx = fixture(|_| Vec::new()).await;
+        let running = spawn_call(
+            &fx,
+            serde_json::json!({
+                "action": "create",
+                "workflow_path": fx.workflow.to_string_lossy(),
+                "cron_expression": "0 0 1 * * *",
+            }),
+            None,
+        );
+        let (card, running) = approval_card(&fx.session.id, running).await;
+        approve(&fx.session.id, &card);
+
+        let text = running.await.unwrap().expect("an approved create succeeds");
+        assert!(
+            text.contains("Successfully created scheduled job"),
+            "{text}"
+        );
+        let jobs = fx.scheduler.jobs.lock().await.clone();
+        assert_eq!(jobs.len(), 1, "{jobs:?}");
+        assert_eq!(
+            jobs[0].creator_session_id.as_deref(),
+            Some(fx.session.id.as_str()),
+            "the schedule must remember the chat it was created from, or its runs fall back \
+             to the global default and leave a private chat's work on a public model"
+        );
+    }
+
+    /// The by-id half of F1. Each of these changes what the user's standing
+    /// automation does — runs it outside its schedule, silences it, re-arms it,
+    /// removes it, stops it mid-run — and each went straight to the scheduler.
+    ///
+    /// Fails the shipped handler on the first action: no card is ever raised.
+    #[tokio::test]
+    async fn every_action_that_changes_a_schedule_asks_first() {
+        let fx = fixture(|workflow| {
+            let mut running = job("nightly-running", workflow);
+            running.currently_running = true;
+            let mut paused = job("nightly-paused", workflow);
+            paused.paused = true;
+            vec![job("nightly", workflow), running, paused]
+        })
+        .await;
+
+        for (action, id) in [
+            ("run_now", "nightly"),
+            ("pause", "nightly"),
+            ("unpause", "nightly-paused"),
+            ("delete", "nightly"),
+            ("kill", "nightly-running"),
+        ] {
+            let running = spawn_call(
+                &fx,
+                serde_json::json!({ "action": action, "job_id": id }),
+                None,
+            );
+            let (card, running) = approval_card(&fx.session.id, running).await;
+            assert_eq!(card.tool_name, PLATFORM_MANAGE_SCHEDULE_TOOL_NAME);
+            assert!(
+                card.prompt.contains(id),
+                "`{action}`'s card must name the schedule it acts on: {}",
+                card.prompt
+            );
+            assert!(
+                card.prompt.contains("Nightly probe"),
+                "`{action}`'s card must name the workflow the schedule runs: {}",
+                card.prompt
+            );
+            deny(&fx.session.id, &card);
+            let refused = running.await.unwrap();
+            assert!(
+                refused
+                    .as_ref()
+                    .is_err_and(|text| text.contains("declined")),
+                "`{action}` declined must fail and say so: {refused:?}"
+            );
+        }
+        assert!(
+            fx.scheduler.mutations().is_empty(),
+            "a declined action still reached the scheduler: {:?}",
+            fx.scheduler.mutations()
+        );
+    }
+
+    /// Approval is a gate, not a wall: the same call, allowed, does the thing.
+    #[tokio::test]
+    async fn an_approved_delete_removes_the_schedule() {
+        let fx = fixture(|workflow| vec![job("nightly", workflow)]).await;
+        let running = spawn_call(
+            &fx,
+            serde_json::json!({ "action": "delete", "job_id": "nightly" }),
+            None,
+        );
+        let (card, running) = approval_card(&fx.session.id, running).await;
+        approve(&fx.session.id, &card);
+        let text = running.await.unwrap().expect("an approved delete succeeds");
+        assert!(text.contains("nightly"), "{text}");
+        assert_eq!(fx.scheduler.mutations(), vec!["remove nightly".to_string()]);
+    }
+
+    /// The guard against over-gating: reading the schedule changes nothing, so
+    /// it asks nobody. A card on `list` would teach users to click through.
+    #[tokio::test]
+    async fn reading_the_schedule_asks_nobody() {
+        let fx = fixture(|workflow| vec![job("nightly", workflow)]).await;
+        for arguments in [
+            serde_json::json!({ "action": "list" }),
+            serde_json::json!({ "action": "inspect", "job_id": "nightly" }),
+            serde_json::json!({ "action": "sessions", "job_id": "nightly" }),
+        ] {
+            let outcome = tokio::time::timeout(
+                Duration::from_secs(10),
+                spawn_call(&fx, arguments.clone(), None),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("{arguments} waited on a person"))
+            .unwrap();
+            assert!(outcome.is_ok(), "{arguments}: {outcome:?}");
+            assert!(
+                PendingUserActions::global()
+                    .pending_cards_for_session(&fx.session.id)
+                    .is_empty(),
+                "{arguments} raised a card"
+            );
+        }
+        assert!(fx.scheduler.mutations().is_empty());
+    }
+
+    /// A card for something that cannot happen spends the user's attention on
+    /// nothing, and teaches them the cards do not matter. Each of these is
+    /// refused at once, with no card: a schedule that does not exist, a Stop for
+    /// a run that is not running, an expression the engine cannot parse, and a
+    /// workflow carrying characters the card could not show.
+    #[tokio::test]
+    async fn what_cannot_happen_is_refused_without_a_card() {
+        let fx = fixture(|workflow| vec![job("nightly", workflow)]).await;
+        let hidden = fx._dir.path().join("hidden.yaml");
+        std::fs::write(
+            &hidden,
+            "title: Innocent\ndescription: looks fine\nprompt: \"summarise\u{E0041}\u{E0042}\"\n",
+        )
+        .unwrap();
+
+        for (arguments, needle) in [
+            (
+                serde_json::json!({ "action": "delete", "job_id": "no-such-job" }),
+                "no schedule with the id 'no-such-job'",
+            ),
+            (
+                serde_json::json!({ "action": "kill", "job_id": "nightly" }),
+                "not running right now",
+            ),
+            (
+                serde_json::json!({
+                    "action": "create",
+                    "workflow_path": fx.workflow.to_string_lossy(),
+                    "cron_expression": "every night please",
+                }),
+                "cannot be created",
+            ),
+            (
+                serde_json::json!({
+                    "action": "create",
+                    "workflow_path": hidden.to_string_lossy(),
+                    "cron_expression": "0 2 * * *",
+                }),
+                "hidden Unicode",
+            ),
+        ] {
+            let outcome = tokio::time::timeout(
+                Duration::from_secs(10),
+                spawn_call(&fx, arguments.clone(), None),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("{arguments} waited on a person"))
+            .unwrap();
+            let refused = outcome.expect_err(&format!("{arguments} must be refused"));
+            assert!(refused.contains(needle), "{arguments}: {refused}");
+            assert!(
+                PendingUserActions::global()
+                    .pending_cards_for_session(&fx.session.id)
+                    .is_empty(),
+                "{arguments} raised a card for something that cannot happen"
+            );
+        }
+        assert!(fx.scheduler.mutations().is_empty());
+    }
+
+    /// A Stop in the chat releases a card nobody answered, and nothing changes.
+    /// Without the turn's token the turn would sit on the card for its whole
+    /// lifetime.
+    #[tokio::test]
+    async fn a_stop_releases_an_unanswered_card_and_changes_nothing() {
+        let fx = fixture(|_| Vec::new()).await;
+        let stop = CancellationToken::new();
+        let running = spawn_call(
+            &fx,
+            serde_json::json!({
+                "action": "create",
+                "workflow_path": fx.workflow.to_string_lossy(),
+                "cron_expression": "0 2 * * *",
+            }),
+            Some(stop.clone()),
+        );
+        let (_card, running) = approval_card(&fx.session.id, running).await;
+        stop.cancel();
+        let refused = tokio::time::timeout(Duration::from_secs(10), running)
+            .await
+            .expect("a Stop must release the parked call")
+            .unwrap()
+            .expect_err("a stopped create is not a success");
+        assert!(refused.contains("Nothing was changed"), "{refused}");
+        assert!(fx.scheduler.mutations().is_empty());
+    }
+
+    /// The sentence is what the user actually decides on, so the shapes people
+    /// write are named — and anything else is quoted rather than guessed, since
+    /// a wrong sentence on an approval card is worse than none.
+    #[test]
+    fn the_cron_sentence_names_the_common_shapes_and_quotes_the_rest() {
+        let local = ", this computer's local time";
+        for (cron, expected) in [
+            ("0 2 * * *", format!("every day at 02:00{local}")),
+            ("0 0 2 * * *", format!("every day at 02:00{local}")),
+            ("30 0 2 * * *", format!("every day at 02:00:30{local}")),
+            (
+                "0 9 * * 1-5",
+                format!("every Monday to Friday at 09:00{local}"),
+            ),
+            (
+                "30 14 * * 1,3,5",
+                format!("every Monday, Wednesday and Friday at 14:30{local}"),
+            ),
+            ("0 8 * * SUN", format!("every Sunday at 08:00{local}")),
+            ("0 8 * * 7", format!("every Sunday at 08:00{local}")),
+            (
+                "0 8 * * 1-7",
+                format!("every Monday to Sunday at 08:00{local}"),
+            ),
+            (
+                "0 0 1 * *",
+                format!("on the 1st of every month at 00:00{local}"),
+            ),
+            (
+                "0 6 22 * *",
+                format!("on the 22nd of every month at 06:00{local}"),
+            ),
+            (
+                "0 6 13 * *",
+                format!("on the 13th of every month at 06:00{local}"),
+            ),
+            ("*/15 * * * *", "every 15 minutes".to_string()),
+            ("* * * * *", "every minute".to_string()),
+            ("* * * * * *", "every second".to_string()),
+            ("*/5 * * * * *", "every 5 seconds".to_string()),
+            ("0 * * * *", "every hour, on the hour".to_string()),
+            ("45 * * * *", "every hour, at 45 minutes past".to_string()),
+            ("0 */6 * * *", "every 6 hours, on the hour".to_string()),
+        ] {
+            assert_eq!(describe_cron(cron), expected, "{cron}");
+        }
+
+        // Not guessed at: a restricted month, both day fields, the engine's own
+        // extensions, a wrapping range, and nonsense.
+        for cron in [
+            "0 9 1 1 *",
+            "0 9 1 * 1",
+            "0 9 * * 1#2",
+            "0 9 * * 5L",
+            "0 9 * * 5-1",
+            "0 9 * * 0-7",
+            "0 25 * * *",
+            "every night",
+            "@daily",
+        ] {
+            assert_eq!(
+                describe_cron(cron),
+                format!("on the cron schedule `{cron}`"),
+                "{cron} must be quoted, not described"
+            );
+        }
+    }
+
+    /// The two sets partition the tool: an action in both would be offered on a
+    /// proofless daemon AND refused there, and one in neither has no posture.
+    #[test]
+    fn the_two_action_sets_partition_the_surface() {
+        for action in MUTATING_ACTIONS {
+            assert!(
+                !READ_ONLY_ACTIONS.contains(action),
+                "`{action}` cannot be both"
+            );
+        }
+        assert_eq!(
+            available_actions(true).len(),
+            MUTATING_ACTIONS.len() + READ_ONLY_ACTIONS.len()
+        );
+    }
+
+    /// Every action the schema offers has an arm in the handler's `match`, and
+    /// the two halves are a schema literal and a `match` that never mention
+    /// each other: an action advertised with no arm answers "Unknown action",
+    /// which reads to the model as its own mistake.
+    #[test]
+    fn every_offered_action_has_a_dispatch_arm() {
+        let source = std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("src/agents/schedule_tool.rs"),
+        )
+        .expect("the audit must not pass vacuously: this file must be readable");
+        let body = source
+            .split("match action.as_str() {")
+            .nth(1)
+            .and_then(|rest| rest.split("other =>").next())
+            .expect("the dispatch match must be findable");
+        for action in available_actions(true) {
+            assert!(
+                body.contains(&format!("\"{action}\" =>")),
+                "`{action}` is offered but has no arm in `handle_schedule_management`"
+            );
+        }
+    }
+
+    /// SD-8, the schema half: on a daemon that can never ask a person, the six
+    /// actions whose card can never be answered are not offered, the reads are,
+    /// and the description says why. The handler half is the refusal below.
+    #[test]
+    fn a_proofless_daemon_is_offered_the_reads_and_told_why_not_the_rest() {
+        let offered = |can_ask_a_person: bool| -> Vec<String> {
+            let tool = crate::agents::platform_tools::manage_schedule_tool(can_ask_a_person);
+            tool.input_schema["properties"]["action"]["enum"]
+                .as_array()
+                .expect("the action enum")
+                .iter()
+                .map(|value| value.as_str().unwrap().to_string())
+                .collect()
+        };
+        let without = offered(false);
+        let with = offered(true);
+        for action in READ_ONLY_ACTIONS {
+            assert!(without.iter().any(|a| a == action), "`{action}` only reads");
+        }
+        for action in MUTATING_ACTIONS {
+            assert!(
+                !without.iter().any(|a| a == action),
+                "`{action}` needs a person and must not be offered without one"
+            );
+            assert!(with.iter().any(|a| a == action));
+        }
+        let description = crate::agents::platform_tools::manage_schedule_tool(false)
+            .description
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            description.contains("cannot ask the user"),
+            "the schema must say why the changes are missing: {description}"
+        );
+
+        let refusal = refusal_without_a_person("create").message.to_string();
+        assert!(refusal.contains("cannot ask anyone"), "{refusal}");
+        for action in READ_ONLY_ACTIONS {
+            assert!(
+                refusal.contains(action),
+                "the refusal should name what still works: {refusal}"
+            );
+        }
     }
 }

--- a/crates/biorouter/src/agents/workflow_tool.rs
+++ b/crates/biorouter/src/agents/workflow_tool.rs
@@ -48,9 +48,6 @@ use crate::session::session_manager::Session;
 use crate::workflow::service::{self, SaveTarget};
 use crate::workflow::Workflow;
 
-/// How long a workflow mutation waits for the user to answer its approval card.
-const WORKFLOW_MUTATION_APPROVAL_TTL: std::time::Duration = std::time::Duration::from_secs(300);
-
 /// The verbs that change something and therefore need a person.
 pub const MUTATING_ACTIONS: &[&str] = &["save", "delete", "import", "schedule"];
 
@@ -588,6 +585,10 @@ impl Agent {
     /// `requires_user_proof: true` matches the extension manager and the skills
     /// client: these writes reshape what future conversations run, so a model
     /// that has been told to "clean up my workflows" cannot do it unattended.
+    ///
+    /// The card itself is [`super::platform_approval`]'s, shared with
+    /// `platform__manage_schedule` so the two tools cannot disagree about whether
+    /// a change to the user's setup is asked about (QA 2026-09-10, F1).
     async fn require_workflow_approval(
         &self,
         action: &str,
@@ -597,55 +598,18 @@ impl Agent {
         risk: crate::permission::tool_risk::ToolRisk,
         cancellation_token: Option<&CancellationToken>,
     ) -> Result<(), ErrorData> {
-        if session_id.is_empty() {
-            return Err(err(format!(
-                "`{action}` needs an active conversation so Biorouter can show its approval card"
-            )));
-        }
-
-        let approval_arguments = arguments
-            .as_object()
-            .cloned()
-            .unwrap_or_else(serde_json::Map::new);
-        let request = crate::pending_user_action::UserActionRequest::ToolApproval(
-            crate::pending_user_action::ToolApprovalRequest {
-                tool_name: super::platform_tools::PLATFORM_MANAGE_WORKFLOW_TOOL_NAME.to_string(),
-                arguments: approval_arguments.clone(),
-                prompt: Some(summary.to_string()),
-                risk: Some(risk),
-                preview: crate::conversation::tool_preview::ToolPreview::for_tool_call(
-                    super::platform_tools::PLATFORM_MANAGE_WORKFLOW_TOOL_NAME,
-                    &approval_arguments,
-                ),
-                requires_user_proof: true,
+        super::platform_approval::require_platform_approval(
+            super::platform_approval::PlatformApproval {
+                tool_name: super::platform_tools::PLATFORM_MANAGE_WORKFLOW_TOOL_NAME,
+                action,
+                session_id,
+                summary,
+                arguments,
+                risk,
             },
-        );
-
-        let parked = crate::pending_user_action::PendingUserActions::global().park(
-            Some(session_id),
-            None,
-            request,
-        );
-        let outcome = parked
-            .wait(WORKFLOW_MUTATION_APPROVAL_TTL, cancellation_token)
-            .await;
-
-        match outcome {
-            crate::pending_user_action::UserActionOutcome::Approved { .. }
-                if !cancellation_token.is_some_and(CancellationToken::is_cancelled) =>
-            {
-                Ok(())
-            }
-            crate::pending_user_action::UserActionOutcome::Approved { .. } => Err(err(format!(
-                "`{action}` was cancelled after approval and before anything changed"
-            ))),
-            crate::pending_user_action::UserActionOutcome::Denied { .. } => Err(err(format!(
-                "The user declined the `{action}`. Nothing was changed."
-            ))),
-            other => Err(err(format!(
-                "`{action}` was not approved ({other:?}). Nothing was changed."
-            ))),
-        }
+            cancellation_token,
+        )
+        .await
     }
 }
 

--- a/crates/biorouter/src/execution/manager.rs
+++ b/crates/biorouter/src/execution/manager.rs
@@ -31,7 +31,11 @@ pub struct AgentManager {
     /// live turn is not idle, and evicting it would restore the very bug
     /// `register_agent` exists to fix.
     pinned: Arc<RwLock<HashMap<String, PinnedAgent>>>,
-    scheduler: Arc<dyn SchedulerTrait>,
+    /// Concrete, not `dyn SchedulerTrait`, so the daemon can start the one
+    /// thing only the concrete scheduler can do — watch its file
+    /// ([`Self::watch_schedule_file`]). Everyone else gets the trait object from
+    /// [`Self::scheduler`].
+    scheduler: Arc<Scheduler>,
     session_manager: Arc<SessionManager>,
     default_provider: Arc<RwLock<Option<Arc<dyn crate::providers::base::Provider>>>>,
 }
@@ -98,7 +102,7 @@ impl AgentManager {
         // runs before this point so that clients never observe the pre-OKF bases
         // startup is purging, or an empty store before its built-in OKF Soul
         // exists.
-        let scheduler = Arc::clone(&manager.scheduler);
+        let scheduler = manager.scheduler();
         if std::env::var_os("BIOROUTER_BLOCKING_STARTUP").is_some() {
             Self::run_first_run_init(scheduler, config_dir).await;
         } else {
@@ -153,7 +157,18 @@ impl AgentManager {
     }
 
     pub fn scheduler(&self) -> Arc<dyn SchedulerTrait> {
-        Arc::clone(&self.scheduler)
+        Arc::clone(&self.scheduler) as Arc<dyn SchedulerTrait>
+    }
+
+    /// Keep this manager's scheduler in step with changes other processes make
+    /// to the schedule file (QA 2026-09-10, F2).
+    ///
+    /// For the daemon to call once at startup, beside its `config.yaml` watcher —
+    /// and deliberately not called from [`Self::new`]: a manager is also built in
+    /// other processes (a terminal session that runs a subagent builds one), and
+    /// only the long-lived daemon should be adopting jobs other processes add.
+    pub fn watch_schedule_file(&self) {
+        self.scheduler.spawn_file_watcher();
     }
 
     /// Get the shared SessionManager for session-only operations
@@ -266,7 +281,7 @@ impl AgentManager {
         let config = AgentConfig::new(
             Arc::clone(&self.session_manager),
             permission_manager,
-            Some(Arc::clone(&self.scheduler)),
+            Some(self.scheduler()),
             mode,
         );
         let agent = Arc::new(Agent::with_config(config));

--- a/crates/biorouter/src/scheduler.rs
+++ b/crates/biorouter/src/scheduler.rs
@@ -152,6 +152,33 @@ fn workflow_copy_extension(original: &Path) -> String {
         .to_string()
 }
 
+/// The 6-field expression the cron engine runs, or why `expression` cannot be
+/// scheduled.
+///
+/// The ONE place both the 5→6 conversion and the validity check live.
+/// [`Scheduler::create_cron_task`] builds every job through it, and
+/// `platform__manage_schedule` calls it to refuse an unschedulable expression
+/// before asking the user to approve it — a card for a schedule that cannot be
+/// created spends their attention on nothing. The check is the engine's own
+/// parser, so "valid" means exactly what the engine will accept.
+pub fn normalize_cron(expression: &str) -> Result<String, SchedulerError> {
+    let fields = expression.split_whitespace().count();
+    let cron = match fields {
+        5 => format!("0 {expression}"),
+        6 => expression.to_string(),
+        _ => {
+            return Err(SchedulerError::CronParseError(format!(
+                "Invalid cron expression '{expression}': expected 5 or 6 fields, got {fields}"
+            )))
+        }
+    };
+    Job::new_async_tz(cron.as_str(), Local::now().timezone(), |_uuid, _lock| {
+        Box::pin(async {})
+    })
+    .map_err(|e| SchedulerError::CronParseError(e.to_string()))?;
+    Ok(cron)
+}
+
 /// Where `make_copy` will put the job's own copy of its workflow, and the check
 /// that there is something to copy.
 ///
@@ -983,25 +1010,14 @@ impl Scheduler {
         // says the job is gone (see `converge_removals`).
         let cron_handle = self.tokio_scheduler.clone();
 
-        let cron_parts: Vec<&str> = job.cron.split_whitespace().collect();
-        let cron = match cron_parts.len() {
-            5 => {
-                tracing::warn!(
-                    "Job '{}' has legacy 5-field cron '{}', converting to 6-field",
-                    job.id,
-                    job.cron
-                );
-                format!("0 {}", job.cron)
-            }
-            6 => job.cron.clone(),
-            _ => {
-                return Err(SchedulerError::CronParseError(format!(
-                    "Invalid cron expression '{}': expected 5 or 6 fields, got {}",
-                    job.cron,
-                    cron_parts.len()
-                )))
-            }
-        };
+        if job.cron.split_whitespace().count() == 5 {
+            tracing::warn!(
+                "Job '{}' has legacy 5-field cron '{}', converting to 6-field",
+                job.id,
+                job.cron
+            );
+        }
+        let cron = normalize_cron(&job.cron)?;
 
         let local_tz = Local::now().timezone();
 

--- a/crates/biorouter/src/scheduler.rs
+++ b/crates/biorouter/src/scheduler.rs
@@ -785,25 +785,100 @@ fn unregister_running_task(tasks: &Arc<StdMutex<RunningTasksMap>>, job_id: &str)
 }
 
 // ---------------------------------------------------------------------------
-// Issue #140, the direction the modify-if-present fix does NOT cover on its own.
+// Issue #140 and QA 2026-09-10 F2: the daemon converges on the file, in BOTH
+// directions.
 //
 // `edit_job` refusing to resurrect a deleted row stops the daemon corrupting the
-// file. It does nothing about the daemon's own copy. The CLI is entirely offline
-// — every `biorouter schedule …` subcommand builds its own `Scheduler` over
-// `<data>/schedule.json` and never contacts `biorouterd` — while the daemon's map
-// is filled exactly once, at construction. So after `biorouter schedule remove`:
-// the row is off disk, and the running daemon still lists the job from
-// `/schedule/list`, still holds its cron entry, and still FIRES it, burning
-// tokens on a schedule the user deleted, until the daemon is restarted.
+// file. It does nothing about the daemon's own copy. Another process writes the
+// same `<data>/schedule.json` — `biorouter schedule …` when it cannot reach the
+// daemon (always the case from an agent's shell, whose environment never
+// carries the daemon's secret), a terminal session's own `/loop` and
+// `/schedule`, a second daemon — while this process's map used to be filled
+// exactly once, at construction.
 //
-// Before the modify-if-present fix that divergence was at least self-limiting —
-// the daemon's whole-map write put the row back, wrongly but visibly. Now it is
-// permanent and silent, which is worse. The file is the shared source of truth,
-// so the fix is the other half of the same rule: **the daemon converges on the
-// file.** A job the file no longer has is dropped from this process's map and
-// from the cron scheduler, at the two moments it matters — before a tick decides
-// to run something, and whenever the job list is served.
+// Issue #140 closed the removal half: a job the file no longer has kept being
+// listed and FIRED until a restart, burning tokens on a schedule the user had
+// deleted. F2 was the addition half, measured: a job `biorouter schedule add`
+// wrote while the desktop app ran was in the file (4 jobs) but not in
+// `/schedule/list` or `manage_schedule list` (3), could not be deleted through
+// either, and would never fire until a restart — after the CLI had printed
+// "Scheduled job added".
+//
+// So [`Scheduler::sync_with_file`] makes this process's map agree with the file
+// — jobs added elsewhere are adopted, jobs removed elsewhere are dropped, and a
+// job changed elsewhere (paused, re-timed) takes the file's fields — at every
+// moment it matters: before a tick decides to run anything, whenever the job
+// list is served, before an operation names a job this process has not seen,
+// and every couple of seconds in the daemon ([`Scheduler::spawn_file_watcher`]),
+// so a job added elsewhere fires even if nobody ever opens a list.
 // ---------------------------------------------------------------------------
+
+/// How often the daemon looks at the schedule file for a change it did not
+/// make.
+///
+/// The same shape, and the same reasoning, as `catalog::WATCH_INTERVAL` for
+/// `config.yaml` (issue #112): a `stat` every two seconds rather than a
+/// filesystem-notification API, because a `stat` costs nothing and behaves
+/// identically on macOS, Windows, Linux and the network mounts a data directory
+/// sometimes lives on.
+const FILE_WATCH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The longest the watcher goes without a full sync even when the file's size
+/// and mtime have not moved — the backstop for a filesystem whose timestamps are
+/// too coarse to tell two same-sized writes apart.
+const FILE_SYNC_BACKSTOP: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// The longest a running Biorouter takes to notice a schedule another process
+/// wrote to the file. Public so a writer that cannot reach the daemon — the CLI
+/// — can tell the user exactly this, and no more.
+pub const EXTERNAL_CHANGE_PICKUP: std::time::Duration = FILE_SYNC_BACKSTOP;
+
+/// Size and mtime, as one comparable value. `None` when the file is absent,
+/// which is itself a state worth noticing.
+fn file_stamp(path: &Path) -> Option<(u64, std::time::SystemTime)> {
+    let meta = fs::metadata(path).ok()?;
+    Some((meta.len(), meta.modified().ok()?))
+}
+
+/// A row as this process holds it: the file's fields, with none of the file's
+/// run state.
+///
+/// `currently_running`, `process_start_time` and `current_session_id` describe
+/// a run IN THIS PROCESS — the cancel-token registry that makes a run stoppable
+/// is per process — so a row read from the file must not import another
+/// process's run into this one. That is also BR-38's load-time rule: a flag
+/// left behind by a run that no longer exists would make [`claim_run_slot`]'s
+/// overlap guard skip the job forever.
+fn without_foreign_run_state(mut row: ScheduledJob) -> ScheduledJob {
+    row.currently_running = false;
+    row.process_start_time = None;
+    row.current_session_id = None;
+    row
+}
+
+/// Is a run of this job in flight in THIS process?
+///
+/// Either half is enough: `currently_running` is set by a claim under the
+/// `jobs` lock, and the cancel token stays registered until the run's
+/// completion has been recorded — so together they cover the whole run,
+/// including the window after the flag clears and before the completion reaches
+/// the file. Asked under the `jobs` lock, the same nesting `claim_run_slot` uses.
+fn runs_here(running_tasks: &Arc<StdMutex<RunningTasksMap>>, job: &ScheduledJob) -> bool {
+    job.currently_running
+        || running_tasks
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains_key(&job.id)
+}
+
+/// What [`Scheduler::sync_with_file`] remembers between runs, behind the lock
+/// that serialises it against this process's own schedule writers.
+#[derive(Default)]
+struct FileSync {
+    /// Rows the sync could not take in, and why — so a row whose workflow file
+    /// is missing is reported once, not on every sync for as long as it stays.
+    refused: HashMap<String, String>,
+}
 
 /// Drop `job_id` from this process's map and cancel its cron entry.
 ///
@@ -831,18 +906,27 @@ async fn forget_job(jobs: &Arc<Mutex<JobsMap>>, tokio_scheduler: &TokioJobSchedu
 /// [`Scheduler::create_cron_task`] because it is the whole lifecycle of a
 /// scheduled run and reads as one sequence; the closure keeps only the argument
 /// clones that a `move` closure has to make per firing.
+///
+/// `scheduler` is weak because the closure that holds it lives inside the
+/// scheduler's own cron engine; a tick that finds its scheduler gone runs
+/// nothing.
 async fn run_cron_tick(
     task_job_id: String,
+    scheduler: std::sync::Weak<Scheduler>,
     current_jobs_arc: Arc<Mutex<JobsMap>>,
     running_tasks: Arc<StdMutex<RunningTasksMap>>,
     local_storage_path: PathBuf,
     cron_handle: TokioJobScheduler,
 ) {
-    // The file is the shared source of truth, and the CLI writes it from another
-    // process. Converge BEFORE claiming a slot: a job the user deleted must not
-    // spend a single token, and the tick that discovers the deletion is the one
-    // that retires the cron entry. A read failure leaves everything alone.
-    if let Err(e) = converge_removals(&local_storage_path, &current_jobs_arc, &cron_handle).await {
+    // The file is the shared source of truth, and other processes write it.
+    // Converge BEFORE claiming a slot: a job the user deleted must not spend a
+    // single token, a job they paused elsewhere must not run, and the tick that
+    // discovers the deletion is the one that retires the cron entry. A read
+    // failure leaves everything alone.
+    let Some(owner) = scheduler.upgrade() else {
+        return;
+    };
+    if let Err(e) = owner.sync_with_file().await {
         tracing::warn!(
             "Could not reconcile {} before running '{}': {}",
             local_storage_path.display(),
@@ -850,6 +934,7 @@ async fn run_cron_tick(
             e
         );
     }
+    drop(owner);
 
     let cancel_token = CancellationToken::new();
     let job_to_execute = match claim_run_slot(
@@ -925,49 +1010,27 @@ async fn run_cron_tick(
     }
 }
 
-/// Drop every in-memory job the schedule file no longer has.
-///
-/// An error reading the file propagates and **nothing is dropped**: a read that
-/// failed is not evidence that a job was deleted, and the cost of the two
-/// mistakes is not symmetric — forgetting a job the user still has means their
-/// schedule silently stops.
-async fn converge_removals(
-    storage_path: &Path,
-    jobs: &Arc<Mutex<JobsMap>>,
-    tokio_scheduler: &TokioJobScheduler,
-) -> Result<(), SchedulerError> {
-    let on_disk: std::collections::HashSet<String> = read_jobs(storage_path)
-        .await?
-        .into_iter()
-        .map(|job| job.id)
-        .collect();
-
-    let vanished: Vec<String> = {
-        let jobs_guard = jobs.lock().await;
-        jobs_guard
-            .keys()
-            .filter(|id| !on_disk.contains(*id))
-            .cloned()
-            .collect()
-    };
-
-    for id in vanished {
-        tracing::info!(
-            "Schedule '{}' is no longer in {}; dropping it from this process",
-            id,
-            storage_path.display()
-        );
-        forget_job(jobs, tokio_scheduler, &id).await;
-    }
-    Ok(())
-}
-
 pub struct Scheduler {
     tokio_scheduler: TokioJobScheduler,
     jobs: Arc<Mutex<JobsMap>>,
     storage_path: PathBuf,
     running_tasks: Arc<StdMutex<RunningTasksMap>>,
     session_manager: Arc<SessionManager>,
+    /// Serialises [`Self::sync_with_file`] against this process's own writers of
+    /// the fields a sync would overwrite — add, remove, pause, unpause, update.
+    ///
+    /// ⚠ Without it a sync can land BETWEEN one of those writers' two halves (the
+    /// in-memory change and the file publish) and undo the change in memory:
+    /// re-adopt a job `remove_scheduled_job` has just taken out of the map but
+    /// not yet out of the file — so a schedule the user deleted fires once more —
+    /// or put back the `paused = false` a Pause is about to publish. Held across
+    /// both halves of every such writer, and across the whole of every sync.
+    file_sync: Mutex<FileSync>,
+    /// This scheduler, weakly, for the cron closures [`Self::create_cron_task`]
+    /// builds: a tick syncs with the file before it claims anything, and the
+    /// closure lives inside this scheduler's own cron engine, so a strong handle
+    /// there would be a cycle.
+    me: std::sync::Weak<Scheduler>,
 }
 
 impl Scheduler {
@@ -982,12 +1045,14 @@ impl Scheduler {
         let jobs = Arc::new(Mutex::new(HashMap::new()));
         let running_tasks = Arc::new(StdMutex::new(HashMap::new()));
 
-        let arc_self = Arc::new(Self {
+        let arc_self = Arc::new_cyclic(|me| Self {
             tokio_scheduler: internal_scheduler,
             jobs,
             storage_path,
             running_tasks,
             session_manager,
+            file_sync: Mutex::new(FileSync::default()),
+            me: me.clone(),
         });
 
         arc_self.load_jobs_from_storage().await;
@@ -1000,14 +1065,286 @@ impl Scheduler {
         Ok(arc_self)
     }
 
+    /// Make this process's schedule agree with the schedule file.
+    ///
+    /// The file is the one source of truth several processes share (see the
+    /// note above [`FILE_WATCH_INTERVAL`]). This process's map is a cache of it
+    /// plus the state of the runs THIS process is making, and this is the one
+    /// place the cache is refreshed:
+    ///
+    /// - a job the file no longer has is dropped, cron entry and all (#140);
+    /// - a job the file has and this process does not is adopted, exactly as a
+    ///   job loaded at startup is — its workflow must exist and its cron must
+    ///   parse, or it is refused (and reported once, not on every sync);
+    /// - a job both have takes the file's fields, and a new cron entry when its
+    ///   schedule changed — unless this process is running it, in which case
+    ///   this process's copy is authoritative until the run has recorded its end,
+    ///   and the next sync catches up.
+    ///
+    /// An error reading the file changes NOTHING and is returned: a read that
+    /// failed is not evidence that anything was added or deleted, and the cost of
+    /// the two mistakes is not symmetric — forgetting a job the user still has
+    /// means their schedule silently stops.
+    pub async fn sync_with_file(&self) -> Result<(), SchedulerError> {
+        let mut state = self.file_sync.lock().await;
+        self.sync_with_file_locked(&mut state, false).await
+    }
+
+    /// `startup` is true only for the first sync, at construction, where a row
+    /// still carrying run state is a run the last process never finished.
+    async fn sync_with_file_locked(
+        &self,
+        state: &mut FileSync,
+        startup: bool,
+    ) -> Result<(), SchedulerError> {
+        let on_disk = read_jobs(&self.storage_path).await?;
+        let on_disk_ids: std::collections::HashSet<String> =
+            on_disk.iter().map(|job| job.id.clone()).collect();
+
+        let vanished: Vec<String> = {
+            let jobs_guard = self.jobs.lock().await;
+            jobs_guard
+                .keys()
+                .filter(|id| !on_disk_ids.contains(*id))
+                .cloned()
+                .collect()
+        };
+        for id in vanished {
+            tracing::info!(
+                "Schedule '{}' is no longer in {}; dropping it from this process",
+                id,
+                self.storage_path.display()
+            );
+            forget_job(&self.jobs, &self.tokio_scheduler, &id).await;
+        }
+        state.refused.retain(|id, _| on_disk_ids.contains(id));
+
+        for row in on_disk {
+            // BR-38: no run survives the process that made it, so at startup a
+            // row persisted mid-run is a run that is already gone. Its flags are
+            // dropped below for every row; only here are they news.
+            if startup
+                && (row.currently_running
+                    || row.current_session_id.is_some()
+                    || row.process_start_time.is_some())
+            {
+                tracing::warn!(
+                    "Resetting stale running state for scheduled job '{}' on load (session {:?} \
+                     did not survive restart)",
+                    row.id,
+                    row.current_session_id
+                );
+            }
+            self.sync_row(without_foreign_run_state(row), state, startup)
+                .await;
+        }
+        Ok(())
+    }
+
+    /// Bring one row of the file into this process. See [`Self::sync_with_file`].
+    ///
+    /// `startup` only quiets the log: at construction every row is new to this
+    /// process, and calling each one an adoption would read as another process
+    /// having written it.
+    async fn sync_row(&self, row: ScheduledJob, state: &mut FileSync, startup: bool) {
+        // What this process holds for the id, read once.
+        let held = {
+            let jobs_guard = self.jobs.lock().await;
+            jobs_guard.get(&row.id).map(|(uuid, job)| {
+                (
+                    *uuid,
+                    job.cron != row.cron,
+                    runs_here(&self.running_tasks, job),
+                )
+            })
+        };
+
+        let old_entry = match held {
+            // A run of ours is in flight: the next sync after it ends catches up.
+            Some((_, _, true)) => return,
+            // Same schedule: adopt the file's fields, keeping the cron entry.
+            // Re-checked under the lock that `claim_run_slot` takes, so a run
+            // that started in between keeps its own state.
+            Some((uuid, false, false)) => {
+                let mut jobs_guard = self.jobs.lock().await;
+                if let Some((held_uuid, job)) = jobs_guard.get_mut(&row.id) {
+                    if *held_uuid == uuid && !runs_here(&self.running_tasks, job) {
+                        *job = row;
+                    }
+                }
+                return;
+            }
+            // Re-timed elsewhere: a new cron entry replaces this one below.
+            Some((uuid, true, false)) => Some(uuid),
+            // Added elsewhere.
+            None => None,
+        };
+
+        // The admission rule `load_jobs_from_storage` has always applied.
+        let admitted = if Path::new(&row.source).exists() {
+            self.create_cron_task(row.clone())
+                .map_err(|e| format!("its cron entry could not be built: {e}"))
+        } else {
+            Err(format!("its workflow file {} was not found", row.source))
+        };
+        let task = match admitted {
+            Ok(task) => task,
+            Err(why) => {
+                if state.refused.get(&row.id) != Some(&why) {
+                    tracing::warn!(
+                        "Not scheduling '{}' from {}: {}",
+                        row.id,
+                        self.storage_path.display(),
+                        why
+                    );
+                    state.refused.insert(row.id.clone(), why);
+                }
+                return;
+            }
+        };
+        state.refused.remove(&row.id);
+
+        let new_uuid = match self.tokio_scheduler.add(task).await {
+            Ok(uuid) => uuid,
+            Err(e) => {
+                tracing::error!("Failed to add job '{}' to the scheduler: {}", row.id, e);
+                return;
+            }
+        };
+
+        // Swap the new entry in only if nothing moved while it was being built;
+        // otherwise hand it back and let the next sync decide. Either way exactly
+        // one cron entry per job survives — a second one keyed on the same id
+        // would fire alongside it.
+        let retire = {
+            let mut jobs_guard = self.jobs.lock().await;
+            let unchanged = match (jobs_guard.get(&row.id), old_entry) {
+                (None, None) => true,
+                (Some((current, job)), Some(old)) => {
+                    *current == old && !runs_here(&self.running_tasks, job)
+                }
+                _ => false,
+            };
+            if unchanged {
+                if !startup {
+                    match old_entry {
+                        None => tracing::info!(
+                            "Adopted schedule '{}' from {}, written by another process",
+                            row.id,
+                            self.storage_path.display()
+                        ),
+                        Some(_) => tracing::info!(
+                            "Schedule '{}' was re-timed in {} by another process; it now runs \
+                             on '{}'",
+                            row.id,
+                            self.storage_path.display(),
+                            row.cron
+                        ),
+                    }
+                }
+                jobs_guard.insert(row.id.clone(), (new_uuid, row));
+                old_entry
+            } else {
+                Some(new_uuid)
+            }
+        };
+        if let Some(uuid) = retire {
+            if let Err(e) = self.tokio_scheduler.remove(&uuid).await {
+                tracing::warn!("Could not remove a superseded cron entry: {}", e);
+            }
+        }
+    }
+
+    /// Sync before looking `id` up, if this process has never heard of it.
+    ///
+    /// Every operation that names a job — delete, pause, run now, stop — used to
+    /// answer "not found" for a job another process had added, because only the
+    /// file knew it. That is how `manage_schedule delete` could not remove the
+    /// job `biorouter schedule add` had just created (QA 2026-09-10, F2).
+    async fn sync_if_unknown(&self, id: &str) {
+        if self.jobs.lock().await.contains_key(id) {
+            return;
+        }
+        if let Err(e) = self.sync_with_file().await {
+            tracing::warn!(
+                "Could not reconcile {} while looking for '{}': {}",
+                self.storage_path.display(),
+                id,
+                e
+            );
+        }
+    }
+
+    /// Keep this process in step with changes other processes make to the
+    /// schedule file, for as long as this scheduler lives.
+    ///
+    /// Started by the daemon — and only by the daemon, which is the one process
+    /// meant to run schedules for as long as it is up. It stats the file every
+    /// [`FILE_WATCH_INTERVAL`] and syncs when the file changed, or at least every
+    /// [`FILE_SYNC_BACKSTOP`]. Without it a job another process adds is adopted
+    /// only when something lists schedules or another job's tick happens to run,
+    /// so it could miss its own time entirely.
+    pub fn spawn_file_watcher(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
+        self.spawn_file_watcher_every(FILE_WATCH_INTERVAL, FILE_SYNC_BACKSTOP)
+    }
+
+    fn spawn_file_watcher_every(
+        self: &Arc<Self>,
+        interval: std::time::Duration,
+        backstop: std::time::Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        let me = Arc::downgrade(self);
+        let path = self.storage_path.clone();
+        tokio::spawn(async move {
+            // ⚠ No baseline until this watcher's own first sync. Taking the
+            // file's stamp when the task starts would adopt, as "already seen",
+            // any write that landed after this scheduler loaded the file and
+            // before the task first ran — and that write would then wait for
+            // the backstop. So the first poll always syncs.
+            let mut seen: Option<Option<(u64, std::time::SystemTime)>> = None;
+            let mut synced_at = tokio::time::Instant::now();
+            let mut reported: Option<String> = None;
+            loop {
+                tokio::time::sleep(interval).await;
+                let Some(scheduler) = me.upgrade() else {
+                    return;
+                };
+                let stamp = file_stamp(&path);
+                if seen.as_ref() == Some(&stamp) && synced_at.elapsed() < backstop {
+                    continue;
+                }
+                match scheduler.sync_with_file().await {
+                    // The stamp read BEFORE the sync is the one recorded, so a
+                    // write that lands during the sync is seen next time.
+                    Ok(()) => {
+                        seen = Some(stamp);
+                        reported = None;
+                    }
+                    // Retried on the next poll; reported once per distinct
+                    // failure, because a corrupt file would otherwise log every
+                    // two seconds until someone repairs it.
+                    Err(e) => {
+                        let text = e.to_string();
+                        if reported.as_deref() != Some(text.as_str()) {
+                            tracing::warn!("Could not sync with {}: {}", path.display(), text);
+                            reported = Some(text);
+                        }
+                    }
+                }
+                synced_at = tokio::time::Instant::now();
+            }
+        })
+    }
+
     fn create_cron_task(&self, job: ScheduledJob) -> Result<Job, SchedulerError> {
         let job_for_task = job.clone();
+        let scheduler = self.me.clone();
         let jobs_arc = self.jobs.clone();
         let storage_path = self.storage_path.clone();
         let running_tasks_arc = self.running_tasks.clone();
         // `JobsSchedulerLocked` is a handle, and cloning it clones the handle —
         // the tick needs one so it can retire its own cron entry when the file
-        // says the job is gone (see `converge_removals`).
+        // says the job is gone (see `Scheduler::sync_with_file`).
         let cron_handle = self.tokio_scheduler.clone();
 
         if job.cron.split_whitespace().count() == 5 {
@@ -1025,6 +1362,7 @@ impl Scheduler {
             tracing::info!("Cron task triggered for job '{}'", job_for_task.id);
             Box::pin(run_cron_tick(
                 job_for_task.id.clone(),
+                scheduler.clone(),
                 jobs_arc.clone(),
                 running_tasks_arc.clone(),
                 storage_path.clone(),
@@ -1045,6 +1383,10 @@ impl Scheduler {
         // duplicate guard, so `{"id": "/tmp/pwned"}` landed `/tmp/pwned.yaml`
         // even on the request paths that answered 400 or 409.
         validate_schedule_id(&original_job_spec.id)?;
+        // Held to the end: between the file write below and the map insert, a
+        // sync would see a row this process does not hold yet and adopt it —
+        // and the insert would then leave a second cron entry for the same job.
+        let _sync = self.file_sync.lock().await;
         {
             let jobs_guard = self.jobs.lock().await;
             if jobs_guard.contains_key(&original_job_spec.id) {
@@ -1151,6 +1493,16 @@ impl Scheduler {
     ) -> Result<(), SchedulerError> {
         let workflow_path_str = workflow_path.to_string_lossy().to_string();
 
+        // A schedule another process made for this same workflow is one this
+        // process has to find, or it adds a second schedule beside it.
+        if let Err(e) = self.sync_with_file().await {
+            tracing::warn!(
+                "Could not reconcile {} before scheduling {}: {}",
+                self.storage_path.display(),
+                workflow_path_str,
+                e
+            );
+        }
         let existing_job_id = {
             let jobs_guard = self.jobs.lock().await;
             jobs_guard
@@ -1213,9 +1565,11 @@ impl Scheduler {
         id
     }
 
-    /// Fill the in-memory map from the schedule file. The ONLY call site is
-    /// [`Scheduler::new`] — there is no re-read, no mtime check and no watcher,
-    /// which is why [`converge_removals`] exists.
+    /// Fill the in-memory map from the schedule file, at construction.
+    ///
+    /// It is the first [`Self::sync_with_file`] — with an empty map every row is
+    /// an addition — so a job loaded at startup and a job adopted from the file
+    /// later pass one admission rule rather than two copies of it.
     ///
     /// ⚠ It goes through [`read_jobs`] rather than opening the file itself. It
     /// used to be a second reader with its own policy — no [`ScheduleFileLock`],
@@ -1223,91 +1577,29 @@ impl Scheduler {
     /// copy aside — and it is the reader most likely to *meet* a corrupt file,
     /// since it runs before anything else in the process has touched it.
     async fn load_jobs_from_storage(self: &Arc<Self>) {
-        let list = match read_jobs(&self.storage_path).await {
-            Ok(list) => list,
-            Err(e) => {
-                tracing::error!(
-                    "Failed to read {}: {}. Starting with an empty schedule list; the file has \
-                     NOT been modified.",
-                    self.storage_path.display(),
-                    e
-                );
-                return;
-            }
-        };
-
-        for mut job_to_load in list {
-            // BR-38: a scheduled run lives only in memory — no process or turn
-            // survives a daemon restart. A job persisted as `currently_running`
-            // was mid-run when we crashed, so its run is already gone. Reconcile
-            // the stale flag on load; otherwise the overlap guard in
-            // `claim_run_slot` would treat the ghost run as still in progress and
-            // skip this job forever.
-            if job_to_load.currently_running
-                || job_to_load.current_session_id.is_some()
-                || job_to_load.process_start_time.is_some()
-            {
-                tracing::warn!(
-                    "Resetting stale running state for scheduled job '{}' on load (session {:?} did not survive restart)",
-                    job_to_load.id,
-                    job_to_load.current_session_id
-                );
-                job_to_load.currently_running = false;
-                job_to_load.current_session_id = None;
-                job_to_load.process_start_time = None;
-            }
-
-            if !Path::new(&job_to_load.source).exists() {
-                tracing::warn!(
-                    "Workflow file {} not found, skipping job '{}'",
-                    job_to_load.source,
-                    job_to_load.id
-                );
-                continue;
-            }
-
-            let cron_task = match self.create_cron_task(job_to_load.clone()) {
-                Ok(task) => task,
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to create cron task for job '{}': {}. Skipping.",
-                        job_to_load.id,
-                        e
-                    );
-                    continue;
-                }
-            };
-
-            let job_uuid = match self.tokio_scheduler.add(cron_task).await {
-                Ok(uuid) => uuid,
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to add job '{}' to scheduler: {}. Skipping.",
-                        job_to_load.id,
-                        e
-                    );
-                    continue;
-                }
-            };
-
-            let mut jobs_guard = self.jobs.lock().await;
-            jobs_guard.insert(job_to_load.id.clone(), (job_uuid, job_to_load));
+        let mut state = self.file_sync.lock().await;
+        if let Err(e) = self.sync_with_file_locked(&mut state, true).await {
+            tracing::error!(
+                "Failed to read {}: {}. Starting with an empty schedule list; the file has \
+                 NOT been modified.",
+                self.storage_path.display(),
+                e
+            );
         }
     }
 
     /// Every schedule this process knows about, after reconciling against the
     /// file.
     ///
-    /// The reconcile is why this is not a bare map read. `/schedule/list` and
-    /// `biorouter schedule list` are the surfaces a user checks after deleting a
-    /// schedule somewhere else, and a daemon whose map was loaded once at
-    /// construction would keep listing it — see [`converge_removals`]. A read
-    /// failure is logged and the map served as-is, because failing to read the
-    /// file is not evidence that anything was deleted.
+    /// The reconcile is why this is not a bare map read. `/schedule/list`,
+    /// `platform__manage_schedule list` and `biorouter schedule list` are the
+    /// surfaces a user checks after changing a schedule somewhere else, and a map
+    /// loaded once at construction would keep listing a deleted job and never
+    /// list an added one — see [`Self::sync_with_file`]. A read failure is logged
+    /// and the map served as-is, because failing to read the file is not
+    /// evidence that anything changed.
     pub async fn list_scheduled_jobs(&self) -> Vec<ScheduledJob> {
-        if let Err(e) =
-            converge_removals(&self.storage_path, &self.jobs, &self.tokio_scheduler).await
-        {
+        if let Err(e) = self.sync_with_file().await {
             tracing::warn!(
                 "Could not reconcile {} while listing schedules: {}",
                 self.storage_path.display(),
@@ -1335,6 +1627,11 @@ impl Scheduler {
         id: &str,
         remove_owned_workflow: bool,
     ) -> Result<(), SchedulerError> {
+        self.sync_if_unknown(id).await;
+        // Held across the map removal AND the file write: a sync between the two
+        // would find the row still on disk and adopt it straight back, and a
+        // schedule the user had just deleted would fire once more.
+        let _sync = self.file_sync.lock().await;
         let (job_uuid, workflow_to_delete) = {
             let mut jobs_guard = self.jobs.lock().await;
             match jobs_guard.remove(id) {
@@ -1346,7 +1643,10 @@ impl Scheduler {
                         .then(|| job.source.clone());
                     (uuid, path)
                 }
-                None => return Err(SchedulerError::JobNotFound(id.to_string())),
+                // Not something this process can schedule — a row whose workflow
+                // file is gone is never adopted — but still a row in the file,
+                // and deleting it is the one way to clear it without an editor.
+                None => return self.remove_unscheduled_row(id).await,
             }
         };
 
@@ -1369,6 +1669,27 @@ impl Scheduler {
         })
         .await?;
         Ok(())
+    }
+
+    /// Delete a row this process holds no job for, straight from the file.
+    ///
+    /// `JobNotFound` only when the file has no such row either. The row's
+    /// workflow file is left alone: a row is left unscheduled almost always
+    /// because that file is already gone, and [`scheduler_owns_source`]'s own
+    /// rule is that a doubtful unlink costs at most an orphaned copy — which is
+    /// why the scheduler still has exactly one `remove_file`, in
+    /// [`Self::remove_scheduled_job`].
+    async fn remove_unscheduled_row(&self, id: &str) -> Result<(), SchedulerError> {
+        let removed_id = id.to_string();
+        persist_change(&self.storage_path, move |list| {
+            let position = list
+                .iter()
+                .position(|job| job.id == removed_id)
+                .ok_or_else(|| SchedulerError::JobNotFound(removed_id.clone()))?;
+            list.remove(position);
+            Ok(())
+        })
+        .await
     }
 
     pub async fn sessions(
@@ -1418,6 +1739,7 @@ impl Scheduler {
     /// registry, an eager persist) re-opens exactly the window this fixes, and
     /// nothing in the type system will say so.
     pub async fn run_now(&self, sched_id: &str) -> Result<String, SchedulerError> {
+        self.sync_if_unknown(sched_id).await;
         let cancel_token = CancellationToken::new();
         let job_to_run = {
             let mut jobs_guard = self.jobs.lock().await;
@@ -1497,6 +1819,10 @@ impl Scheduler {
     }
 
     pub async fn pause_schedule(&self, sched_id: &str) -> Result<(), SchedulerError> {
+        self.sync_if_unknown(sched_id).await;
+        // Held across the memory change and its publish, so a sync cannot land
+        // between them and put the old `paused` back from the file.
+        let _sync = self.file_sync.lock().await;
         {
             let mut jobs_guard = self.jobs.lock().await;
             match jobs_guard.get_mut(sched_id) {
@@ -1517,6 +1843,8 @@ impl Scheduler {
     }
 
     pub async fn unpause_schedule(&self, sched_id: &str) -> Result<(), SchedulerError> {
+        self.sync_if_unknown(sched_id).await;
+        let _sync = self.file_sync.lock().await;
         {
             let mut jobs_guard = self.jobs.lock().await;
             match jobs_guard.get_mut(sched_id) {
@@ -1556,6 +1884,10 @@ impl Scheduler {
         sched_id: &str,
         new_cron: String,
     ) -> Result<(), SchedulerError> {
+        self.sync_if_unknown(sched_id).await;
+        // Held across the swap of the cron entry and the publish: a sync in
+        // between would read the old cron from the file and build a second entry.
+        let _sync = self.file_sync.lock().await;
         let (old_uuid, updated_job) = {
             let mut jobs_guard = self.jobs.lock().await;
             match jobs_guard.get_mut(sched_id) {
@@ -1620,6 +1952,7 @@ impl Scheduler {
     /// window: reaching it means the run already finished (or that this process
     /// is not the one running it), and the caller must be told.
     pub async fn kill_running_job(&self, sched_id: &str) -> Result<(), SchedulerError> {
+        self.sync_if_unknown(sched_id).await;
         {
             let jobs_guard = self.jobs.lock().await;
             match jobs_guard.get(sched_id) {
@@ -1663,6 +1996,7 @@ impl Scheduler {
         &self,
         sched_id: &str,
     ) -> Result<Option<(String, DateTime<Utc>)>, SchedulerError> {
+        self.sync_if_unknown(sched_id).await;
         let jobs_guard = self.jobs.lock().await;
         match jobs_guard.get(sched_id) {
             Some((_, job)) if job.currently_running => {
@@ -3324,21 +3658,33 @@ mod tests {
         }
         assert!(fired, "precondition: the job fires while it is on disk");
 
-        // The CLI, in another process, deletes it. Modelled as a direct write to
-        // the file because that is exactly what the offline CLI's own
-        // `Scheduler` does, and because writing it here proves the daemon reads
-        // the file rather than being told by an API call.
-        fs::write(&storage_path, "[]").unwrap();
-
-        // ⚠ CONVERGES, not instantaneous — and the difference is a real race, not
-        // test hygiene. This job fires every second, and a tick already in flight
-        // when the write lands will finish by persisting its own run state, which
-        // puts the row back in the file the test just emptied. The daemon then
-        // drops it on the NEXT reconcile. Asserting emptiness on the first call
-        // therefore fails whenever a tick happens to straddle the write — which
-        // it did once in a full-suite run while passing 3/3 in isolation.
+        // The CLI, in another process, deletes it — through the same locked
+        // read-modify-write its own `Scheduler` uses (`remove_scheduled_job` →
+        // `persist_change`), because that is what the CLI does, and because
+        // writing it here proves the daemon reads the file rather than being
+        // told by an API call.
         //
-        // Production's contract is convergence, so that is what this asserts.
+        // ⚠ Not a raw `fs::write(.., "[]")`, which this used to be. A raw write
+        // takes no `ScheduleFileLock`, so it can land INSIDE a firing tick's
+        // locked read-modify-write — after the tick read the row, before it
+        // renamed its edit over the file — and the tick then puts the row back
+        // for good. No real writer can do that: every one of them goes through
+        // the lock. And this test makes the collision likely, because the loop
+        // above breaks the instant a tick has claimed a run, i.e. just before
+        // that tick's writes. Measured: 1 failure in 40 full-module runs, at
+        // "must stop being served".
+        persist_change(&storage_path, |list| {
+            list.clear();
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        // ⚠ CONVERGES, not instantaneous. This job fires every second, and a tick
+        // already in flight when the delete lands still records its own
+        // completion in this process; the daemon drops the job on the NEXT
+        // reconcile. Production's contract is convergence, so that is what this
+        // asserts.
         let mut converged = false;
         for _ in 0..40 {
             if daemon.list_scheduled_jobs().await.is_empty() {
@@ -3354,8 +3700,10 @@ mod tests {
 
         // And it must stop firing — which is also a CONVERGENT property, for the
         // same reason. A tick already running when the delete landed may still
-        // record its own completion, so both the run count and the on-disk row
-        // can move once more before the next reconcile drops the job for good.
+        // record its own completion, so this process's run count can move once
+        // more before the next reconcile drops the job for good. (The on-disk row
+        // cannot come back: the tick's edit is modify-if-present, under the same
+        // lock as the delete.)
         //
         // Settle first, then assert the count is frozen. Asserting immediately
         // measures whether a tick happened to be in flight, which is a property
@@ -3916,6 +4264,157 @@ mod tests {
         );
         assert!(prompt.contains("Scheduled job:"), "{prompt}");
     }
+
+    /// Two `Scheduler`s over one file: the daemon, started first and holding
+    /// nothing, and a second process — the CLI — that adds a job to the file.
+    async fn daemon_and_cli(temp_dir: &Path) -> (PathBuf, Arc<Scheduler>, Arc<Scheduler>) {
+        let storage_path = temp_dir.join("schedule.json");
+        let session_manager = || Arc::new(SessionManager::new(temp_dir.to_path_buf()));
+        let daemon = Scheduler::new(storage_path.clone(), session_manager())
+            .await
+            .unwrap();
+        let cli = Scheduler::new(storage_path.clone(), session_manager())
+            .await
+            .unwrap();
+        (storage_path, daemon, cli)
+    }
+
+    fn ids(jobs: Vec<ScheduledJob>) -> Vec<String> {
+        let mut ids: Vec<String> = jobs.into_iter().map(|job| job.id).collect();
+        ids.sort();
+        ids
+    }
+
+    /// QA 2026-09-10, F2, measured: `biorouter schedule add` wrote a fourth job
+    /// to `schedule.json` while the desktop app ran, and `/schedule/list`,
+    /// `manage_schedule list` and the Scheduler page all showed three. The
+    /// daemon's map was filled once, at construction, and #140's reconcile only
+    /// ever REMOVED what the file had lost.
+    ///
+    /// Fails the shipped scheduler: the daemon lists nothing.
+    #[tokio::test]
+    async fn a_job_another_process_adds_is_listed_here() {
+        let temp_dir = tempdir().unwrap();
+        let (storage_path, daemon, cli) = daemon_and_cli(temp_dir.path()).await;
+        let workflow = create_test_workflow(temp_dir.path(), "qaf_run2_workflow");
+        cli.add_scheduled_job(dormant_job("qaf-run2-workflow", &workflow), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            ids_on_disk(&storage_path),
+            vec!["qaf-run2-workflow".to_string()],
+            "precondition: the other process's job reached the file"
+        );
+
+        assert_eq!(
+            ids(daemon.list_scheduled_jobs().await),
+            ids_on_disk(&storage_path),
+            "the daemon's list must agree with the file it serves"
+        );
+    }
+
+    /// The same measurement's second half: `manage_schedule delete` could not
+    /// remove the CLI's job, "because the daemon cannot see it" — it took a
+    /// second CLI call. A delete by id is the one call that never lists first
+    /// (`DELETE /schedule/delete/{id}` goes straight to the scheduler), so it
+    /// has to find a job this process has not heard of on its own.
+    ///
+    /// Fails the shipped scheduler with `JobNotFound`.
+    #[tokio::test]
+    async fn a_job_another_process_adds_can_be_deleted_here_by_id() {
+        let temp_dir = tempdir().unwrap();
+        let (storage_path, daemon, cli) = daemon_and_cli(temp_dir.path()).await;
+        let workflow = create_test_workflow(temp_dir.path(), "cli_added");
+        cli.add_scheduled_job(dormant_job("cli-added", &workflow), false)
+            .await
+            .unwrap();
+
+        daemon
+            .remove_scheduled_job("cli-added", false)
+            .await
+            .expect("a job in the file must be deletable through the daemon");
+        assert!(ids_on_disk(&storage_path).is_empty());
+        assert!(daemon.list_scheduled_jobs().await.is_empty());
+    }
+
+    /// A row this process will not schedule — its workflow file is gone, so it
+    /// is never adopted, exactly as it was never loaded — is still a row in the
+    /// file. Deleting it is the one way to clear it without an editor.
+    ///
+    /// Fails the shipped scheduler with `JobNotFound`.
+    #[tokio::test]
+    async fn a_row_that_cannot_be_scheduled_can_still_be_deleted() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let gone = temp_dir.path().join("deleted-workflow.yaml");
+        fs::write(
+            &storage_path,
+            serde_json::to_string(&vec![dormant_job("orphan", &gone)]).unwrap(),
+        )
+        .unwrap();
+        let daemon = Scheduler::new(
+            storage_path.clone(),
+            Arc::new(SessionManager::new(temp_dir.path().to_path_buf())),
+        )
+        .await
+        .unwrap();
+        assert!(
+            daemon.list_scheduled_jobs().await.is_empty(),
+            "a job whose workflow is missing is not scheduled"
+        );
+
+        daemon
+            .remove_scheduled_job("orphan", true)
+            .await
+            .expect("the row is in the file, so deleting it is not `JobNotFound`");
+        assert!(ids_on_disk(&storage_path).is_empty());
+        assert!(matches!(
+            daemon.remove_scheduled_job("orphan", true).await,
+            Err(SchedulerError::JobNotFound(_))
+        ));
+    }
+
+    /// Adoption is not only of new ids. A job both processes hold can be paused
+    /// or re-timed by the other one — a terminal session's `/schedule pause`
+    /// writes the file — and the daemon kept listing it, and FIRING it, on the
+    /// old terms: a schedule the user paused ran anyway.
+    ///
+    /// Fails the shipped scheduler: the daemon still reports it unpaused and on
+    /// its old cron.
+    #[tokio::test]
+    async fn a_job_changed_by_another_process_takes_the_files_terms_here() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let session_manager = || Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let workflow = create_test_workflow(temp_dir.path(), "shared");
+        let daemon = Scheduler::new(storage_path.clone(), session_manager())
+            .await
+            .unwrap();
+        daemon
+            .add_scheduled_job(dormant_job("shared", &workflow), false)
+            .await
+            .unwrap();
+        // The other process starts after the job exists, so it loads it.
+        let other = Scheduler::new(storage_path.clone(), session_manager())
+            .await
+            .unwrap();
+
+        other.pause_schedule("shared").await.unwrap();
+        persist_change(&storage_path, |list| {
+            assert!(edit_job(list, "shared", |job| job.cron = "0 0 9 * * *".to_string()));
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        let held = daemon.list_scheduled_jobs().await;
+        assert_eq!(held.len(), 1, "{held:?}");
+        assert!(held[0].paused, "a pause made elsewhere must hold here too");
+        assert_eq!(
+            held[0].cron, "0 0 9 * * *",
+            "a schedule re-timed elsewhere must be re-timed here"
+        );
+    }
 }
 
 /// Issue #56, Task 24 (§9.3 C2 / R5): a scheduled job created from a private
@@ -4159,5 +4658,105 @@ mod privacy_c2_tests {
             jobs[0].last_error.is_some(),
             "a failed run must leave a job-level error the schedules UI can show"
         );
+    }
+}
+
+/// The daemon's watch on the schedule file (QA 2026-09-10, F2).
+///
+/// Its own module because it is the one F2 test that needs a hook the shipped
+/// scheduler did not have, and the fail-before run for the rest of the F2 tests
+/// swaps in the old production code with this module left out.
+#[cfg(test)]
+mod file_watch_tests {
+    use super::*;
+    use tempfile::tempdir;
+    use tokio::time::{sleep, Duration};
+
+    /// A job another process adds must FIRE, not merely be listed. Listing is
+    /// not something the daemon can wait for: nobody may open the Scheduler page
+    /// before 02:00. So nothing here lists — the only thing that can find the
+    /// job is the watcher.
+    ///
+    /// The job is born at its run cap (`max_runs: Some(0)`), so its first tick
+    /// runs no agent: it auto-pauses and publishes `paused: true` to the file.
+    /// That write is the proof a tick of THIS daemon fired for a job only the
+    /// file knew about, observed without asking the daemon anything.
+    #[serial_test::serial]
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_job_another_process_adds_fires_without_anyone_listing() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let workflow = temp_dir.path().join("added-elsewhere.yaml");
+        fs::write(&workflow, "prompt: test\n").unwrap();
+
+        let daemon = Scheduler::new(
+            storage_path.clone(),
+            Arc::new(SessionManager::new(temp_dir.path().to_path_buf())),
+        )
+        .await
+        .unwrap();
+        let _watch =
+            daemon.spawn_file_watcher_every(Duration::from_millis(50), Duration::from_secs(30));
+
+        // Another process's write — and, deliberately, a SYNCHRONOUS one, made
+        // before this test first yields. On this current-thread runtime the
+        // watcher task cannot run until then, so the write lands before its
+        // first poll every time: the ordering that a watcher taking its baseline
+        // stamp at startup would swallow as "already seen" (it did, once in six
+        // runs, before the first poll was made to always sync).
+        let job = ScheduledJob {
+            id: "added-elsewhere".to_string(),
+            source: workflow.to_string_lossy().into_owned(),
+            cron: "* * * * * *".to_string(),
+            last_run: None,
+            currently_running: false,
+            paused: false,
+            current_session_id: None,
+            process_start_time: None,
+            run_count: 0,
+            max_runs: Some(0),
+            creator_session_id: None,
+            last_error: None,
+            owns_source: Some(false),
+        };
+        write_jobs_file(&storage_path, &[job]).unwrap();
+
+        let mut fired = false;
+        for _ in 0..80 {
+            sleep(Duration::from_millis(100)).await;
+            let on_disk: Vec<ScheduledJob> =
+                serde_json::from_str(&fs::read_to_string(&storage_path).unwrap()).unwrap();
+            if on_disk
+                .iter()
+                .any(|job| job.id == "added-elsewhere" && job.paused)
+            {
+                fired = true;
+                break;
+            }
+        }
+        assert!(
+            fired,
+            "a job only the file knew about never fired in this daemon: it would never run"
+        );
+    }
+
+    /// The watcher belongs to the scheduler it watches: once that is gone, the
+    /// task ends rather than polling a file nobody is scheduling from.
+    #[tokio::test]
+    async fn the_watch_ends_with_its_scheduler() {
+        let temp_dir = tempdir().unwrap();
+        let daemon = Scheduler::new(
+            temp_dir.path().join("schedule.json"),
+            Arc::new(SessionManager::new(temp_dir.path().to_path_buf())),
+        )
+        .await
+        .unwrap();
+        let watch =
+            daemon.spawn_file_watcher_every(Duration::from_millis(20), Duration::from_secs(30));
+        drop(daemon);
+        tokio::time::timeout(Duration::from_secs(5), watch)
+            .await
+            .expect("the watch must end once its scheduler is dropped")
+            .unwrap();
     }
 }

--- a/crates/biorouter/tests/agent.rs
+++ b/crates/biorouter/tests/agent.rs
@@ -307,24 +307,27 @@ mod tests {
             }
         }
 
-        /// Issue #56 (R5), the third schedule-creating surface.
+        /// QA 2026-09-10, finding F1, through the real dispatch path: a schedule
+        /// the agent creates is a standing agent run, so it waits for a person
+        /// — in Completely Autonomous mode too, which is where it used to go
+        /// straight through while saving a workflow file asked first.
         ///
-        /// `/loop` and `/schedule` record the chat that made them, so
-        /// `resolve_scheduled_provider` can run the job on that chat's model
-        /// instead of the user's commercial default. The agent's own
-        /// `schedule_management` tool did not, so a schedule an agent creates on
-        /// the user's behalf *from a private chat* still fell through to
-        /// `Config::global()` — the exact hole the rest of the task closes.
+        /// This test used to assert the opposite — that `create` returned with
+        /// the job recorded (`an_agent_created_schedule_records_the_chat_that_asked_for_it`,
+        /// issue #56 R5). That assertion sits behind a proof-backed approval
+        /// now, which an integration test cannot grant, so it moved to
+        /// `agents::schedule_tool::tests::an_approved_create_schedules_it_for_the_chat_that_asked`
+        /// with its reasoning intact. What is left to prove from out here is
+        /// the gate: a card appears, nothing is scheduled while it is
+        /// unanswered, and a Stop releases it with nothing changed.
         ///
-        /// ⚠ The id comes from `dispatch_tool_call`'s own `session` argument,
-        /// NOT from `session_context::current_session_id()`. That task-local is
-        /// scoped around a *scheduled* run (`scheduler.rs`) and a *subagent* run
-        /// (`subagent_handler.rs`) and nowhere else — in particular not around
-        /// `Agent::reply` on the ordinary chat path — so it reads `None` in
-        /// precisely the case this closes. The dispatcher has the real session
-        /// in hand; that is the honest source.
+        /// The session id is minted here rather than by `create_session`, which
+        /// numbers every test database's first chat `YYYYMMDD_1` — and the card
+        /// registry read below is process-global and keyed by that id.
         #[tokio::test]
-        async fn an_agent_created_schedule_records_the_chat_that_asked_for_it() {
+        async fn an_agent_created_schedule_waits_for_a_person() {
+            use biorouter::conversation::message::MessageContent;
+            use biorouter::pending_user_action::PendingUserActions;
             use rmcp::model::CallToolRequestParams;
 
             let temp_dir = TempDir::new().unwrap();
@@ -332,21 +335,18 @@ mod tests {
             let session_manager = Arc::new(SessionManager::new(data_dir.clone()));
             let permission_manager = Arc::new(PermissionManager::new(data_dir.clone()));
             let mock_scheduler = Arc::new(MockScheduler::new());
-            let agent = Agent::with_config(AgentConfig::new(
-                session_manager.clone(),
+            let agent = Arc::new(Agent::with_config(AgentConfig::new(
+                session_manager,
                 permission_manager,
                 Some(mock_scheduler.clone()),
                 BioRouterMode::Auto,
-            ));
-
-            let session = session_manager
-                .create_session(
-                    data_dir.clone(),
-                    "the chat that asked".to_string(),
-                    biorouter::session::session_manager::SessionType::User,
-                )
-                .await
-                .unwrap();
+            )));
+            let session = Session {
+                id: format!("schedule-create-{}", uuid::Uuid::new_v4()),
+                session_type: biorouter::session::session_manager::SessionType::User,
+                working_dir: data_dir.clone(),
+                ..Default::default()
+            };
 
             let workflow_path = data_dir.join("nightly.yaml");
             std::fs::write(
@@ -355,35 +355,72 @@ mod tests {
             )
             .unwrap();
 
-            let (_id, result) = agent
-                .dispatch_tool_call(
-                    CallToolRequestParams {
-                        task: None,
-                        meta: None,
-                        name: PLATFORM_MANAGE_SCHEDULE_TOOL_NAME.into(),
-                        arguments: serde_json::json!({
-                            "action": "create",
-                            "workflow_path": workflow_path.to_str().unwrap(),
-                            "cron_expression": "0 0 1 * * *",
-                        })
-                        .as_object()
-                        .cloned(),
-                    },
-                    "req-1".to_string(),
-                    None,
-                    &session,
-                )
-                .await;
-            // `ToolCallResult` is not `Debug`; the error side is what matters.
-            assert!(result.is_ok(), "{:?}", result.as_ref().err());
+            let stop = tokio_util::sync::CancellationToken::new();
+            let running = tokio::spawn({
+                let agent = Arc::clone(&agent);
+                let session = session.clone();
+                let stop = stop.clone();
+                async move {
+                    let (_id, dispatched) = agent
+                        .dispatch_tool_call(
+                            CallToolRequestParams {
+                                task: None,
+                                meta: None,
+                                name: PLATFORM_MANAGE_SCHEDULE_TOOL_NAME.into(),
+                                arguments: serde_json::json!({
+                                    "action": "create",
+                                    "workflow_path": workflow_path.to_str().unwrap(),
+                                    "cron_expression": "0 2 * * *",
+                                })
+                                .as_object()
+                                .cloned(),
+                            },
+                            "req-1".to_string(),
+                            Some(stop),
+                            &session,
+                        )
+                        .await;
+                    match dispatched {
+                        Ok(call) => call.result.await.map(|_| ()).map_err(|e| e.message),
+                        Err(e) => Err(e.message),
+                    }
+                }
+            });
 
-            let jobs = mock_scheduler.list_scheduled_jobs().await;
-            assert_eq!(jobs.len(), 1, "{jobs:?}");
-            assert_eq!(
-                jobs[0].creator_session_id.as_deref(),
-                Some(session.id.as_str()),
-                "the schedule must remember the chat it was created from, or its runs fall back \
-                 to the global default and leave a private chat's work on a public model"
+            let carded = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                loop {
+                    let cards = PendingUserActions::global().pending_cards_for_session(&session.id);
+                    if cards
+                        .iter()
+                        .flat_map(|card| card.content.iter())
+                        .any(|content| matches!(content, MessageContent::ActionRequired(_)))
+                    {
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            })
+            .await;
+            if carded.is_err() {
+                let outcome =
+                    tokio::time::timeout(std::time::Duration::from_secs(5), running).await;
+                panic!("no approval card within 10s; the call instead returned {outcome:?}");
+            }
+            assert!(
+                mock_scheduler.list_scheduled_jobs().await.is_empty(),
+                "nothing may be scheduled while the card is unanswered"
+            );
+
+            stop.cancel();
+            let outcome = tokio::time::timeout(std::time::Duration::from_secs(10), running)
+                .await
+                .expect("a Stop must release the parked call")
+                .unwrap();
+            let refused = outcome.expect_err("a create nobody approved is not a success");
+            assert!(refused.contains("Nothing was changed"), "{refused}");
+            assert!(
+                mock_scheduler.list_scheduled_jobs().await.is_empty(),
+                "a create nobody approved scheduled something"
             );
         }
     }

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -674,6 +674,16 @@ biorouter schedule run-now --schedule-id daily-report
 biorouter schedule remove --schedule-id daily-report
 ```
 
+**Which process makes the change.** `add`, `remove`, `list` and `run-now` go to a running daemon when this terminal can reach one. They find it the way `session send` does: `BIOROUTER_SERVER__SECRET_KEY` and `BIOROUTER_PORT` (default 3000) from this shell, and a daemon answering there. That daemon then makes the change itself, so the schedule is live, listed and deletable in the app at once, and `run-now` runs inside the daemon, where the app's Stop button can reach it. A daemon that rejects the key is reported as an error. The command does not fall back to editing the file behind the daemon's back.
+
+When no daemon can be reached, the command writes `schedule.json` in Biorouter's data directory itself and says so. For example:
+
+```text
+No running Biorouter could be reached from this terminal (no daemon answered on 127.0.0.1:3000), so the job was written to the schedule file directly. A Biorouter that is already running — the desktop app included — picks it up from that file within 60 seconds; if none is running, it first runs the next time Biorouter starts.
+```
+
+This is always the case next to the desktop app. The app's own daemon uses a random port and a new secret every launch, so a terminal cannot reach it. It is also always the case in an agent's shell, because the daemon's secret is never passed to a tool. A running Biorouter polls the file and usually picks up the change within a couple of seconds, but the promise is 60. `sessions` reads the session store directly and never needs a daemon.
+
 ### mcp
 
 Run an enabled MCP server specified by `<name>` (e.g. `'Google Drive'`). MCP is the Model Context Protocol, the standard biorouter extensions speak.

--- a/docs/workflows/scheduled-jobs.md
+++ b/docs/workflows/scheduled-jobs.md
@@ -15,7 +15,7 @@ The scheduler lets you:
 - Persist scheduled jobs across sessions
 - Manage (list, pause, delete) scheduled jobs through the Desktop UI or CLI
 
-Scheduled jobs are stored persistently in an SQLite database, so they survive application restarts.
+Scheduled jobs are stored in `schedule.json` in Biorouter's data directory, so they survive application restarts. Every Biorouter process on the machine shares that file. See [One schedule, several processes](#one-schedule-several-processes).
 
 ## Creating a scheduled job
 
@@ -106,8 +106,16 @@ The Schedule panel shows all active and paused jobs with:
 biorouter schedule list
 
 # Delete a scheduled job by ID
-biorouter schedule delete <job-id>
+biorouter schedule remove --schedule-id <job-id>
 ```
+
+### One schedule, several processes
+
+Whichever process runs a schedule keeps it in memory, but all of them share `schedule.json`. So a job added in a terminal, by a terminal session's `/schedule`, or by a second Biorouter is still one schedule:
+
+- **A running Biorouter follows the file.** It checks the file every couple of seconds. It picks up jobs other processes added or removed, and jobs they paused or re-timed, within 60 seconds at most. It checks again before every run, so it does not run a job that was deleted or paused elsewhere. Before this, a job added from a terminal while the app was running was missing from the Scheduler page and from the agent's list, could not be deleted from either, and never ran until the app restarted.
+- **`biorouter schedule` asks the running daemon first.** When this terminal can reach a daemon (`BIOROUTER_SERVER__SECRET_KEY` and `BIOROUTER_PORT` in its environment), `add`, `remove`, `list` and `run-now` go to that daemon, and the change is live at once. When it cannot, the command writes the file itself and says when a running Biorouter will pick up the change. A terminal next to the desktop app can never reach the app's own daemon, which uses a random port and secret, so it takes the second path, and the app picks the job up from the file. See the [`schedule` command reference](../cli/command-reference.md#schedule).
+- **A row the app cannot schedule** is not listed. Usually this is a row whose workflow file has been deleted. You can still remove it by ID.
 
 ## Headless (non-interactive) mode
 

--- a/docs/workflows/scheduled-jobs.md
+++ b/docs/workflows/scheduled-jobs.md
@@ -41,9 +41,29 @@ biorouter session
 > Schedule the "nightly-analysis" workflow to run every day at 2am
 ```
 
-Biorouter will create the scheduled job and confirm the cron expression.
+Biorouter asks you to approve the job before creating it, then confirms the cron expression.
 
 > **Note.** To register a job non-interactively, use `biorouter schedule add`. Its flags and a worked example are in [Creating and sharing workflows](creating-and-sharing-workflows.md#schedule-a-workflow) and the [`schedule` command reference](../cli/command-reference.md#schedule).
+
+### When the agent schedules something, you approve it
+
+A scheduled job is a standing agent run. Once it exists, a new session starts on its schedule with nobody watching and does whatever its workflow says. So the agent cannot set one up, or change one, without you. Every change the `platform__manage_schedule` tool can make raises an approval card first:
+
+| Action | What the card asks |
+|---|---|
+| `create` | Run this workflow automatically on this schedule. |
+| `run_now` | Run this schedule once, right now, outside its schedule. |
+| `pause` / `unpause` | Stop this schedule running, or start it running again. |
+| `delete` | Remove this schedule for good. |
+| `kill` | Stop the run that is in progress now. |
+
+The card says in words when the job runs (for example *every day at 02:00, this computer's local time*), which workflow it runs, and how: in the background, on the chat's model, under your permission mode. The card for `create` also shows the whole workflow, not just its path, because the workflow is what the unattended run will do. The exact cron expression is always on the card as well. A schedule written in a shape the card cannot put into words is quoted rather than paraphrased.
+
+- **The card appears in every permission mode**, Autonomous included. The tool parks the card itself, so the permission mode does not decide whether you are asked. The card for saving a workflow with `platform__manage_workflow` works the same way.
+- **Only you can approve it.** The card needs proof that a person clicked it, so an agent cannot approve its own schedule.
+- **Reading asks nothing.** `list`, `inspect`, `sessions` and `session_content` change nothing and raise no card.
+- **Impossible changes are refused without a card.** For example: a schedule that does not exist, stopping a run that is not running, a cron expression the scheduler cannot parse, or a workflow that hides characters the card could not show.
+- **In a browser session started by `biorouter serve`**, nobody can approve anything, so the tool offers only the read actions. Make changes in the desktop app or with the `biorouter` command line instead.
 
 ## Cron expression format
 


### PR DESCRIPTION
Two HIGH findings from the 2026-09-10 composer-driven QA run on `main` at 7c96d796. There is one commit for each.

## An agent could create a daily agent run without asking (F1)

In one Autonomous turn, the model asked for approval to **save a workflow YAML file**. It then created a **daily 02:00 agent run with `developer` capability** through `platform__manage_schedule`, and nobody was asked. `create`, `delete` and `kill` went straight to the scheduler (`schedule_tool.rs:56-75`), while the sibling workflow tool asked for `save`, `delete`, `import` and `schedule`.

**Fix.** Every schedule-changing action now parks the same proof-backed card the workflow tool parks: `create`, `run_now`, `pause`, `unpause`, `delete` and `kill`. The two tools share one helper (`agents/platform_approval.rs`), so they cannot drift apart again.

- **Every permission mode.** The handler parks the card itself, so the permission mode does not decide whether it appears.
- **The card says when, what and how.** It gives the cron in words ("every day at 02:00, this computer's local time") next to the raw expression. Unrecognised shapes are quoted, not paraphrased. For `create` the card shows the whole workflow, because the path could name a file anything wrote a moment ago.
- **Reads stay free.** `list`, `inspect`, `sessions` and `session_content` raise no card.
- **Impossible changes are refused before any card.** That covers an unknown id, killing a job that is not running, pausing one mid-run, an unparseable cron (checked by the scheduler's own parser, now shared as `scheduler::normalize_cron`), and a workflow carrying hidden Unicode tag characters.
- **SD-8.** A proofless `biorouter serve` daemon is not offered the six mutating actions and refuses them, as the workflow tool already does.
- **Stop.** A Stop releases an unanswered card, and nothing changes.

## The CLI created schedules the running daemon never saw (F2)

A chat without the platform tool used `developer__shell` to run `biorouter schedule add`, which printed "Scheduled job 'qaf-run2-workflow' added." `schedule.json` then held **4** jobs. `manage_schedule list` and the Scheduler page showed **3**, and the missing job could not be deleted through either and would never fire. The daemon read the file once at startup, and the reconcile from #140 only ever removed jobs.

**Daemon.** `Scheduler::sync_with_file` makes the daemon's map agree with the file in both directions. It adopts additions (same admission rule as startup), drops removals, and takes a changed row's fields, with a new cron entry when the cron changed. It skips rows this process is running. It runs:

- before every tick,
- whenever the list is served,
- before a by-id operation names an unknown job,
- from a daemon-only watcher. The watcher follows the pattern of the `config.yaml` watcher from #112: a stat every 2 s, and a full sync at least every 60 s.

A sync lock serialises it against this process's own writers. A row that cannot be scheduled (its workflow file is gone) can now be deleted by id.

**CLI.** `schedule add/remove/list/run-now` reach a running daemon the same way `session send` does (`BIOROUTER_SERVER__SECRET_KEY` + `BIOROUTER_PORT` + a `/status` probe). The daemon then makes the change itself. A key the daemon refuses is reported, never worked around by writing the file. When no daemon is reachable, the command writes the file and says so, instead of printing "added":

> No running Biorouter could be reached from this terminal (BIOROUTER_SERVER__SECRET_KEY is not set), so the job was written to the schedule file directly. A Biorouter that is already running — the desktop app included — picks it up from that file within 60 seconds; if none is running, it first runs the next time Biorouter starts.

An agent's shell is always on that path, by design: the daemon's secret is stripped from tool children (#57). The daemon half is what fixes the QA scenario.

## Evidence

**Fail-before** (each new test was run against the unfixed code):
- F1: 4 of the 5 behavioural lib tests failed with "no approval card was raised". `create`, `delete` and `run_now` completed at once, for example `Ok(Ok(Ok("Successfully deleted job 'nightly'")))`. The rewritten `tests/agent.rs` test failed with `the call instead returned Ok(Ok(Ok(())))`.
- F2 daemon: 4 of 4 failed. The headline test reproduces the QA measurement: `left: []`, `right: ["qaf-run2-workflow"]`. The watcher test cannot build against the old code (it uses the new hook). Separately, it fails 3 of 3 against the watcher's own first draft (details under Reviewer notes).
- F2 CLI: 7 failed. Every daemon-route test hit "a daemon was reachable, so this terminal must not write the schedule file", and the no-daemon report was just `Scheduled job 'qaf-probe' added.`

**Runtime.** I ran my build of the desktop app in a `BIOROUTER_PATH_ROOT` sandbox cloned from the seed config, on `versa_azure` `gpt-5.5`, in Autonomous mode. The app ran my `target/debug/biorouterd` on an ephemeral port, which is the QA topology.

- I asked the chat to save a probe workflow and schedule it daily at 02:00 with `manage_schedule create`. The save card appeared as before. Then the new card appeared, and nothing was scheduled while it was pending (`/schedule/list` showed only `daily-meditation`). The card read:
  > Run the workflow 'f1f2-schedule-probe' automatically every day at 02:00, this computer's local time, in background mode: every run is a new session that nobody watches, on this chat's model, under your permission mode (currently Autonomous).
  > Run Manage Schedule? · Modifies data · Arguments `{"action": "create", "schedule": "every day at 02:00, this computer's local time", "cron_expression": "0 2 * * *", "execution_mode": "background", "workflow_path": "…/f1f2-schedule-probe.yaml", "workflow": {…the whole workflow…}}` · Allow Once / Deny
- I ran `biorouter schedule add` from a shell **without** the daemon's key (the QA's Route B). The daemon's watcher adopted the job about **1 s** after the write, with nothing listing (`Adopted schedule 'f1f2-watch-only' … written by another process`).
- I ran the same command **with** the daemon's port and key: `added to the running Biorouter on 127.0.0.1:52837; it is live now.` The daemon's own `/schedule/create` handler logged it.
- The four surfaces agreed. `schedule.json`: 5. `GET /schedule/list`: 5. The Scheduler page: 5. `manage_schedule list` from the chat: 5.
- `manage_schedule delete` on the terminal-created job raised a card ("Delete the schedule 'f1f2-cli-file', which runs the workflow 'f1f2-schedule-probe' every day at 04:30, this computer's local time. It will never run again." · Destructive) and removed it.
- All probe schedules and the probe workflow were deleted afterwards. The sandbox's `daily-meditation` row matched the seed field for field. The sandbox is removed.

**Tests** (final tree):
- `cargo test -p biorouter --lib`: 3811 passed. The scheduler module plus the schedule tool passed 54/54 in each of 20 consecutive runs.
- `cargo test -p biorouter --lib -- schedule workflow`: 175 passed.
- `--test agent`: 17. `--test privacy_guard_wiring`: 3. `--test privacy_capability`: 4.
- `cargo test -p biorouter-cli` with an isolated `HOME`: 405 passed.
- `cargo test -p biorouter-server --lib routes::schedule`: 8 passed.
- `cargo fmt --check` is clean. Workspace clippy with `-D warnings` is clean, with no new `too_many_lines` entries.

## Reviewer notes

- **Concurrency.** `HOWTOAI.md` asks for human review of async and concurrency logic. The parts worth reading:
  - `Scheduler::sync_row`'s swap-or-retire of cron entries, which keeps exactly one entry per job.
  - The "this process is running it" test, `runs_here`, which covers the claim-to-completion window.
  - The `file_sync` lock, held across both halves of add, remove, pause, unpause and update.
- **An existing test changed.** `a_job_deleted_from_the_file_stops_being_served_and_stops_firing` modelled the CLI's delete as a raw, unlocked `fs::write`. That write can land inside a firing tick's locked read-modify-write and put the row back. No real writer can do that, and the test failed 1 in 40 full-module runs. It now deletes through the locked `persist_change` the CLI actually uses. Its assertions are unchanged. On the pre-F2 code it was 0 in 30 runs, so it is recorded as a modelling fix rather than a proven regression.
- **The watcher's first draft had a bug.** It took its baseline stamp when its task started, which could swallow a write landing before that. It now syncs on its first poll. The watcher test pins this deterministically: the write happens before the task first runs, and the test fails 3 of 3 against the first draft.
- **Small behaviour changes.**
  - The tool's parameter errors are now `INVALID_PARAMS`.
  - An unknown action lists the available ones.
  - `create` no longer echoes a model-supplied `execution_mode`.
  - `an_agent_created_schedule_records_the_chat_that_asked_for_it` moved from `tests/agent.rs` into the lib tests, because an integration test cannot grant a proof-backed card. Its reasoning is intact.
- **Not in this PR.** An agent with a shell can still create a schedule with `biorouter schedule add`, and nobody is asked. The command now tells the truth, and the job appears on the Scheduler page within about a second, but the shell path is still not a boundary. The QA report says so ("The withholding is not a boundary"). Closing it is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
