### PR TITLE
test(privacy): the census row for the workspace_set_tools pre-flight's capability sample

### DIFF
--- a/crates/biorouter/tests/privacy_capability.rs
+++ b/crates/biorouter/tests/privacy_capability.rs
@@ -156,23 +156,28 @@ const EXPECTED: &[Site] = &[
                §7's write row (`refuse_unless_writable`), Gate F reach for each \
                ADDED extension, the manageability refusal for each REMOVED one, \
                and `privacy::bind_allowed` for a provider switch — so the answer \
-               is either a Deny carrying the handler's own sentence or the \
-               always-confirm card, and a card for a change this caller's model \
-               may not make asks the user to authorise nothing. It is NOT the \
+               is a Deny carrying the handler's own sentence, the always-confirm \
+               card when the change is one §5 asks about, or silence and on to \
+               dispatch; a card for a change this caller's model may not make \
+               asks the user to authorise nothing. It is NOT the \
                gate: `handle_set_tools` re-runs the same pre-flight against the \
                capability the call is finally admitted on, so a model swapped \
                between inspection and dispatch can only make this sample stale in \
                the fail-safe direction. \
-               ⚠ Both funnel into `inspect_with_pinned_capability`, whose first \
-               act is `let mut sampled = capability` — a pinned pair is used AS \
-               IS and the provider mutex is never read. The only caller that pins \
-               one is the coding-agent bridge, which threads the pair it fixed at \
-               issue time so a bridged child's calls cannot re-read the flag \
-               across the process boundary; the agent loop and the approval relay \
-               pass `None`. (2) additionally samples LAZILY — inside the \
-               `is_set_tools_call` arm only, memoising back into `sampled` — so a \
-               batch carrying no `workspace_set_tools` call samples nothing at \
-               all, and one carrying two still gates on one model",
+               ⚠ Each funnels into its OWN `inspect_with_pinned_capability`, \
+               and in both a pinned pair WINS and the provider mutex is never \
+               read — but by different mechanisms, so grep for the right one: (2) \
+               binds `let mut sampled = capability` up front and memoises into \
+               it, while (1) has no `sampled` binding at all and matches the \
+               `Option` once at its sample point, after the early return above. \
+               The only caller that pins a pair is the coding-agent bridge, which \
+               threads the one it fixed at issue time so a bridged child's calls \
+               cannot re-read the flag across the process boundary; the agent \
+               loop, the approval relay and the non-capability entry point pass \
+               `None`. (2) additionally samples LAZILY — inside the \
+               `is_set_tools_call` arm only — so a batch carrying no \
+               `workspace_set_tools` call samples nothing at all, and one \
+               carrying two still gates on one model",
     },
     Site {
         needle: "CallCapability::sample(",

--- a/crates/biorouter/tests/privacy_capability.rs
+++ b/crates/biorouter/tests/privacy_capability.rs
@@ -136,18 +136,34 @@ const EXPECTED: &[Site] = &[
     Site {
         needle: "CallCapability::sample(",
         file: "crates/biorouter/src/agents/workspace_inspector.rs",
-        count: 1,
-        what: "`WorkspaceCrossingInspector::inspect`, the first-crossing \
-               disclosure. A `ToolInspector` runs BEFORE the dispatch that would \
-               admit a capability — that is the point of an inspector — so there \
-               is none in scope to inherit, and the alternative to sampling here \
-               is not inheriting but deciding on `Config::global()`, which is the \
-               bug this type exists to prevent. Sampled ONCE per batch rather than \
+        count: 2,
+        what: "TWO inspectors in this file, each deciding for a batch it sees \
+               BEFORE the dispatch that would admit a capability — that is the \
+               point of an inspector — so neither has one in scope to inherit on \
+               the ordinary agent path, and the alternative to sampling is not \
+               inheriting but deciding on `Config::global()`, which is the bug \
+               this type exists to prevent. \
+               (1) `WorkspaceCrossingInspector::inspect_with_pinned_capability`, \
+               the first-crossing disclosure, sampled ONCE per batch rather than \
                per request, because two calls in one batch must not be able to \
                gate on two different models, and only after a cheap name check \
                has established that the batch contains a cross-session write at \
                all: an ordinary turn must not pay a provider-mutex read for a \
-               disclosure that cannot apply to it",
+               disclosure that cannot apply to it. \
+               (2) `WorkspaceMutationInspector::inspect_with_pinned_capability`'s \
+               `workspace_set_tools` pre-flight (QA finding F4), which asks \
+               `WorkspaceClient::set_tools_preflight_refusal` whether the \
+               tool-set change CAN be made before the user is asked to approve \
+               it — a card for an impossible change is a request for authority \
+               over nothing — and therefore needs the caller's pair to ask the \
+               tier gate with. It samples LAZILY, only once a `set_tools` call \
+               has been found in the batch, and memoises the result in `sampled`, \
+               so an ordinary batch pays no provider-mutex read and two such \
+               calls in one batch still gate on one model. \
+               ⚠ Both PREFER a capability threaded in and sample only when handed \
+               `None`: a bridge grant supplies the pair it fixed at issue time, \
+               which is what keeps a bridged coding agent's calls from re-reading \
+               the flag on this side of the process boundary",
     },
     Site {
         needle: "CallCapability::sample(",
@@ -280,21 +296,31 @@ const EXPECTED: &[Site] = &[
     Site {
         needle: "CallCapability::public_enforced(",
         file: "crates/biorouter/src/providers/coding_agent/bridge.rs",
-        count: 1,
-        what: "NOT a production decider: `mod tests`' `test_capability()` helper, \
-               which every `BridgeGrant` the bridge's own unit tests build takes its \
-               pair from — the most restrictive one, rather than a permissive one \
-               invented for a test's convenience. Counted for the same reason \
-               `privacy/grant.rs`'s test helper is — a line-wise grep cannot tell a \
-               `#[cfg(test)]` block from production, and a filter that tried would \
-               blind the census to production too. The production side of this \
-               bridge decides in `Agent::issue_tool_bridge`, which is a `sample(` \
-               row above. ⚠ This row read `dummy_grant()` while four inline \
-               spellings had accumulated in that file, so the census sat RED \
-               through a whole branch whose own gate list never ran this binary. \
-               The single helper is what stops it drifting that way again: a new \
-               test that inlines the constructor still moves the count off 1 and \
-               still fires here",
+        count: 2,
+        what: "NOT a production decider: the bridge's two TEST fixtures, each \
+               taking the most restrictive pair rather than a permissive one \
+               invented for a test's convenience. (1) `mod tests`' \
+               `test_capability()`, which every `BridgeGrant` the bridge's own \
+               unit tests build takes its pair from. (2) the module-level \
+               `inert_grant_for_test()` — `#[cfg(test)] pub(crate)`, a grant that \
+               dispatches nothing and needs no runtime — which tests in OTHER \
+               modules of this crate build on. They are two rather than one \
+               because a `pub(crate)` fixture cannot live inside `mod tests`, and \
+               from outside that module its private `test_capability()` is not \
+               visible; funnelling both through one helper at module level would \
+               return this row to 1 and is the bridge authors' call, not this \
+               census's. Counted for the same reason `privacy/grant.rs`'s test \
+               helper is — a line-wise grep cannot tell a `#[cfg(test)]` block \
+               from production, and a filter that tried would blind the census to \
+               production too. The production side of this bridge decides in \
+               `Agent::issue_tool_bridge`, which is a `sample(` row above. \
+               ⚠ This row read `dummy_grant()` while four inline spellings had \
+               accumulated in that file, so the census sat RED through a whole \
+               branch whose own gate list never ran this binary; it then sat RED \
+               again from `inert_grant_for_test()`'s arrival until CI began \
+               running `tests/*.rs` and anyone saw it. A new test that inlines the \
+               constructor rather than calling one of these two still moves the \
+               count and still fires here",
     },
     // ---------------------------------------------------------- DR-26's third
     // axis, asked through the free function rather than off a capability. Its

--- a/crates/biorouter/tests/privacy_capability.rs
+++ b/crates/biorouter/tests/privacy_capability.rs
@@ -140,30 +140,39 @@ const EXPECTED: &[Site] = &[
         what: "TWO inspectors in this file, each deciding for a batch it sees \
                BEFORE the dispatch that would admit a capability — that is the \
                point of an inspector — so neither has one in scope to inherit on \
-               the ordinary agent path, and the alternative to sampling is not \
+               the ordinary agent loop, and the alternative to sampling is not \
                inheriting but deciding on `Config::global()`, which is the bug \
                this type exists to prevent. \
-               (1) `WorkspaceCrossingInspector::inspect_with_pinned_capability`, \
-               the first-crossing disclosure, sampled ONCE per batch rather than \
-               per request, because two calls in one batch must not be able to \
-               gate on two different models, and only after a cheap name check \
-               has established that the batch contains a cross-session write at \
-               all: an ordinary turn must not pay a provider-mutex read for a \
-               disclosure that cannot apply to it. \
-               (2) `WorkspaceMutationInspector::inspect_with_pinned_capability`'s \
-               `workspace_set_tools` pre-flight (QA finding F4), which asks \
-               `WorkspaceClient::set_tools_preflight_refusal` whether the \
-               tool-set change CAN be made before the user is asked to approve \
-               it — a card for an impossible change is a request for authority \
-               over nothing — and therefore needs the caller's pair to ask the \
-               tier gate with. It samples LAZILY, only once a `set_tools` call \
-               has been found in the batch, and memoises the result in `sampled`, \
-               so an ordinary batch pays no provider-mutex read and two such \
-               calls in one batch still gate on one model. \
-               ⚠ Both PREFER a capability threaded in and sample only when handed \
-               `None`: a bridge grant supplies the pair it fixed at issue time, \
-               which is what keeps a bridged coding agent's calls from re-reading \
-               the flag on this side of the process boundary",
+               (1) `WorkspaceCrossingInspector`, the first-crossing disclosure, \
+               sampled ONCE per batch rather than per request, because two calls \
+               in one batch must not be able to gate on two different models, and \
+               only after a cheap name check has established that the batch \
+               contains a cross-session write at all: an ordinary turn must not \
+               pay a provider-mutex read for a disclosure that cannot apply to \
+               it. \
+               (2) `WorkspaceMutationInspector`'s `workspace_set_tools` \
+               pre-flight (QA finding F4). The pair it samples is handed to \
+               `set_tools_preflight_refusal` → `preflight_set_tools`, which asks \
+               §7's write row (`refuse_unless_writable`), Gate F reach for each \
+               ADDED extension, the manageability refusal for each REMOVED one, \
+               and `privacy::bind_allowed` for a provider switch — so the answer \
+               is either a Deny carrying the handler's own sentence or the \
+               always-confirm card, and a card for a change this caller's model \
+               may not make asks the user to authorise nothing. It is NOT the \
+               gate: `handle_set_tools` re-runs the same pre-flight against the \
+               capability the call is finally admitted on, so a model swapped \
+               between inspection and dispatch can only make this sample stale in \
+               the fail-safe direction. \
+               ⚠ Both funnel into `inspect_with_pinned_capability`, whose first \
+               act is `let mut sampled = capability` — a pinned pair is used AS \
+               IS and the provider mutex is never read. The only caller that pins \
+               one is the coding-agent bridge, which threads the pair it fixed at \
+               issue time so a bridged child's calls cannot re-read the flag \
+               across the process boundary; the agent loop and the approval relay \
+               pass `None`. (2) additionally samples LAZILY — inside the \
+               `is_set_tools_call` arm only, memoising back into `sampled` — so a \
+               batch carrying no `workspace_set_tools` call samples nothing at \
+               all, and one carrying two still gates on one model",
     },
     Site {
         needle: "CallCapability::sample(",
@@ -296,31 +305,21 @@ const EXPECTED: &[Site] = &[
     Site {
         needle: "CallCapability::public_enforced(",
         file: "crates/biorouter/src/providers/coding_agent/bridge.rs",
-        count: 2,
-        what: "NOT a production decider: the bridge's two TEST fixtures, each \
-               taking the most restrictive pair rather than a permissive one \
-               invented for a test's convenience. (1) `mod tests`' \
-               `test_capability()`, which every `BridgeGrant` the bridge's own \
-               unit tests build takes its pair from. (2) the module-level \
-               `inert_grant_for_test()` — `#[cfg(test)] pub(crate)`, a grant that \
-               dispatches nothing and needs no runtime — which tests in OTHER \
-               modules of this crate build on. They are two rather than one \
-               because a `pub(crate)` fixture cannot live inside `mod tests`, and \
-               from outside that module its private `test_capability()` is not \
-               visible; funnelling both through one helper at module level would \
-               return this row to 1 and is the bridge authors' call, not this \
-               census's. Counted for the same reason `privacy/grant.rs`'s test \
-               helper is — a line-wise grep cannot tell a `#[cfg(test)]` block \
-               from production, and a filter that tried would blind the census to \
-               production too. The production side of this bridge decides in \
-               `Agent::issue_tool_bridge`, which is a `sample(` row above. \
-               ⚠ This row read `dummy_grant()` while four inline spellings had \
-               accumulated in that file, so the census sat RED through a whole \
-               branch whose own gate list never ran this binary; it then sat RED \
-               again from `inert_grant_for_test()`'s arrival until CI began \
-               running `tests/*.rs` and anyone saw it. A new test that inlines the \
-               constructor rather than calling one of these two still moves the \
-               count and still fires here",
+        count: 1,
+        what: "NOT a production decider: `mod tests`' `test_capability()` helper, \
+               which every `BridgeGrant` the bridge's own unit tests build takes its \
+               pair from — the most restrictive one, rather than a permissive one \
+               invented for a test's convenience. Counted for the same reason \
+               `privacy/grant.rs`'s test helper is — a line-wise grep cannot tell a \
+               `#[cfg(test)]` block from production, and a filter that tried would \
+               blind the census to production too. The production side of this \
+               bridge decides in `Agent::issue_tool_bridge`, which is a `sample(` \
+               row above. ⚠ This row read `dummy_grant()` while four inline \
+               spellings had accumulated in that file, so the census sat RED \
+               through a whole branch whose own gate list never ran this binary. \
+               The single helper is what stops it drifting that way again: a new \
+               test that inlines the constructor still moves the count off 1 and \
+               still fires here",
     },
     // ---------------------------------------------------------- DR-26's third
     // axis, asked through the free function rather than off a capability. Its


### PR DESCRIPTION
## What is broken

`privacy_capability::the_sites_that_decide_how_far_a_caller_reaches_are_exactly_these` is **red on `main`** ([run 34649064272](https://github.com/BaranziniLab/biorouter/actions/runs/34649064272), `d6b39693`), so every PR that merges `main` inherits it. Two sites that decide how far a caller reaches were added while `rust.yml` still ran only `--lib --bins`; #239 (merged 20:49) made CI run `tests/*.rs`, and the census has been red since.

**This PR is one half of the fix — `agents/workspace_inspector.rs`.** The other half is **#259** (`fix/census-bridge-test-capability`), which *removes* `bridge.rs`'s extra site rather than describing it. **`main` goes green only when both land**, and the two are disjoint — #259 never touches the census file, so either merge order is safe.

Measured on the combination (this branch with #259 merged locally):

```
cargo test -p biorouter --test privacy_capability   # 4 passed, 0 failed
```

On this branch **alone** the census still fails, with exactly one delta and nothing else — `bridge.rs` `CallCapability::public_enforced(` found 2 against a row of 1 — which is #259's half. That failure is expected here.

I deliberately do **not** add a `bridge.rs` row: #259 takes that file back to one occurrence, so a row of 2 here would re-break `main` the moment it lands. ⚠ Note for anyone checking by hand: the census **skips comment lines**, so a plain `git grep -c` over-counts that file by one — `bridge.rs:2490` is a doc comment naming the constructor, not a site.

## The change

`agents/workspace_inspector.rs`, `CallCapability::sample(`: **`count: 1` → `2`**, with the row's prose rewritten to describe both sites. No production code. The census mechanism is untouched.

Extending the existing row rather than adding a second is forced by the test: `found` is a `BTreeMap` keyed by `(needle, file)` with `+= hits`, `want` is one tuple per `EXPECTED` row with no aggregation, and the comparison is a flat `assert_eq!` — so two rows for one file fail even at `count: 1` each. The file's convention agrees (`agent.rs` is one row at 5).

## Should the second site exist? Yes

An inspector runs *before* the dispatch that would admit a capability, so there is none in scope to inherit on the ordinary agent loop — the same reason already written for its sibling in this file. The alternatives are worse: read the master toggle directly (the bug `CallCapability` exists to prevent), or hoist the privacy gates out of the pre-flight so the always-confirm card is raised without them. And it is **not** the gate: `handle_set_tools` re-runs the same pre-flight against the capability the call is finally admitted on, so a model swapped between inspection and dispatch can only make this sample stale in the fail-safe direction. Nothing is removed.

## What I verified by reading the code (please still check me)

- A pinned pair wins in both inspectors and the provider mutex is never read — but by **different mechanisms**, which the row now names separately after review caught it: the mutation inspector binds `let mut sampled = capability` and memoises into it; the crossing inspector has no `sampled` binding at all and matches the `Option` once at its sample point, after its `candidates.is_empty()` early return.
- The mutation inspector's `sample(` runs only inside the `is_set_tools_call` arm, only when nothing was pinned: at most one sample per batch, **zero** for a batch with no `workspace_set_tools` call.
- The pre-flight has **three** outcomes, not two (also from review): a Deny with the handler's sentence, the always-confirm card, or no card-worthy reason and on to dispatch.
- The only caller that pins a pair is the coding-agent bridge (`bridge.rs:815`); `tool_inspection.rs`'s non-capability entry point passes `None`, as do the agent loop and the approval relay.
- The pair is handed to `set_tools_preflight_refusal` → `preflight_set_tools`, which asks `refuse_unless_writable` (§7's write row), `resolve_added_extensions` (Gate F reach per added extension), `preflight_extension_removals` (manageability per removed one) and `privacy::bind_allowed` (a provider switch).
- `handle_set_tools` calls `preflight_set_tools(caller_session_id, cap, &args)` at dispatch — the re-run above.
- `bridge.rs`'s occurrences are `#[cfg(test)]` helpers, never production deciders. With #259 in, the census counts **one** there (`:2513`), matching its unchanged row; a plain grep also reports the doc comment at `:2490`, which the census skips.

**Previously tagged as inferred, now answered by #244's author and checkable in the tree:** sampling here is intended, and threading the pair from further up would be a *regression*. The agent loop's authoritative sample lives inside `dispatch_tool_call` (`agent.rs`, "THE sample for the agent loop's tool calls"), which runs **after** inspection and after any approval; the loop's inspection entries pass no capability. Hoisting that read to before inspection would fix the pair before an always-confirm card that can park for minutes, so a model swapped while the card sat parked would be ignored — the fail-open direction. Keeping this inspector's sample separate and non-authoritative is what makes its staleness fail safe, which is why the row says it is not the gate. The bridge is the one case where fixing the pair earlier is right, for the opposite reason: its child's calls arrive from another process with nothing to inherit.

## Verification

```
cargo test -p biorouter --test privacy_capability   # workspace_inspector entry now matches;
                                                    # only the bridge.rs delta remains (above)
cargo test -p biorouter --test privacy_guard_wiring # 3 passed
cargo fmt --all -- --check                          # clean
```

⚠ This may not turn the ubuntu check green even once both halves land: the job's earlier `--lib --bins` step has been failing intermittently on `agent_drafter::bundle::tests::a_timed_out_esbuild_reaps_its_whole_process_group` (a process-reaping race in `biorouter-mcp`; it passes on `main`), and when it does, the integration step never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
