### PR TITLE
Desktop: the Browse modals match a search word by word, ranked like the model's search (F5)

### DIFF
--- a/docs/extensions/extensions-and-skills-guide.md
+++ b/docs/extensions/extensions-and-skills-guide.md
@@ -107,6 +107,8 @@ Marketplace installs never ask you for a file. **Extensions** → **Browse Exten
 
 The **Add Extension** button beside it is the local route, and that one does take a file: drag a `.brxt` onto it, or browse for one.
 
+Both marketplace browsers — **Browse Extensions**, and **Browse Skills** on the **Skills** page — search word by word: a phrase such as `R scripting ggplot visualization` lists every entry that matches any of its words, best match first, ranked the way the agent's own marketplace search ranks them. Clear the search box to browse the whole catalog again.
+
 If an extension needs an API key, passcode or token, Biorouter asks for it in its own dialog and stores it in your operating system's credential store. **Never type a credential into the chat** — it cannot configure anything from there, and it would be visible to every model that reads the conversation. The same is true of the command line: `biorouter extension install` prompts with echo off rather than taking a value as an argument. See [Installing an extension, and where its credentials go](installing-an-extension.md).
 
 ### Developing a custom extension

--- a/ui/desktop/src/components/baam/BrowseExtensionsModal.test.tsx
+++ b/ui/desktop/src/components/baam/BrowseExtensionsModal.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen, waitFor, within } from '@testing-library/react
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import BrowseExtensionsModal from './BrowseExtensionsModal';
+import { MARKETPLACE_EXTENSIONS } from './marketplace.fixture';
 import type { BrxtEnvVar, BrxtManifest } from '../../types/brxt';
 
 /**
@@ -20,12 +21,12 @@ const loadRegistry = vi.hoisted(() => vi.fn());
 // Spread the real module rather than listing members: a partial factory means
 // every export this component newly reaches for (`effectivePrivacy`,
 // `catalogFreshnessLine`) arrives `undefined` and the modal dies at render, in a
-// test that has nothing to say about either. Only the two seams the test
-// actually controls are replaced.
+// test that has nothing to say about either. Only the seam the test actually
+// controls is replaced; the search is the real one, and no test here types a
+// query, so every entry is listed.
 vi.mock('./registry', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./registry')>()),
   loadRegistry,
-  extensionMatches: () => true,
 }));
 
 vi.mock('../ConfigContext', () => ({
@@ -351,5 +352,39 @@ describe('BrowseExtensionsModal — installed rows (issue #116)', () => {
 
     await screen.findByText('Installed');
     expect(screen.queryByRole('button', { name: 'Configure' })).toBeNull();
+  });
+});
+
+/** The extension names the list shows, top to bottom. */
+function shownExtensionNames(): string[] {
+  return Array.from(document.querySelectorAll('div.biorouter-modal-row')).map(
+    (row) => row.querySelector('span')?.textContent ?? ''
+  );
+}
+
+/// Finding F5 in the extensions catalog: the phrase occurs in no field
+/// verbatim, so the whole-phrase matcher this replaced listed nothing for it.
+/// The ranking itself is pinned in `search.test.ts`; this pins that the list
+/// on screen is the ranked one.
+describe('BrowseExtensionsModal — a multi-word search (finding F5)', () => {
+  it('lists what the phrase matches, best match first', async () => {
+    loadRegistry.mockResolvedValue({
+      live: true,
+      registry: { extensions: MARKETPLACE_EXTENSIONS, skills: [] },
+    });
+    const user = userEvent.setup();
+    renderModal();
+
+    await screen.findByText('SPOKEAgent');
+    expect(shownExtensionNames()).toEqual([
+      'CDWAgent',
+      'SPOKEAgent',
+      'CodeGraph Agent',
+      'PrimeKGAgent',
+    ]);
+
+    await user.type(screen.getByPlaceholderText(/Search extensions/), 'SPOKE knowledge graph');
+
+    expect(shownExtensionNames()).toEqual(['SPOKEAgent', 'PrimeKGAgent', 'CodeGraph Agent']);
   });
 });

