### PR TITLE
test(frontend): fix three harness defects that made the suite's exit code meaningless

### DIFF
--- a/ui/desktop/src/components/MentionPopover.privateChat.test.tsx
+++ b/ui/desktop/src/components/MentionPopover.privateChat.test.tsx
@@ -64,7 +64,6 @@ function renderPalette() {
  */
 describe('the / palette in a private chat', () => {
   let savedElectron: unknown;
-  let savedScrollIntoView: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,14 +71,12 @@ describe('the / palette in a private chat', () => {
     Object.assign(window, {
       electron: { getUserActionKey: vi.fn(async () => USER_ACTION_KEY) },
     });
-    // jsdom has no `scrollIntoView`, and the palette scrolls its selected row
-    // into view on every render — an effect that throws unmounts the palette.
-    savedScrollIntoView = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
-    Object.defineProperty(Element.prototype, 'scrollIntoView', {
-      configurable: true,
-      writable: true,
-      value: vi.fn(),
-    });
+    // The palette scrolls its selected row into view on every render, and jsdom
+    // implements no `scrollIntoView`. The polyfill is installed ONCE in
+    // src/test/setup.ts and deliberately not re-installed here: that scroll runs
+    // from a PASSIVE effect, which React can flush after this file's `afterEach`
+    // has run, so a polyfill with a per-test lifetime is removed while an effect
+    // that needs it is still queued. See the note in setup.ts.
     mocks.getSlashCommands.mockResolvedValue({ data: { commands: [] } });
     mocks.getSessionExtensions.mockResolvedValue({ data: { extensions: [] } });
     mocks.listBases.mockResolvedValue({
@@ -105,11 +102,6 @@ describe('the / palette in a private chat', () => {
 
   afterEach(() => {
     Object.assign(window, { electron: savedElectron });
-    if (savedScrollIntoView) {
-      Object.defineProperty(Element.prototype, 'scrollIntoView', savedScrollIntoView);
-    } else {
-      delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
-    }
   });
 
   it("offers this chat's knowledge bases, not every base, and names its primary", async () => {

--- a/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.test.tsx
+++ b/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.test.tsx
@@ -444,18 +444,21 @@ describe('IngestPanel paste box visibility', () => {
    * that is where its Stage button sits.
    */
   it('scrolls the summoned box into view', () => {
-    const scrollIntoView = vi.fn();
-    Object.defineProperty(Element.prototype, 'scrollIntoView', {
-      configurable: true,
-      writable: true,
-      value: scrollIntoView,
-    });
+    // SPY on the polyfill src/test/setup.ts installs, rather than redefining the
+    // property: `mockRestore` puts the no-op back, where a redefinition leaves
+    // whatever the last test wrote. The polyfill itself is process-wide on
+    // purpose — the scroll runs from an effect React can flush after the test
+    // has returned, so a per-test lifetime is a race. See setup.ts.
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView');
+    try {
+      render(<IngestPanel />);
+      fireEvent.click(screen.getByTestId('knowledge-ingest-paste-text'));
 
-    render(<IngestPanel />);
-    fireEvent.click(screen.getByTestId('knowledge-ingest-paste-text'));
-
-    expect(scrollIntoView).toHaveBeenCalledTimes(1);
-    expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: 'end' }));
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: 'end' }));
+    } finally {
+      scrollIntoView.mockRestore();
+    }
   });
 
   /**

--- a/ui/desktop/src/components/settings/providers/ProviderCatalog.test.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderCatalog.test.tsx
@@ -40,6 +40,25 @@ vi.mock('../../ConfigContext', () => ({
 vi.mock('../../InAppTerminalDock', () => ({
   default: () => <div data-testid="in-app-terminal-dock" />,
 }));
+// The Local tab mounts `OllamaInlineCard`, whose mount effect calls
+// `checkOllamaStatus()` -> `fetch('http://127.0.0.1:11434/api/tags')`. Left
+// un-mocked that is a REAL request to whatever the developer is running: with
+// `ollama serve` up it resolves `isRunning: true`, takes the branch at
+// OllamaInlineCard.tsx:39, fires a second request for `hasModel()`, and lands two
+// more state updates after the test body. CI, where nothing listens on 11434,
+// takes neither. Reporting "not running" is what CI sees, so that is what every
+// machine should see. App.test.tsx, App.routing.test.tsx and
+// LocalModelInventory.test.tsx already mock this module; this suite did not.
+vi.mock('../../../utils/ollamaDetection', () => ({
+  checkOllamaStatus: vi.fn(async () => ({ isRunning: false, host: 'http://127.0.0.1:11434' })),
+  getOllamaModels: vi.fn(async () => []),
+  hasModel: vi.fn(async () => false),
+  pullOllamaModel: vi.fn(async () => false),
+  deleteOllamaModel: vi.fn(async () => false),
+  pollForOllama: vi.fn(() => () => {}),
+  getOllamaDownloadUrl: () => 'https://ollama.com/download',
+  getPreferredModel: () => 'gpt-oss:20b',
+}));
 
 type Backend = {
   tier?: ProviderTier;

--- a/ui/desktop/src/test/networkGuard.test.ts
+++ b/ui/desktop/src/test/networkGuard.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The regression guard for the ambient-network defect.
+ *
+ * The suite passed with `ollama serve` running and passed without it, while
+ * `ProviderCatalog.test.tsx` took a different path through `OllamaInlineCard` in
+ * each case (see src/test/networkGuard.ts). Nothing could have noticed, because
+ * nothing was looking at whether a request had been attempted. These tests are
+ * what looks.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  KNOWN_NETWORK_ATTEMPTS,
+  NEVER_ALLOWED_HOSTS,
+  OFFLINE_FETCH_MESSAGE,
+  assertNoUnexpectedNetworkAttempts,
+  recordedAttempts,
+  resetRecordedAttempts,
+  specKey,
+  unexpectedAttempts,
+} from './networkGuard';
+
+const DESKTOP_ROOT = join(__dirname, '../..');
+
+// This spec deliberately triggers the offline fetch, so it must leave nothing
+// recorded for `setup.ts`'s own check to trip over. Registered here, which vitest
+// runs BEFORE the hook in setup.ts.
+afterEach(() => {
+  resetRecordedAttempts();
+});
+
+describe('the offline fetch installed for every spec', () => {
+  it('rejects instead of leaving the machine, and names the URL', async () => {
+    await expect(fetch('http://127.0.0.1:11434/api/tags')).rejects.toThrow(
+      /Un-stubbed network request in a test: GET http:\/\/127\.0\.0\.1:11434\/api\/tags/
+    );
+  });
+
+  it('records the attempt even though the caller may swallow the rejection', async () => {
+    // This is the shape that made the defect invisible: `ollamaDetection.ts`
+    // catches the failure and returns `{ isRunning: false }`, so a rejecting stub
+    // on its own reports nothing. The record is what survives the catch.
+    await fetch('http://localhost/some/route').catch(() => undefined);
+    expect(recordedAttempts()).toContain('http://localhost/some/route');
+  });
+
+  it('reads a Request and a URL object, not only a string', async () => {
+    await fetch(new URL('http://localhost/from-url-object')).catch(() => undefined);
+    await fetch(new Request('http://localhost/from-request')).catch(() => undefined);
+    expect(recordedAttempts()).toEqual(
+      expect.arrayContaining(['http://localhost/from-url-object', 'http://localhost/from-request'])
+    );
+  });
+
+  it('fails a spec that has no allowance, naming the spec and the URL', async () => {
+    const invented = '/repo/ui/desktop/src/components/Invented.test.tsx';
+    await fetch('http://127.0.0.1:11434/api/tags').catch(() => undefined);
+    expect(() => assertNoUnexpectedNetworkAttempts(invented)).toThrow(
+      /src\/components\/Invented\.test\.tsx/
+    );
+    // Drained by the report, so the same attempt is not blamed on the next test.
+    expect(() => assertNoUnexpectedNetworkAttempts(invented)).not.toThrow();
+  });
+
+  it('passes an attempt the spec has an allowance for', () => {
+    const spec = 'src/components/settings/SettingsView.test.tsx';
+    expect(unexpectedAttempts(spec, ['http://localhost/privacy/disclosure'])).toEqual([]);
+    expect(unexpectedAttempts(spec, ['http://localhost/sessions'])).toEqual([
+      'http://localhost/sessions',
+    ]);
+  });
+
+  it('fails closed on a path shape it does not recognise', () => {
+    // An unknown key must not accidentally match an entry, so no allowance
+    // applies and the attempt is reported.
+    expect(specKey(undefined)).toBe('<unknown spec>');
+    expect(unexpectedAttempts(undefined, ['http://localhost/anything'])).toEqual([
+      'http://localhost/anything',
+    ]);
+  });
+});
+
+describe('the allowance table', () => {
+  it('never grants the Ollama host to any spec', () => {
+    // The one host a developer is genuinely likely to be running, and the one
+    // this whole guard exists for. An entry here would re-open the defect while
+    // every test still passed.
+    const offenders = Object.entries(KNOWN_NETWORK_ATTEMPTS).flatMap(([spec, urls]) =>
+      urls
+        .filter((url) => NEVER_ALLOWED_HOSTS.some((host) => url.includes(host)))
+        .map((url) => `${spec} -> ${url}`)
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not grant ProviderCatalog.test.tsx the reach it used to have', () => {
+    // Named explicitly because this is the spec the defect was found in: it
+    // mocks `utils/ollamaDetection` now, so it attempts nothing on 11434 and
+    // needs no allowance for it.
+    const allowed =
+      KNOWN_NETWORK_ATTEMPTS['src/components/settings/providers/ProviderCatalog.test.tsx'];
+    expect(allowed).toBeDefined();
+    expect(allowed!.some((url) => url.includes('11434'))).toBe(false);
+  });
+
+  it('names only spec files that exist, so the table cannot rot', () => {
+    const missing = Object.keys(KNOWN_NETWORK_ATTEMPTS).filter(
+      (spec) => !existsSync(join(DESKTOP_ROOT, spec))
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps the message prefix the two reports share', () => {
+    // Both the rejection and the end-of-test report open with it, so a developer
+    // greps one string.
+    expect(OFFLINE_FETCH_MESSAGE).toBe('Un-stubbed network request in a test:');
+  });
+});

--- a/ui/desktop/src/test/networkGuard.ts
+++ b/ui/desktop/src/test/networkGuard.ts
@@ -1,0 +1,175 @@
+/**
+ * The suite makes no HTTP requests, and says so out loud when one is attempted.
+ *
+ * ## Why this exists
+ *
+ * jsdom inherits Node's real `fetch`, so an un-stubbed request in a renderer
+ * test does not fail — it *leaves the machine*. What comes back then depends on
+ * what the developer happens to be running, which makes the suite's result a
+ * property of their laptop rather than of the code. The concrete case, measured
+ * on 2026-09-11:
+ *
+ *   ProviderCatalog.test.tsx renders the Local tab, which mounts
+ *   `OllamaInlineCard`, whose mount effect (`OllamaInlineCard.tsx:45`) calls
+ *   `checkOllamaStatus()` -> `fetch('http://127.0.0.1:11434/api/tags')`
+ *   (`utils/ollamaDetection.ts:36`).
+ *
+ * On CI nothing listens on 11434, the request is refused in about a
+ * millisecond, `isRunning` is false and the `if` at `OllamaInlineCard.tsx:39`
+ * is not taken. On a developer's machine with `ollama serve` running, the
+ * request succeeds, a SECOND request goes out for `hasModel()`, and two more
+ * state updates land — after the test body has finished. Two different code
+ * paths through the component, selected by an ambient daemon. That is worse
+ * than a flaky test: it is green on CI and misbehaves only where a human will
+ * be trained to ignore it.
+ *
+ * The other ten measured requests all went to `http://localhost` **port 80**
+ * (the generated client's test base URL), where nothing listens here — so they
+ * behaved like CI *by luck*. A developer with anything bound to port 80 would
+ * start feeding real responses to `/sessions` and `/config/extensions`.
+ *
+ * ## The mechanism
+ *
+ * One default `fetch` in `src/test/setup.ts`, for the whole suite, which:
+ *
+ *   1. **rejects** every request, so behaviour is identical to CI's
+ *      "nothing is listening" regardless of what the developer is running, and
+ *   2. **records** the attempt, so the guard can report it even when the caller
+ *      swallows the rejection — and `ollamaDetection.ts` does exactly that
+ *      (`catch` -> `{ isRunning: false }`), which is why rejecting alone would
+ *      be silent.
+ *
+ * A spec that legitimately needs `fetch` assigns its own (six already do); that
+ * replaces this one and records nothing, which is the point.
+ *
+ * ## The allowance table is debt, not permission
+ *
+ * `KNOWN_NETWORK_ATTEMPTS` is the census measured across all 446 spec files on
+ * 2026-09-11 — the specs that already reach for the network. They are recorded
+ * rather than fixed because making each one's request succeed with stub data
+ * would change what its component sees, and therefore risks changing what it
+ * asserts; leaving the request to fail preserves today's behaviour exactly. A
+ * spec NOT in this table that attempts a request fails immediately, with the
+ * URL in the message. Entries should leave this table, never arrive.
+ *
+ * The Ollama host is deliberately absent from every entry, and
+ * `networkGuard.test.ts` asserts it can never be added: that host is the one a
+ * developer is actually likely to be running.
+ */
+
+/** Prefix of the rejection every un-stubbed request gets. */
+export const OFFLINE_FETCH_MESSAGE = 'Un-stubbed network request in a test:';
+
+/**
+ * Hosts that must never appear in `KNOWN_NETWORK_ATTEMPTS`, because something
+ * plausibly listens there on a developer's machine. Asserted, not documented.
+ */
+export const NEVER_ALLOWED_HOSTS = ['127.0.0.1:11434', 'localhost:11434'] as const;
+
+/**
+ * The measured census. Key: spec path from `src/` onwards. Value: the URL
+ * prefixes that spec is known to attempt.
+ */
+export const KNOWN_NETWORK_ATTEMPTS: Readonly<Record<string, readonly string[]>> = {
+  'src/components/workflows/shared/__tests__/WorkflowFormFields.test.tsx': [
+    'http://localhost/config/extensions',
+  ],
+  'src/components/chatGroups/keyboardResubmitGuard.test.tsx': ['http://localhost/sessions'],
+  'src/components/chatGroups/ChatGroupsShell.tearOff.test.tsx': ['http://localhost/sessions'],
+  'src/components/chatGroups/ChatGroupsShell.terminal.test.tsx': ['http://localhost/sessions'],
+  'src/components/chatGroups/ChatGroupsShell.sessionName.test.tsx': ['http://localhost/sessions'],
+  'src/components/chatGroups/duplicateSubmissionWiring.test.tsx': ['http://localhost/sessions'],
+  'src/components/settings/SettingsView.test.tsx': ['http://localhost/privacy/disclosure'],
+  // Note what is NOT here: `http://127.0.0.1:11434/api/tags`. This spec used to
+  // reach the developer's own Ollama; it now mocks `utils/ollamaDetection`.
+  'src/components/settings/providers/ProviderCatalog.test.tsx': [
+    'http://localhost/llamacpp/status',
+    'http://localhost/config/detectable-providers',
+  ],
+  'src/components/settings/models/subcomponents/SwitchModelModal.privacy.test.tsx': [
+    'http://localhost/llamacpp/status',
+  ],
+};
+
+let attempts: string[] = [];
+
+/** Every URL recorded since the last drain, in order. */
+export function recordedAttempts(): readonly string[] {
+  return attempts;
+}
+
+/** Forget what has been recorded. Used by the guard's own tests. */
+export function resetRecordedAttempts(): void {
+  attempts = [];
+}
+
+/**
+ * Normalise a spec path to the `src/…` key shape used by the table. Returns the
+ * input unchanged when it holds no `src/` segment, so an unknown shape fails
+ * closed rather than matching an entry by accident.
+ */
+export function specKey(testPath: string | undefined): string {
+  if (!testPath) return '<unknown spec>';
+  const normalised = testPath.replace(/\\/g, '/');
+  const at = normalised.lastIndexOf('/src/');
+  return at === -1 ? normalised : normalised.slice(at + 1);
+}
+
+/** The recorded attempts this spec has no allowance for. */
+export function unexpectedAttempts(
+  testPath: string | undefined,
+  recorded: readonly string[]
+): string[] {
+  const allowed = KNOWN_NETWORK_ATTEMPTS[specKey(testPath)] ?? [];
+  return [...new Set(recorded.filter((url) => !allowed.some((prefix) => url.startsWith(prefix))))];
+}
+
+/**
+ * Install the offline `fetch`. Re-installing is harmless; a spec that assigns
+ * its own afterwards simply wins.
+ */
+export function installOfflineFetch(): void {
+  // Typed off `fetch` itself rather than by naming `RequestInfo`/`RequestInit`,
+  // which tsc knows from lib.dom but eslint's `no-undef` does not.
+  type FetchInput = Parameters<typeof fetch>[0];
+  type FetchInit = Parameters<typeof fetch>[1];
+  globalThis.fetch = ((input: FetchInput, init?: FetchInit) => {
+    const asRequest = input as { url?: string; method?: string };
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (asRequest?.url ?? String(input));
+    attempts.push(url);
+    const method = (init?.method ?? asRequest?.method ?? 'GET').toUpperCase();
+    return Promise.reject(
+      new Error(
+        `${OFFLINE_FETCH_MESSAGE} ${method} ${url}\n` +
+          'Tests must not reach the network — what comes back would depend on what the ' +
+          'developer happens to be running. Mock the module that makes this call (see the ' +
+          '`vi.mock` of utils/ollamaDetection in App.test.tsx for the shape), or assign ' +
+          'your own `globalThis.fetch` in the spec. src/test/networkGuard.ts explains why.'
+      )
+    );
+  }) as typeof fetch;
+}
+
+/**
+ * Fail the current test if an un-allowed request was attempted, then drain.
+ * Called from `setup.ts` after `cleanup()` — unmounting is what flushes the
+ * passive effects that make these calls, so checking before it would miss them.
+ */
+export function assertNoUnexpectedNetworkAttempts(testPath: string | undefined): void {
+  const recorded = attempts;
+  attempts = [];
+  const unexpected = unexpectedAttempts(testPath, recorded);
+  if (unexpected.length === 0) return;
+  throw new Error(
+    `${OFFLINE_FETCH_MESSAGE}\n` +
+      unexpected.map((url) => `  ${url}`).join('\n') +
+      `\n\nThis spec (${specKey(testPath)}) reached for the network, so its result would ` +
+      'depend on what is running on this machine. Mock the module that makes the call. ' +
+      'See src/test/networkGuard.ts.'
+  );
+}

--- a/ui/desktop/src/test/scrollIntoViewPolyfill.test.tsx
+++ b/ui/desktop/src/test/scrollIntoViewPolyfill.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+import { useEffect, useRef, useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The regression guard for the `scrollIntoView` polyfill in ./setup.ts.
+ *
+ * The bug this replaces was read as flakiness for exactly as long as it took to
+ * notice WHERE the throw came from: `commitHookPassiveMountEffects`. Two specs
+ * installed the polyfill in `beforeEach` and deleted it in `afterEach`, and a
+ * passive effect is not flushed when the test body returns — React commits a
+ * render in one scheduler callback and flushes that render's passive effects in
+ * the next. vitest's `afterEach` hooks run in reverse registration order, so the
+ * spec's teardown removed the property BEFORE setup.ts's `cleanup()` unmounted
+ * the tree, and unmounting is what flushes the queue. The effect then threw
+ * inside React and failed a test that had already asserted its point.
+ *
+ * ⚠ This file is written to open that exact window, so it fails if the polyfill
+ * ever regains a per-test lifetime. `Deferred` returns one macrotask after
+ * render: the re-render its promise triggers is committed by then, its passive
+ * effects are not yet flushed, and the flush therefore lands in `cleanup()` —
+ * after every `afterEach` this file could possibly register.
+ */
+function Deferred() {
+  const [rows, setRows] = useState<string[]>([]);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Stands in for a palette's async reads: each resolution re-renders.
+  useEffect(() => {
+    let alive = true;
+    void Promise.resolve(['a', 'b']).then((next) => {
+      if (alive) setRows(next);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // PASSIVE, exactly like MentionPopover's scroll — not `useLayoutEffect`.
+  useEffect(() => {
+    const selected = listRef.current?.children[0] as HTMLElement | undefined;
+    selected?.scrollIntoView({ block: 'nearest', behavior: 'auto' });
+  });
+
+  return (
+    <div ref={listRef}>
+      {rows.map((row) => (
+        <div key={row}>{row}</div>
+      ))}
+    </div>
+  );
+}
+
+describe('the process-wide scrollIntoView polyfill', () => {
+  it('is installed for every spec, because jsdom implements none', () => {
+    expect(typeof Element.prototype.scrollIntoView).toBe('function');
+  });
+
+  it('survives a spy that a spec restores', () => {
+    const spy = vi.spyOn(Element.prototype, 'scrollIntoView');
+    document.createElement('div').scrollIntoView();
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+    // Restoring puts the polyfill back rather than leaving the property gone —
+    // which is the whole reason a spec must spy rather than redefine.
+    expect(typeof Element.prototype.scrollIntoView).toBe('function');
+  });
+
+  it('is still there when a passive effect is flushed by cleanup(), after every afterEach', async () => {
+    render(<Deferred />);
+    // One macrotask: long enough for the promise's re-render to COMMIT, short
+    // enough that its passive effects are still queued when this test returns.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(typeof Element.prototype.scrollIntoView).toBe('function');
+    // The assertion that matters is made by the runner, not by this line: if the
+    // polyfill has a per-test lifetime, the flush inside cleanup() throws
+    // `TypeError: … scrollIntoView is not a function` and this test fails.
+  });
+});

--- a/ui/desktop/src/test/setup.ts
+++ b/ui/desktop/src/test/setup.ts
@@ -1,13 +1,28 @@
 import '@testing-library/jest-dom';
-import { vi, afterEach } from 'vitest';
+import { vi, afterEach, afterAll, expect } from 'vitest';
 import { cleanup, configure } from '@testing-library/react';
 import { ASYNC_UTIL_TIMEOUT_MS, TEST_TIMEOUT_MS, MIN_TIMEOUT_HEADROOM } from './timeouts';
+import { assertNoUnexpectedNetworkAttempts, installOfflineFetch } from './networkGuard';
 import { client } from '../api/client.gen';
 
 // This is the standard setup to ensure that React Testing Library's
 // automatic cleanup runs after each test.
+//
+// The network check is in this SAME callback, deliberately, rather than its own
+// `afterEach`. vitest runs `afterEach` hooks in reverse registration order, so a
+// separate hook could not be ordered after `cleanup()` from here — and it has to
+// be after it, because unmounting is what flushes the passive effects that make
+// these calls. See src/test/networkGuard.ts.
 afterEach(() => {
   cleanup();
+  assertNoUnexpectedNetworkAttempts(expect.getState().testPath);
+});
+
+// A request whose promise settles after the last test's `afterEach` — the late
+// resolution that started this — is recorded with nothing left to report it.
+// This is where it surfaces.
+afterAll(() => {
+  assertNoUnexpectedNetworkAttempts(expect.getState().testPath);
 });
 
 // Keep routine application logging quiet. Warnings and errors stay connected to
@@ -151,3 +166,18 @@ if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !=
 client.setConfig({
   baseUrl: 'http://localhost',
 });
+
+/**
+ * jsdom inherits Node's real `fetch`, so an un-stubbed request in a test does
+ * not fail — it leaves the machine, and the suite's result becomes a property of
+ * whatever the developer happens to be running. `ProviderCatalog.test.tsx` was
+ * reaching a live `ollama serve` on 127.0.0.1:11434 and taking a different path
+ * through `OllamaInlineCard` than CI takes.
+ *
+ * Installed LAST, after `client.setConfig`, because the generated client
+ * resolves `globalThis.fetch` per call rather than capturing it at import time —
+ * so order does not matter for correctness, but reading it here next to the base
+ * URL it neutralises does. src/test/networkGuard.ts holds the reasoning and the
+ * measured census of specs that already reach out.
+ */
+installOfflineFetch();

--- a/ui/desktop/src/test/setup.ts
+++ b/ui/desktop/src/test/setup.ts
@@ -105,6 +105,49 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
   });
 }
 
+/**
+ * jsdom implements no `Element.prototype.scrollIntoView`, and several components
+ * call it from an effect — `MentionPopover` scrolls its selected row into view
+ * on every render, `IngestPanel` brings the summoned paste box up, and
+ * `ArtifactViewer`, `ChatTabStrip` and `ExtensionsView` all do the same.
+ *
+ * ⚠ **It is installed ONCE, for the whole process, and must never be removed
+ * per test.** Two specs used to install it in `beforeEach` and DELETE it in
+ * `afterEach`, and that is a race the polyfill cannot win, because the effect
+ * that needs it does not run inside the test body:
+ *
+ *   - `scrollIntoView` is called from a PASSIVE effect. React commits a render
+ *     in one scheduler callback and flushes that render's passive effects in
+ *     the NEXT one, so a render committed by a late async resolution leaves
+ *     `commitHookPassiveMountEffects` still queued when the test returns.
+ *   - vitest runs `afterEach` hooks in reverse registration order, so a spec's
+ *     own `afterEach` runs BEFORE this file's `cleanup()`. The property is
+ *     therefore already gone when `cleanup()` unmounts — and unmounting is
+ *     precisely what flushes the queued passive effects.
+ *
+ * The effect then throws `TypeError: … scrollIntoView is not a function` from
+ * inside React, which unmounts the tree and fails a test that had already
+ * asserted everything it came to assert. The window is a single scheduler turn
+ * wide, so it opens on a loaded CI runner and almost never locally — i.e. it
+ * reads as flakiness rather than as the deterministic ordering bug it is.
+ * Measured with a probe that returns one macrotask after render: it throws
+ * every time with the per-test install and never with this one.
+ *
+ * A spec that wants to ASSERT on the scroll should spy on the prototype with
+ * `vi.spyOn(Element.prototype, 'scrollIntoView')` and restore the spy, which
+ * puts this no-op back rather than leaving the property undefined. See
+ * src/test/scrollIntoViewPolyfill.test.tsx for the regression guard.
+ */
+if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !== 'function') {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    writable: true,
+    value: function scrollIntoView(): void {
+      /* jsdom has no layout, so there is nothing to scroll. */
+    },
+  });
+}
+
 client.setConfig({
   baseUrl: 'http://localhost',
 });

--- a/ui/desktop/src/utils/artifactCdnAssets.browser.test.ts
+++ b/ui/desktop/src/utils/artifactCdnAssets.browser.test.ts
@@ -14,7 +14,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium, type Browser } from 'playwright';
+import { chromium, type Browser, type BrowserServer } from 'playwright';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { inlineArtifactCdnAssets } from './artifactCdnAssets';
 import { injectArtifactBrowserCsp } from './artifactSecurity';
@@ -36,15 +36,65 @@ const fetchVendored = async (url: string): Promise<string> => {
 };
 
 /**
+ * Every step of teardown gets this long, and no longer.
+ *
+ * ⚠ Chosen so the WHOLE hook — disconnect, close, kill, reap — is strictly
+ * bounded well under `HOOK_TIMEOUT_MS` (30s). Three steps at 5s is 15s worst
+ * case, which leaves the runner's own limit as a backstop rather than as the
+ * thing that fires.
+ */
+const TEARDOWN_STEP_MS = 5_000;
+
+/** Resolve `true` if `work` settled within `ms`, `false` if it ran out of time. */
+const settledWithin = async (work: Promise<unknown>, ms: number): Promise<boolean> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), ms);
+    // Never hold the loop open on account of the watchdog itself.
+    (timer as unknown as { unref?: () => void }).unref?.();
+  });
+  try {
+    // A rejected close is still a settled one: the point here is elapsed time,
+    // and a browser that refused to close is handled by the caller's next step.
+    return (
+      (await Promise.race([
+        work.then(
+          () => true,
+          () => true
+        ),
+        expired,
+      ])) !== false
+    );
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
+
+/**
  * Launch whichever Chromium build this machine downloaded. Playwright's default
  * is the headless shell, which is a *separate* download from full Chromium, so
  * a tree that only has one of the two must not be reported as "no browser".
+ *
+ * ⚠ **`launchServer` + `connect`, not `launch`, and the reason is teardown.**
+ * A `Browser` from `chromium.launch()` exposes no handle on the Chromium
+ * process, so `browser.close()` is the ONLY way to end it — and when that call
+ * is slow there is nothing left to do but wait for it. Under load it is slow:
+ * with the machine saturated, `close()` blocked past the 30s hook limit while
+ * both tests had already passed, so the file failed with ZERO failing tests and
+ * `npm run test:run` exited 1 for a reason no test name could explain. A
+ * `BrowserServer` hands back `process()`, which makes the last resort a SIGKILL
+ * instead of an unbounded await.
  */
-const launchChromium = async (): Promise<Browser | null> => {
+const launchChromium = async (): Promise<{ server: BrowserServer; browser: Browser } | null> => {
   for (const options of [{}, { channel: 'chromium' }] as const) {
+    let server: BrowserServer | null = null;
     try {
-      return await chromium.launch(options);
+      server = await chromium.launchServer(options);
+      return { server, browser: await chromium.connect(server.wsEndpoint()) };
     } catch {
+      // Launched but could not be connected to: end it here rather than leaking
+      // a Chromium for the next option to sit beside.
+      if (server) await settledWithin(server.close(), TEARDOWN_STEP_MS);
       // try the next build
     }
   }
@@ -53,9 +103,15 @@ const launchChromium = async (): Promise<Browser | null> => {
 
 describe('a CDN-mode Mermaid figure in a real browser', () => {
   let browser: Browser | null = null;
+  let server: BrowserServer | null = null;
 
   beforeAll(async () => {
-    browser = await launchChromium();
+    // Launched ONCE. A second launch would strand the first browser with no
+    // handle left to close it by.
+    if (browser) return;
+    const launched = await launchChromium();
+    browser = launched?.browser ?? null;
+    server = launched?.server ?? null;
     if (!browser) {
       // Say so out loud: a silently skipped browser test reads as a passing one.
       console.warn(
@@ -65,8 +121,27 @@ describe('a CDN-mode Mermaid figure in a real browser', () => {
     }
   }, 120_000);
 
+  /**
+   * Bounded, and closed exactly once.
+   *
+   * The handles are nulled BEFORE anything is awaited, so a re-entered hook
+   * cannot start a second shutdown of the same browser — and so a later
+   * `browser` read cannot hand a test a connection that is being torn down.
+   */
   afterAll(async () => {
-    await browser?.close();
+    const connection = browser;
+    const launched = server;
+    browser = null;
+    server = null;
+
+    if (connection) await settledWithin(connection.close(), TEARDOWN_STEP_MS);
+    if (!launched) return;
+
+    if (await settledWithin(launched.close(), TEARDOWN_STEP_MS)) return;
+
+    // Still up. Stop asking.
+    launched.process().kill('SIGKILL');
+    await settledWithin(launched.close(), TEARDOWN_STEP_MS);
   });
 
   /** Render a prepared artifact document under the real artifact CSP. */

--- a/ui/desktop/src/utils/sessionBindingSync.test.ts
+++ b/ui/desktop/src/utils/sessionBindingSync.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { announceSessionBinding, subscribeSessionBindingChanges } from './sessionBindingSync';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  announceSessionBinding,
+  subscribeSessionBindingChanges,
+  type SessionBindingChange,
+} from './sessionBindingSync';
 
 /**
  * Handoff 04 — a per-chat model switch made in one window has to reach the
@@ -13,9 +17,81 @@ import { announceSessionBinding, subscribeSessionBindingChanges } from './sessio
  * it), and a malformed message from another window is dropped rather than used
  * to patch a row with `undefined`.
  */
+const CHANNEL_NAME = 'biorouter:session-binding';
+
+/**
+ * A well-formed message whose only job is to be delivered LAST.
+ *
+ * ⚠ **`await new Promise((r) => setTimeout(r, 0))` is not a delivery barrier
+ * for a `BroadcastChannel`, and believing it was is what made these two tests
+ * flaky together.** Under vitest's jsdom environment the channel is Node's, so
+ * a message is delivered from the libuv POLL phase while `setTimeout(0)` —
+ * clamped to 1ms — fires from the TIMERS phase, which runs first in a loop
+ * turn. Measured ordering in this environment:
+ *
+ *     sync > microtask > nextTick > setImmediate > DELIVERED > timeout0
+ *
+ * so the tick normally loses to the delivery and the tests normally pass. But
+ * the timer is armed immediately after `postMessage`, and if >=1ms of wall clock
+ * passes before the loop next turns — one descheduled slice on a loaded runner,
+ * one GC pause — the timer is already due and the timers phase fires it AHEAD of
+ * the delivery. The test then asserts on an empty `seen`, the message lands a
+ * moment later, and because the module's listener set is process-global it is
+ * handed to whatever listener the NEXT test has just subscribed. That is the
+ * signature failure: 'delivers a binding another window announced' fails empty
+ * and 'drops a malformed message' fails holding the previous test's `s3`.
+ * Reproduced deterministically by burning 3ms between arming the tick and
+ * awaiting it.
+ *
+ * So wait for delivery itself. One channel is one MessagePort and a port is
+ * FIFO, so a barrier posted after the payloads is delivered after them: its
+ * arrival proves every earlier message has already been processed — including
+ * the malformed ones that are supposed to leave no trace.
+ */
+const BARRIER = {
+  sessionId: '__barrier__',
+  provider: '__barrier__',
+  model: '__barrier__',
+} as const;
+
+/** Resolve once everything already posted on `other` has been delivered. */
+function drain(other: BroadcastChannel): Promise<void> {
+  return new Promise((resolve) => {
+    const stop = subscribeSessionBindingChanges((change) => {
+      if (change.sessionId !== BARRIER.sessionId) return;
+      stop();
+      resolve();
+    });
+    other.postMessage(BARRIER);
+  });
+}
+
+/** Everything a test's listener saw, minus the barrier it is not about. */
+function payloadsOnly(listener: (change: SessionBindingChange) => void) {
+  return (change: SessionBindingChange) => {
+    if (change.sessionId !== BARRIER.sessionId) listener(change);
+  };
+}
+
 describe('sessionBindingSync', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  /**
+   * Belt and braces: every test above drains its own posts, so nothing should
+   * be in flight — but a test that fails an assertion returns early, and a
+   * message that leaked into the next test is the failure this file exists to
+   * stop reproducing. One more barrier round trip guarantees the channel is
+   * quiet before the next test subscribes.
+   */
+  afterEach(async () => {
+    const sweeper = new BroadcastChannel(CHANNEL_NAME);
+    try {
+      await drain(sweeper);
+    } finally {
+      sweeper.close();
+    }
   });
 
   it('calls local listeners synchronously, before the announcement returns', () => {
@@ -54,18 +130,23 @@ describe('sessionBindingSync', () => {
 
   it('delivers a binding another window announced', async () => {
     const seen: string[] = [];
-    const unsubscribe = subscribeSessionBindingChanges((change) =>
-      seen.push(`${change.sessionId}:${change.model}`)
+    const unsubscribe = subscribeSessionBindingChanges(
+      payloadsOnly((change) => seen.push(`${change.sessionId}:${change.model}`))
     );
 
     // A second window, speaking on the same channel.
-    const other = new BroadcastChannel('biorouter:session-binding');
-    other.postMessage({ sessionId: 's3', provider: 'versa_azure', model: 'gpt-5.2-2025-12-11' });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    other.close();
-    unsubscribe();
+    const other = new BroadcastChannel(CHANNEL_NAME);
+    try {
+      other.postMessage({ sessionId: 's3', provider: 'versa_azure', model: 'gpt-5.2-2025-12-11' });
+      await drain(other);
 
-    expect(seen).toEqual(['s3:gpt-5.2-2025-12-11']);
+      expect(seen).toEqual(['s3:gpt-5.2-2025-12-11']);
+    } finally {
+      // In a `finally` so a failed assertion cannot leave a listener subscribed
+      // to a process-global set that the next test also subscribes to.
+      other.close();
+      unsubscribe();
+    }
   });
 
   /**
@@ -76,16 +157,24 @@ describe('sessionBindingSync', () => {
    */
   it('drops a malformed message rather than patching a row from it', async () => {
     const seen: unknown[] = [];
-    const unsubscribe = subscribeSessionBindingChanges((change) => seen.push(change));
+    const unsubscribe = subscribeSessionBindingChanges(payloadsOnly((change) => seen.push(change)));
 
-    const other = new BroadcastChannel('biorouter:session-binding');
-    other.postMessage({ sessionId: 's4' });
-    other.postMessage({ provider: 'versa_azure', model: 'gpt-5.5-2026-04-24' });
-    other.postMessage(null);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    other.close();
-    unsubscribe();
+    const other = new BroadcastChannel(CHANNEL_NAME);
+    try {
+      other.postMessage({ sessionId: 's4' });
+      other.postMessage({ provider: 'versa_azure', model: 'gpt-5.5-2026-04-24' });
+      other.postMessage(null);
+      // The barrier is posted on the SAME channel, after the three malformed
+      // messages, so one FIFO port guarantees they were all processed by the
+      // time it arrives. Without that, an empty `seen` would equally mean
+      // "nothing has been delivered yet" — which is how this assertion used to
+      // pass for the wrong reason and then fail holding another test's payload.
+      await drain(other);
 
-    expect(seen).toEqual([]);
+      expect(seen).toEqual([]);
+    } finally {
+      other.close();
+      unsubscribe();
+    }
   });
 });


### PR DESCRIPTION
`npm run test:run` exited **1 with zero failing tests** on `main`, and two more
specs failed intermittently on loaded CI runners. A fourth defect, found after the
first three were fixed, went further: a spec was reaching a live `ollama serve` on
the developer's own machine, so the suite's behaviour was a property of their laptop
rather than of the code. None of the four is a bug in what a test asserts — all four
are harness defects whose failures land on innocent tests, which is exactly why they
read as flakiness. What the tests assert is unchanged throughout.

## Before / after

| | `npm run test:run` |
|---|---|
| before (`5181f544`, detached, pristine) | **exit 1** · 108.91 s · `Test Files 1 failed \| 444 passed (445)` · `Tests 5009 passed \| 1 skipped` — **zero failing tests** |
| after (this branch) | **exit 0** · 89.04 s · `Test Files 446 passed (446)` · `Tests 5012 passed \| 1 skipped` |

The extra file and three tests are the new regression guard. The ~20 s that came
off the wall clock is the hang.

---

## Defect 1 — the `scrollIntoView` polyfill was torn down under React's passive effects

**Mechanism (confirmed).** `MentionPopover.privateChat.test.tsx` installed the
jsdom polyfill in `beforeEach` and **deleted** it in `afterEach`. That lifetime
is narrower than the window in which React can run the effect that needs it:

- the call is in a **passive** effect (`MentionPopover.tsx:813`, a plain
  `useEffect`). React commits a render in one scheduler callback and flushes
  that render's passive effects in the **next** one, so a render committed by a
  late async resolution leaves `commitHookPassiveMountEffects` still queued when
  the test body returns;
- vitest runs `afterEach` hooks in **reverse registration order**, so the spec's
  own teardown runs *before* `src/test/setup.ts`'s `cleanup()` — and unmounting
  is precisely what flushes the queue.

The effect then throws `TypeError: selectedElement.scrollIntoView is not a
function` from inside React, failing a test that had already asserted everything
it came to assert. The window is one scheduler turn wide, so it opens on a loaded
runner and almost never locally.

**Fail-before.** A probe in the same shape — polyfill installed in `beforeEach`
and deleted in `afterEach`, component scrolling from a passive effect — returning
one macrotask after `render`:

```
TypeError: el?.scrollIntoView is not a function
 ❯ commitHookEffectListMount   react-dom-client.development.js:13249:29
 ❯ commitHookPassiveMountEffects  react-dom-client.development.js:13336:11
 ❯ flushPassiveEffects          react-dom-client.development.js:18432:9
 ❯ flushPendingEffects          react-dom-client.development.js:18358:14
```

Returning synchronously, or after a single microtask, passed — the failure is
specifically the commit/flush gap. The reported stack frames match exactly.

**Fix.** Installed **once**, process-wide, in `src/test/setup.ts`, with the
reasoning recorded there. The per-test install/delete is gone from
`MentionPopover.privateChat.test.tsx`; `IngestPanel.test.tsx` now `vi.spyOn`s the
prototype and restores in a `finally`, which puts the no-op back instead of
leaving the property undefined. Swept the tree: those were the only two specs
patching `Element.prototype.scrollIntoView`.

**Guard.** `src/test/scrollIntoViewPolyfill.test.tsx` opens that exact window on
purpose. Neutralising the polyfill in `setup.ts` turns it red, and takes the
MentionPopover spec with it:

```
× is still there when a passive effect is flushed by cleanup(), after every afterEach
× offers this chat's knowledge bases, not every base, and names its primary
TypeError: selectedElement.scrollIntoView is not a function
```

## Defect 2 — `sessionBindingSync.test.ts` delivery race

**Mechanism (confirmed).** The two tests used `await new Promise(r =>
setTimeout(r, 0))` as a delivery barrier for a `BroadcastChannel`. It is not
one. Under vitest's jsdom environment the channel is **Node's** (jsdom
implements none), so delivery arrives from the libuv **poll** phase while
`setTimeout(0)` — clamped to 1 ms — fires from the **timers** phase, which runs
first in a loop turn. Measured ordering in this environment:

```
sync > microtask > nextTick > setImmediate > DELIVERED > timeout0
```

so the tick normally loses to the delivery and the tests normally pass. But the
timer is armed immediately after `postMessage`: if ≥1 ms of wall clock passes
before the loop next turns — one descheduled slice, one GC pause — the timer is
already due and fires **ahead** of the delivery. The test asserts on an empty
`seen`, the message lands a moment later, and because the module's listener set
is process-global it is handed to whatever listener the **next** test has just
subscribed.

**Fail-before.** Burning 3 ms between arming the tick and awaiting it reproduces
the reported CI signature exactly — both tests failing together, the second one
holding the first one's payload:

```
FAIL  sessionBindingSync > delivers a binding another window announced
AssertionError: expected [] to deeply equal [ 's3:gpt-5.2-2025-12-11' ]

FAIL  sessionBindingSync > drops a malformed message rather than patching a row from it
AssertionError: expected [ { sessionId: 's3', …(2) } ] to deeply equal []
+   { "model": "gpt-5.2-2025-12-11", "provider": "versa_azure", "sessionId": "s3" }
```

**Fix.** Wait for delivery itself rather than for a tick. One channel is one
`MessagePort` and a port is FIFO, so a well-formed **barrier** posted after the
payloads is delivered after them — its arrival proves every earlier message has
already been processed, including the malformed ones that are supposed to leave
no trace. Without that, an empty `seen` equally meant "nothing has been
delivered yet", which is how the assertion used to pass for the wrong reason.
Channels and listeners are torn down in `finally` so a failed assertion cannot
leave a subscriber on a process-global set, and an `afterEach` barrier sweep
guarantees the channel is quiet before the next test subscribes. No timeout was
increased.

**Pass-after under the same hostility.** With a **25 ms** burn (8× what broke
the old version) injected at the same point: 5/5 runs green.

## Defect 3 — `artifactCdnAssets.browser.test.ts` hanging `afterAll`

**Mechanism — sharper than "under load".** `await browser?.close()` blew the
30 s hook limit while both tests passed, so the file failed with zero failing
tests and the suite's exit code stopped meaning anything. Measured directly:

```
launch                       2230 ms
browser.close(plain launch) 30012 ms     ← on a completely IDLE machine
```

So it is not contention: this Playwright/Chromium takes ~30 s to shut down and
loses the 30 s hook race by milliseconds, which is why it presents as
intermittent. Under 14 CPU burners it is reliable:

```
Error: Hook timed out in 30000ms.
 ❯ src/utils/artifactCdnAssets.browser.test.ts:68:3
     68|   afterAll(async () => {
     69|     await browser?.close();
 Test Files  1 failed (1)
      Tests  2 passed (2)
   Duration  36.72s        (the two tests account for 5.7 s of it)
```

**Fix.** Teardown is bounded — 5 s per step, at most three steps, so the whole
hook is strictly inside the 30 s limit — and ends in a **SIGKILL** rather than an
unbounded await. Killing needs a handle on the process, and a `Browser` from
`chromium.launch()` exposes none (`browser.process` is `undefined` in Playwright
1.58), so the browser is launched through `launchServer()` + `connect()`, whose
`BrowserServer.process()` is public API. Launched once, closed once: the handles
are nulled before anything is awaited, so a re-entered hook cannot start a second
shutdown. A failed `connect` closes the server it just launched rather than
leaking it.

Verified: the file goes from 36.7 s/failed to ~15 s/passed, and
`pgrep -f ms-playwright` reports **0** stray processes afterwards.

## Defect 4 — a locally running Ollama put the developer's machine inside the result

`ProviderCatalog.test.tsx` reached the developer's own `ollama serve`:

```
src/components/settings/providers/ProviderCatalog.test.tsx   (no ollamaDetection mock)
  -> ProviderCatalog.tsx:399        <OllamaInlineCard chrome="bare" …/>   (Local tab)
  -> OllamaInlineCard.tsx:45        mount effect calls checkInitial()
  -> OllamaInlineCard.tsx:37        await checkOllamaStatus()
  -> utils/ollamaDetection.ts:36    fetch('http://127.0.0.1:11434/api/tags')
```

jsdom inherits Node's real `fetch`, so an un-stubbed request does not fail — it
*leaves the machine*. On CI nothing listens on 11434, the request is refused in
about a millisecond, `isRunning` is false and the branch at
`OllamaInlineCard.tsx:39` is not taken. With `ollama serve` running it resolves
true, a **second** request goes out for `hasModel()`, and two more state updates
land after the test body has finished. Two different code paths through one
component, selected by an ambient daemon — green on CI, misbehaving only on a
developer's machine, which is how people learn to ignore a suite.

Three sibling specs already mock this module (`App.test.tsx:77`,
`App.routing.test.tsx:74`, `LocalModelInventory.test.tsx:25`). This one did not.

**Attribution, since it matters here:** the historical symptom "exit 1 with zero
failing tests when Ollama answers" does **not** reproduce on this branch — Defect 3
above (the `artifactCdnAssets.browser` `afterAll` hang) was its cause, and it is
fixed. Verified first, with Ollama live: `npm run test:run` at `99bf4151` exited
**0**, 446 files / 5012 passed. The *ambient dependency* underneath it was still
real, and that is what this commit removes.

### The measurement

A temporary second setup file wrapped `globalThis.fetch` and logged every call with
its calling spec and a stack, across the whole 446-file suite. Complete census —
**7 files, 39 requests**:

| count | spec | URL |
|---|---|---|
| 20 | `workflows/shared/__tests__/WorkflowFormFields.test.tsx` | `http://localhost/config/extensions` |
| 4 | `chatGroups/keyboardResubmitGuard.test.tsx` | `http://localhost/sessions?…` |
| 4 | `chatGroups/ChatGroupsShell.tearOff.test.tsx` | `http://localhost/sessions?…` |
| 3 | `settings/SettingsView.test.tsx` | `http://localhost/privacy/disclosure` |
| **2** | **`settings/providers/ProviderCatalog.test.tsx`** | **`http://127.0.0.1:11434/api/tags`** |
| 1 | `settings/providers/ProviderCatalog.test.tsx` | `http://localhost/llamacpp/status` |
| 1 | `settings/providers/ProviderCatalog.test.tsx` | `http://localhost/config/detectable-providers` |
| 1 | `settings/models/subcomponents/SwitchModelModal.privacy.test.tsx` | `http://localhost/llamacpp/status` |
| 1 | `chatGroups/duplicateSubmissionWiring.test.tsx` | `http://localhost/sessions?…` |
| 1 | `chatGroups/ChatGroupsShell.terminal.test.tsx` | `http://localhost/sessions?…` |
| 1 | `chatGroups/ChatGroupsShell.sessionName.test.tsx` | `http://localhost/sessions?…` |

**Exactly one row reaches a port anything is listening on.** The other ten go to
`http://localhost` **port 80** — the generated client's test base URL — where
nothing listens here, so they behave like CI *by luck*, not by design. A developer
with anything bound to port 80 (nginx, a docs server, a Docker publish) would start
feeding real responses to `/sessions` and `/config/extensions`. The count of **two**
requests for ProviderCatalog is itself the proof the daemon changed control flow:
`hasModel()` is only reached when `isRunning` is true.

**Was anything passing only because real Ollama answered? No.** Every assertion in
`ProviderCatalog.test.tsx:394-413` is on test ids (`provider-row-panel-ollama`,
`provider-row-panel-llamacpp`). What the live daemon bought was the extra request and
the extra `setModelStatus` / `setIsChecking` updates landing after the test — the
late-resolution shape, not a wrong expectation.

### The fix — one mechanism, not per-spec patches

`src/test/networkGuard.ts` installs a default `fetch` for the whole suite that both

1. **rejects** every request, so every machine sees CI's "nothing is listening"
   whatever the developer is running, and
2. **records** the attempt.

Both halves are needed: `ollamaDetection.ts` *catches* the failure and returns
`{ isRunning: false }`, so a rejecting stub on its own would be completely silent.
The record is what survives the caller's `catch`.

`setup.ts` checks the record inside the **same** `afterEach` callback as `cleanup()`,
after it — not in its own hook — because vitest runs `afterEach` in reverse
registration order, so a separate hook could not be ordered after `cleanup()`, and
unmounting is what flushes the passive effects that make these calls. An `afterAll`
catches a promise settling after the final `afterEach`: the late resolution that
started this.

`KNOWN_NETWORK_ATTEMPTS` records the 7 measured files as **debt, not permission**.
They are recorded rather than fixed because making each request *succeed* with stub
data would change what its component sees, and therefore risks changing what it
asserts; leaving the request to fail preserves today's behaviour exactly. The Ollama
host is in **no** entry, and `networkGuard.test.ts` asserts it can never be added —
that host is the one a developer is actually likely to be running. A spec not in the
table that reaches out fails immediately, with the URL in the message.

`ProviderCatalog.test.tsx` gains the `vi.mock('../../../utils/ollamaDetection')` its
three siblings already had, so it attempts nothing on 11434 and needs no allowance
for it.

**Global rather than scoped, because it was measured to break nothing:** only 6 of
446 spec files assign their own `globalThis.fetch`, and assigning simply replaces
this one and records nothing. Before → after with Ollama live: **exit 0 both times**,
446 → 447 files and 5012 → 5022 tests — the deltas are exactly the new guard spec,
with zero pre-existing specs broken.

### Proven by reintroduction

With the new `vi.mock` temporarily deleted, Ollama live:

```
FAIL  src/components/settings/providers/ProviderCatalog.test.tsx
      > ProviderCatalog — modes > opens a local row into its setup panel in onboarding mode
Error: Un-stubbed network request in a test:
  http://127.0.0.1:11434/api/tags

This spec (src/components/settings/providers/ProviderCatalog.test.tsx) reached for the
network, so its result would depend on what is running on this machine. …
 Tests  1 failed | 23 passed (24)
```

**And the guard's own limit, probed rather than assumed.** Two throwaway probe specs: a
fetch fired from a timer in test 1 of a two-test file *is* reported (by test 2's
`afterEach`); a fetch fired from a timer in a file's **only** test is **not** — both hooks
run before it lands. So the *reporting* has a gap after a file's last hook. The
*determinism* has none: the offline `fetch` still rejects that request, so it can never
reach the network whenever it lands. Stated here rather than left as an implied claim that
the guard is total.

Mock restored, the spec passes 24/24. `networkGuard.test.ts` adds 10 tests: the stub
rejects and names the URL; the attempt is recorded through a `catch`; `URL` and
`Request` inputs are read, not only strings; an un-allowed attempt is reported once
and drained; an unrecognised spec path fails closed; **no allowance may name 11434**;
`ProviderCatalog` holds no 11434 allowance; every key in the table names a file that
exists. Residual transports checked, not assumed: no spec wraps the real `fetch`, there
is no `XMLHttpRequest` in `ui/desktop/src`, and the single `new WebSocket` call site
(`hooks/useWorkspaceChannel.ts:113`) is stubbed by its own spec.

---

## Verification

All of it with `ollama serve` live on 11434 — the ambient condition Defect 4 is about.
The user's daemon was never stopped: a suite that only passes when you turn something
off has not been fixed.

| check | result |
|---|---|
| `npx vitest run src/utils/sessionBindingSync.test.ts` ×10 | **10/10 pass** |
| `npx vitest run` popover + ingest + guard, together, ×10 | **10/10 pass** (29 tests) |
| `npx vitest run src/test/networkGuard.test.ts` | **10/10 pass** |
| `npx vitest run` guard + all 9 allowance-table specs + `ollamaDetection.test.ts` | 11 files / **146 pass** |
| `npm run test:run` — before defect 4 (`99bf4151`, Ollama live) | **exit 0**, 181.67 s, 446 files / 5012 passed / 1 skipped |
| `npm run test:run` — after (Ollama live) | **exit 0**, 120.82 s, **447 files / 5022 passed / 1 skipped** |
| `npm run lint:check` | pass (typecheck + eslint + themes + 332 contrast assertions + tokens) |
| `npm run format:check` | pass — *All matched files use Prettier code style* |


No Rust touched; no `npm install` / `npm ci` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

