### PR TITLE
Census: the bridge's inert test grant takes the file's one capability pair (#228 follow-up)

### DIFF
--- a/crates/biorouter/src/providers/coding_agent/bridge.rs
+++ b/crates/biorouter/src/providers/coding_agent/bridge.rs
@@ -1076,6 +1076,11 @@ impl BridgeToolDispatch for InertDispatch {
 }
 
 /// A grant that dispatches nothing and needs no runtime to build.
+///
+/// Its capability comes from [`tests::test_capability`], not an inline
+/// constructor: `tests/privacy_capability.rs` counts this file's spellings of
+/// that constructor line by line, `#[cfg(test)]` code included, and its row for
+/// this file allows exactly the one in that helper.
 #[cfg(test)]
 pub(crate) fn inert_grant_for_test() -> BridgeGrant {
     BridgeGrant::new(
@@ -1083,7 +1088,7 @@ pub(crate) fn inert_grant_for_test() -> BridgeGrant {
         BioRouterMode::Auto,
         Arc::new(InertDispatch),
         Arc::new(ToolInspectionManager::new()),
-        CallCapability::public_enforced(),
+        tests::test_capability(),
         Vec::new(),
         Conversation::new_unvalidated(vec![]),
         None,
@@ -2498,7 +2503,13 @@ mod tests {
     /// genuinely new decider in this file — or a new test that inlines the
     /// constructor instead of calling this — still moves the count off 1 and
     /// still fires.
-    fn test_capability() -> CallCapability {
+    ///
+    /// `pub(super)` because the census counts the whole file, not this module:
+    /// `inert_grant_for_test`, which the claude_code and codex mirror tests build
+    /// their leases from, sits outside `mod tests` and takes its pair from here
+    /// too. It inlined the constructor when it landed with #228 and turned this
+    /// census red again, which is how it came to call this instead.
+    pub(super) fn test_capability() -> CallCapability {
         CallCapability::public_enforced()
     }
 


### PR DESCRIPTION
Closes the half of the privacy-capability census that PR #228 (QA-E F4) broke. **It touches only `bridge.rs` — `crates/biorouter/tests/privacy_capability.rs` is deliberately not edited**, so it cannot conflict with the PR adding the `workspace_inspector.rs` row (#244's site, being handled separately).

## The one-sentence answer

`public_enforced` was not needed at the site F4 added, so the site is gone rather than given a row.

## What was wrong

`inert_grant_for_test()` (`bridge.rs:1086`, added by #228) inlined `CallCapability::public_enforced()`. The census counts that constructor line by line, `#[cfg(test)]` code included, and this file's row allows exactly one — the `test_capability()` helper every grant the file's own tests build takes its pair from. That row's own documentation names this exact drift:

> a new test that inlines the constructor instead of calling this — still moves the count off 1 and still fires.

So the fix is the one the census asks for: the helper takes its pair from `tests::test_capability()`, now `pub(super)` because the helper sits outside `mod tests` (the `claude_code` and `codex` mirror tests reach it via `lease_holding_for_test`). The row, its count and its description are unchanged and true again.

It earns no row of its own because it decides nothing a caller reaches: it builds a `BridgeGrant` whose dispatcher returns an error, for tests that need a grant to hold a recorded result and need no Tokio runtime.

## ⚠ A plain grep overcounts this file: three hits, two sites

The report that flagged this listed three lines. The census sees two:

| Line | What it is | Counted? |
| --- | --- | --- |
| 1086 | `inert_grant_for_test()` — added by #228 | yes → **this PR removes it** |
| 2485 | the **doc comment** on `test_capability()` | no — the census skips `//` lines (`privacy_capability.rs:487-488`), and it predates #228 (`638e4c7c`, already in this PR's base `7c96d796`) |
| 2502 | `test_capability()` itself | yes — the site the row describes |

A row written from `grep -c` (3) would have left the census red.

## Verification

`cargo test -p biorouter --test privacy_capability` on this branch. `bridge.rs` now matches its row exactly, and the only remaining difference is the other PR's:

```
FOUND not WANT: ("CallCapability::sample(", "crates/biorouter/src/agents/workspace_inspector.rs", 2)
WANT not FOUND: ("CallCapability::sample(", "crates/biorouter/src/agents/workspace_inspector.rs", 1)
bridge.rs found: ("CallCapability::public_enforced(", ".../coding_agent/bridge.rs", 1)   ← equals the row
```

`cargo test -p biorouter --lib -- providers::coding_agent providers::claude_code providers::codex` passes (the helper's callers), and `cargo fmt` is clean. This binary is one CI does run since #239, so the census will start blocking as soon as the load-flaky esbuild test above it settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