--- a/ui/desktop/src/components/baam/BrowseExtensionsModal.tsx
+++ b/ui/desktop/src/components/baam/BrowseExtensionsModal.tsx
@@ -4,7 +4,7 @@ import { Package } from '../icons/app-icons';
 import { BrxtInstallModal } from '../BrxtInstallModal';
 import {
   loadRegistry,
-  extensionMatches,
+  rankExtensions,
   effectivePrivacy,
   catalogFreshnessLine,
   type BaamRegistry,
@@ -73,9 +73,10 @@ export default function BrowseExtensionsModal({
   const isInstalled = (e: RegistryExtension) =>
     installedNames.has(e.name.toLowerCase()) || installedNames.has(e.id.toLowerCase());
 
+  /** Best match first under a query; registry order when there is none. */
   const filtered = useMemo(() => {
     if (!registry) return [];
-    return registry.extensions.filter((e) => extensionMatches(e, search));
+    return rankExtensions(registry.extensions, search).hits.map((hit) => hit.entry);
   }, [registry, search]);
 
   /**

--- a/ui/desktop/src/components/baam/BrowseSkillsModal.test.tsx
+++ b/ui/desktop/src/components/baam/BrowseSkillsModal.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MARKETPLACE_SKILLS } from './marketplace.fixture';
 
 const mocks = vi.hoisted(() => ({ loadRegistry: vi.fn() }));
 
@@ -91,5 +93,121 @@ describe('BrowseSkillsModal — the install label has one space between words', 
     // `textContent` rather than the accessible name, which normalises runs of
     // whitespace and would report the bug as fixed while it was still there.
     expect(button.textContent).toBe('Install skills');
+  });
+});
+
+/** The skill names the list shows, top to bottom: one checkbox per row. */
+function shownSkillNames(): string[] {
+  return screen
+    .queryAllByRole('checkbox')
+    .map((box) => box.closest('label')?.querySelector('span')?.textContent ?? '');
+}
+
+async function openWithMarketplaceSkills() {
+  mocks.loadRegistry.mockResolvedValue({
+    registry: { version: 2, source: 'test', extensions: [], skills: MARKETPLACE_SKILLS },
+    live: true,
+    fetchedAt: '2026-09-10T00:00:00Z',
+  });
+  const user = userEvent.setup();
+  render(<BrowseSkillsModal onClose={vi.fn()} onInstalled={vi.fn()} installedIds={new Set()} />);
+  await screen.findByText('R Scripting');
+  return { user, searchBox: screen.getByPlaceholderText(/Search skills/) };
+}
+
+/// Finding F5, in the desktop modal. The model-facing search (#242) and this one
+/// were the same defect in two languages: the WHOLE query had to occur inside a
+/// single field, so every word of `R scripting ggplot visualization` finds a
+/// skill on its own and the phrase found none.
+describe('BrowseSkillsModal — a multi-word search (finding F5)', () => {
+  it('shows the union of what each word finds, best match first', async () => {
+    const { user, searchBox } = await openWithMarketplaceSkills();
+
+    await user.type(searchBox, 'R scripting ggplot visualization');
+
+    expect(shownSkillNames()).toEqual([
+      'ggplot2 Visualization',
+      'R Scripting',
+      'Data Visualization',
+      'Python Scripting',
+      'Clinical Biostatistics',
+    ]);
+  });
+
+  /// The two single-word controls the QA run measured beside the phrase.
+  it('finds exactly the two ggplot skills for `ggplot`', async () => {
+    const { user, searchBox } = await openWithMarketplaceSkills();
+
+    await user.type(searchBox, 'ggplot');
+
+    expect(shownSkillNames()).toEqual(['ggplot2 Visualization', 'Data Visualization']);
+  });
+
+  it('puts the skill a query names first', async () => {
+    const { user, searchBox } = await openWithMarketplaceSkills();
+
+    await user.type(searchBox, 'r-scripting');
+
+    expect(shownSkillNames()[0]).toBe('R Scripting');
+  });
+});
+
+/** The section headings above the list, top to bottom. */
+function shownHeadings(): string[] {
+  return screen.queryAllByRole('heading', { level: 3 }).map((heading) => heading.textContent ?? '');
+}
+
+describe('BrowseSkillsModal — browsing is grouped, a search is ranked', () => {
+  it('groups the catalog under its category headings, in registry order', async () => {
+    await openWithMarketplaceSkills();
+
+    expect(shownHeadings()).toEqual(['Core skills (4)', 'Biomedical analysis (3)']);
+    expect(shownSkillNames()).toEqual([
+      'Scientific Visual Communication',
+      'ggplot2 Visualization',
+      'R Scripting',
+      'Python Scripting',
+      'Clinical Biostatistics',
+      'Data Visualization',
+      'Single-cell',
+    ]);
+  });
+
+  /// Under the category headings, Python Scripting (one term matched) would sit
+  /// above Data Visualization (two) only because Core is listed before
+  /// Biomedical — the ranking would be computed and then not shown.
+  it('shows a search as one list in rank order', async () => {
+    const { user, searchBox } = await openWithMarketplaceSkills();
+
+    await user.type(searchBox, 'R scripting ggplot visualization');
+
+    expect(shownHeadings()).toEqual(['Matches (5)']);
+  });
+
+  it('treats a query of only spaces as browsing', async () => {
+    const { user, searchBox } = await openWithMarketplaceSkills();
+
+    await user.type(searchBox, '   ');
+
+    expect(shownHeadings()).toEqual(['Core skills (4)', 'Biomedical analysis (3)']);
+  });
+
+  it('keeps the category filter under a search', async () => {
+    const { user, searchBox } = await openWithMarketplaceSkills();
+
+    await user.click(screen.getByRole('button', { name: 'Biomedical analysis' }));
+    await user.type(searchBox, 'R scripting ggplot visualization');
+
+    expect(shownSkillNames()).toEqual(['Data Visualization', 'Clinical Biostatistics']);
+  });
+
+  it('says so when nothing matches', async () => {
+    const { user, searchBox } = await openWithMarketplaceSkills();
+
+    await user.type(searchBox, 'xylophone');
+
+    expect(shownSkillNames()).toEqual([]);
+    expect(shownHeadings()).toEqual([]);
+    expect(screen.getByText('No skills match your search.')).toBeInTheDocument();
   });
 });

--- a/ui/desktop/src/components/baam/BrowseSkillsModal.tsx
+++ b/ui/desktop/src/components/baam/BrowseSkillsModal.tsx
@@ -3,12 +3,13 @@ import { Button } from '../ui/button';
 import { toastSuccess, toastError } from '../../toasts';
 import {
   loadRegistry,
-  skillMatches,
+  rankSkills,
   catalogFreshnessLine,
   type BaamRegistry,
   type RegistrySkill,
   type SkillCategory,
 } from './registry';
+import { isBrowseQuery } from './search';
 import { installRegistrySkill } from './installSkill';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../ui/dialog';
 
@@ -76,19 +77,28 @@ export default function BrowseSkillsModal({ onClose, onInstalled, installedIds }
   const isInstalled = (s: RegistrySkill) =>
     installedIds.has(s.id.toLowerCase()) || installedIds.has(s.name.toLowerCase());
 
+  /** Best match first under a query; registry order when there is none. */
   const filtered = useMemo(() => {
     if (!registry) return [];
-    return registry.skills.filter(
-      (s) => (filter === 'All' || s.category === filter) && skillMatches(s, search)
-    );
+    const inCategory = registry.skills.filter((s) => filter === 'All' || s.category === filter);
+    return rankSkills(inCategory, search).hits.map((hit) => hit.entry);
   }, [registry, filter, search]);
 
-  const grouped = useMemo(() => {
-    const map = new Map<SkillCategory, RegistrySkill[]>();
-    for (const cat of CATEGORY_ORDER) map.set(cat, []);
-    for (const s of filtered) map.get(s.category)?.push(s);
-    return map;
-  }, [filtered]);
+  /**
+   * Browsing groups the catalog under its category headings. A search is one
+   * list in rank order instead: under the headings, a Core skill matching one
+   * word of the query would sit above a Biomedical skill matching all of them.
+   */
+  const sections = useMemo(() => {
+    if (!isBrowseQuery(search)) {
+      return filtered.length > 0 ? [{ key: 'matches', label: 'Matches', items: filtered }] : [];
+    }
+    return CATEGORY_ORDER.map((cat) => ({
+      key: cat,
+      label: CATEGORY_LABELS[cat],
+      items: filtered.filter((s) => s.category === cat),
+    })).filter((section) => section.items.length > 0);
+  }, [filtered, search]);
 
   const selectableFiltered = filtered.filter((s) => !isInstalled(s));
   const allFilteredSelected =
@@ -237,13 +247,11 @@ export default function BrowseSkillsModal({ onClose, onInstalled, installedIds }
             </p>
           )}
           {registry &&
-            CATEGORY_ORDER.map((cat) => {
-              const items = grouped.get(cat) ?? [];
-              if (items.length === 0) return null;
+            sections.map(({ key, label, items }) => {
               return (
-                <div key={cat} className="mb-4">
+                <div key={key} className="mb-4">
                   <h3 className="text-xs font-medium text-text-muted uppercase tracking-wider mb-2">
-                    {CATEGORY_LABELS[cat]} ({items.length})
+                    {label} ({items.length})
                   </h3>
                   <div className="flex flex-col gap-1.5">
                     {items.map((skill) => {

--- a/ui/desktop/src/components/baam/marketplace.fixture.ts
+++ b/ui/desktop/src/components/baam/marketplace.fixture.ts
@@ -1,0 +1,191 @@
+// Shared test fixture, deliberately NOT a `.test.ts` file: importing one test
+// file from another re-registers its suites in the importer.
+import type { RegistryExtension, RegistrySkill } from './registry';
+
+/**
+ * Seven skill rows copied VERBATIM from `landing/registry.json` at 7c96d796 —
+ * the registry the 2026-09-10 composer QA run measured finding F5 against — and
+ * kept in that document's order, because registry order is the tie-break a
+ * ranked search falls back to and the order an empty query browses in.
+ *
+ * Frozen here rather than read from `registry.fallback.json`, so the exact
+ * rankings the tests pin cannot move when the registry gains a skill. PR #242
+ * pins the model-facing Rust matcher against the same seven rows, so the two
+ * searches can be compared row for row.
+ */
+export const MARKETPLACE_SKILLS: RegistrySkill[] = [
+  {
+    id: 'scientific-visual-communication',
+    name: 'Scientific Visual Communication',
+    category: 'Core',
+    type: 'User-invocable · /scientific-visual-communication',
+    description:
+      'Plans schematics, posters, slides, figure panels, infographics, visual abstracts, and source-to-visual traceability.',
+    tags: ['Visuals', 'Posters', 'Apache-2.0'],
+    keywords: [
+      'scientific-visual-communication',
+      'schematics',
+      'infographics',
+      'posters',
+      'slides',
+      'visual',
+      'abstracts',
+      'apache',
+    ],
+    download:
+      'https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-scientific-visual-communication/scientific-visual-communication.zip',
+    filename: 'scientific-visual-communication.zip',
+    license: 'Apache-2.0',
+  },
+  {
+    id: 'ggplot-visualization',
+    name: 'ggplot2 Visualization',
+    category: 'Core',
+    type: 'Auto-applied · R plotting',
+    description: 'Applies ggplot2 best-practice style when writing R plotting code.',
+    tags: ['R', 'ggplot2'],
+    keywords: [],
+    download:
+      'https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-ggplot-visualization/ggplot-visualization.zip',
+    filename: 'ggplot-visualization.zip',
+    license: 'Apache-2.0',
+  },
+  {
+    id: 'r-scripting',
+    name: 'R Scripting',
+    category: 'Core',
+    type: 'Auto-applied · R code',
+    description:
+      'Applies tidyverse conventions and documentation standards when writing or reviewing R code.',
+    tags: ['R', 'Tidyverse'],
+    keywords: [],
+    download:
+      'https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-r-scripting/r-scripting.zip',
+    filename: 'r-scripting.zip',
+    license: 'Apache-2.0',
+  },
+  {
+    id: 'python-scripting',
+    name: 'Python Scripting',
+    category: 'Core',
+    type: 'Auto-applied · Python code',
+    description:
+      'Applies Python naming, typing, error handling, and project structure conventions when writing Python code.',
+    tags: ['Python'],
+    keywords: [],
+    download:
+      'https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-python-scripting/python-scripting.zip',
+    filename: 'python-scripting.zip',
+    license: 'Apache-2.0',
+  },
+  {
+    id: 'clinical-biostatistics',
+    name: 'Clinical Biostatistics',
+    category: 'Biomedical',
+    type: '6 skills · auto-applied',
+    description: 'Survival, mixed models, and clinical-trial statistical analysis.',
+    tags: ['survival', 'R', 'lme4'],
+    keywords: ['clinical-biostatistics', 'survival', 'r', 'lme4'],
+    download:
+      'https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-clinical-biostatistics/clinical-biostatistics.zip',
+    filename: 'clinical-biostatistics.zip',
+    license: 'Apache-2.0',
+  },
+  {
+    id: 'data-visualization',
+    name: 'Data Visualization',
+    category: 'Biomedical',
+    type: '13 skills · auto-applied',
+    description: 'Publication-quality plots: heatmaps, volcano, Manhattan, dimplots.',
+    tags: ['ggplot2', 'matplotlib', 'ComplexHeatmap'],
+    keywords: ['data-visualization', 'ggplot2', 'matplotlib', 'complexheatmap'],
+    download:
+      'https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-data-visualization/data-visualization.zip',
+    filename: 'data-visualization.zip',
+    license: 'Apache-2.0',
+  },
+  {
+    id: 'single-cell',
+    name: 'Single-cell',
+    category: 'Biomedical',
+    type: '14 skills · auto-applied',
+    description: 'scRNA-seq clustering, annotation, trajectory, and integration.',
+    tags: ['Scanpy', 'Seurat', 'scVI'],
+    keywords: ['single-cell', 'scanpy', 'seurat', 'scvi'],
+    download:
+      'https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-single-cell/single-cell.zip',
+    filename: 'single-cell.zip',
+    license: 'Apache-2.0',
+  },
+];
+
+/**
+ * Four extension rows copied VERBATIM from `landing/registry.json` at 7c96d796,
+ * in that document's order: three about knowledge graphs, and one private row
+ * that is about none.
+ */
+export const MARKETPLACE_EXTENSIONS: RegistryExtension[] = [
+  {
+    id: 'cdwagent',
+    name: 'CDWAgent',
+    organization: 'BaranziniLab · UCSF',
+    version: 'v0.5.1',
+    description:
+      'Multimodal access to the UCSF Clinical Data Warehouse through natural language. One-call cohort building across diagnoses, medications, procedures, labs, radiology/imaging, immunizations, allergies, and vitals; clinical-notes/NLP search; read-only queries, schema discovery, and structured results. Requires UCSF network credentials (CAMPUS\\username and password).',
+    tags: ['UCSF', 'MCP', 'CDW', 'Clinical'],
+    github: 'https://github.com/BaranziniLab/CDWAgent',
+    download:
+      'https://github.com/BaranziniLab/CDWAgent/releases/download/v0.5.1-brxt/cdwagent.brxt',
+    filename: 'cdwagent.brxt',
+    license: 'Apache-2.0',
+    privacy: 'private',
+    extension_name: 'cdwagent',
+    affiliation: ['ucsf'],
+  },
+  {
+    id: 'spokeagent',
+    name: 'SPOKEAgent',
+    organization: 'BaranziniLab · UCSF',
+    version: 'v0.4.1',
+    description:
+      'Structure-aware access to the SPOKE biomedical knowledge graph (43M nodes): live schema introspection, entity/identifier resolution, node profiling, shortest-path finding, and guarded read-only Cypher across diseases, genes, proteins, drugs, and pathways. Includes a bundled spoke-knowledge-graph skill. Requires a SPOKEAGENT_PASSCODE (see credentials page).',
+    tags: ['UCSF', 'MCP', 'Knowledge Graph'],
+    github: 'https://github.com/BaranziniLab/SPOKEAgent',
+    download:
+      'https://github.com/BaranziniLab/SPOKEAgent/releases/download/v0.4.1/spokeagent-0.4.1.brxt',
+    filename: 'spokeagent-0.4.1.brxt',
+    license: 'Apache-2.0',
+    privacy: 'public',
+    extension_name: 'spokeagent',
+  },
+  {
+    id: 'codegraphagent',
+    name: 'CodeGraph Agent',
+    organization: 'Broccolito · UCSF',
+    version: 'v0.1.0',
+    description:
+      'Pre-indexed code knowledge graph. Ask "who calls X?", "what does Y call?", or "what breaks if I change Z?" across 23 languages including R, Julia, MATLAB, Perl. Vendored fork of CodeGraph on tree-sitter.',
+    tags: ['MCP', 'Code Intelligence', 'R', 'Tree-sitter'],
+    github: 'https://github.com/Broccolito/CodeGraphAgent',
+    download:
+      'https://github.com/Broccolito/CodeGraphAgent/releases/download/v0.1.0/codegraphagent.brxt',
+    filename: 'codegraphagent.brxt',
+    license: 'Apache-2.0',
+    privacy: 'public',
+  },
+  {
+    id: 'primekgagent',
+    name: 'PrimeKGAgent',
+    organization: 'BaranziniLab · BRXT',
+    version: 'v0.1.0',
+    description:
+      'MCP adapter for PrimeKG-style biomedical knowledge graph files and APIs, with guarded metadata lookup and graph-resource summaries.',
+    tags: ['MCP', 'PrimeKG', 'Knowledge Graph', 'Biomedical', 'Apache-2.0'],
+    github: 'https://github.com/BaranziniLab/PrimeKGAgent',
+    download:
+      'https://github.com/BaranziniLab/PrimeKGAgent/releases/download/v0.1.0-brxt/primekgagent.brxt',
+    filename: 'primekgagent.brxt',
+    license: 'Apache-2.0',
+    privacy: 'public',
+  },
+];

--- a/ui/desktop/src/components/baam/registry.ts
+++ b/ui/desktop/src/components/baam/registry.ts
@@ -8,6 +8,14 @@ import { nameToKey } from '../settings/extensions/utils';
 import { rememberPrivateExtensionKeys } from './privateSet';
 import fallback from './registry.fallback.json';
 import { classifyExtension } from '../settings/extensions/extensionPrivacy';
+import {
+  EXTENSION_NOISE,
+  rankEntries,
+  SKILL_NOISE,
+  Weight,
+  type SearchField,
+  type SearchResult,
+} from './search';
 
 export interface RegistryExtension {
   id: string;
@@ -369,29 +377,56 @@ export function catalogFreshnessLine(load: { live: boolean; fetchedAt?: string }
   return `catalog last updated ${when.toLocaleDateString()}`;
 }
 
-/** Case-insensitive match of a query against a skill's searchable fields. */
-export function skillMatches(skill: RegistrySkill, q: string): boolean {
-  if (!q) return true;
-  const needle = q.toLowerCase();
-  return (
-    skill.name.toLowerCase().includes(needle) ||
-    skill.description.toLowerCase().includes(needle) ||
-    skill.category.toLowerCase().includes(needle) ||
-    skill.tags.some((t) => t.toLowerCase().includes(needle)) ||
-    skill.keywords.some((t) => t.toLowerCase().includes(needle)) ||
-    (skill.license?.toLowerCase().includes(needle) ?? false)
-  );
+/**
+ * Every label in a list, as a search field. Total, because an entry can omit
+ * any field — `isRegistryDocument` checks only that an entry is an object — and
+ * a search that throws in render takes the whole modal with it.
+ */
+function labelFields(labels: readonly string[] | undefined): SearchField[] {
+  return Array.isArray(labels) ? labels.map((label): SearchField => [label, Weight.Label]) : [];
 }
 
-/** Case-insensitive match of a query against an extension's searchable fields. */
-export function extensionMatches(ext: RegistryExtension, q: string): boolean {
-  if (!q) return true;
-  const needle = q.toLowerCase();
-  return (
-    ext.name.toLowerCase().includes(needle) ||
-    ext.description.toLowerCase().includes(needle) ||
-    ext.organization.toLowerCase().includes(needle) ||
-    ext.tags.some((t) => t.toLowerCase().includes(needle)) ||
-    (ext.license?.toLowerCase().includes(needle) ?? false)
-  );
+/**
+ * Rank skills against what the user typed in Browse skills, best first; an
+ * empty query returns them all in registry order. How a query is matched — and
+ * why a phrase is a union of its words rather than one substring (finding F5) —
+ * is documented in `search.ts`.
+ *
+ * The fields are exactly the Rust catalog's (`MarketplaceCatalog::search_skills`),
+ * so this modal and the model's search tool agree. ⚠ That excludes the license,
+ * which the whole-phrase matcher searched: every skill and extension in the
+ * registry is Apache-2.0, so it separates nothing, and under word matching it
+ * made `PACS` list every skill — a plural's singular, `pac`, is inside `apache`.
+ */
+export function rankSkills(
+  skills: readonly RegistrySkill[],
+  query: string
+): SearchResult<RegistrySkill> {
+  return rankEntries(query, SKILL_NOISE, skills, (skill) => [
+    [skill.id, Weight.Name],
+    [skill.name, Weight.Name],
+    [skill.category, Weight.Label],
+    [skill.description, Weight.Prose],
+    ...labelFields(skill.tags),
+    ...labelFields(skill.keywords),
+  ]);
+}
+
+/**
+ * Rank extensions against what the user typed in Browse extensions, matched as
+ * {@link rankSkills} is, over exactly the Rust catalog's fields
+ * (`MarketplaceCatalog::search_extensions`).
+ */
+export function rankExtensions(
+  extensions: readonly RegistryExtension[],
+  query: string
+): SearchResult<RegistryExtension> {
+  return rankEntries(query, EXTENSION_NOISE, extensions, (ext) => [
+    [ext.id, Weight.Name],
+    [ext.extension_name, Weight.Name],
+    [ext.name, Weight.Name],
+    [ext.organization, Weight.Label],
+    [ext.description, Weight.Prose],
+    ...labelFields(ext.tags),
+  ]);
 }

--- a/ui/desktop/src/components/baam/search.test.ts
+++ b/ui/desktop/src/components/baam/search.test.ts
@@ -10,6 +10,7 @@ import {
   searchTerms,
   SKILL_NOISE,
   Weight,
+  writtenIn,
   type SearchField,
   type SearchResult,
 } from './search';
@@ -143,16 +144,50 @@ describe('marketplace search — matching and ranking', () => {
     expect(ids(rank('scripting'))).toEqual(['r-scripting', 'prose-only']);
   });
 
-  /// Everything the substring matcher found is still found: a query that
-  /// occurs verbatim in a field is a hit even when its terms are too short to
-  /// match on their own.
-  it('still finds a verbatim occurrence', () => {
-    expect(rank('s p').hits).toEqual([]);
-
-    const search = rank('dy');
-    // `dy` inside `Tidyverse`.
+  /// The query as written is held to the same edges as a short term. Until PR
+  /// #266 the whole-query check was a plain substring test, so a query that IS
+  /// one short term came back in through every word containing it: `r` alone
+  /// found `complex-plots` through "Draws" and `prose-only` through its own
+  /// name, each with no matched term at all.
+  it('reads a one-letter query as a whole word, not a letter inside one', () => {
+    const search = rank('R');
     expect(ids(search)).toEqual(['r-scripting']);
-    expect(search.hits[0].matchedTerms).toEqual([]);
+    expect(search.hits[0].matchedTerms).toEqual(['r']);
+  });
+
+  /// The query as written outranks any count of separate words, so it has to be
+  /// written there: `r scripting` inside "for scripting" is the tail of `for`
+  /// and then a word. Read as a substring it ranked the entry matching one of
+  /// the two words above the entry matching both.
+  it('does not read a phrase found only inside longer words as written', () => {
+    const entries: Entry[] = [
+      {
+        id: 'shell-snippets',
+        name: 'Shell Snippets',
+        description: 'Snippets for scripting the shell.',
+        tags: [],
+      },
+      {
+        id: 'tidy-style',
+        name: 'Tidy Style',
+        description: 'Scripting conventions for R.',
+        tags: ['R'],
+      },
+    ];
+    const search = rankEntries('R scripting', [], entries, fields);
+
+    expect(ids(search)).toEqual(['tidy-style', 'shell-snippets']);
+    expect(search.hits[0].matchedTerms).toEqual(['r', 'scripting']);
+    expect(search.hits[1].matchedTerms).toEqual(['scripting']);
+  });
+
+  /// A fragment of a word is not the query as written, so a query of nothing but
+  /// short terms finds nothing at all — `dy` is inside "Tidyverse", not a word of
+  /// it. The `s p` half held under the substring rule; the `dy` half is the leak
+  /// that rule asserted as a feature.
+  it('finds nothing for a query written only inside longer words', () => {
+    expect(rank('dy').hits).toEqual([]);
+    expect(rank('s p').hits).toEqual([]);
   });
 
   it('browses every entry in registry order for an empty query', () => {
@@ -197,19 +232,29 @@ describe('marketplace search — the score', () => {
     expect(twoTermsInProse.score).toBeGreaterThan(oneTermInTheName.score);
   });
 
-  /// Verbatim is a tier of its own, not one more term: here it wins while
-  /// matching FEWER terms, because `io` is too short to match inside `audio`.
-  it('ranks a verbatim match above every term match, even one matching more terms', () => {
-    const query = parseQuery('io pipe');
-    const verbatimInProse = scoreEntry(query, [['audio pipeline', Weight.Prose]]);
-    const bothTermsInNames = scoreEntry(query, [
-      ['IO', Weight.Name],
-      ['Pipe', Weight.Name],
+  /// The query as written is a tier of its own, not one more term. It can no
+  /// longer be pitted against a HIGHER term count, as the substring rule allowed
+  /// — a phrase written in a field has every one of its words in that field as a
+  /// whole word, so it always matches every term — so the weaker criterion it is
+  /// pitted against here is placement: prose against two names.
+  it('ranks the query as written above the same words scattered in weightier fields', () => {
+    const query = parseQuery('tidy code');
+    const writtenInProse = scoreEntry(query, [['Writes tidy code.', Weight.Prose]]);
+    const scatteredInNames = scoreEntry(query, [
+      ['Code Tidy', Weight.Name],
+      ['code-tidy', Weight.Name],
     ]);
 
-    expect(verbatimInProse.matchedTerms).toEqual(['pipe']);
-    expect(bothTermsInNames.matchedTerms).toEqual(['io', 'pipe']);
-    expect(verbatimInProse.score).toBeGreaterThan(bothTermsInNames.score);
+    expect(writtenInProse.matchedTerms).toEqual(['tidy', 'code']);
+    expect(scatteredInNames.matchedTerms).toEqual(['tidy', 'code']);
+    expect(writtenInProse.score).toBeGreaterThan(scatteredInNames.score);
+
+    // The same pair ranked, as `catalog_search.rs` asserts it.
+    const entries: Entry[] = [
+      { id: 'code-tidy', name: 'Code Tidy', description: 'Formatting rules.', tags: [] },
+      { id: 'styler', name: 'Styler', description: 'Writes tidy code.', tags: [] },
+    ];
+    expect(ids(rankEntries('tidy code', [], entries, fields))).toEqual(['styler', 'code-tidy']);
   });
 
   it('skips a field with no text rather than throwing', () => {
@@ -293,22 +338,17 @@ describe('rankSkills — the rules that keep a union useful', () => {
     ]);
   });
 
-  /// A one-letter query occurs verbatim inside most entries, and a verbatim hit
-  /// is kept so nothing the old matcher showed is lost. The whole-word rule
-  /// still decides the order: the three skills about R lead, and the verbatim-
-  /// only hits follow in registry order.
-  it('ranks the R skills first for `R` alone, above what merely contains an r', () => {
+  /// A one-letter query is the letter as a word: the three skills that are about
+  /// R, and nothing that merely contains an r. Until PR #266 this returned six —
+  /// these three, then scientific-visual-communication, python-scripting and
+  /// single-cell, each matching no term at all and kept only by the substring
+  /// test. Measured against the live registry rather than this fixture, that rule
+  /// returned 125 of 129 skills, 117 of them with no matched term.
+  it('finds only the R skills for `R` alone, not what merely contains an r', () => {
     const search = rankSkills(MARKETPLACE_SKILLS, 'R');
 
-    expect(ids(search)).toEqual([
-      'r-scripting',
-      'ggplot-visualization',
-      'clinical-biostatistics',
-      'scientific-visual-communication',
-      'python-scripting',
-      'single-cell',
-    ]);
-    expect(search.hits.map((hit) => hit.matchedTerms)).toEqual([['r'], ['r'], ['r'], [], [], []]);
+    expect(ids(search)).toEqual(['r-scripting', 'ggplot-visualization', 'clinical-biostatistics']);
+    expect(search.hits.map((hit) => hit.matchedTerms)).toEqual([['r'], ['r'], ['r']]);
   });
 
   it('finds a singular field word for a plural term', () => {
@@ -421,8 +461,46 @@ describe('the fields each catalog searches, and what a match in each is worth', 
   });
 });
 
+/**
+ * The word-boundary test the whole-query rank runs on, ported case for case from
+ * `written_in` in `catalog_search.rs`, and then pushed at the characters where
+ * JavaScript's own `\b` disagrees with Rust's `char::is_alphanumeric`. Those
+ * cases are why this is a hand-written scan over code points and not a regular
+ * expression — and every one of them is invisible to an ASCII fixture.
+ */
+describe('marketplace search — the query as written', () => {
+  it('reads a phrase as written only between word boundaries', () => {
+    expect(writtenIn('r scripting', 'r scripting')).toBe(true);
+    // The second `r`, the one that is a word of its own.
+    expect(writtenIn('tidy code for r.', 'r')).toBe(true);
+    expect(writtenIn('snippets for scripting', 'r scripting')).toBe(false);
+    expect(writtenIn('tidyverse', 'dy')).toBe(false);
+    // Written at the second `a`, which overlaps the refused first occurrence —
+    // so every position is tried, not only the first one a search would find.
+    expect(writtenIn('ba a a', 'a a')).toBe(true);
+    // An edge that is not a letter or digit is a boundary itself.
+    expect(writtenIn('c++ code', '++')).toBe(true);
+  });
+
+  it('reads a word character as Rust does, not as `\b` does', () => {
+    // `_` is a boundary here and a word character to `\b`, which would refuse
+    // this.
+    expect(writtenIn('snake_case', 'case')).toBe(true);
+    // `ï` is a word character here and a boundary to `\b`, which would accept
+    // this.
+    expect(writtenIn('naïve', 'naï')).toBe(false);
+    expect(writtenIn('naïve bayes', 'naïve')).toBe(true);
+    // A letter outside the BMP is ONE character, so it closes a word. Compared
+    // as UTF-16 units its trailing half is a lone surrogate, which matches no
+    // letter, and the phrase would be read as written.
+    expect(writtenIn('𝐚rna', 'rna')).toBe(false);
+    // A digit is a word character, the same way `words` keeps `ggplot2` whole.
+    expect(writtenIn('ggplot2 plots', 'ggplot')).toBe(false);
+  });
+});
+
 describe('rankExtensions — the same matcher over the extensions catalog', () => {
-  /// The phrase is in no field verbatim — SPOKEAgent says "SPOKE biomedical
+  /// No field holds the phrase as written — SPOKEAgent says "SPOKE biomedical
   /// knowledge graph" and "spoke-knowledge-graph" — so the matcher this replaced
   /// showed nothing for it.
   it('ranks a multi-word query by the terms each extension matches', () => {

--- a/ui/desktop/src/components/baam/search.test.ts
+++ b/ui/desktop/src/components/baam/search.test.ts
@@ -15,10 +15,11 @@ import {
 } from './search';
 
 /**
- * The marketplace matcher, ported from `crates/biorouter/src/marketplace/search.rs`
- * (PR #242). The first half ports that file's own tests against the same three
- * synthetic entries, so the two languages are pinned by one set of cases; the
- * second half runs finding F5's queries against real registry rows.
+ * The marketplace matcher, ported from `crates/biorouter/src/catalog_search.rs`
+ * (PR #242; moved there from `marketplace/search.rs`, and given the word-boundary
+ * rule, by PR #266). The first half ports that file's own tests against the same
+ * three synthetic entries, so the two languages are pinned by one set of cases;
+ * the second half runs finding F5's queries against real registry rows.
  */
 
 interface Entry {

--- a/ui/desktop/src/components/baam/search.test.ts
+++ b/ui/desktop/src/components/baam/search.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, it } from 'vitest';
+import { MARKETPLACE_EXTENSIONS, MARKETPLACE_SKILLS } from './marketplace.fixture';
+import { rankExtensions, rankSkills, type RegistryExtension, type RegistrySkill } from './registry';
+import {
+  EXTENSION_NOISE,
+  isBrowseQuery,
+  parseQuery,
+  rankEntries,
+  scoreEntry,
+  searchTerms,
+  SKILL_NOISE,
+  Weight,
+  type SearchField,
+  type SearchResult,
+} from './search';
+
+/**
+ * The marketplace matcher, ported from `crates/biorouter/src/marketplace/search.rs`
+ * (PR #242). The first half ports that file's own tests against the same three
+ * synthetic entries, so the two languages are pinned by one set of cases; the
+ * second half runs finding F5's queries against real registry rows.
+ */
+
+interface Entry {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+}
+
+const ENTRIES: Entry[] = [
+  {
+    id: 'complex-plots',
+    name: 'Complex Plots',
+    description: 'Draws annotated heat maps with the ComplexHeatmap package.',
+    tags: ['ComplexHeatmap'],
+  },
+  {
+    id: 'prose-only',
+    name: 'Prose Only',
+    description: 'Mentions scripting in passing.',
+    tags: [],
+  },
+  {
+    id: 'r-scripting',
+    name: 'R Scripting',
+    description: 'Tidyverse conventions for R code.',
+    tags: ['R'],
+  },
+];
+
+function fields(entry: Entry): SearchField[] {
+  return [
+    [entry.id, Weight.Name],
+    [entry.name, Weight.Name],
+    [entry.description, Weight.Prose],
+    ...entry.tags.map((tag): SearchField => [tag, Weight.Label]),
+  ];
+}
+
+function rank(query: string): SearchResult<Entry> {
+  return rankEntries(query, [], ENTRIES, fields);
+}
+
+function ids<T extends { id: string }>(search: SearchResult<T>): string[] {
+  return search.hits.map((hit) => hit.entry.id);
+}
+
+describe('marketplace search — reading a query', () => {
+  it('splits a query at whitespace and punctuation, lowercased and de-duplicated', () => {
+    expect(searchTerms('R scripting, ggplot/Visualization')).toEqual([
+      'r',
+      'scripting',
+      'ggplot',
+      'visualization',
+    ]);
+    expect(searchTerms('r-scripting')).toEqual(['r', 'scripting']);
+    expect(searchTerms('ggplot2 ggplot2')).toEqual(['ggplot2']);
+  });
+
+  /// A letter is a letter in any script, as Rust's `char::is_alphanumeric`
+  /// has it: an `\w`-style ASCII class would cut `naïve` in two.
+  it('keeps letters and digits of any script inside a word', () => {
+    expect(searchTerms('scRNA-seq, naïve B-cells')).toEqual([
+      'scrna',
+      'seq',
+      'naïve',
+      'b',
+      'cells',
+    ]);
+  });
+
+  it('drops filler words unless they are all there is', () => {
+    expect(searchTerms('a skill about R scripting or ggplot', SKILL_NOISE)).toEqual([
+      'r',
+      'scripting',
+      'ggplot',
+    ]);
+    expect(searchTerms('I need something for R', SKILL_NOISE)).toEqual(['something', 'r']);
+    expect(searchTerms('skills', SKILL_NOISE)).toEqual(['skills']);
+    expect(searchTerms('the', SKILL_NOISE)).toEqual(['the']);
+    // A catalog's own noise words are its own.
+    expect(searchTerms('skills', EXTENSION_NOISE)).toEqual(['skills']);
+    expect(searchTerms('an extension for skills', EXTENSION_NOISE)).toEqual(['skills']);
+  });
+
+  it('treats an empty or all-whitespace query as browsing', () => {
+    expect(isBrowseQuery('')).toBe(true);
+    expect(isBrowseQuery('  \t ')).toBe(true);
+    expect(isBrowseQuery(' r ')).toBe(false);
+  });
+});
+
+describe('marketplace search — matching and ranking', () => {
+  /// `r` as a substring is in nearly every word of prose; as a term it must
+  /// mean the R language.
+  it('matches a term under three characters to whole words only', () => {
+    const search = rank('R scripting');
+    const prose = search.hits.find((hit) => hit.entry.id === 'prose-only');
+    // `scripting` is in its description, and the `r` inside it is not the R language.
+    expect(prose?.matchedTerms).toEqual(['scripting']);
+    // Nor is the `r` inside `Draws`.
+    expect(ids(search)).not.toContain('complex-plots');
+  });
+
+  it('matches a longer term inside a word, and a plural by its singular', () => {
+    // `heatmap` inside `complexheatmap`.
+    expect(ids(rank('heatmap'))).toEqual(['complex-plots']);
+    // No field says `heatmaps`; its singular is inside `complexheatmap`.
+    expect(ids(rank('heatmaps'))).toEqual(['complex-plots']);
+    // `scripts` is not in `scripting`, but `script` starts it.
+    expect(ids(rank('scripts'))).toEqual(['r-scripting', 'prose-only']);
+  });
+
+  it('returns the union, ranked by terms matched and then by where they matched', () => {
+    const search = rank('R scripting');
+    expect(ids(search)).toEqual(['r-scripting', 'prose-only']);
+    expect(search.hits[0].matchedTerms).toEqual(['r', 'scripting']);
+    expect(search.hits[1].matchedTerms).toEqual(['scripting']);
+
+    // A match in the name outranks the same match in the description.
+    expect(ids(rank('scripting'))).toEqual(['r-scripting', 'prose-only']);
+  });
+
+  /// Everything the substring matcher found is still found: a query that
+  /// occurs verbatim in a field is a hit even when its terms are too short to
+  /// match on their own.
+  it('still finds a verbatim occurrence', () => {
+    expect(rank('s p').hits).toEqual([]);
+
+    const search = rank('dy');
+    // `dy` inside `Tidyverse`.
+    expect(ids(search)).toEqual(['r-scripting']);
+    expect(search.hits[0].matchedTerms).toEqual([]);
+  });
+
+  it('browses every entry in registry order for an empty query', () => {
+    const search = rank('   ');
+    expect(search.terms).toEqual([]);
+    expect(ids(search)).toEqual(['complex-plots', 'prose-only', 'r-scripting']);
+  });
+
+  /// Like the matcher this replaced, so an entry too malformed to read a field
+  /// from is still listed while the user is only browsing.
+  it('reads no field at all to browse', () => {
+    const unreadable = (): SearchField[] => {
+      throw new Error('a field was read');
+    };
+    expect(ids(rankEntries('', [], ENTRIES, unreadable))).toEqual([
+      'complex-plots',
+      'prose-only',
+      'r-scripting',
+    ]);
+  });
+});
+
+/// The ranking is packed into one number, and the packing is where a subtle
+/// defect would hide: a scale too small lets a better placement leak into the
+/// tier above it. Each case pits a stronger lower criterion against a weaker
+/// higher one.
+describe('marketplace search — the score', () => {
+  it('is 0 for an entry that matches nothing, with no terms matched', () => {
+    expect(scoreEntry(parseQuery('ggplot'), [['Data Visualization', Weight.Name]])).toEqual({
+      score: 0,
+      matchedTerms: [],
+    });
+  });
+
+  it('ranks more terms matched above better placement', () => {
+    const query = parseQuery('heatmap volcano');
+    const oneTermInTheName = scoreEntry(query, [['Heatmap', Weight.Name]]);
+    const twoTermsInProse = scoreEntry(query, [['complexheatmap and volcanoes', Weight.Prose]]);
+
+    expect(oneTermInTheName.matchedTerms).toEqual(['heatmap']);
+    expect(twoTermsInProse.matchedTerms).toEqual(['heatmap', 'volcano']);
+    expect(twoTermsInProse.score).toBeGreaterThan(oneTermInTheName.score);
+  });
+
+  /// Verbatim is a tier of its own, not one more term: here it wins while
+  /// matching FEWER terms, because `io` is too short to match inside `audio`.
+  it('ranks a verbatim match above every term match, even one matching more terms', () => {
+    const query = parseQuery('io pipe');
+    const verbatimInProse = scoreEntry(query, [['audio pipeline', Weight.Prose]]);
+    const bothTermsInNames = scoreEntry(query, [
+      ['IO', Weight.Name],
+      ['Pipe', Weight.Name],
+    ]);
+
+    expect(verbatimInProse.matchedTerms).toEqual(['pipe']);
+    expect(bothTermsInNames.matchedTerms).toEqual(['io', 'pipe']);
+    expect(verbatimInProse.score).toBeGreaterThan(bothTermsInNames.score);
+  });
+
+  it('skips a field with no text rather than throwing', () => {
+    expect(
+      scoreEntry(parseQuery('ggplot'), [
+        [undefined, Weight.Label],
+        ['ggplot2', Weight.Label],
+      ]).matchedTerms
+    ).toEqual(['ggplot']);
+  });
+});
+
+/// Finding F5, measured by the 2026-09-10 composer QA run against the live
+/// registry and reproduced here against seven of its rows. Before this port,
+/// the desktop modal showed no skill for the phrase, and none for `r-scripting`
+/// either: the id was not a searched field.
+describe('rankSkills — the QA queries (finding F5)', () => {
+  it('returns the union for `R scripting ggplot visualization`, ggplot-visualization first', () => {
+    const search = rankSkills(MARKETPLACE_SKILLS, 'R scripting ggplot visualization');
+
+    expect(search.terms).toEqual(['r', 'scripting', 'ggplot', 'visualization']);
+    // Three of the four terms, then two, then one.
+    expect(ids(search)).toEqual([
+      'ggplot-visualization',
+      'r-scripting',
+      'data-visualization',
+      'python-scripting',
+      'clinical-biostatistics',
+    ]);
+    expect(search.hits[0].matchedTerms).toEqual(['r', 'ggplot', 'visualization']);
+    // `visual` is not `visualization`: a long term must be found in the entry,
+    // not the other way round.
+    expect(ids(search)).not.toContain('scientific-visual-communication');
+  });
+
+  it('finds exactly the two ggplot skills for `ggplot`', () => {
+    expect(ids(rankSkills(MARKETPLACE_SKILLS, 'ggplot'))).toEqual([
+      'ggplot-visualization',
+      'data-visualization',
+    ]);
+  });
+
+  it('puts the skill `r-scripting` names first', () => {
+    const search = rankSkills(MARKETPLACE_SKILLS, 'r-scripting');
+
+    expect(search.hits[0].entry.id).toBe('r-scripting');
+    expect(search.hits[0].matchedTerms).toEqual(['r', 'scripting']);
+    // Then one term each: in a name before in a tag, and a tie in registry order.
+    expect(ids(search)).toEqual([
+      'r-scripting',
+      'python-scripting',
+      'ggplot-visualization',
+      'clinical-biostatistics',
+    ]);
+  });
+});
+
+describe('rankSkills — the rules that keep a union useful', () => {
+  /// Without the filler rule `and` is a term, and it is a whole word in the
+  /// description of every skill below that matches nothing else: single-cell,
+  /// python-scripting, scientific-visual-communication.
+  it('drops filler, so a skill that only says `and` is not a hit', () => {
+    const search = rankSkills(MARKETPLACE_SKILLS, 'skills for R and ggplot');
+
+    expect(search.terms).toEqual(['r', 'ggplot']);
+    expect(ids(search)).toEqual([
+      'ggplot-visualization',
+      'r-scripting',
+      'clinical-biostatistics',
+      'data-visualization',
+    ]);
+  });
+
+  it('reads `R` in a phrase as the R language, not the r inside `writing`', () => {
+    // python-scripting's description says `error`, `structure` and `writing`.
+    expect(ids(rankSkills(MARKETPLACE_SKILLS, 'R ggplot'))).toEqual([
+      'ggplot-visualization',
+      'r-scripting',
+      'clinical-biostatistics',
+      'data-visualization',
+    ]);
+  });
+
+  /// A one-letter query occurs verbatim inside most entries, and a verbatim hit
+  /// is kept so nothing the old matcher showed is lost. The whole-word rule
+  /// still decides the order: the three skills about R lead, and the verbatim-
+  /// only hits follow in registry order.
+  it('ranks the R skills first for `R` alone, above what merely contains an r', () => {
+    const search = rankSkills(MARKETPLACE_SKILLS, 'R');
+
+    expect(ids(search)).toEqual([
+      'r-scripting',
+      'ggplot-visualization',
+      'clinical-biostatistics',
+      'scientific-visual-communication',
+      'python-scripting',
+      'single-cell',
+    ]);
+    expect(search.hits.map((hit) => hit.matchedTerms)).toEqual([['r'], ['r'], ['r'], [], [], []]);
+  });
+
+  it('finds a singular field word for a plural term', () => {
+    // No field says `visualizations`, and `visuals` is not a visualization.
+    expect(ids(rankSkills(MARKETPLACE_SKILLS, 'visualizations'))).toEqual([
+      'ggplot-visualization',
+      'data-visualization',
+    ]);
+    expect(ids(rankSkills(MARKETPLACE_SKILLS, 'scripts'))).toEqual([
+      'r-scripting',
+      'python-scripting',
+    ]);
+  });
+
+  it('browses every skill in registry order for an empty query', () => {
+    expect(ids(rankSkills(MARKETPLACE_SKILLS, ''))).toEqual(
+      MARKETPLACE_SKILLS.map((skill) => skill.id)
+    );
+  });
+
+  /// `isRegistryDocument` admits any object as an entry, so a cached v1 or
+  /// hand-edited document can omit fields. The ranker must not be what throws on
+  /// one: browsing reads no field at all, and a search skips what is missing.
+  /// The matcher this replaced threw on the missing `name` the moment a query
+  /// was typed.
+  it('lists a malformed entry and searches past it without throwing', () => {
+    const malformed = { id: 'r-scripting' } as unknown as RegistrySkill;
+
+    expect(ids(rankSkills([malformed], ''))).toEqual(['r-scripting']);
+    expect(ids(rankSkills([malformed], 'R scripting'))).toEqual(['r-scripting']);
+  });
+});
+
+/// Which fields a catalog searches is part of the port. In the registry's own
+/// rows, keywords repeat the id and the tags, so a field dropped from the list
+/// changes no ranking the QA queries pin; each field is asserted on its own
+/// instead, carrying a word no other field holds.
+describe('the fields each catalog searches, and what a match in each is worth', () => {
+  const blankSkill: RegistrySkill = {
+    id: 'blank',
+    name: 'Blank',
+    category: 'Core',
+    type: '',
+    description: '',
+    tags: [],
+    keywords: [],
+    download: '',
+    filename: '',
+  };
+  const blankExtension: RegistryExtension = {
+    id: 'blank',
+    name: 'Blank',
+    organization: '',
+    version: '',
+    description: '',
+    tags: [],
+    github: '',
+    download: '',
+    filename: '',
+  };
+
+  it.each<[string, Partial<RegistrySkill>, string]>([
+    // The matcher this replaced never searched the id.
+    ['id', { id: 'zebrafish-imaging' }, 'zebrafish'],
+    ['name', { name: 'Zebrafish Imaging' }, 'zebrafish'],
+    ['category', { category: 'Biomedical' }, 'biomedical'],
+    ['description', { description: 'Segments zebrafish embryos.' }, 'zebrafish'],
+    ['tag', { tags: ['Zebrafish'] }, 'zebrafish'],
+    ['keyword', { keywords: ['zebrafish'] }, 'zebrafish'],
+  ])('finds a skill by its %s', (_field, override, query) => {
+    expect(rankSkills([{ ...blankSkill, ...override }], query).hits).toHaveLength(1);
+  });
+
+  /// The one field the whole-phrase matcher searched and the Rust catalog does
+  /// not. Every registry entry is Apache-2.0, so it separates nothing — and
+  /// under word matching it listed every skill for `PACS`, whose singular `pac`
+  /// is inside `apache`.
+  it('does not search the license, in either catalog', () => {
+    expect(rankSkills([{ ...blankSkill, license: 'Apache-2.0' }], 'PACS').hits).toEqual([]);
+    expect(rankExtensions([{ ...blankExtension, license: 'Apache-2.0' }], 'PACS').hits).toEqual([]);
+  });
+
+  it('ranks a skill matched by id or name above a label, and a label above prose', () => {
+    const skills: RegistrySkill[] = [
+      { ...blankSkill, id: 'in-the-description', description: 'Segments zebrafish embryos.' },
+      { ...blankSkill, id: 'in-a-keyword', keywords: ['zebrafish'] },
+      { ...blankSkill, id: 'in-a-tag', tags: ['Zebrafish'] },
+      { ...blankSkill, id: 'in-the-name', name: 'Zebrafish Imaging' },
+    ];
+
+    expect(ids(rankSkills(skills, 'zebrafish'))).toEqual([
+      'in-the-name',
+      // Two labels tie, and a tie keeps registry order.
+      'in-a-keyword',
+      'in-a-tag',
+      'in-the-description',
+    ]);
+  });
+
+  it.each<[string, Partial<RegistryExtension>]>([
+    ['id', { id: 'zebrafish-0.1.0' }],
+    // The installed config name, which can differ from the id and the display name.
+    ['extension name', { extension_name: 'zebrafishagent' }],
+    ['name', { name: 'Zebrafish Agent' }],
+    ['organization', { organization: 'Zebrafish Lab' }],
+    ['description', { description: 'Segments zebrafish embryos.' }],
+    ['tag', { tags: ['Zebrafish'] }],
+  ])('finds an extension by its %s', (_field, override) => {
+    expect(rankExtensions([{ ...blankExtension, ...override }], 'zebrafish').hits).toHaveLength(1);
+  });
+});
+
+describe('rankExtensions — the same matcher over the extensions catalog', () => {
+  /// The phrase is in no field verbatim — SPOKEAgent says "SPOKE biomedical
+  /// knowledge graph" and "spoke-knowledge-graph" — so the matcher this replaced
+  /// showed nothing for it.
+  it('ranks a multi-word query by the terms each extension matches', () => {
+    const search = rankExtensions(MARKETPLACE_EXTENSIONS, 'SPOKE knowledge graph');
+
+    expect(ids(search)).toEqual(['spokeagent', 'primekgagent', 'codegraphagent']);
+    expect(search.hits[0].matchedTerms).toEqual(['spoke', 'knowledge', 'graph']);
+  });
+
+  it('drops its own catalog noise: every entry is an extension', () => {
+    expect(rankExtensions(MARKETPLACE_EXTENSIONS, 'a knowledge graph extension').terms).toEqual([
+      'knowledge',
+      'graph',
+    ]);
+  });
+});

--- a/ui/desktop/src/components/baam/search.ts
+++ b/ui/desktop/src/components/baam/search.ts
@@ -2,13 +2,17 @@
  * Free-text search over the marketplace catalog — the matcher behind the Browse
  * skills and Browse extensions modals.
  *
- * A port of the model-facing matcher, `crates/biorouter/src/marketplace/search.rs`
- * (PR #242), and it has to stay one: a user typing into the modal and a model
- * calling `skills__searchMarketplaceSkills` on that user's behalf read the same
- * catalog, and the same words must find the same entries, ranked the same way.
- * Only a tie can fall differently, because each side breaks ties by its own
- * registry order — the document's here, the id's in Rust. A change to a rule
- * below is a change to both files.
+ * A port of the model-facing matcher, `crates/biorouter/src/catalog_search.rs`
+ * (PR #242, moved there from `marketplace/search.rs` by PR #266 when the
+ * installed-skill search became its second caller), and it has to stay one: a
+ * user typing into the modal and a model calling
+ * `skills__searchMarketplaceSkills` on that user's behalf read the same catalog,
+ * and the same words must find the same entries, ranked the same way. Only a tie
+ * can fall differently, because each side breaks ties by its own registry order —
+ * the document's here, the id's in Rust. **A change to a rule below is a change
+ * to both files**, which is how the word-boundary rule PR #266 added arrived
+ * here; the types it returns are `CatalogSearch` / `CatalogSearchHit` there and
+ * {@link SearchResult} / {@link SearchHit} here.
  *
  * ⚠ **A query is a set of words, not a substring.** The matcher this replaced
  * asked whether the WHOLE lowercased query occurred inside a single field — the

--- a/ui/desktop/src/components/baam/search.ts
+++ b/ui/desktop/src/components/baam/search.ts
@@ -27,9 +27,9 @@
  * user happened to type, and an AND over a phrase is the same empty list with a
  * different cause. Precision comes from the ranking instead, best first:
  *
- * 1. an entry containing the query **verbatim** — what the old matcher found,
- *    so nothing it showed is lost, bar what only the license matched (no longer
- *    a searched field: see `rankSkills` in `registry.ts`);
+ * 1. an entry holding the query **as written** — its words, in that order, as
+ *    whole words, so `r scripting` is in "R scripting" but not in "for
+ *    scripting" — which no scatter of the same words outranks;
  * 2. then by **how many terms** it matched, so an entry matching every term
  *    precedes one matching some;
  * 3. then by **where** each term matched — the id or name outweighs a tag,
@@ -41,7 +41,15 @@
  * measured query itself:
  *
  * - **A term under three characters matches whole words only.** `r` has to find
- *   the R language; as a substring it matched nearly every entry.
+ *   the R language; as a substring it matched nearly every entry. The query as
+ *   written is held to the same edges (see {@link writtenIn}) — it counts only
+ *   where it starts and ends at a word boundary. Tested as a plain substring,
+ *   which is what this file did until PR #266, a query that IS one short term
+ *   came back in through every word containing it: measured over the live
+ *   `landing/registry.json`, `R` returned 125 of 129 skills, 117 of them
+ *   matching no term at all, and ranked `empirical-paper-submission-rr` above
+ *   `r-scripting`. Refusing that leak drops 198 hits across 76 searches and adds
+ *   none, and only a query whose every term is short changes at all.
  * - **Filler words are dropped** ("a skill about R" is `r`), because in a union
  *   a word like `for` or `and` inflates the term count of every entry whose
  *   prose happens to use it, which ranks noise above the real hit.
@@ -135,6 +143,20 @@ const MAX_TERM_QUALITY = 3 * Weight.Name;
 const WORD_BREAK = /[^\p{Alphabetic}\p{N}]+/u;
 
 /**
+ * One letter or digit: Rust's `char::is_alphanumeric` itself. The complement of
+ * {@link WORD_BREAK}, and it has to stay the complement — {@link words} splits a
+ * field on one and {@link writtenIn} tests the other, so a term and the query
+ * around it are held to the same edges.
+ *
+ * ⚠ **Not `\b`**, which JavaScript defines over `[A-Za-z0-9_]` alone. It reads
+ * `_` as a word character where Rust does not, and every non-ASCII letter — `é`,
+ * `π`, `中` — as a boundary where Rust reads a word character. On `-` and `.` the
+ * two agree, which is exactly why an ASCII fixture would pass over the
+ * disagreement.
+ */
+const WORD_CHAR = /[\p{Alphabetic}\p{N}]/u;
+
+/**
  * Lowercase words, split at every character that is not a letter or digit —
  * whitespace and punctuation alike, so `r-scripting` is `r` + `scripting` and
  * `ggplot2` stays one word.
@@ -149,6 +171,43 @@ function words(text: string): string[] {
 /** Length in characters rather than UTF-16 code units, like Rust's `chars().count()`. */
 function charCount(text: string): number {
   return Array.from(text).length;
+}
+
+/** Is `char` a letter or digit? The text's edge — `undefined` — is not. */
+function isWordChar(char: string | undefined): boolean {
+  return char !== undefined && WORD_CHAR.test(char);
+}
+
+/**
+ * Does `text` hold `phrase` as written — starting and ending at a word boundary,
+ * not inside a longer word? `r scripting` is in "R scripting" but not in "for
+ * scripting", where its `r` is the tail of `for`. Both are lowercase already.
+ *
+ * An edge of `phrase` that is not a letter or digit needs no boundary: it is
+ * one, so `++` is written in "c++".
+ *
+ * Every character position is tried, not only the occurrences `indexOf` would
+ * step through, because a refused occurrence can overlap an accepted one:
+ * `a a` in "ba a a" is written only from the second `a`.
+ *
+ * Compared as code points rather than UTF-16 units, like Rust's `char_indices`,
+ * so an astral character is one character on both sides of the port.
+ *
+ * Exported only so the boundary cases can be asserted directly, the way Rust
+ * asserts them from inside the module.
+ */
+export function writtenIn(text: string, phrase: string): boolean {
+  const chars = Array.from(text);
+  const wanted = Array.from(phrase);
+  const startsWord = isWordChar(wanted[0]);
+  const endsWord = isWordChar(wanted[wanted.length - 1]);
+  for (let start = 0; start < chars.length; start += 1) {
+    if (!wanted.every((want, offset) => chars[start + offset] === want)) continue;
+    const opens = !startsWord || !isWordChar(chars[start - 1]);
+    const closes = !endsWord || !isWordChar(chars[start + wanted.length]);
+    if (opens && closes) return true;
+  }
+  return false;
 }
 
 /**
@@ -196,7 +255,7 @@ function termStrength(term: string, word: string): number {
 
 /** A query as the matcher reads it. */
 export interface SearchQuery {
-  /** The whole query, trimmed and lowercased: what a verbatim match looks for. */
+  /** The whole query, trimmed and lowercased: what {@link writtenIn} looks for. */
   phrase: string;
   /** Its distinct words, without filler. See {@link searchTerms}. */
   terms: string[];
@@ -209,15 +268,17 @@ export function parseQuery(query: string, noise: readonly string[] = []): Search
 /** How one entry matched one query. */
 export interface EntryMatch {
   /**
-   * 0 is no match; otherwise higher ranks first. It packs the ranking —
-   * verbatim, then terms matched, then where and how well they matched — into
-   * one number whose scale depends on the query's term count, so it compares
-   * entries scored against the SAME query and means nothing across two.
+   * 0 is no match; otherwise higher ranks first. It packs the ranking — the
+   * query as written, then terms matched, then where and how well they matched —
+   * into one number whose scale depends on the query's term count, so it
+   * compares entries scored against the SAME query and means nothing across two.
    */
   score: number;
   /**
-   * The terms this entry matched, in query order. Empty for an entry that only
-   * the verbatim query found.
+   * The terms this entry matched, in query order. Empty only when the query holds
+   * no word at all (`++`), so that nothing but the query as written could have
+   * found the entry — a query written in a field has every one of its words in
+   * that field as a whole word, and so matches every term.
    */
   matchedTerms: string[];
 }
@@ -232,7 +293,7 @@ export function scoreEntry(query: SearchQuery, fields: readonly SearchField[]): 
   const present = fields.filter(
     (field): field is readonly [string, FieldWeight] => typeof field[0] === 'string'
   );
-  const verbatim = present.some(([text]) => text.toLowerCase().includes(query.phrase));
+  const written = present.some(([text]) => writtenIn(text.toLowerCase(), query.phrase));
   const entryWords = present.flatMap(([text, weight]) =>
     words(text).map((word) => ({ word, weight }))
   );
@@ -250,12 +311,13 @@ export function scoreEntry(query: SearchQuery, fields: readonly SearchField[]): 
     }
   }
 
-  // Lexicographic (verbatim, terms matched, quality) as one number. `quality`
-  // is at most MAX_TERM_QUALITY per term, so it stays below `scale`; the terms
-  // matched never exceed the term count, so a verbatim match outranks them.
+  // Lexicographic (written, terms matched, quality) as one number — the same key
+  // Rust sorts on. `quality` is at most MAX_TERM_QUALITY per term, so it stays
+  // below `scale`; the terms matched never exceed the term count, so the query
+  // as written outranks any scatter of its words.
   const termCount = query.terms.length;
   const scale = MAX_TERM_QUALITY * termCount + 1;
-  const tier = (verbatim ? termCount + 1 : 0) + matchedTerms.length;
+  const tier = (written ? termCount + 1 : 0) + matchedTerms.length;
   return { score: tier * scale + quality, matchedTerms };
 }
 

--- a/ui/desktop/src/components/baam/search.ts
+++ b/ui/desktop/src/components/baam/search.ts
@@ -1,0 +1,294 @@
+/**
+ * Free-text search over the marketplace catalog — the matcher behind the Browse
+ * skills and Browse extensions modals.
+ *
+ * A port of the model-facing matcher, `crates/biorouter/src/marketplace/search.rs`
+ * (PR #242), and it has to stay one: a user typing into the modal and a model
+ * calling `skills__searchMarketplaceSkills` on that user's behalf read the same
+ * catalog, and the same words must find the same entries, ranked the same way.
+ * Only a tie can fall differently, because each side breaks ties by its own
+ * registry order — the document's here, the id's in Rust. A change to a rule
+ * below is a change to both files.
+ *
+ * ⚠ **A query is a set of words, not a substring.** The matcher this replaced
+ * asked whether the WHOLE lowercased query occurred inside a single field — the
+ * defect the 2026-09-10 composer QA run measured as finding F5, present here in
+ * TypeScript as well as in Rust. Measured in this modal against seven rows of
+ * `landing/registry.json`: `R scripting ggplot visualization` showed no skill
+ * at all while `ggplot` alone showed two, and `r-scripting` — a skill's own id —
+ * showed none, because the id was not searched.
+ *
+ * So a query is split into terms and an entry is a hit when it matches ANY of
+ * them. The union is deliberate: no single entry has to contain every word a
+ * user happened to type, and an AND over a phrase is the same empty list with a
+ * different cause. Precision comes from the ranking instead, best first:
+ *
+ * 1. an entry containing the query **verbatim** — what the old matcher found,
+ *    so nothing it showed is lost, bar what only the license matched (no longer
+ *    a searched field: see `rankSkills` in `registry.ts`);
+ * 2. then by **how many terms** it matched, so an entry matching every term
+ *    precedes one matching some;
+ * 3. then by **where** each term matched — the id or name outweighs a tag,
+ *    which outweighs the description — and how exactly (the whole word, the
+ *    start of one, or inside one);
+ * 4. then registry order, so a result never reshuffles.
+ *
+ * Two rules keep the union from drowning the useful hits, both needed by the
+ * measured query itself:
+ *
+ * - **A term under three characters matches whole words only.** `r` has to find
+ *   the R language; as a substring it matched nearly every entry.
+ * - **Filler words are dropped** ("a skill about R" is `r`), because in a union
+ *   a word like `for` or `and` inflates the term count of every entry whose
+ *   prose happens to use it, which ranks noise above the real hit.
+ */
+
+/** How much a match in one field says about an entry. */
+export const Weight = {
+  /** Free prose: a description. */
+  Prose: 1,
+  /** Curated labels: tags, keywords, a category, an organization. */
+  Label: 2,
+  /** What the entry is called: its registry id and names. */
+  Name: 3,
+} as const;
+
+/** One of the {@link Weight}s. */
+export type FieldWeight = (typeof Weight)[keyof typeof Weight];
+
+/** One searchable field of an entry, and what a match there counts for. */
+export type SearchField = readonly [text: string | undefined, weight: FieldWeight];
+
+/**
+ * Words that say how a request is phrased, not what it is for. Dropped from a
+ * query unless nothing else is left, so a query made only of them (`agent`,
+ * `or`) still searches for what it says. The Rust list, word for word.
+ */
+const FILLER: ReadonlySet<string> = new Set([
+  'a',
+  'about',
+  'an',
+  'and',
+  'any',
+  'are',
+  'baam',
+  'be',
+  'by',
+  'can',
+  'do',
+  'does',
+  'find',
+  'for',
+  'from',
+  'help',
+  'how',
+  'i',
+  'in',
+  'into',
+  'is',
+  'it',
+  'its',
+  'looking',
+  'marketplace',
+  'me',
+  'my',
+  'need',
+  'of',
+  'on',
+  'or',
+  'please',
+  'search',
+  'some',
+  'that',
+  'the',
+  'this',
+  'to',
+  'use',
+  'using',
+  'via',
+  'want',
+  'what',
+  'which',
+  'with',
+]);
+
+/** Filler specific to the skills catalog: every entry in it is a skill. */
+export const SKILL_NOISE: readonly string[] = ['skill', 'skills'];
+
+/** Filler specific to the extensions catalog: every entry in it is an extension. */
+export const EXTENSION_NOISE: readonly string[] = ['extension', 'extensions'];
+
+/** Below this many characters a term matches whole words only. */
+const MIN_PARTIAL_CHARS = 3;
+
+/** The best a single term can score: a whole-word match (3) in a name (3). */
+const MAX_TERM_QUALITY = 3 * Weight.Name;
+
+/**
+ * Anything that is not a letter or a digit, in any script — the complement of
+ * Rust's `char::is_alphanumeric`, which is Unicode `Alphabetic` or `Numeric`.
+ */
+const WORD_BREAK = /[^\p{Alphabetic}\p{N}]+/u;
+
+/**
+ * Lowercase words, split at every character that is not a letter or digit —
+ * whitespace and punctuation alike, so `r-scripting` is `r` + `scripting` and
+ * `ggplot2` stays one word.
+ */
+function words(text: string): string[] {
+  return text
+    .split(WORD_BREAK)
+    .filter((word) => word !== '')
+    .map((word) => word.toLowerCase());
+}
+
+/** Length in characters rather than UTF-16 code units, like Rust's `chars().count()`. */
+function charCount(text: string): number {
+  return Array.from(text).length;
+}
+
+/**
+ * An empty or all-whitespace query is the browse case: every entry, in
+ * registry order.
+ */
+export function isBrowseQuery(query: string): boolean {
+  return query.trim() === '';
+}
+
+/** The distinct terms of `query`, in the order written, without filler. */
+export function searchTerms(query: string, noise: readonly string[] = []): string[] {
+  const all: string[] = [];
+  for (const word of words(query)) {
+    if (!all.includes(word)) all.push(word);
+  }
+  const meaningful = all.filter((term) => !FILLER.has(term) && !noise.includes(term));
+  return meaningful.length > 0 ? meaningful : all;
+}
+
+/**
+ * How well `term` matches one field word: 3 for the whole word, 2 for its
+ * start, 1 for anywhere inside it (`heatmap` in `complexheatmap`), 0 for no
+ * match. A short term matches whole words only.
+ */
+function strength(term: string, word: string): number {
+  if (word === term) return 3;
+  if (charCount(term) < MIN_PARTIAL_CHARS) return 0;
+  if (word.startsWith(term)) return 2;
+  if (word.includes(term)) return 1;
+  return 0;
+}
+
+/**
+ * `term`'s strength against `word`, falling back to its singular so
+ * `visualizations` finds `visualization` and `heatmaps` finds `heatmap`.
+ * `class` and `gis` are left alone.
+ */
+function termStrength(term: string, word: string): number {
+  const direct = strength(term, word);
+  if (direct > 0 || !term.endsWith('s')) return direct;
+  const stem = term.slice(0, -1);
+  return charCount(stem) >= MIN_PARTIAL_CHARS && !stem.endsWith('s') ? strength(stem, word) : 0;
+}
+
+/** A query as the matcher reads it. */
+export interface SearchQuery {
+  /** The whole query, trimmed and lowercased: what a verbatim match looks for. */
+  phrase: string;
+  /** Its distinct words, without filler. See {@link searchTerms}. */
+  terms: string[];
+}
+
+export function parseQuery(query: string, noise: readonly string[] = []): SearchQuery {
+  return { phrase: query.trim().toLowerCase(), terms: searchTerms(query, noise) };
+}
+
+/** How one entry matched one query. */
+export interface EntryMatch {
+  /**
+   * 0 is no match; otherwise higher ranks first. It packs the ranking —
+   * verbatim, then terms matched, then where and how well they matched — into
+   * one number whose scale depends on the query's term count, so it compares
+   * entries scored against the SAME query and means nothing across two.
+   */
+  score: number;
+  /**
+   * The terms this entry matched, in query order. Empty for an entry that only
+   * the verbatim query found.
+   */
+  matchedTerms: string[];
+}
+
+/**
+ * Score one entry's fields against a query. Pure, and total over absent field
+ * text. Under the browse query every entry matches, equally.
+ */
+export function scoreEntry(query: SearchQuery, fields: readonly SearchField[]): EntryMatch {
+  if (query.phrase === '') return { score: 1, matchedTerms: [] };
+
+  const present = fields.filter(
+    (field): field is readonly [string, FieldWeight] => typeof field[0] === 'string'
+  );
+  const verbatim = present.some(([text]) => text.toLowerCase().includes(query.phrase));
+  const entryWords = present.flatMap(([text, weight]) =>
+    words(text).map((word) => ({ word, weight }))
+  );
+
+  const matchedTerms: string[] = [];
+  let quality = 0;
+  for (const term of query.terms) {
+    let best = 0;
+    for (const { word, weight } of entryWords) {
+      best = Math.max(best, termStrength(term, word) * weight);
+    }
+    if (best > 0) {
+      matchedTerms.push(term);
+      quality += best;
+    }
+  }
+
+  // Lexicographic (verbatim, terms matched, quality) as one number. `quality`
+  // is at most MAX_TERM_QUALITY per term, so it stays below `scale`; the terms
+  // matched never exceed the term count, so a verbatim match outranks them.
+  const termCount = query.terms.length;
+  const scale = MAX_TERM_QUALITY * termCount + 1;
+  const tier = (verbatim ? termCount + 1 : 0) + matchedTerms.length;
+  return { score: tier * scale + quality, matchedTerms };
+}
+
+/** One entry a search returned. */
+export interface SearchHit<T> extends EntryMatch {
+  entry: T;
+}
+
+/** A ranked search: what the query was read as, and every entry that matched it, best first. */
+export interface SearchResult<T> {
+  /** The query's terms, after filler was dropped. Empty for the browse query. */
+  terms: string[];
+  /** Best first; equal scores keep registry order. The browse query returns every entry. */
+  hits: SearchHit<T>[];
+}
+
+/**
+ * Rank `entries` against `query`. `fields` names the text of one entry that is
+ * searched, and what a match there counts for; `noise` is the catalog's own
+ * filler (every entry in the skills catalog is a skill).
+ */
+export function rankEntries<T>(
+  query: string,
+  noise: readonly string[],
+  entries: readonly T[],
+  fields: (entry: T) => readonly SearchField[]
+): SearchResult<T> {
+  const parsed = parseQuery(query, noise);
+  if (parsed.phrase === '') {
+    // Browsing reads no field at all — nor did the matcher this replaced — so
+    // an entry too malformed to search is still listed.
+    return { terms: [], hits: entries.map((entry) => ({ entry, score: 1, matchedTerms: [] })) };
+  }
+  const hits = entries
+    .map((entry) => ({ entry, ...scoreEntry(parsed, fields(entry)) }))
+    .filter((hit) => hit.score > 0);
+  // `Array.prototype.sort` is stable, so equal scores keep registry order.
+  hits.sort((left, right) => right.score - left.score);
+  return { terms: parsed.terms, hits };
+}


### PR DESCRIPTION
## Summary

#242 fixed QA finding F5 for the **model-facing** marketplace search. The desktop app's own BAAM search had the same defect in TypeScript: `skillMatches` / `extensionMatches` in `ui/desktop/src/components/baam/registry.ts` checked whether the **whole** query was a substring of a single field.

This PR ports `crates/biorouter/src/catalog_search.rs` (landed on main via #242 as `marketplace/search.rs`; moved, and given the word-boundary rule, by #266) to TypeScript as `ui/desktop/src/components/baam/search.ts`, and both Browse modals use it:

- the query is split at whitespace and punctuation, lowercased and de-duplicated
- an entry matching **any** term is a hit
- terms under 3 characters match whole words only
- filler words are dropped unless nothing else is left
- a plural falls back to its singular
- ranking: the query **as written** first — its words, in that order, as whole words — then terms matched, then field weight × match quality, then registry order

`scoreEntry` is the pure per-entry function: it returns a `score` (0 means no match) and the `matchedTerms`. `rankSkills` / `rankExtensions` replace the old matchers. Their only callers were `BrowseSkillsModal`, `BrowseExtensionsModal` and one test mock, and all three are updated.

## Measured before → after

In the real `BrowseSkillsModal`, rendered with seven rows copied verbatim from `landing/registry.json`, on the unfixed code:

| query | before | after |
|---|---|---|
| `R scripting ggplot visualization` | **0 rows** | 5: ggplot-visualization, r-scripting, data-visualization, python-scripting, clinical-biostatistics |
| `ggplot` | 2 | exactly the same 2 |
| `r-scripting` | **0 rows** (the id was never searched) | r-scripting first |

On the full registry (129 skills, 37 extensions): the phrase goes 0 → 11 (the same count #242 reports for the model-facing search), `r-scripting` 0 → 9, and the extension query `SPOKE knowledge graph` 0 → 3.

## Behaviour changes, each deliberate

- **A search shows one ranked list headed "Matches (n)".** Browsing with no query keeps the category headings in registry order. Under the headings, a Core skill matching one word of the query would sit above a Biomedical skill matching all of them, so the ranking would exist but not be visible. The category filter chips still apply.
- **The id is searched** (and an extension's `extension_name`), as in the Rust catalog.
- **The license is no longer searched.** All 166 registry entries are `Apache-2.0`, so the field never told entries apart. Under word matching it also made `PACS` list all 129 skills, because the singular `pac` is inside `apache`. The Rust catalog never searched it, and dropping it gives exact parity (below). `apache` still finds the 49 skills that carry it as a tag or keyword.
- **A query of only spaces now browses.** Before, it searched for the spaces and showed "No skills match your search."
- **Malformed entries are handled.** Browsing reads no field at all. A search skips missing fields where it used to throw during render, because `isRegistryDocument` only checks that each entry is an object.

## Parity with the Rust matcher

⚠ This was measured **before #266**, against the file at `marketplace/search.rs`; the realignment section below re-measures the one rule that has changed since. I compiled the real `search.rs` (byte-identical to main's at the time) into a small std-only Rust harness and diffed it against the TypeScript functions on the full registry. The query set was 1,345 skill and 336 extension queries: hand-written phrases, every id, name, tag and keyword, and description openings, including filler, plurals, short terms, punctuation and non-ASCII text. **`rankSkills` / `rankExtensions` return the same entries, matched terms and order: 0 mismatches over 11,920 compared hits.**

To check that the harness can fail, I mutated the TypeScript. Raising the short-term threshold by one produced 82 mismatches, and deleting a single filler word produced 13.

The only allowed divergence is tie order. Rust breaks ties by id (a `BTreeMap`), while the modal breaks them by the registry document's order, which is also the order it browses in.

## Tests

- `search.test.ts` (43 tests):
  - the Rust file's own cases, ported, including its six `written_in` boundary cases
  - the score packing: more terms beat better placement, and the query as written beats the same words scattered in weightier fields
  - the three QA queries
  - filler words, short terms, plurals and Unicode
  - robustness against malformed entries
  - the searched field set and weights of each catalog, one field at a time
  - that the license is not searched
- `BrowseSkillsModal.test.tsx` (+8): the QA queries typed into the real modal, the grouped browse view against the ranked "Matches" view, a whitespace-only query, the category filter during a search, and the empty state.
- `BrowseExtensionsModal.test.tsx` (+1): the ranked list on screen. The `extensionMatches` mock is gone; that suite now runs the real search.
- I mutation-tested every rule and each piece of modal wiring. Two first-draft gaps were caught this way and closed: the whole-query tier being demoted to "one more term", and `keywords` being dropped from the searched fields.

## Realigned onto #266 (`catalog_search.rs`)

#266 changes two things under this port, and the header's own sentence — *"A change to a rule below is a change to both files"* — is what made that findable. Both are answered here, one commit each:

**1. The file moved.** `crates/biorouter/src/marketplace/search.rs` → `crates/biorouter/src/catalog_search.rs`, `MarketplaceSearch`/`MarketplaceSearchHit` → `CatalogSearch`/`CatalogSearchHit`. `search.ts` and `search.test.ts` now cite the real path and names. The sentence is kept word for word.

**2. The whole-query rank rule changed**, and `search.ts:231` still had the substring test it replaced. A query now counts as *written* only where it starts **and** ends at a word boundary (`written_in`), the same edges the three-character term rule already enforced.

### Measured, before → after

Same harness, the **real `search.ts` bundled twice** — this branch's previous commit and the new one — ranking the live `landing/registry.json` (129 skills + 37 extensions), 38 queries × both catalogs = 76 searches, full ordered hit lists compared. Control run (old vs old): 0 of 76 changed, so a 0 means something.

```
entries that START being returned:   0
entries that STOP being returned:  198
searches whose ranked list changes:  7 of 76
every changed search has all terms under 3 chars: true
```

| catalog | query | before | after | leading entries unchanged | before top | after top |
|---|---|---|---|---|---|---|
| skills | `R` | **125** | 8 | 8 of 8 | empirical-paper-submission-rr | empirical-paper-submission-rr |
| skills | `dy` | 6 | 0 | — | financial-accounting-econometrics | — |
| skills | `s p` | 6 | 1 | 0 of 1 | research-evaluation-venues | frontend-design |
| skills | `ml` | 9 | 3 | 3 of 3 | scientific-machine-learning | scientific-machine-learning |
| skills | `AI` | 24 | 2 | 2 of 2 | clinical-ai-modeling | clinical-ai-modeling |
| extensions | `R` | 37 | 1 | 1 of 1 | codegraphagent | codegraphagent |
| extensions | `s p` | 7 | 1 | 0 of 1 | spokeagent | playwrightagent |

That is #266's blast radius reproduced from the TypeScript side, drop for drop: **0 start / 198 stop / 7 of 76**, every one a query whose every term is short, and `R` 125→8 with its whole surviving list in the same order. Every survivor list is a **prefix** of its before-list except the two `s p` searches — #266's "only two searches change their first result, both for `s p`". The other 33 queries (`ggplot`, `complexheatmap`, `python`, `rna`, `knowledge graph`, `differential expression`, `R scripting ggplot visualization`, `r-scripting`, `SPOKE knowledge graph`, `c++`, `ucsf`, …) return the identical list in the identical order in **both** catalogs.

Fail-before, on the rule this replaces: a one-letter `R` returned **125 of 129 skills, 117 of them matching no term at all**, and ranked `empirical-paper-submission-rr` above `r-scripting`.

### The word boundary, and why it is not `\b`

`writtenIn` is a transliteration of `written_in`, not a regular expression, and that is measured rather than assumed. JavaScript defines `\b` over `[A-Za-z0-9_]` alone, so a `\b`-built test disagrees with Rust on **4 of the 11 cases now asserted**:

| text | phrase | ours (= Rust) | `\b` |
|---|---|---|---|
| `c++ code` | `++` | true | **false** — an edge that is not a letter or digit is a boundary itself |
| `snake_case` | `case` | true | **false** — `_` is a word character to `\b`, not to Rust |
| `naïve` | `naï` | false | **true** — `ï` is a boundary to `\b`, a letter to Rust |
| `𝐚rna` | `rna` | false | **true** — an astral letter read as two UTF-16 halves |

The scan compares **code points**, like Rust's `char_indices`: read as UTF-16 units, the trailing half of an astral letter is a lone surrogate matching no letter class, so the phrase would be read as written where Rust refuses it. It also tries **every** position rather than the first occurrence, because a refused occurrence can overlap an accepted one (`a a` in `ba a a`). `WORD_CHAR` is spelled as the explicit complement of the `WORD_BREAK` that `words()` already splits on, so a term and the query around it can never be held to different edges.

### Tests

Three existing tests change — the same three #266 changed in Rust — and no modal test moves (15 + 12 keep passing):

- `still finds a verbatim occurrence`: its `dy` half asserted the leak as a feature, exactly as Rust's `a_verbatim_occurrence_is_still_a_hit` did. Replaced by three tests: a one-letter query as a whole word, a phrase found only inside longer words, and `dy`/`s p` both empty.
- `ranks a verbatim match above every term match, even one matching more terms`: the premise is now unreachable. A phrase written in a field has every one of its own words in that field as a whole word, so a written entry always matches **every** term. Re-pitted against placement instead (prose vs two names), with `catalog_search.rs`'s own `tidy code` → `[styler, code-tidy]` ranking beside it.
- `R` alone over the fixture: 6 hits, 3 matching no term → the 3 skills that are about R.

Added: a direct `writtenIn` describe carrying Rust's six `written_in` cases plus the four `\b` divergences. `writtenIn` is exported for it, the way Rust asserts them from inside the module.

**Mutation check.** Reverting the body to `return text.includes(phrase)` and changing nothing else fails **6 of 43** tests, both boundary tests among them. The one new test that survives is the score/packing one — correctly: it pins the tier arithmetic, not the boundary rule.

### Follow-up, deliberately not in this PR

#266 found the same whole-phrase filter a third and fourth time, both renderer TypeScript with no shared code: `ui/desktop/src/components/skills/SkillsView.tsx:72-86` (Settings → Skills) and `ui/desktop/src/components/bottom_menu/BottomMenuSkillSelection.tsx:84-101` (the composer picker). Pointing them at this branch's `search.ts` is the right move, and it does **not** fit yet:

- **They list rows, not skills.** `SkillCatalogEntry` is a union — a single skill, or a **bundle row** whose searchable text is `displayName`, `name` and its **member skill names**. The Rust matcher has no bundle row: it ranks individual skills and carries the bundle as a `Label` field on each member (`skills_extension.rs::search_fields`). A member's name is therefore a `Name` field of a *different* entry there, and weighting it on the bundle row would be a TypeScript-only rule — in the one file whose whole value is that every rule is shared, with no Rust row to diff it against.
- **`SkillsView` discards the ranking.** It re-groups its filtered entries by provenance (Biorouter / project / per-extension / other) and renders them grouped, so the ranking would be thrown away unless that view switches to one ranked list under a query, the way `BrowseSkillsModal` does here. That is a layout decision with its own tests, not a port.
- #266 is unmerged, so the weights to port can still move; #266's own body files this as a follow-up "once it lands".

## Verification

- `npx vitest run src/components/baam/`: **84 passed** (80 before the realignment)
- `npm run lint:check`: exit 0 (re-run after the realignment)
- `npm run format:check` / `npx prettier --check` on both changed files: exit 0
- `npm run test:run`: **5,061 passed, 1 skipped, 0 failed**, but the run exits 1. Every test passes; the `afterAll` teardown (`browser.close()` on a real Playwright Chromium) in `src/utils/artifactCdnAssets.browser.test.ts` hangs past 30 s. It fails the same way when run alone and on pristine `main` (6455bc21), so it is not caused by this branch. With that one file excluded: 445/445 files, exit 0. I've flagged it as a separate task.
- I did **not** check this in the running Electron app. The modal tests render the real component in jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

