### PR TITLE
fix(design-system): check-token-mirrors reads the real @theme inline block, not a comment

### DIFF
--- a/ui/desktop/scripts/check-token-mirrors.mjs
+++ b/ui/desktop/scripts/check-token-mirrors.mjs
@@ -25,6 +25,25 @@
  * actually named by a Tailwind colour utility somewhere in src/, and (3)
  * missing its `--color-*` mirror. An unused token is not a bug, and a token
  * only ever read through `var()` is not one either.
+ *
+ * WHERE THE MIRRORS ARE READ FROM is the one thing this check must not guess.
+ * A mirror is a `--color-*` inside an `@theme inline { … }` block, found by a
+ * line that BEGINS `@theme inline {` once comments are blanked out, and read
+ * only up to that block's own closing brace. Until 2026-09-11 the block was
+ * found with `indexOf('@theme inline')` and read to the end of the file — and
+ * the first occurrence of that phrase is a comment in the plain `@theme` block,
+ * far above the real one. So every `--color-*` below the comment counted: the
+ * palette primitives in the plain `@theme` (`--color-coral-*`,
+ * `--color-neutral-*`, …) and their remaps in the family selector blocks — 91
+ * "mirrors" where the block held 61. Tailwind generates utilities from `@theme`
+ * declarations and never from a selector block, so a mirror moved into
+ * `:root[data-theme='alma-mater']` generated nothing — and passed.
+ *
+ * Exit 0: every token a utility names is mirrored. Exit 1: some are not, and
+ * they are listed. Exit 2: no `@theme inline` block was found, or one never
+ * closes — a refusal, not a pass. Falling back to an empty read would report
+ * every token missing, which says nothing about any of them; falling back to
+ * the whole file would report them all present.
  */
 import { readFile, readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -56,6 +75,18 @@ const COLOR_PREFIXES = [
 ];
 
 const css = await readFile(CSS, 'utf8');
+const lineOf = (offset) => css.slice(0, offset).split('\n').length;
+const at = (offset) => `${relative(ROOT, CSS)}:${lineOf(offset)}`;
+
+/** The check cannot run. Exit 2, never 0 — see WHERE THE MIRRORS ARE READ FROM. */
+function refuse(...lines) {
+  console.error('CANNOT READ THE @theme inline MIRROR BLOCK\n');
+  for (const line of lines) console.error(line);
+  console.error(
+    '\nRefusing to report OK: exit 2 means this check could not run, not that it passed.'
+  );
+  process.exit(2);
+}
 
 /**
  * Every `--name:` declared anywhere outside the `@theme` / `@theme inline`
@@ -64,10 +95,65 @@ const css = await readFile(CSS, 'utf8');
 const declared = new Set();
 for (const m of css.matchAll(/^\s{2,}(--[a-z0-9-]+)\s*:/gm)) declared.add(m[1].slice(2));
 
-/** The `@theme inline` mirror block: `--color-x: var(--x)`. */
-const inlineBlock = css.slice(css.indexOf('@theme inline'));
+/**
+ * main.css with every comment and string blanked to spaces. Line breaks stay
+ * and nothing moves, so an offset in `code` is an offset in the real file. One
+ * pattern does both because a global match starts at the EARLIEST position: a
+ * quote inside a comment is swallowed by the comment, and a `/*` inside a string
+ * by the string. Left unterminated, each runs to where CSS ends it — the end of
+ * the file for a comment, the end of the line for a string.
+ */
+const code = css.replace(
+  /\/\*[\s\S]*?(?:\*\/|$)|"(?:[^"\\\n]|\\[\s\S])*"?|'(?:[^'\\\n]|\\[\s\S])*'?/g,
+  (m) => m.replace(/[^\n]/g, ' ')
+);
+
+/** Offset of the `}` that closes the `{` at `open` in `code`, or -1 if none does. */
+function closingBrace(open) {
+  for (let depth = 0, i = open; i < code.length; i++) {
+    if (code[i] === '{') depth++;
+    else if (code[i] === '}' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/**
+ * The `@theme inline` mirror blocks, as `{ open, close }` brace offsets. Every
+ * one counts, because Tailwind reads every `@theme` block. Not `blocks()` from
+ * lib/theme-tokens.mjs: that one counts braces inside comments and runs an
+ * unclosed block to the end of the file — the two ways this read can silently
+ * widen back into the bug described above.
+ */
+const mirrorBlocks = [];
+for (const m of code.matchAll(/^@theme[ \t]+inline[ \t]*\{/gm)) {
+  const open = m.index + m[0].length - 1;
+  const close = closingBrace(open);
+  if (close === -1) {
+    refuse(
+      `The \`@theme inline\` block opened at ${at(open)} never closes.`,
+      'Reading on to the end of the file would count every `--color-*` below it as a mirror.'
+    );
+  }
+  mirrorBlocks.push({ open, close });
+}
+if (mirrorBlocks.length === 0) {
+  refuse(
+    `No line of ${relative(ROOT, CSS)} begins \`@theme inline {\` outside a comment.`,
+    'Mirrors are read from that block and nowhere else — a `--color-*` in a plain `@theme` or',
+    'in a family selector block is not one — so without it there is nothing to check against.'
+  );
+}
+const readFrom = `${relative(ROOT, CSS)}:${mirrorBlocks
+  .map(({ open, close }) => `${lineOf(open)}-${lineOf(close)}`)
+  .join(', ')}`;
+
+/** Their `--color-x: var(--x)` entries. Nothing outside the braces counts. */
 const mirrored = new Set();
-for (const m of inlineBlock.matchAll(/^\s+--color-([a-z0-9-]+)\s*:/gm)) mirrored.add(m[1]);
+for (const { open, close } of mirrorBlocks) {
+  for (const m of code.slice(open + 1, close).matchAll(/^\s+--color-([a-z0-9-]+)\s*:/gm)) {
+    mirrored.add(m[1]);
+  }
+}
 
 /** Walk src/ for class strings. */
 async function* files(dir) {
@@ -116,13 +202,15 @@ if (broken.length === 0) {
   console.log(
     `     (${declared.size} declared, ${mirrored.size} mirrored, ${used.size} reached from a utility)`
   );
+  console.log(`     mirrors read from ${readFrom}`);
   process.exit(0);
 }
 
 console.error('MISSING @theme inline MIRRORS\n');
 console.error('These tokens are declared in main.css and named by a Tailwind colour utility,');
 console.error('but have no `--color-<name>` entry — so the utility is never generated and the');
-console.error('call sites below silently render a fallback colour.\n');
+console.error('call sites below silently render a fallback colour.');
+console.error(`(Mirrors read from ${readFrom}.)\n`);
 for (const token of broken) {
   console.error(`  --${token}`);
   console.error(`      add to @theme inline:  --color-${token}: var(--${token});`);


### PR DESCRIPTION
## Summary

`ui/desktop/scripts/check-token-mirrors.mjs` could pass a missing mirror. It runs as `npm run check:tokens`, which is part of `lint:check` and, since #241, the **Token mirrors (@theme inline)** step of `frontend.yml`.

It found the mirror block with `css.slice(css.indexOf('@theme inline'))`. The first occurrence of that text in `main.css` is a **comment** at line 68, inside the plain `@theme` block, about 1,200 lines above the real `@theme inline {` at line 1257. The slice then ran to the end of the file, so every indented `--color-*` below the comment counted as a mirror. That included the 30 palette primitives in the plain `@theme` (`--color-coral-*`, `--color-neutral-*`, `--color-white`, …) and their remaps in the family selector blocks: 91 "mirrored" where the block holds 61. Tailwind generates utilities from `@theme` declarations and never from a selector block, so a mirror moved into `:root[data-theme='alma-mater']` generates nothing, and the check exited 0.

**Nothing is masked on main today.** The corrected read passes with 61 mirrored and the same 57 tokens reached from a utility.

## What changed

- **Finding the block.** A line that *begins* `@theme inline {` (whitespace-tolerant) is matched against a copy of `main.css` with comments and strings blanked to spaces. Offsets and line numbers are unchanged, so a mention of the phrase in a comment can no longer be taken for the block.
- **Ending the read.** The read stops at the block's own closing brace, counted on the blanked copy, so a brace inside a comment cannot move it. No `--color-*` follows the block today (nothing after line 1443), so this changes no count now. It stops a future one from counting.
- **Missing or unclosed block.** Either case exits 2 with a message saying which. The alternatives would both be silent: an empty read reports every token "missing", and a whole-file read reports every token "present".
- **Several blocks.** Every `@theme inline` block counts, because Tailwind reads all of them.
- **Where the mirrors came from.** The OK line and the failure header now name the lines the mirrors were read from (`src/styles/main.css:1257-1443`). Printed this way, the old read would have said `68-4254`.
- **Header comment.** It now documents where mirrors are read from, why, and the three exit codes.

Unchanged: what counts as **declared** or **used**.

## Evidence

Each row is a scratch clone of `ui/desktop/src` with one mutation to `main.css`. Each script variant is copied in beside the clone, so its `ROOT` resolves to it. The variants:

- `shipped`: main's script.
- `anchored`: a start-only fix (`css.search(/^@theme inline \{/m)`, still reading to EOF), for comparison.
- `fixed`: this PR.
- `no-strings`: this PR with string blanking removed, there only to show that row can fail.

Measured on `6455bc21` + this commit. Exit codes; ✗ marks a wrong answer.

| case | shipped | anchored | fixed | no-strings |
|---|---|---|---|---|
| clean tree | 0 (91 mirrored) | 0 (61) | **0 (61)** | 0 (61) |
| mirror moved into the alma-mater block, after line 948 | 0 ✗ | 1 | **1**, `--border-focus` | 1 |
| mirror deleted outright | 1 | 1 | **1**, `--border-focus`, all 8 files | 1 |
| `inline` dropped, so the block is a plain `@theme` | 0 ✗ | 1 ✗ (all 57 "missing") | **2**, no block | 2 |
| mirror commented out inside the block | 0 ✗ | 0 ✗ | **1** | 1 |
| mirror declared after the block closes | 0 ✗ | 0 ✗ | **1** | 1 |
| column-0 example block inside a comment above the block | 0 ✗ | 0 ✗ | **1** | 1 |
| the block's closing brace removed | 0 ✗ | 0 ✗ | **2**, never closes | 2 |
| mirror in a second `@theme inline` block (a real mirror) | 0 | 0 | **0** | 0 |
| `'/* not a comment'` string just above the block | 0 | 0 | **0** | 2 ✗ |
| mirror sharing its line with a leading comment (a real declaration) | 1 ✗ | 1 ✗ | **0** | 0 |

The moved-mirror row, from the fixed script:

```
MISSING @theme inline MIRRORS

These tokens are declared in main.css and named by a Tailwind colour utility,
but have no `--color-<name>` entry — so the utility is never generated and the
call sites below silently render a fallback colour.
(Mirrors read from src/styles/main.css:1258-1443.)

  --border-focus
      add to @theme inline:  --color-border-focus: var(--border-focus);
      used by: src/components/MarkdownContent.tsx
      used by: src/components/artifacts/ArtifactViewer.tsx
      used by: src/components/schedule/ScheduleDetailView.tsx
      used by: src/components/schedule/SchedulesView.tsx
      used by: src/components/sessions/SessionListView.tsx
      used by: src/components/skills/SkillItem.tsx
      used by: src/components/skills/SkillsView.tsx
      used by: src/components/ui/Select.tsx
```

The `inline`-dropped row:

```
CANNOT READ THE @theme inline MIRROR BLOCK

No line of src/styles/main.css begins `@theme inline {` outside a comment.
Mirrors are read from that block and nowhere else — a `--color-*` in a plain `@theme` or
in a family selector block is not one — so without it there is nothing to check against.

Refusing to report OK: exit 2 means this check could not run, not that it passed.
```

Also run on the rebased branch: `npm run lint:check` passes (typecheck, eslint, `check:themes`, `check:contrast` with 332 assertions, `check:tokens`). `prettier --check` passes on the script; `format:check` does not cover `scripts/`.

## Not in this PR (measured, left alone)

- **The `declared` comment is inaccurate.** It says declarations are read "outside the `@theme` / `@theme inline` blocks", but its regex reads the whole file, and 142 of the 341 declared names come only from `@theme` blocks (`--radius-*`, `--spacing-*`, the `--color-*` primitives, …). A larger declared set can only add reports, never hide one, and this change was scoped not to touch what counts as declared, so the comment stays as it is.
- **`blocks()` in `scripts/lib/theme-tokens.mjs` has the same two widening modes.** `check-contrast.mjs` and `generate-themes.mjs` (via `buildScopes`) read through it, and measured, a `{` inside a comment or an unclosed block both run its read to EOF. That's why this script doesn't reuse it. Fixing it changes what those two guards read, so it belongs in its own PR.

<details><summary>Reproduce: the proof harness (<code>prove-mirrors.mjs</code>)</summary>

Run it from a checkout of this branch with `node prove-mirrors.mjs /tmp/mirrors-proof`. `SHIPPED_REF` picks the baseline script and defaults to `origin/main`. Every mutation asserts that it applied exactly once, so a case can't pass by changing nothing.

```js
#!/usr/bin/env node
// Proof harness for ui/desktop/scripts/check-token-mirrors.mjs.
//
// For each case: clone ui/desktop/src into <out>/<case>/src (cp -Rc, APFS
// clone), apply one mutation to its main.css, then run BOTH the shipped script
// (git HEAD) and the working-tree script against that copy. Each script is
// placed at <out>/<case>/<variant>/check-token-mirrors.mjs, so its
// `ROOT = HERE/..` resolves to <out>/<case> and it reads the mutated copy.
//
//   cd <repo checkout> && node prove-mirrors.mjs <out-dir> [case ...]
//   (SHIPPED_REF=<ref> picks the baseline script; default origin/main.)
import { execFileSync, spawnSync } from 'node:child_process';
import { mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
import { join } from 'node:path';

const REPO = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
const DESKTOP = join(REPO, 'ui/desktop');
const SCRIPT = 'scripts/check-token-mirrors.mjs';
const [OUT, ...only] = process.argv.slice(2);
if (!OUT) throw new Error('usage: prove-mirrors.mjs <out-dir> [case ...]');

/** `source` with `from` replaced by `to`, asserting it occurred exactly once. */
function swap(source, from, to) {
  const n = source.split(from).length - 1;
  if (n !== 1) throw new Error(`variant: expected one ${JSON.stringify(from)}, found ${n}`);
  return source.replace(from, () => to);
}

// The shipped script: main's copy, not HEAD's, once the fix is committed.
const SHIPPED_REF = process.env.SHIPPED_REF ?? 'origin/main';
const HEAD_SRC = execFileSync('git', ['-C', REPO, 'show', `${SHIPPED_REF}:ui/desktop/${SCRIPT}`], {
  encoding: 'utf8',
});
const FIXED_SRC = readFileSync(join(DESKTOP, SCRIPT), 'utf8');
const VARIANTS = {
  // What main ships.
  shipped: HEAD_SRC,
  // The anchored slice measured in the report: start fixed, end still EOF.
  anchored: swap(
    HEAD_SRC,
    "css.slice(css.indexOf('@theme inline'))",
    'css.slice(css.search(/^@theme inline \\{/m))'
  ),
  // The working tree.
  fixed: FIXED_SRC,
  // The working tree with string blanking removed — exists only to show the
  // `comment-opener-inside-string` case can fail.
  'no-strings': swap(
    FIXED_SRC,
    String.raw`/\/\*[\s\S]*?(?:\*\/|$)|"(?:[^"\\\n]|\\[\s\S])*"?|'(?:[^'\\\n]|\\[\s\S])*'?/g`,
    String.raw`/\/\*[\s\S]*?(?:\*\/|$)/g`
  ),
};

const MIRROR = '  --color-border-focus: var(--border-focus);';
const OPEN = '@theme inline {';

/** Assert `needle` occurs exactly once, so a mutation can never half-apply. */
function once(css, needle) {
  const n = css.split(needle).length - 1;
  if (n !== 1) throw new Error(`expected exactly one ${JSON.stringify(needle)}, found ${n}`);
}
const lineOf = (css, needle) => css.slice(0, css.indexOf(needle)).split('\n').length;
const drop = (css) => (once(css, MIRROR + '\n'), css.replace(MIRROR + '\n', ''));

const CASES = {
  // The tree as it is.
  clean: (css) => css,

  // The reported mutant: move the mirror out of `@theme inline` and into the
  // alma-mater FAMILY block, right after line 948. Tailwind generates nothing
  // from a selector block, so this is a missing mirror.
  'move-into-family-block': (css) => {
    once(css, MIRROR + '\n');
    const lines = css.split('\n');
    if (lines[942] !== ":root[data-theme='alma-mater'] {")
      throw new Error(`line 943 is not the alma-mater block: ${lines[942]}`);
    if (!/^ {2}--color-coral-400:/.test(lines[947]))
      throw new Error(`line 948 is not a declaration in that block: ${lines[947]}`);
    const at = lines.indexOf(MIRROR);
    if (at < 948) throw new Error('mirror sits above line 948; the splice below would shift');
    lines.splice(at, 1);
    lines.splice(948, 0, MIRROR); // after line 948 (index 947)
    return lines.join('\n');
  },

  // Delete the mirror outright: must fail and name every call site.
  'delete-mirror': drop,

  // Drop `inline`: the block becomes a plain `@theme`, which the design forbids
  // for mirrors (it freezes the value). There is now NO `@theme inline` block.
  'block-made-plain-theme': (css) => (once(css, `\n${OPEN}\n`), css.replace(`\n${OPEN}\n`, '\n@theme {\n')),

  // The mirror commented out with a multi-line comment, inside the block.
  'mirror-commented-out': (css) => (
    once(css, MIRROR + '\n'),
    css.replace(MIRROR + '\n', `  /* disabled while testing:\n${MIRROR}\n  */\n`)
  ),

  // The mirror declared AFTER the block closes, in an ordinary `:root` rule.
  'mirror-after-block': (css) => drop(css) + `\n:root {\n${MIRROR}\n}\n`,

  // A column-0 example block inside a COMMENT above the real block, mirror
  // deleted from the real one. The anchor must not take the example for code.
  'example-block-in-comment': (css) => {
    const css2 = drop(css);
    once(css2, `\n${OPEN}\n`);
    const example = `/* For example:\n${OPEN}\n${MIRROR}\n}\n*/\n`;
    return css2.replace(`\n${OPEN}\n`, `\n${example}${OPEN}\n`);
  },

  // The block's closing brace removed: it never closes.
  'block-unterminated': (css) => {
    const start = css.indexOf(`\n${OPEN}\n`);
    const close = css.indexOf('\n}\n', start);
    if (start === -1 || close === -1) throw new Error('cannot find the block to unterminate');
    if (lineOf(css, `\n${OPEN}\n`) + 1 !== 1257) throw new Error('block moved from line 1257');
    return css.slice(0, close) + '\n' + css.slice(close + 3);
  },

  // The mirror moved into a SECOND `@theme inline` block. Tailwind reads every
  // @theme block, so this is a real mirror and must still pass.
  'mirror-in-second-inline-block': (css) => drop(css) + `\n${OPEN}\n${MIRROR}\n}\n`,

  // A string holding `/*` just above the block. A blanker that did not know
  // strings would open a "comment" there and run it to the block's first `*/`,
  // swallowing the `@theme inline {` line. Nothing is broken: must pass.
  'comment-opener-inside-string': (css) => (
    once(css, `\n${OPEN}\n`),
    css.replace(`\n${OPEN}\n`, `\n:root {\n  --x-note: '/* not a comment';\n}\n\n${OPEN}\n`)
  ),

  // A real mirror sharing its line with a leading comment. It is a
  // declaration, and must count: must pass.
  'mirror-after-comment-on-same-line': (css) => (
    once(css, MIRROR + '\n'),
    css.replace(MIRROR + '\n', `  /* D-15 */ ${MIRROR.trimStart()}\n`)
  ),
};

rmSync(OUT, { recursive: true, force: true });
mkdirSync(OUT, { recursive: true });
const pristine = readFileSync(join(DESKTOP, 'src/styles/main.css'), 'utf8');
const results = [];

for (const [name, mutate] of Object.entries(CASES)) {
  if (only.length && !only.includes(name)) continue;
  const dir = join(OUT, name);
  mkdirSync(dir, { recursive: true });
  execFileSync('cp', ['-Rc', join(DESKTOP, 'src'), join(dir, 'src')]);
  const mutated = mutate(pristine);
  if (name !== 'clean' && mutated === pristine) throw new Error(`${name}: mutation changed nothing`);
  writeFileSync(join(dir, 'src/styles/main.css'), mutated);

  const row = [name.padEnd(34)];
  for (const [variant, source] of Object.entries(VARIANTS)) {
    mkdirSync(join(dir, variant), { recursive: true });
    const script = join(dir, variant, 'check-token-mirrors.mjs');
    writeFileSync(script, source);
    const r = spawnSync(process.execPath, [script], { encoding: 'utf8' });
    const text = (r.stdout + r.stderr).trimEnd();
    writeFileSync(join(dir, `${variant}.out`), `exit ${r.status}\n${text}\n`);
    const mirrored = text.match(/, (\d+) mirrored,/)?.[1];
    const missing = [...text.matchAll(/^ {2}(--[a-z0-9-]+)$/gm)].map((m) => m[1]).join(' ');
    const cell =
      r.status === 0 ? `0 ok (${mirrored})` : r.status === 1 ? `1 ${missing}` : `${r.status} refused`;
    row.push(cell.padEnd(22));
  }
  results.push(row.join(''));
}

console.log(['case'.padEnd(34), ...Object.keys(VARIANTS).map((v) => v.padEnd(22))].join(''));
for (const r of results) console.log(r);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
