### PR TITLE
fix(ui): the measured UI defect cluster — recurring extension toast, stale Recents row, five small defects, copy drift

### DIFF
--- a/crates/biorouter-mcp/src/autovisualiser/mod.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/mod.rs
@@ -772,7 +772,7 @@ impl AutoVisualiserRouter {
             - **network**: force-directed node-link graph (knowledge graphs, PPI, gene networks)
             - **sankey**: flow diagrams between stages
             - **chord**: pairwise flows between entities (square matrix)
-            - **heatmap**: matrix as a colour grid (expression/correlation matrices)
+            - **heatmap**: matrix as a color grid (expression/correlation matrices)
             - **treemap**: hierarchical proportional boxes
             - **sunburst**: hierarchical radial chart
             - **dendrogram**: hierarchical clustering / phylogenetic tree

--- a/crates/biorouter-mcp/src/autovisualiser/tools_charts.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/tools_charts.rs
@@ -416,7 +416,7 @@ Example:
 - All observations must be finite; negative-log p-values and thresholds must be non-negative. Supply already-transformed values; the renderer does not adjust p-values.
 - title (optional)
 
-Points are coloured up/down/non-significant against the thresholds.
+Points are colored up/down/non-significant against the thresholds.
 
 Example:
 {"title":"Tumor vs Normal","points":[{"label":"TP53","log2fc":2.4,"negLog10P":6.1},{"label":"GAPDH","log2fc":0.1,"negLog10P":0.3}]}"#
@@ -463,7 +463,7 @@ Example:
 - Positions, negative-log p-values and the threshold must be finite and non-negative.
 - title (optional)
 
-Points are grouped and coloured by chromosome along a cumulative x-axis.
+Points are grouped and colored by chromosome along a cumulative x-axis.
 
 Example:
 {"title":"GWAS","points":[{"chrom":"1","pos":12345,"negLog10P":3.2},{"chrom":"1","pos":98765,"negLog10P":8.1,"label":"rs123"},{"chrom":"2","pos":4567,"negLog10P":2.0}]}"#

--- a/crates/biorouter-mcp/src/autovisualiser/tools_d3.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/tools_d3.rs
@@ -12,7 +12,7 @@ pub struct NetworkNode {
     /// Display label (defaults to id)
     #[serde(default)]
     pub label: Option<String>,
-    /// Group/cluster for colouring
+    /// Group/cluster for coloring
     #[serde(default)]
     pub group: Option<String>,
     /// Relative size
@@ -260,7 +260,7 @@ impl AutoVisualiserRouter {
         name = "render_network",
         description = r#"Render an interactive force-directed network (node-link) graph. Ideal for knowledge graphs, gene/protein interaction networks, dependency graphs.
 
-- nodes (required): [{id, label?, group?, value?}]; group colours nodes, value sizes them
+- nodes (required): [{id, label?, group?, value?}]; group colors nodes, value sizes them
 - links (required): [{source, target, value?, label?}]; source/target reference node ids
 - directed (optional, default false): draw arrowheads
 - title (optional)
@@ -304,10 +304,10 @@ Example:
         )
     }
 
-    /// Heatmap (matrix as a colour grid)
+    /// Heatmap (matrix as a color grid)
     #[tool(
         name = "render_heatmap",
-        description = r#"Render a heatmap of a matrix as a coloured grid (expression matrices, correlation matrices, confusion matrices).
+        description = r#"Render a heatmap of a matrix as a colored grid (expression matrices, correlation matrices, confusion matrices).
 
 - xLabels (required): column labels
 - yLabels (required): row labels

--- a/crates/biorouter-mcp/src/autovisualiser/tools_dashboard.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/tools_dashboard.rs
@@ -133,7 +133,7 @@ pub struct DashboardSection {
     pub panels: Vec<DashboardPanel>,
 }
 
-/// Report colour theme. `Auto` (default) follows the desktop app's light/dark
+/// Report color theme. `Auto` (default) follows the desktop app's light/dark
 /// setting so the report matches the rest of the UI (and stays identical in the
 /// side-panel preview and the expanded view); `Light`/`Dark` force a look
 /// regardless of the host — set one when the user asks for a specific background.
@@ -196,7 +196,7 @@ pub struct RenderDashboardParams {
     /// Closing prose: caveats, data provenance, next steps.
     #[serde(default)]
     pub footer: Option<String>,
-    /// Report colour theme: `auto` (default, follows the app's light/dark setting),
+    /// Report color theme: `auto` (default, follows the app's light/dark setting),
     /// `light`, or `dark`. Set `light` or `dark` when the user asks for a specific
     /// background; leave it `auto` to match whatever theme the app is in.
     #[serde(default)]

--- a/crates/biorouter-mcp/src/autovisualiser/tools_geo.rs
+++ b/crates/biorouter-mcp/src/autovisualiser/tools_geo.rs
@@ -4,7 +4,7 @@
 pub struct ChoroplethData {
     /// A GeoJSON FeatureCollection describing the region boundaries
     pub geojson: Value,
-    /// Name of a numeric property within each feature's `properties` to colour by.
+    /// Name of a numeric property within each feature's `properties` to color by.
     /// Alternatively supply `values` keyed by an id property.
     #[serde(default, rename = "valueProperty")]
     pub value_property: Option<String>,
@@ -43,7 +43,7 @@ impl AutoVisualiserRouter {
         description = r#"Render a choropleth map: GeoJSON regions shaded by a value (disease prevalence by region, metrics by country/state, etc.).
 
 - geojson (required): a GeoJSON FeatureCollection of region polygons
-- valueProperty (optional): name of a numeric field in each feature's properties to colour by
+- valueProperty (optional): name of a numeric field in each feature's properties to color by
   OR values + idProperty: a {regionId: value} map matched on a feature property
 - nameProperty (optional): feature property used for hover labels
 - title, legendTitle, center {lat,lng}, zoom (optional)
@@ -70,7 +70,7 @@ Provide GeoJSON you have already obtained (e.g. read from a file or fetched). Ex
         check_limit(features.len(), MAX_MARKERS, "features")?;
         if d.value_property.is_none() && d.values.is_none() {
             return Err(invalid(
-                "Provide either `valueProperty` or `values`+`idProperty` to colour regions.",
+                "Provide either `valueProperty` or `values`+`idProperty` to color regions.",
             ));
         }
         let data_json = js_value(d)?;

--- a/crates/biorouter-mcp/src/knowledge/credibility/host_patterns.rs
+++ b/crates/biorouter-mcp/src/knowledge/credibility/host_patterns.rs
@@ -6,7 +6,7 @@ pub fn classify_url(url: &str) -> Option<Credibility> {
         return Some(make(
             CredibilityTier::Preprint,
             0.9,
-            "Host is a recognised preprint server.",
+            "Host is a recognized preprint server.",
             Some(&host),
         ));
     }
@@ -22,7 +22,7 @@ pub fn classify_url(url: &str) -> Option<Credibility> {
         return Some(make(
             CredibilityTier::Web,
             0.6,
-            "Generic web URL with no recognised academic provenance.",
+            "Generic web URL with no recognized academic provenance.",
             Some(&host),
         ));
     }

--- a/crates/biorouter-mcp/src/knowledge/instructions.md
+++ b/crates/biorouter-mcp/src/knowledge/instructions.md
@@ -39,7 +39,7 @@ Common operations:
   retracted or too weak for the claims resting on them. Writes nothing and fixes
   nothing. Run it after a batch of edits, and before exporting or sharing a base. Read
   `diagnostics.total`, not `items.len()` — the list is capped.
-- `kb_get_graph` — derived nodes+edges for visualisation. The graph is
+- `kb_get_graph` — derived nodes+edges for visualization. The graph is
   rebuilt automatically whenever you `kb_write_page`, so pages you author show
   up in the Knowledge tab without any extra step.
 - `kb_export` — export a knowledge base to a `.brkb` archive file on disk

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-biookf/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-biookf/SKILL.md
@@ -218,7 +218,7 @@ edges:
 
 # Tocilizumab
 
-An IL-6 receptor antagonist, trialled in severe COVID-19.
+An IL-6 receptor antagonist, trialed in severe COVID-19.
 ```
 
 ## Pitfalls

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-okf/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-ingest-okf/SKILL.md
@@ -70,7 +70,7 @@ carry them are still read, permanently, and must not be rewritten, but do not wr
 ones. (BioOKF has its own `[[predicate:: Object | key=value]]` inline edge form. That is
 a different grammar and belongs only in a BioOKF base.)
 
-**8 — Bookkeep.** Update `index.md` so the new pages are catalogued, then
+**8 — Bookkeep.** Update `index.md` so the new pages are cataloged, then
 `kb_append_log` with `kind: "ingest"` and a one-line summary plus a `delta` like
 `+3 pages, +7 links`.
 

--- a/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
+++ b/crates/biorouter/src/agents/builtin_skills/knowledge-lint/SKILL.md
@@ -36,7 +36,7 @@ being read, rendered or linked — it will. So do not "fix" a diagnostic by dele
 content or by loosening the page until the report goes quiet. Fix the thing it names, or
 decide deliberately not to and say why.
 
-Two corollaries worth internalising:
+Two corollaries worth internalizing:
 
 - A base that predates both formats is not linted at all — `kb_lint` **refuses** it,
   because that retired pre-OKF storage is purged on startup. `kb_read_page` and

--- a/ui/desktop/src/components/BaseChat.artifacts.test.ts
+++ b/ui/desktop/src/components/BaseChat.artifacts.test.ts
@@ -1076,3 +1076,56 @@ describe('shouldAutoRepairArtifact', () => {
     expect(shouldAutoRepairArtifact(ChatState.Idle, 0, now)).toBe(false);
   });
 });
+
+/**
+ * Defect 3.5. Four sibling FILES named in the assistant's prose were offered as
+ * artifacts and the DIRECTORY holding them was not. Nothing downstream is at
+ * fault — `looksLikePreviewableFile` accepts a folder, the main process stats
+ * the path and answers `kind: 'directory'`, and the panel has
+ * `DirectoryTreePreview` ready for it. The gap is in collection:
+ * `PREVIEWABLE_TEXT_ARTIFACT_RE` requires a literal `.` plus an extension from
+ * a closed allowlist, and a directory has neither.
+ *
+ * The signal used is a TRAILING SLASH, not "any extensionless path". A bare
+ * `/usr/bin` is indistinguishable from an extensionless file and would drag
+ * every command path and prose fragment into the tab strip; `results/` is the
+ * convention the assistant actually writes when it means a folder.
+ */
+describe('a directory named in prose', () => {
+  it('is offered alongside its siblings', () => {
+    const messages = [
+      visibleMessage([
+        {
+          type: 'text',
+          text: 'Everything landed in /work/results/ — see /work/results/plot.png for the figure.',
+        },
+      ]),
+    ];
+
+    expect(collectArtifactsFromMessages(messages, '/work')).toEqual([
+      { kind: 'file', title: 'results', path: '/work/results', mentionedOnly: true },
+      { kind: 'file', title: 'plot.png', path: '/work/results/plot.png', mentionedOnly: true },
+    ]);
+  });
+
+  it('anchors a relative folder against the working dir, and drops it without one', () => {
+    const messages = [visibleMessage([{ type: 'text', text: 'Wrote them all to ./results/.' }])];
+
+    expect(collectArtifactsFromMessages(messages, '/work')).toEqual([
+      { kind: 'file', title: 'results', path: '/work/results', mentionedOnly: true },
+    ]);
+    expect(collectArtifactsFromMessages(messages)).toEqual([]);
+  });
+
+  // The discipline the trailing slash buys. Without it every one of these
+  // becomes a tab.
+  it('does not treat a bare extensionless word as a folder', () => {
+    const messages = [
+      visibleMessage([
+        { type: 'text', text: 'It is on the PATH at /usr/bin and the ratio was 3/4.' },
+      ]),
+    ];
+
+    expect(collectArtifactsFromMessages(messages, '/work')).toEqual([]);
+  });
+});

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -125,10 +125,36 @@ const HEADER_ACTION_BUTTON_CLASS =
 // The image half of this alternation is generated from `utils/imageFormats`, so
 // adding a format cannot leave prose discovery behind. The non-image half stays
 // a literal: it is a deliberately closed list, not a mirror of another set.
+//
+// Anchors a path may start with — absolute, home-relative, dot-relative, a
+// Windows drive, a UNC share, or a `file://` URI.
+const ARTIFACT_PATH_ANCHOR = String.raw`(?:file://|~[\\/]|\.{1,2}[\\/]|[a-z]:[\\/]|/|\\\\)`;
+// What may follow the path before the sentence resumes.
+const ARTIFACT_PATH_TAIL = String.raw`(?=$|[\s)\]},;]|[.!?](?=$|[\s)\]},;]))`;
+const ARTIFACT_PATH_BODY = String.raw`[^\s)\]}\x60"'<>]`;
+// ⚠ **A DIRECTORY is recognised by its trailing slash, and by nothing else.**
+// Four sibling files named in prose were offered as artifacts while the folder
+// holding them was not, because the only shape this matched was `.` plus an
+// extension from the closed list above. Everything downstream already handles a
+// folder — `looksLikePreviewableFile` accepts one, the main process stats the
+// path and answers `kind: 'directory'`, and the panel has `DirectoryTreePreview`
+// — so the whole gap was here, in collection.
+//
+// The temptation is to accept any extensionless path. Do not: `/usr/bin`,
+// `/dev/null` and half the command lines in a transcript are indistinguishable
+// from an extensionless file, and every one of them would become a tab. A
+// trailing slash is what the assistant actually writes when it means a folder,
+// and it is unambiguous.
 const PREVIEWABLE_TEXT_ARTIFACT_RE = new RegExp(
-  String.raw`(?<![^\s(\[{])(?:file://|~[\\/]|\.{1,2}[\\/]|[a-z]:[\\/]|/|\\\\)[^\s)\]}\x60"'<>]+\.(?:` +
+  String.raw`(?<![^\s(\[{])${ARTIFACT_PATH_ANCHOR}(?:` +
+    // A file: named extension, optionally followed by a line/fragment suffix.
+    String.raw`${ARTIFACT_PATH_BODY}+\.(?:` +
     `html?|${imageExtensionAlternation()}|` +
-    String.raw`pdf|docx|xlsx|pptx|ipynb|sql|md|qmd|rmd|txt|log|json|csv|tsv|ya?ml|toml|xml|css|ts|tsx|js|jsx|py|r|rs|go|java|c|cpp|h|hpp)(?::\d+|#L\d+|%[^\s)\]}\x60"'<>.,!?;]*)?(?=$|[\s)\]},;]|[.!?](?=$|[\s)\]},;]))`,
+    String.raw`pdf|docx|xlsx|pptx|ipynb|sql|md|qmd|rmd|txt|log|json|csv|tsv|ya?ml|toml|xml|css|ts|tsx|js|jsx|py|r|rs|go|java|c|cpp|h|hpp)(?::\d+|#L\d+|%[^\s)\]}\x60"'<>.,!?;]*)?` +
+    // …or a directory, which is any path that ends in a separator. The file
+    // branch is first so `/work/out/plot.png` is never truncated to `/work/out/`.
+    String.raw`|${ARTIFACT_PATH_BODY}*[\\/]` +
+    String.raw`)${ARTIFACT_PATH_TAIL}`,
   'gi'
 );
 

--- a/ui/desktop/src/components/BioRouterSidebar/AppSidebar.test.tsx
+++ b/ui/desktop/src/components/BioRouterSidebar/AppSidebar.test.tsx
@@ -26,6 +26,7 @@ vi.mock('./SidebarUpdateButton', () => ({
 }));
 
 import AppSidebar from './AppSidebar';
+import { SAME_ROUTE_RESET_EVENT } from '../../hooks/useSameRouteReset';
 
 const session: SessionSummary = {
   id: 'session-1',
@@ -312,5 +313,64 @@ describe('AppSidebar — actions do not stay lit (§4.1.3)', () => {
     // mid-rail with no visible focus and nowhere obvious to resume from.
     fireEvent.click(newSession, { detail: 0 });
     expect(document.activeElement).toBe(newSession);
+  });
+});
+
+/**
+ * Defect 3.3. Clicking a sidebar item you are already on did nothing at all:
+ * react-router reconciles a same-path navigation rather than remounting, so a
+ * page holding sub-state (a schedule's run detail) stayed exactly where it was
+ * and only the in-page Back escaped. The row is lit — the user reads that as
+ * "this is the destination" and expects the destination, not the sub-view they
+ * drilled into.
+ */
+describe('clicking the sidebar item you are already on', () => {
+  // Scheduler lives behind the collapsed `Components` disclosure.
+  beforeEach(() => {
+    window.localStorage.setItem('biorouter:sidebar-components-expanded', 'true');
+  });
+
+  it('announces a reset for that route instead of being a dead click', () => {
+    const seen: string[] = [];
+    const listener = (event: Event) =>
+      seen.push((event as CustomEvent<{ path: string }>).detail.path);
+    window.addEventListener(SAME_ROUTE_RESET_EVENT, listener);
+
+    try {
+      render(
+        <MemoryRouter initialEntries={['/schedules']}>
+          <SidebarHarness />
+        </MemoryRouter>
+      );
+
+      fireEvent.click(screen.getByTestId('sidebar-scheduler-button'));
+
+      expect(seen).toEqual(['/schedules']);
+    } finally {
+      window.removeEventListener(SAME_ROUTE_RESET_EVENT, listener);
+    }
+  });
+
+  // Navigating somewhere else is a navigation, not a reset — otherwise every
+  // arrival would clear state the destination is entitled to keep.
+  it('says nothing when the click is a real navigation', () => {
+    const seen: string[] = [];
+    const listener = () => seen.push('reset');
+    window.addEventListener(SAME_ROUTE_RESET_EVENT, listener);
+
+    try {
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <SidebarHarness />
+        </MemoryRouter>
+      );
+
+      fireEvent.click(screen.getByTestId('sidebar-scheduler-button'));
+
+      expect(seen).toEqual([]);
+      expect(screen.getByTestId('location-state')).toHaveTextContent('/schedules');
+    } finally {
+      window.removeEventListener(SAME_ROUTE_RESET_EVENT, listener);
+    }
   });
 });

--- a/ui/desktop/src/components/BioRouterSidebar/AppSidebar.tsx
+++ b/ui/desktop/src/components/BioRouterSidebar/AppSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronDown, Home, Plus, Settings } from '../icons/app-icons';
 import { ENTITY_ICONS } from '../icons/entity-icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { announceSameRouteReset } from '../../hooks/useSameRouteReset';
 import {
   SidebarContent,
   SidebarFooter,
@@ -202,6 +203,18 @@ const AppSidebar: React.FC<SidebarProps> = ({ currentPath }) => {
     if (path === '/pair') {
       chatContext?.resetChat();
       navigateWithViewTransition(navigate, '/pair', { newChat: true });
+      return;
+    }
+
+    // Re-selecting the destination you are already on used to do NOTHING.
+    // React Router reconciles a same-path navigation rather than remounting
+    // the route element, so a page holding sub-state — a schedule's run detail,
+    // and the session history nested inside that — stayed exactly where it was
+    // and only the in-page Back escaped. The row is lit the whole time, which
+    // is this rail telling the user "you are here"; pressing it should get them
+    // here, not leave them three levels down with no visible way out.
+    if (path === currentPath) {
+      announceSameRouteReset(path);
       return;
     }
 

--- a/ui/desktop/src/components/BioRouterSidebar/useSidebarSessions.test.ts
+++ b/ui/desktop/src/components/BioRouterSidebar/useSidebarSessions.test.ts
@@ -5,6 +5,7 @@ import useSidebarSessions, {
   appendSessionPage,
   SIDEBAR_SESSION_PAGE_SIZE,
 } from './useSidebarSessions';
+import { notifySessionListChanged } from '../../utils/sessionListCache';
 
 const mocks = vi.hoisted(() => ({
   listSidebarSessions: vi.fn(),
@@ -109,5 +110,58 @@ describe('useSidebarSessions', () => {
       query: { limit: 10, offset: 0 },
       throwOnError: true,
     });
+  });
+});
+
+/**
+ * M11. A deleted chat left History, the tab strip and the database immediately
+ * and stayed in the sidebar Recents until a renderer reload.
+ *
+ * Two independent breaks produced it, and BOTH have to be closed:
+ *   (a) the delete handler never announced membership at all, and
+ *   (b) `appendSessionPage` is additive — it appends and replaces by id, and
+ *       has no removal branch — so even a full re-read of the first page leaves
+ *       an id the server no longer returns sitting in the merged list.
+ *
+ * (b) cannot be fixed by inferring removals from a refetch: `loadPage(true)`
+ * re-reads only the FIRST page, and an entry can drop out of that window
+ * because other chats were touched, not because it was deleted. So the removal
+ * is announced explicitly, by id.
+ */
+describe('a deleted chat leaves Recents without a reload', () => {
+  it('drops the announced id, in this window and from a sibling window', async () => {
+    const firstPage = Array.from({ length: 10 }, (_, index) => makeSummary(index));
+    mocks.listSidebarSessions.mockResolvedValue({
+      data: { sessions: firstPage, has_more: false, next_offset: null },
+    });
+
+    const { result } = renderHook(() => useSidebarSessions());
+    await waitFor(() => expect(result.current.sessions).toHaveLength(10));
+
+    act(() => notifySessionListChanged({ removed: 'session-3' }));
+
+    await waitFor(() => expect(result.current.sessions).toHaveLength(9));
+    expect(result.current.sessions.map((session) => session.id)).not.toContain('session-3');
+  });
+
+  // The scrolled-in pages are the thing a naive prune-on-refresh would destroy;
+  // `useSidebarSessions.test.ts`'s refresh case already pins that. Removing one
+  // id must not cost the others.
+  it('keeps every other loaded page', async () => {
+    const firstPage = Array.from({ length: 10 }, (_, index) => makeSummary(index));
+    const secondPage = Array.from({ length: 10 }, (_, index) => makeSummary(index + 10));
+    mocks.listSidebarSessions
+      .mockResolvedValueOnce({ data: { sessions: firstPage, has_more: true, next_offset: 10 } })
+      .mockResolvedValueOnce({ data: { sessions: secondPage, has_more: false, next_offset: null } });
+
+    const { result } = renderHook(() => useSidebarSessions());
+    await waitFor(() => expect(result.current.sessions).toHaveLength(10));
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.sessions).toHaveLength(20));
+
+    act(() => notifySessionListChanged({ removed: 'session-15' }));
+
+    await waitFor(() => expect(result.current.sessions).toHaveLength(19));
+    expect(result.current.sessions.map((session) => session.id)).toContain('session-19');
   });
 });

--- a/ui/desktop/src/components/BioRouterSidebar/useSidebarSessions.test.ts
+++ b/ui/desktop/src/components/BioRouterSidebar/useSidebarSessions.test.ts
@@ -152,7 +152,9 @@ describe('a deleted chat leaves Recents without a reload', () => {
     const secondPage = Array.from({ length: 10 }, (_, index) => makeSummary(index + 10));
     mocks.listSidebarSessions
       .mockResolvedValueOnce({ data: { sessions: firstPage, has_more: true, next_offset: 10 } })
-      .mockResolvedValueOnce({ data: { sessions: secondPage, has_more: false, next_offset: null } });
+      .mockResolvedValueOnce({
+        data: { sessions: secondPage, has_more: false, next_offset: null },
+      });
 
     const { result } = renderHook(() => useSidebarSessions());
     await waitFor(() => expect(result.current.sessions).toHaveLength(10));

--- a/ui/desktop/src/components/BioRouterSidebar/useSidebarSessions.ts
+++ b/ui/desktop/src/components/BioRouterSidebar/useSidebarSessions.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { listSidebarSessions, type SessionSummary } from '../../api';
 import { subscribeSessionNameChanges } from '../../utils/sessionNameSync';
-import { subscribeSessionListChanges } from '../../utils/sessionListCache';
+import { subscribeSessionListChanges, subscribeSessionRemoved } from '../../utils/sessionListCache';
 
 export const SIDEBAR_SESSION_PAGE_SIZE = 10;
 
@@ -103,12 +103,29 @@ export default function useSidebarSessions(): SidebarSessionsState {
     // unrelated turn happened to finish. Now every list change re-reads.
     const unsubscribeList = subscribeSessionListChanges(scheduleRefresh);
 
+    // M11. A removal is the one membership change the nudge above cannot carry:
+    // `appendSessionPage` merges a re-read INTO what we hold and has no removal
+    // branch, so a deleted chat survived every refresh and cleared only on a
+    // renderer reload. Splice it out by id instead — exact, and with no risk of
+    // evicting a live chat that merely fell out of the first page.
+    //
+    // `nextOffsetRef` moves down with it: the server's list lost the same row,
+    // so leaving the offset alone would make the next `loadMore` skip one.
+    const unsubscribeRemoved = subscribeSessionRemoved((sessionId) => {
+      const remaining = sessionsRef.current.filter((session) => session.id !== sessionId);
+      if (remaining.length === sessionsRef.current.length) return;
+      sessionsRef.current = remaining;
+      setSessions(remaining);
+      nextOffsetRef.current = Math.max(0, nextOffsetRef.current - 1);
+    });
+
     window.addEventListener('session-created', scheduleRefresh);
     window.addEventListener('message-stream-finished', scheduleRefresh);
 
     return () => {
       unsubscribeNames();
       unsubscribeList();
+      unsubscribeRemoved();
       if (refreshTimer !== undefined) window.clearTimeout(refreshTimer);
       window.removeEventListener('session-created', scheduleRefresh);
       window.removeEventListener('message-stream-finished', scheduleRefresh);

--- a/ui/desktop/src/components/artifacts/artifactFileProvenance.ts
+++ b/ui/desktop/src/components/artifacts/artifactFileProvenance.ts
@@ -33,7 +33,17 @@ export function referencedFilePaths(
   const add = (value: string) => {
     if (!/[\\/]/.test(value) || !looksLikePreviewableFile(value)) return;
     const resolved = resolveFileLink(value, workingDir);
-    if (resolved.kind === 'resolved') paths.add(resolved.path);
+    // A trailing separator is how a DIRECTORY announces itself in prose, and it
+    // must not survive into the path. `/work/out/` and `/work/out` name the same
+    // node, and the artifact list keys on the string — so leaving the slash on
+    // opens the same folder twice under two tabs the moment the assistant writes
+    // it both ways. (Only the absolute branch keeps it; the relative branch is
+    // normalised by the resolver, which is exactly the kind of asymmetry that
+    // makes the duplicate look like a different bug.)
+    //
+    // Safe to strip unconditionally: `looksLikePreviewableFile` has already
+    // rejected a bare root (`/`, `~`, `C:`), so this can never empty the path.
+    if (resolved.kind === 'resolved') paths.add(resolved.path.replace(/(?<=.)[\\/]+$/, ''));
   };
   let prose = text
     .replace(/<info-msg>[\s\S]*?<\/info-msg>/gi, '')

--- a/ui/desktop/src/components/artifacts/artifactUtils.test.ts
+++ b/ui/desktop/src/components/artifacts/artifactUtils.test.ts
@@ -816,3 +816,19 @@ describe('sandboxedSurface', () => {
     );
   });
 });
+
+/**
+ * Defect 3.5's other half, pinned rather than changed. The prose matcher was
+ * the only place a directory was rejected — the tool-call extractor has never
+ * applied an extension filter to a write tool's path argument, so a tool that
+ * creates a folder already yields it. Asserting that here keeps a future
+ * "tighten the collector" change from quietly re-introducing the same gap on
+ * the receipt side, where it would be much harder to notice.
+ */
+describe('fileArtifactPathsFromToolCall — a folder is a path like any other', () => {
+  it('keeps an extensionless write target', () => {
+    expect(
+      fileArtifactPathsFromToolCall('developer__write_file', { path: 'results' }, '/work')
+    ).toEqual(['/work/results']);
+  });
+});

--- a/ui/desktop/src/components/bottom_menu/BottomMenuExtensionSelection.test.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuExtensionSelection.test.tsx
@@ -222,7 +222,7 @@ describe('BottomMenuExtensionSelection', () => {
     // Five attached, three of them shipped capabilities → 2. Counting the whole
     // session would say 5.
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (2 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (2 added)')).toBeInTheDocument()
     );
 
     // …and the menu lists every user extension, attached or not, so the chip is
@@ -254,7 +254,7 @@ describe('BottomMenuExtensionSelection', () => {
 
     // 1, not 2 (the capability counted) and not 0 (the unknown swallowed).
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (1 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (1 added)')).toBeInTheDocument()
     );
   });
 
@@ -272,7 +272,7 @@ describe('BottomMenuExtensionSelection', () => {
     // Four extensions are enabled in the fixture. Two are capabilities
     // (autovisualiser, code_execution) and do not count; two are the user's own
     // (spoke, workspace) and do.
-    expect(screen.getByLabelText('Manage extensions (2 enabled)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Manage extensions (2 added)')).toBeInTheDocument();
   });
 
   it('moves the chip the moment a row is toggled, before the refetch', async () => {
@@ -294,7 +294,7 @@ describe('BottomMenuExtensionSelection', () => {
 
     render(<BottomMenuExtensionSelection sessionId="session-1" />);
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (1 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (1 added)')).toBeInTheDocument()
     );
 
     fireEvent.pointerDown(screen.getByLabelText(/Manage extensions/), {
@@ -304,7 +304,7 @@ describe('BottomMenuExtensionSelection', () => {
     fireEvent.click(await screen.findByRole('menuitemcheckbox', { name: 'example' }));
 
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (2 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (2 added)')).toBeInTheDocument()
     );
     await act(async () => {
       resolveEnable?.();
@@ -325,9 +325,9 @@ describe('BottomMenuExtensionSelection', () => {
     } as never);
     render(<BottomMenuExtensionSelection sessionId="catalog-still-loading" />);
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (1 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (1 added)')).toBeInTheDocument()
     );
-    expect(screen.queryByLabelText('Manage extensions (4 enabled)')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Manage extensions (4 added)')).not.toBeInTheDocument();
   });
 
   it('refetches and refreshes this chat when the catalog changes', async () => {
@@ -357,7 +357,7 @@ describe('BottomMenuExtensionSelection', () => {
       path: { session_id: 'session-1' },
     });
     await waitFor(() => expect(example).toHaveAttribute('aria-checked', 'true'));
-    expect(screen.getByLabelText('Manage extensions (1 enabled)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Manage extensions (1 added)')).toBeInTheDocument();
 
     const callsBeforeDetach = mocks.getSessionExtensions.mock.calls.length;
     mocks.getSessionExtensions.mockResolvedValue({ data: { extensions: [] } } as never);
@@ -368,7 +368,7 @@ describe('BottomMenuExtensionSelection', () => {
       { timeout: 1_500 }
     );
     await waitFor(() => expect(example).toHaveAttribute('aria-checked', 'false'));
-    expect(screen.getByLabelText('Manage extensions (0 enabled)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Manage extensions (0 added)')).toBeInTheDocument();
   });
 
   /**
@@ -384,7 +384,7 @@ describe('BottomMenuExtensionSelection', () => {
 
     render(<BottomMenuExtensionSelection sessionId="session-1" />);
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (0 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (0 added)')).toBeInTheDocument()
     );
     expect(screen.queryByRole('menuitemcheckbox')).not.toBeInTheDocument();
     const callsBeforeChange = mocks.getSessionExtensions.mock.calls.length;
@@ -402,7 +402,7 @@ describe('BottomMenuExtensionSelection', () => {
       path: { session_id: 'session-1' },
     });
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (1 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (1 added)')).toBeInTheDocument()
     );
   });
 
@@ -425,7 +425,7 @@ describe('BottomMenuExtensionSelection', () => {
     rerender(<BottomMenuExtensionSelection sessionId="current-chat" />);
 
     await waitFor(() =>
-      expect(screen.getByLabelText('Manage extensions (1 enabled)')).toBeInTheDocument()
+      expect(screen.getByLabelText('Manage extensions (1 added)')).toBeInTheDocument()
     );
 
     await act(async () => {
@@ -440,7 +440,7 @@ describe('BottomMenuExtensionSelection', () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByLabelText('Manage extensions (1 enabled)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Manage extensions (1 added)')).toBeInTheDocument();
   });
 
   /**
@@ -490,7 +490,7 @@ describe('BottomMenuExtensionSelection', () => {
     render(<BottomMenuExtensionSelection sessionId={null} />);
 
     // Four extensions enabled in the config, two of them capabilities → 2.
-    const trigger = screen.getByLabelText('Manage extensions (2 enabled)');
+    const trigger = screen.getByLabelText('Manage extensions (2 added)');
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
 
     expect(await screen.findAllByRole('menuitemcheckbox')).toHaveLength(3);

--- a/ui/desktop/src/components/bottom_menu/BottomMenuExtensionSelection.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuExtensionSelection.tsx
@@ -476,7 +476,18 @@ export const BottomMenuExtensionSelection = ({
               // for a dense control — the override is explained once in
               // ChatInput.tsx, search "THE RAILS' TYPE".
               className="flex h-7 items-center rounded-md px-0.5 cursor-pointer [&_svg]:size-4 text-text-default/70 hover:bg-background-medium hover:text-text-default text-supporting"
-              aria-label={`Manage extensions (${activeCount} enabled)`}
+              // ⚠ "added", not "enabled", and the distinction is the whole
+              // point. This label read "Manage extensions (0 enabled)" in chats
+              // where tools demonstrably worked, which a screen-reader user
+              // hears as "you have no tools" — and the count is not wrong, the
+              // verb is. `activeCount` deliberately excludes the shipped
+              // capabilities (see the docblock above it), because it has to
+              // count the same population as the list this button labels; a
+              // chat always has those, so "enabled" describes a state they
+              // share and the number cannot be read against. "Added" names the
+              // act the number actually measures, so zero of them is a true
+              // statement rather than a false one about capability.
+              aria-label={`Manage extensions (${activeCount} added)`}
             >
               <Puzzle className="mr-0.5 h-4 w-4" />
               <span>{activeCount}</span>

--- a/ui/desktop/src/components/chatGroups/ChatTabStrip.reveal.test.tsx
+++ b/ui/desktop/src/components/chatGroups/ChatTabStrip.reveal.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import { ChatTabStrip, ChatTabStripProps } from './ChatTabStrip';
+import { ChatTab } from './chatGroupsTypes';
+
+/**
+ * Defect 3.2. Resizing the window scrolled the ACTIVE tab off-screen and
+ * nothing brought it back.
+ *
+ * The strip is a CSS scroll box; the browser preserves `scrollLeft` while both
+ * `clientWidth` and the left gutter change under it. The only `scrollIntoView`
+ * in the file was an effect keyed on `[activeTabId, tabs.length]` — neither of
+ * which a resize touches — and the documented escape hatch, the ▾ overflow
+ * menu, calls `onSelect(tabId)` with the comment "selecting scrolls it into
+ * view through the effect above". For the tab that is ALREADY active, that
+ * effect's deps are unchanged, so the one offered way back was a no-op for
+ * exactly the tab that was off-screen.
+ *
+ * ⚠ Nothing here claims the tab is VISIBLE — jsdom computes no layout and has
+ * no `scrollIntoView` at all (the production call is feature-detected for that
+ * reason). What is asserted is that the reveal is REQUESTED on the active tab,
+ * on each of the two paths that previously requested nothing. Whether it lands
+ * is on the live checklist.
+ */
+function tab(over: Partial<ChatTab> = {}): ChatTab {
+  return { tabId: 'tab-1', sessionId: 's1', title: 'Cohort query', userSetName: false, ...over };
+}
+
+const TABS = [
+  tab(),
+  tab({ tabId: 'tab-2', sessionId: 's2', title: 'Variant calls' }),
+  tab({ tabId: 'tab-3', sessionId: 's3', title: 'Third' }),
+];
+
+function renderStrip(over: Partial<ChatTabStripProps> = {}) {
+  const props: ChatTabStripProps = {
+    tabs: TABS,
+    activeTabId: 'tab-3',
+    runningSessionIds: [],
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    onReorder: vi.fn(),
+    reserveTitlebar: false,
+    isCompactSidebarOverlayOpen: false,
+    ...over,
+  };
+  return { ...render(<ChatTabStrip {...props} />), props };
+}
+
+let resizeCallbacks: Array<() => void> = [];
+let scrollIntoView: ReturnType<typeof vi.fn>;
+const originalResizeObserver = globalThis.ResizeObserver;
+
+beforeEach(() => {
+  resizeCallbacks = [];
+  scrollIntoView = vi.fn();
+  (Element.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = scrollIntoView;
+  class FakeResizeObserver {
+    constructor(callback: () => void) {
+      resizeCallbacks.push(callback);
+    }
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+  }
+  globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
+  delete (Element.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView;
+});
+
+describe('the active tab is brought back into view', () => {
+  it('after the strip is resized', () => {
+    const { container } = renderStrip();
+    scrollIntoView.mockClear();
+
+    act(() => {
+      for (const callback of resizeCallbacks) callback();
+    });
+
+    expect(scrollIntoView).toHaveBeenCalled();
+    // The ref sits on the tab's LABEL BUTTON, not on `.br-tab` — the wrapper
+    // owns the drag gesture and nothing new may be declared on it.
+    const active = container.querySelector('[data-tab-id="tab-3"] button[role="tab"]');
+    expect(scrollIntoView.mock.instances).toContain(active);
+  });
+
+  it('when the overflow menu selects the tab that is already active', async () => {
+    const { container } = renderStrip();
+    scrollIntoView.mockClear();
+
+    // The ▾ menu and the tab itself share one `handleSelect`; the ▾ is gated on
+    // a measurement jsdom cannot make, so the shared handler is exercised
+    // through the tab. Selecting the tab you are ALREADY on is the case the
+    // effect's deps cannot see, and the case the ▾ exists to serve.
+    const activeTabButton = container.querySelector(
+      '[data-tab-id="tab-3"] button[role="tab"]'
+    ) as HTMLElement;
+    fireEvent.click(activeTabButton);
+
+    expect(scrollIntoView.mock.instances).toContain(activeTabButton);
+  });
+});

--- a/ui/desktop/src/components/chatGroups/ChatTabStrip.tsx
+++ b/ui/desktop/src/components/chatGroups/ChatTabStrip.tsx
@@ -274,12 +274,35 @@ export function ChatTabStrip({
     // Keyed on the rendered order string — the DOM is the dependency here.
   }, [orderKey]);
 
+  // Feature-detected: scrollIntoView is absent in jsdom, and keeping the
+  // focused tab visible must never be able to take the strip down.
+  const revealActiveTab = useCallback(() => {
+    activeTabRef.current?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+  }, []);
+
   // Keep the focused tab in view as the strip scrolls past its shrink floor.
   useEffect(() => {
-    // Feature-detected: scrollIntoView is absent in jsdom, and keeping the
-    // focused tab visible must never be able to take the strip down.
-    activeTabRef.current?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
-  }, [activeTabId, tabs.length]);
+    revealActiveTab();
+  }, [activeTabId, tabs.length, revealActiveTab]);
+
+  // ⚠ **And again when the BOX changes, which the deps above cannot see.** The
+  // strip is a CSS scroll box whose `clientWidth` and left gutter both move on a
+  // window resize (the gutter flips when `AppLayout` auto-collapses the
+  // sidebar), and the browser preserves `scrollLeft` across that — so a resize
+  // scrolled the active tab out of sight and nothing put it back. This is the
+  // same division of labour `useTabStripOverflow` documents one file over: the
+  // observer catches the box changing, the effect above catches the content
+  // changing, and neither implies the other.
+  //
+  // No feedback loop to fear: `scrollIntoView` moves `scrollLeft`, which is not
+  // a size, so it cannot re-trigger the observer that called it.
+  useEffect(() => {
+    const el = stripRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(revealActiveTab);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [revealActiveTab]);
 
   /**
    * Rung 3 of the yield ladder (D-32): shrink to the TAB_MIN_WIDTH floor (the
@@ -294,14 +317,22 @@ export function ChatTabStrip({
    */
   const showOverflowMenu = useTabStripOverflow(stripRef, tabs.length);
 
-  const handleOverflowSelect = useCallback(
+  /**
+   * Selecting a tab must also SHOW it — the menu is a way to reach a
+   * scrolled-out tab, so landing on it without showing it is half an answer.
+   *
+   * ⚠ The effect above does that for a tab that was not already active, and
+   * ONLY for one: its deps are `activeTabId` and `tabs.length`, both unchanged
+   * when you pick the tab you are already on. That made the one documented way
+   * back a no-op for exactly the tab a resize had pushed off-screen. Revealing
+   * explicitly here closes it, for the ▾ menu and for a click on the tab itself.
+   */
+  const handleSelect = useCallback(
     (tabId: ChatTabId) => {
-      // Selecting scrolls it into view through the effect above — the menu is a
-      // way to REACH a scrolled-out tab, so landing on it without showing it
-      // would be half an answer.
       onSelect(tabId);
+      if (tabId === activeTabId) revealActiveTab();
     },
-    [onSelect]
+    [onSelect, activeTabId, revealActiveTab]
   );
 
   // getSessionTitlePadding moved here from BaseChat: the strip is now its only
@@ -515,7 +546,7 @@ export function ChatTabStrip({
                       // Swallow the synthetic click that ends a drag — otherwise
                       // dropping a tab also activates whatever you dropped it on.
                       if (guardClick()) return;
-                      onSelect(tab.tabId);
+                      handleSelect(tab.tabId);
                     }}
                   >
                     {/* ⚠ The leading glyph now carries BOTH what the tab is and
@@ -628,7 +659,7 @@ export function ChatTabStrip({
               <DropdownMenuItem
                 key={tab.tabId}
                 data-testid={`chat-tab-overflow-item-${tab.tabId}`}
-                onSelect={() => handleOverflowSelect(tab.tabId)}
+                onSelect={() => handleSelect(tab.tabId)}
                 className={cn('gap-2', tab.tabId === activeTabId && 'font-medium')}
               >
                 {/* The overflow menu draws the SAME glyph as the strip: a tab

--- a/ui/desktop/src/components/conversation/SearchBar.tsx
+++ b/ui/desktop/src/components/conversation/SearchBar.tsx
@@ -223,7 +223,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
             onClick={toggleCaseSensitive}
             variant="ghost"
             className={`no-drag flex items-center justify-center min-w-[32px] h-[28px] rounded transition-colors duration-[var(--motion-fast)] ${caseSensitive ? 'bg-background-medium text-text-default hover:bg-background-strong' : 'text-text-muted hover:text-text-default hover:bg-background-medium'}`}
-            title="Case Sensitive"
+            title="Case sensitive"
           >
             <span className="text-sm font-normal">Aa</span>
           </Button>

--- a/ui/desktop/src/components/extensions/ExtensionLoadFailureNotice.test.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionLoadFailureNotice.test.tsx
@@ -66,10 +66,7 @@ describe('ExtensionLoadFailureNotice', () => {
    * mock that can keep passing after the line is deleted.
    */
   it('is mounted by the Extensions page — the surface the failure is about', () => {
-    const source = fs.readFileSync(
-      path.join(__dirname, 'ExtensionsView.tsx'),
-      'utf8'
-    );
+    const source = fs.readFileSync(path.join(__dirname, 'ExtensionsView.tsx'), 'utf8');
     expect(source).toContain('<ExtensionLoadFailureNotice');
   });
 });

--- a/ui/desktop/src/components/extensions/ExtensionLoadFailureNotice.test.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionLoadFailureNotice.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ExtensionLoadFailureNotice } from './ExtensionLoadFailureNotice';
+import {
+  recordExtensionLoadResults,
+  resetExtensionLoadFailuresForTests,
+  getExtensionLoadFailures,
+} from '../../utils/extensionLoadFailures';
+
+/**
+ * Defect 1, second half. The recurring toast pointed at the Extensions page and
+ * the page said "No extensions yet" — the destination denied that the thing
+ * that had just failed existed. These cases pin the name, the reason and at
+ * least one thing to do about it onto that page.
+ */
+describe('ExtensionLoadFailureNotice', () => {
+  beforeEach(() => {
+    resetExtensionLoadFailuresForTests();
+  });
+
+  it('renders nothing when nothing has failed', () => {
+    const { container } = render(<ExtensionLoadFailureNotice />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names the failed extension and shows the FULL error, not a truncation', () => {
+    const error =
+      'failed to start the MCP server: spawn uvx ENOENT — the command is not on PATH for this login shell';
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error }]);
+
+    render(<ExtensionLoadFailureNotice />);
+
+    expect(screen.getByText('Cdwagent failed to load')).toBeInTheDocument();
+    expect(screen.getByText(error)).toBeInTheDocument();
+  });
+
+  it('offers something actionable, not just the bad news', () => {
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }]);
+    const onAskBiorouter = vi.fn();
+
+    render(<ExtensionLoadFailureNotice onAskBiorouter={onAskBiorouter} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ask Biorouter' }));
+    expect(onAskBiorouter).toHaveBeenCalledTimes(1);
+    expect(onAskBiorouter.mock.calls[0][0]).toContain('spawn ENOENT');
+
+    expect(screen.getByRole('button', { name: 'Copy error' })).toBeInTheDocument();
+  });
+
+  it('dismissing drops the record rather than hiding it for one page load', () => {
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }]);
+    render(<ExtensionLoadFailureNotice />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(screen.queryByText('Cdwagent failed to load')).not.toBeInTheDocument();
+    expect(getExtensionLoadFailures()).toHaveLength(0);
+  });
+
+  /**
+   * The wiring, asserted at the source. Rendering `ExtensionsView` here would
+   * drag in `ConfigContext`, the marketplace registry and three modals for a
+   * claim about one JSX line, and a mock deep enough to make that work is a
+   * mock that can keep passing after the line is deleted.
+   */
+  it('is mounted by the Extensions page — the surface the failure is about', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, 'ExtensionsView.tsx'),
+      'utf8'
+    );
+    expect(source).toContain('<ExtensionLoadFailureNotice');
+  });
+});

--- a/ui/desktop/src/components/extensions/ExtensionLoadFailureNotice.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionLoadFailureNotice.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+import { Note } from '../ui/note';
+import { Button } from '../ui/button';
+import { AlertCircle } from '../icons/app-icons';
+import { formatExtensionName } from '../settings/extensions/subcomponents/ExtensionList';
+import {
+  dismissExtensionLoadFailure,
+  getExtensionLoadFailures,
+  subscribeExtensionLoadFailures,
+  type ExtensionLoadFailure,
+} from '../../utils/extensionLoadFailures';
+import { createExtensionRecoverHints } from '../../utils/extensionErrorUtils';
+import { useTransientValue } from '../../hooks/useTransientFlag';
+
+/**
+ * The standing extension-failure notice, on the page the failure is ABOUT.
+ *
+ * The defect this closes had two halves and they compounded: a toast recurred
+ * on every renderer load (fixed in `extensionLoadFailures`), and the Extensions
+ * page it sent you to answered "No extensions yet" — the destination denied
+ * that the thing that had just failed existed at all. An extension that fails
+ * at load can be absent from the configured list for perfectly ordinary reasons
+ * (it was removed while a chat still referenced it, it is session-scoped, its
+ * config row failed to parse), and in every one of them the page owes the user
+ * the name, the reason and a next step rather than an empty state.
+ *
+ * Tier: this is a Banner, not a Toast (`toasts.tsx`) — a standing condition
+ * that must stay put, not a confirmation that expires. It carries per-item
+ * actions, which is also why it is not a toast.
+ */
+export function ExtensionLoadFailureNotice({
+  onAskBiorouter,
+}: {
+  /** Hands the failure to the agent. Omitted where no chat can be started. */
+  onAskBiorouter?: (hints: string) => void;
+}) {
+  const [failures, setFailures] = useState<ExtensionLoadFailure[]>(() =>
+    getExtensionLoadFailures()
+  );
+  const [copied, markCopied] = useTransientValue<string>(2000);
+
+  useEffect(() => {
+    // Re-read on mount as well as subscribing: the record is written by the
+    // chat shell's `/agent/resume`, which has usually already run by the time
+    // anyone navigates here, so a subscription alone would show nothing.
+    setFailures(getExtensionLoadFailures());
+    return subscribeExtensionLoadFailures(() => setFailures(getExtensionLoadFailures()));
+  }, []);
+
+  if (failures.length === 0) return null;
+
+  return (
+    <div className="mb-6 space-y-2" data-testid="extension-load-failures">
+      {failures.map((failure) => (
+        <Note
+          key={failure.name}
+          tone="danger"
+          role="alert"
+          icon={AlertCircle}
+          action={
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => dismissExtensionLoadFailure(failure.name)}
+            >
+              Dismiss
+            </Button>
+          }
+        >
+          <div className="font-medium text-text-default">
+            {formatExtensionName(failure.name)} failed to load
+          </div>
+          {/* The FULL error, not the toast's truncation. This surface has room,
+              and the truncated form is what sent people looking for details in
+              the first place. */}
+          <div className="mt-1 [overflow-wrap:anywhere]">{failure.error}</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {onAskBiorouter && (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => onAskBiorouter(createExtensionRecoverHints(failure.error))}
+              >
+                Ask Biorouter
+              </Button>
+            )}
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                navigator.clipboard?.writeText(failure.error);
+                markCopied(failure.name);
+              }}
+            >
+              {copied === failure.name ? 'Copied!' : 'Copy error'}
+            </Button>
+          </div>
+        </Note>
+      ))}
+    </div>
+  );
+}
+
+export default ExtensionLoadFailureNotice;

--- a/ui/desktop/src/components/extensions/ExtensionsView.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionsView.tsx
@@ -24,7 +24,6 @@ import { PageHeader } from '../Layout/PageHeader';
 import { ExtensionLoadFailureNotice } from './ExtensionLoadFailureNotice';
 import { startNewSession } from '../../sessions';
 import { getInitialWorkingDir } from '../../utils/workingDir';
-import { useNavigation } from '../../hooks/useNavigation';
 
 export type ExtensionsViewOptions = {
   deepLinkConfig?: ExtensionConfig;
@@ -37,6 +36,7 @@ export function getExtensionScrollBehavior(): 'auto' | 'smooth' {
 }
 
 export default function ExtensionsView({
+  setView,
   viewOptions,
 }: {
   onClose: () => void;
@@ -58,7 +58,6 @@ export default function ExtensionsView({
   const highlightTimerRef = useRef<number | null>(null);
   const highlightedElementRef = useRef<HTMLElement | null>(null);
   const { addExtension, getExtensions } = useConfig();
-  const setView = useNavigation();
 
   // Track configured extension names so Browse can flag what's already installed.
   useEffect(() => {

--- a/ui/desktop/src/components/extensions/ExtensionsView.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionsView.tsx
@@ -21,6 +21,10 @@ import { BrxtInstallModal } from '../BrxtInstallModal';
 import BrowseExtensionsModal from '../baam/BrowseExtensionsModal';
 import { ReadableContent } from '../Layout/ReadableContent';
 import { PageHeader } from '../Layout/PageHeader';
+import { ExtensionLoadFailureNotice } from './ExtensionLoadFailureNotice';
+import { startNewSession } from '../../sessions';
+import { getInitialWorkingDir } from '../../utils/workingDir';
+import { useNavigation } from '../../hooks/useNavigation';
 
 export type ExtensionsViewOptions = {
   deepLinkConfig?: ExtensionConfig;
@@ -54,6 +58,7 @@ export default function ExtensionsView({
   const highlightTimerRef = useRef<number | null>(null);
   const highlightedElementRef = useRef<HTMLElement | null>(null);
   const { addExtension, getExtensions } = useConfig();
+  const setView = useNavigation();
 
   // Track configured extension names so Browse can flag what's already installed.
   useEffect(() => {
@@ -199,6 +204,13 @@ export default function ExtensionsView({
         />
 
         <ReadableContent size="chat" className="px-6 pt-6 pb-8">
+          {/* Above the list, because it is about an extension the list may not
+              contain. The toast that used to carry this news pointed here and
+              the page answered "No extensions yet" — the destination denied the
+              failure existed. */}
+          <ExtensionLoadFailureNotice
+            onAskBiorouter={(hints) => startNewSession(getInitialWorkingDir(), hints, setView)}
+          />
           <SearchView onSearch={(term) => setSearchTerm(term)} placeholder="Search extensions...">
             <ExtensionsSection
               key={refreshKey}

--- a/ui/desktop/src/components/parameter/ParameterInput.tsx
+++ b/ui/desktop/src/components/parameter/ParameterInput.tsx
@@ -112,7 +112,7 @@ const ParameterInput: React.FC<ParameterInputProps> = ({
           {/* Controls row */}
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className={labelCls}>Input Type</label>
+              <label className={labelCls}>Input type</label>
               <select
                 className={selectCls}
                 value={parameter.input_type || 'string'}
@@ -145,7 +145,7 @@ const ParameterInput: React.FC<ParameterInputProps> = ({
           {/* Default value — only for optional */}
           {requirement === 'optional' && (
             <div>
-              <label className={labelCls}>Default Value</label>
+              <label className={labelCls}>Default value</label>
               <input
                 type="text"
                 value={defaultValue}

--- a/ui/desktop/src/components/schedule/SchedulesView.tsx
+++ b/ui/desktop/src/components/schedule/SchedulesView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useSameRouteReset } from '../../hooks/useSameRouteReset';
 import {
   listSchedules,
   createSchedule,
@@ -246,6 +247,16 @@ const SchedulesView: React.FC<SchedulesViewProps> = ({ onClose: _onClose }) => {
   const actionsInProgressRef = useRef<Set<string>>(new Set());
   const [viewingScheduleId, setViewingScheduleId] = useState<string | null>(null);
   const [scheduleToDeleteId, setScheduleToDeleteId] = useState<string | null>(null);
+
+  // Defect 3.3. `viewingScheduleId` (and the session history nested inside
+  // `ScheduleDetailView`) is local state, not a URL — so re-selecting Scheduler
+  // in the rail reconciled this component unchanged and left the user parked in
+  // a run detail. Dropping the id here unmounts the detail view, which takes
+  // its own `selectedSession` with it.
+  useSameRouteReset('/schedules', () => {
+    setViewingScheduleId(null);
+    setScheduleToDeleteId(null);
+  });
 
   const beginAction = (id: string) => {
     if (actionsInProgressRef.current.has(id)) return false;

--- a/ui/desktop/src/components/sessions/SessionListView.test.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.test.tsx
@@ -4,7 +4,11 @@ import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SessionListView from './SessionListView';
-import { clearSessionListCache, updateCachedSessionList } from '../../utils/sessionListCache';
+import {
+  clearSessionListCache,
+  subscribeSessionRemoved,
+  updateCachedSessionList,
+} from '../../utils/sessionListCache';
 import type { Session } from '../../api';
 
 const mocks = vi.hoisted(() => ({
@@ -286,6 +290,48 @@ describe('SessionListView row actions', () => {
       path: { session_id: session.id },
       throwOnError: true,
     });
+  });
+
+  /**
+   * M11. The row left History, the tab strip and the database at once; only the
+   * sidebar Recents entry survived, clearing on a renderer reload. Delete was
+   * the one membership mutation that never announced itself on the list
+   * channel — create, diverge and import all do — and Recents reads a different
+   * endpoint and merges its re-reads, so it could not discover the removal on
+   * its own.
+   */
+  it('announces the removal by id on the session-list channel', async () => {
+    const user = userEvent.setup();
+    const session = {
+      id: 'session-1',
+      name: 'Deleted chat',
+      created_at: '2026-07-14T12:00:00Z',
+      updated_at: '2026-07-14T12:00:00Z',
+      extension_data: {},
+      message_count: 3,
+      working_dir: '/Users/wgu/Desktop',
+    };
+    mocks.listSessions.mockResolvedValue({ data: { sessions: [session] } });
+    const removed: string[] = [];
+    const unsubscribe = subscribeSessionRemoved((id) => removed.push(id));
+
+    try {
+      render(
+        <MemoryRouter>
+          <SessionListView onSelectSession={vi.fn()} />
+        </MemoryRouter>
+      );
+
+      await user.click(
+        await screen.findByRole('button', { name: `More actions for ${session.name}` })
+      );
+      await user.click(await screen.findByRole('menuitem', { name: `Delete ${session.name}` }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Confirm deletion' }));
+
+      await waitFor(() => expect(removed).toEqual(['session-1']));
+    } finally {
+      unsubscribe();
+    }
   });
 
   it('the Show-subagent-runs toggle refetches with include_subagents and nests children', async () => {

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -962,6 +962,13 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         currentSessions.filter((session) => session.id !== sessionToDeleteId);
       updateCachedSessionList(removeDeletedSession);
       setSessions(removeDeletedSession);
+      // M11. The two lines above fix THIS view and the cache behind it; every
+      // other list surface learns of membership changes over the list channel,
+      // and delete was the one mutation that never announced itself there —
+      // which is why a deleted chat sat in the sidebar Recents until a renderer
+      // reload. The id is carried because Recents merges its re-reads and
+      // cannot discover a removal by refetching; see `SessionListChange`.
+      notifySessionListChanged({ removed: sessionToDeleteId });
       toastSuccess({
         title: 'Chat deleted',
         msg: `"${sessionName}" was removed from chat history.`,

--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -201,7 +201,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
 
           <div className="biorouter-settings-row flex items-center justify-between px-3 py-2.5">
             <div className="min-w-0 flex-1">
-              <p className="text-label text-text-default">Prevent Sleep</p>
+              <p className="text-label text-text-default">Prevent sleep</p>
               <p className="mt-0.5 max-w-md text-supporting text-text-muted">
                 Keep your computer awake while Biorouter is running a task (screen can still lock)
               </p>
@@ -216,7 +216,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
           {COST_TRACKING_ENABLED && (
             <div className="biorouter-settings-row flex items-center justify-between px-3 py-2.5">
               <div className="min-w-0 flex-1">
-                <p className="text-label text-text-default">Cost Tracking</p>
+                <p className="text-label text-text-default">Cost tracking</p>
                 <p className="mt-0.5 max-w-md text-supporting text-text-muted">
                   Show model pricing and usage costs
                 </p>
@@ -344,7 +344,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
               {/* `text-iconStandard` is not a token — it had no effect and no
                   definition. The two dialog titles now agree on 20px. */}
               <Settings size={20} />
-              How to Enable Notifications
+              How to enable notifications
             </DialogTitle>
           </DialogHeader>
 

--- a/ui/desktop/src/components/settings/dictation/ProviderSelector.tsx
+++ b/ui/desktop/src/components/settings/dictation/ProviderSelector.tsx
@@ -75,7 +75,7 @@ export const ProviderSelector = ({ settings, onProviderChange }: ProviderSelecto
     <div className="space-y-4">
       <div className="flex items-center justify-between py-2 px-2 hover:bg-background-muted rounded-element transition-all">
         <div>
-          <h3 className="text-text-default">Dictation Provider</h3>
+          <h3 className="text-text-default">Dictation provider</h3>
           <p className="text-xs text-text-muted max-w-md mt-[2px]">
             Choose how voice is converted to text
           </p>

--- a/ui/desktop/src/components/settings/dictation/VoiceDictationToggle.tsx
+++ b/ui/desktop/src/components/settings/dictation/VoiceDictationToggle.tsx
@@ -66,7 +66,7 @@ export const VoiceDictationToggle = () => {
     <div className="space-y-1">
       <div className="flex items-center justify-between py-2 px-2 hover:bg-background-muted rounded-element transition-all">
         <div>
-          <h3 className="text-text-default">Enable Voice Dictation</h3>
+          <h3 className="text-text-default">Enable voice dictation</h3>
           <p className="text-xs text-text-muted max-w-md mt-[2px]">
             Show microphone button for voice input
           </p>

--- a/ui/desktop/src/components/settings/hostManagedSettings.browserSurface.test.tsx
+++ b/ui/desktop/src/components/settings/hostManagedSettings.browserSurface.test.tsx
@@ -160,7 +160,7 @@ describe('Settings > Models — Lead/Worker', () => {
     browser();
     render(<LeadWorkerSettings isOpen onClose={vi.fn()} />);
 
-    const save = await screen.findByRole('button', { name: 'Save Settings' });
+    const save = await screen.findByRole('button', { name: 'Save settings' });
     expect(save).toBeDisabled();
     expect(screen.getByTestId('host-managed-model-note')).toBeInTheDocument();
   });
@@ -173,7 +173,7 @@ describe('Settings > Models — Lead/Worker', () => {
     browser();
     render(<LeadWorkerSettings isOpen onClose={vi.fn()} />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Save Settings' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Save settings' }));
     await waitFor(() => expect(mocks.read).toHaveBeenCalled());
     expect(mocks.upsert).not.toHaveBeenCalled();
     expect(mocks.remove).not.toHaveBeenCalled();
@@ -188,7 +188,7 @@ describe('Settings > Models — Lead/Worker', () => {
   it('still saves in the desktop application', async () => {
     render(<LeadWorkerSettings isOpen onClose={vi.fn()} />);
 
-    const save = await screen.findByRole('button', { name: 'Save Settings' });
+    const save = await screen.findByRole('button', { name: 'Save settings' });
     expect(save).toBeEnabled();
     expect(screen.queryByTestId('host-managed-model-note')).toBeNull();
 

--- a/ui/desktop/src/components/settings/mode/ConversationLimitsDropdown.tsx
+++ b/ui/desktop/src/components/settings/mode/ConversationLimitsDropdown.tsx
@@ -30,7 +30,7 @@ export const ConversationLimitsDropdown = ({
    *
    * As siblings, `:last-child` lands correctly in both states with no extra
    * rule: collapsed, the trigger is last and drops its hairline; expanded, the
-   * trigger keeps it (it is now a separator) and Max Turns drops its own.
+   * trigger keeps it (it is now a separator) and Max turns drops its own.
    *
    * The cost is the max-height/opacity collapse, which needs the panel mounted
    * to animate. A mount-time fade is the honest replacement — `animate-in
@@ -57,7 +57,7 @@ export const ConversationLimitsDropdown = ({
       {isExpanded && (
         <div className="biorouter-settings-row flex min-w-0 animate-in items-center justify-between gap-3 px-3 py-2.5 fade-in duration-100">
           <div className="min-w-0 flex-1">
-            <h4 className="text-label text-text-default">Max Turns</h4>
+            <h4 className="text-label text-text-default">Max turns</h4>
             <p className="mt-0.5 max-w-md text-supporting text-text-muted">
               Maximum agent turns before Biorouter asks for user input
             </p>

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.browserSurface.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.browserSurface.test.tsx
@@ -8,7 +8,7 @@ import { BROWSER_SURFACE_MARKER } from '../../../../utils/surface';
  * SD-1 at the composer's model chip — the surface a browser user is most likely
  * to reach first, because it is the only model control visible without opening
  * Settings. Both of its menu items write capability config keys:
- * "Change Model" through `/config/set_provider`, "Lead/Worker Settings" through
+ * "Change model" through `/config/set_provider`, "Lead/worker settings" through
  * `/config/upsert` on `BIOROUTER_PROVIDER` and `BIOROUTER_LEAD_*`.
  */
 
@@ -97,7 +97,7 @@ describe('ModelsBottomBar on a browser-served surface', () => {
   /**
    * ⚠ **Fails against today's code**: neither item carries `disabled`, so
    * neither renders `aria-disabled`, and `findByTestId` has no note to resolve.
-   * Today the chip offers "Change Model", the dialog opens, and the refusal
+   * Today the chip offers "Change model", the dialog opens, and the refusal
    * arrives as a toast written for an AI agent.
    */
   it('greys out both menu items and says who chose the model', async () => {
@@ -108,11 +108,11 @@ describe('ModelsBottomBar on a browser-served surface', () => {
     const note = await screen.findByTestId('host-managed-model-note');
     expect(note.textContent).toMatch(/biorouter serve/);
 
-    expect(screen.getByRole('menuitem', { name: /Change Model/ })).toHaveAttribute(
+    expect(screen.getByRole('menuitem', { name: /Change model/ })).toHaveAttribute(
       'aria-disabled',
       'true'
     );
-    expect(screen.getByRole('menuitem', { name: /Lead\/Worker Settings/ })).toHaveAttribute(
+    expect(screen.getByRole('menuitem', { name: /Lead\/worker settings/ })).toHaveAttribute(
       'aria-disabled',
       'true'
     );
@@ -132,7 +132,7 @@ describe('ModelsBottomBar on a browser-served surface', () => {
     openChip();
 
     await screen.findByTestId('host-managed-model-note');
-    fireEvent.click(screen.getByRole('menuitem', { name: /Change Model/ }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Change model/ }));
 
     expect(screen.queryByText('SWITCH-MODEL-MODAL')).toBeNull();
   });
@@ -147,7 +147,7 @@ describe('ModelsBottomBar on a browser-served surface', () => {
     renderBar();
     openChip();
 
-    const item = await screen.findByRole('menuitem', { name: /Change Model/ });
+    const item = await screen.findByRole('menuitem', { name: /Change model/ });
     expect(item).not.toHaveAttribute('aria-disabled', 'true');
     expect(screen.queryByTestId('host-managed-model-note')).toBeNull();
 

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.noProvider.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.noProvider.test.tsx
@@ -77,7 +77,7 @@ describe('the model chip with no provider configured', () => {
 
   /**
    * ⚠ **The dropdown is replaced, not disabled.** Its two items are "Change
-   * Model" and "Lead/Worker Settings", which both read as adjustments to a model
+   * model" and "Lead/worker settings", which both read as adjustments to a model
    * that does not exist.
    */
   it('offers no model dropdown at all in that state', () => {

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -414,7 +414,7 @@ export default function ModelsBottomBar({
    * a user can now enter the app before configuring anything.
    *
    * ⚠ A plain button rather than a disabled dropdown: the menu's items are
-   * "Change Model" and "Lead/Worker Settings", both of which read as adjustments
+   * "Change model" and "Lead/worker settings", both of which read as adjustments
    * to a model that does not exist. One control, one meaning.
    */
   if (hasNoModelConfigured(modelConfigStatus, currentProvider)) {
@@ -606,7 +606,7 @@ export default function ModelsBottomBar({
               title={hostManaged ? HOST_MANAGED_MODEL_REASON : undefined}
               onClick={hostManaged ? undefined : () => setIsAddModelModalOpen(true)}
             >
-              <span>Change Model</span>
+              <span>Change model</span>
               <SlidersHorizontal className="ml-auto size-3.5" />
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -615,7 +615,7 @@ export default function ModelsBottomBar({
               title={hostManaged ? HOST_MANAGED_MODEL_REASON : undefined}
               onClick={hostManaged ? undefined : () => setIsLeadWorkerModalOpen(true)}
             >
-              <span>Lead/Worker Settings</span>
+              <span>Lead/worker settings</span>
               <SlidersHorizontal className="ml-auto size-3.5" />
             </DropdownMenuItem>
           </div>

--- a/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.test.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.test.tsx
@@ -91,13 +91,13 @@ describe('LeadWorkerSettings', () => {
 
     // Wait for modal content (not loading)
     await waitFor(() => {
-      expect(screen.getByText('Lead/Worker Mode')).toBeInTheDocument();
+      expect(screen.getByText('Lead/worker mode')).toBeInTheDocument();
     });
 
     // Labels should be present with back-to-list controls
     await waitFor(() => {
-      expect(screen.getByText('Lead Model')).toBeInTheDocument();
-      expect(screen.getByText('Worker Model')).toBeInTheDocument();
+      expect(screen.getByText('Lead model')).toBeInTheDocument();
+      expect(screen.getByText('Worker model')).toBeInTheDocument();
       // Back to model list appears for each section when in custom mode
       const backLinks = screen.getAllByText('Back to model list');
       expect(backLinks.length).toBeGreaterThanOrEqual(2);
@@ -110,7 +110,7 @@ describe('LeadWorkerSettings', () => {
     expect(workerInput.value).toBe('my-custom-worker');
 
     // Save settings
-    const saveBtn = screen.getByRole('button', { name: 'Save Settings' });
+    const saveBtn = screen.getByRole('button', { name: 'Save settings' });
     expect(saveBtn).toBeEnabled();
     fireEvent.click(saveBtn);
 
@@ -130,7 +130,7 @@ describe('LeadWorkerSettings', () => {
     render(<LeadWorkerSettings isOpen={true} onClose={onClose} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Lead/Worker Mode')).toBeInTheDocument();
+      expect(screen.getByText('Lead/worker mode')).toBeInTheDocument();
     });
 
     // Toggle off. The enable control is a Radix Switch (role="switch"),
@@ -140,7 +140,7 @@ describe('LeadWorkerSettings', () => {
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-checked', 'false');
 
-    const saveBtn = screen.getByRole('button', { name: 'Save Settings' });
+    const saveBtn = screen.getByRole('button', { name: 'Save settings' });
     expect(saveBtn).toBeEnabled();
     fireEvent.click(saveBtn);
 

--- a/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
@@ -206,7 +206,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent aria-describedby={undefined} className="p-0 sm:max-w-[560px]">
           <DialogHeader className="px-5 pb-2 pt-5">
-            <DialogTitle>Lead/Worker Mode</DialogTitle>
+            <DialogTitle>Lead/worker mode</DialogTitle>
           </DialogHeader>
           <div className="px-5 pb-5 text-sm text-text-muted">Loading...</div>
         </DialogContent>
@@ -218,7 +218,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="max-h-[min(720px,calc(100vh-2rem))] overflow-y-auto p-0 sm:max-w-[620px]">
         <DialogHeader className="px-5 pb-2 pt-5">
-          <DialogTitle>Lead/Worker Mode</DialogTitle>
+          <DialogTitle>Lead/worker mode</DialogTitle>
         </DialogHeader>
         <div className="space-y-5 px-5 pb-5">
           <DialogDescription className="text-sm text-text-muted">
@@ -247,7 +247,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
           <div className={`space-y-4 ${!isEnabled ? 'opacity-60' : ''}`}>
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <label className="text-sm font-medium text-text-default">Lead Model</label>
+                <label className="text-sm font-medium text-text-default">Lead model</label>
                 {isLeadCustomModel && (
                   <button
                     onClick={() => setIsLeadCustomModel(false)}
@@ -296,7 +296,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
 
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <label className="text-sm font-medium text-text-default">Worker Model</label>
+                <label className="text-sm font-medium text-text-default">Worker model</label>
                 {isWorkerCustomModel && (
                   <button
                     onClick={() => setIsWorkerCustomModel(false)}
@@ -346,7 +346,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
             <div className="biorouter-modal-panel grid grid-cols-3 gap-3 rounded-container p-3">
               <div className="space-y-2">
                 <label className="flex items-center gap-1 text-sm font-medium text-text-default">
-                  Initial Lead Turns
+                  Initial lead turns
                 </label>
                 <Input
                   type="number"
@@ -362,7 +362,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
 
               <div className="space-y-2">
                 <label className="flex items-center gap-1 text-sm font-medium text-text-default">
-                  Failure Threshold
+                  Failure threshold
                 </label>
                 <Input
                   type="number"
@@ -378,7 +378,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
 
               <div className="space-y-2">
                 <label className="flex items-center gap-1 text-sm font-medium text-text-default">
-                  Fallback Turns
+                  Fallback turns
                 </label>
                 <Input
                   type="number"
@@ -403,7 +403,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
               disabled={hostManaged || (isEnabled && (!leadModel || !workerModel))}
               title={hostManaged ? HOST_MANAGED_MODEL_REASON : undefined}
             >
-              Save Settings
+              Save settings
             </Button>
           </div>
         </div>

--- a/ui/desktop/src/components/settings/permission/PermissionSetting.tsx
+++ b/ui/desktop/src/components/settings/permission/PermissionSetting.tsx
@@ -87,7 +87,7 @@ export default function PermissionSettingsView({ onClose }: { onClose: () => voi
                 <circle cx="7.5" cy="15.5" r="5.5" />
               </svg>
             </div>
-            <h1 className="text-title text-text-default mt-4">Permission Rules</h1>
+            <h1 className="text-title text-text-default mt-4">Permission rules</h1>
             <p className="text-text-muted">
               Hidden instructions that will be passed to the provider to help direct and add context
               to your responses.

--- a/ui/desktop/src/components/settings/tunnel/TunnelSection.test.tsx
+++ b/ui/desktop/src/components/settings/tunnel/TunnelSection.test.tsx
@@ -57,7 +57,7 @@ describe('TunnelSection config cache', () => {
     });
 
     render(<TunnelSection />);
-    fireEvent.click(await screen.findByRole('button', { name: 'Stop Tunnel' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop tunnel' }));
 
     await waitFor(() => expect(mocks.stopTunnel).toHaveBeenCalledOnce());
     expect(mocks.refreshConfig).toHaveBeenCalledOnce();

--- a/ui/desktop/src/components/settings/tunnel/TunnelSection.tsx
+++ b/ui/desktop/src/components/settings/tunnel/TunnelSection.tsx
@@ -145,7 +145,7 @@ export default function TunnelSection() {
     <>
       <Card className="rounded-element">
         <CardHeader className="pb-0">
-          <CardTitle className="mb-1">Remote Access</CardTitle>
+          <CardTitle className="mb-1">Remote access</CardTitle>
           <CardDescription className="flex flex-col gap-2">
             <div className="flex items-start gap-2 p-2 bg-background-info/10 border border-border-info/40 rounded">
               <Info className="h-4 w-4 text-text-info flex-shrink-0 mt-0.5" />
@@ -182,7 +182,7 @@ export default function TunnelSection() {
 
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-text-default text-xs">Tunnel Status</h3>
+              <h3 className="text-text-default text-xs">Tunnel status</h3>
               <p className="text-xs text-text-muted max-w-md mt-[2px]">
                 {STATUS_MESSAGES[tunnelInfo.state]}
               </p>
@@ -196,10 +196,10 @@ export default function TunnelSection() {
               ) : tunnelInfo.state === 'running' ? (
                 <>
                   <Button onClick={() => setShowQRModal(true)} variant="default" size="sm">
-                    Show QR Code
+                    Show QR code
                   </Button>
                   <Button onClick={handleToggleTunnel} variant="destructive" size="sm">
-                    Stop Tunnel
+                    Stop tunnel
                   </Button>
                 </>
               ) : (
@@ -223,7 +223,7 @@ export default function TunnelSection() {
       <Dialog open={showQRModal} onOpenChange={setShowQRModal}>
         <DialogContent className="sm:max-w-[500px]">
           <DialogHeader>
-            <DialogTitle>Remote Access Connection</DialogTitle>
+            <DialogTitle>Remote access connection</DialogTitle>
           </DialogHeader>
 
           {tunnelInfo.state === 'running' && (
@@ -244,7 +244,7 @@ export default function TunnelSection() {
                   onClick={() => setShowDetails(!showDetails)}
                   className="flex items-center justify-between w-full text-sm font-medium hover:opacity-70 transition-opacity"
                 >
-                  <span>Connection Details</span>
+                  <span>Connection details</span>
                   {showDetails ? (
                     <ChevronUp className="h-4 w-4" />
                   ) : (
@@ -272,7 +272,7 @@ export default function TunnelSection() {
                     </div>
 
                     <div>
-                      <h3 className="text-xs font-medium mb-1 text-text-muted">Secret Key</h3>
+                      <h3 className="text-xs font-medium mb-1 text-text-muted">Secret key</h3>
                       <div className="flex items-center gap-2">
                         <code className="flex-1 p-2 bg-background-medium rounded text-xs break-all overflow-hidden">
                           {tunnelInfo.secret}
@@ -304,7 +304,7 @@ export default function TunnelSection() {
               Close
             </Button>
             <Button variant="destructive" onClick={handleToggleTunnel}>
-              Stop Tunnel
+              Stop tunnel
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/ui/desktop/src/components/ui/Diagnostics.test.tsx
+++ b/ui/desktop/src/components/ui/Diagnostics.test.tsx
@@ -56,7 +56,7 @@ describe('DiagnosticsModal', () => {
 
     render(<DiagnosticsModal isOpen onClose={onClose} sessionId="20260716_27" />);
 
-    expect(screen.getByRole('dialog', { name: 'Report a Problem' })).toBeVisible();
+    expect(screen.getByRole('dialog', { name: 'Report a problem' })).toBeVisible();
     fireEvent.click(screen.getByRole('button', { name: 'Generate diagnostics' }));
 
     await waitFor(() => {
@@ -95,7 +95,7 @@ describe('DiagnosticsModal', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Generate diagnostics' })).toBeEnabled();
     });
-    expect(screen.getByRole('dialog', { name: 'Report a Problem' })).toBeVisible();
+    expect(screen.getByRole('dialog', { name: 'Report a problem' })).toBeVisible();
     expect(onClose).not.toHaveBeenCalled();
     expect(toastSuccessMock).not.toHaveBeenCalled();
   });
@@ -117,7 +117,7 @@ describe('DiagnosticsModal', () => {
       });
     });
     expect(onClose).not.toHaveBeenCalled();
-    expect(screen.getByRole('dialog', { name: 'Report a Problem' })).toBeVisible();
+    expect(screen.getByRole('dialog', { name: 'Report a problem' })).toBeVisible();
   });
 
   /**

--- a/ui/desktop/src/components/ui/Diagnostics.tsx
+++ b/ui/desktop/src/components/ui/Diagnostics.tsx
@@ -223,7 +223,7 @@ Add any other context about the problem here.
               <AlertTriangle size={20} />
             </div>
             <div className="min-w-0 flex-1">
-              <DialogTitle>Report a Problem</DialogTitle>
+              <DialogTitle>Report a problem</DialogTitle>
               <DialogDescription className="mt-2">
                 You can download a diagnostics zip file to share with the team, or file a bug
                 directly on GitHub with your system details pre-filled. A diagnostics report

--- a/ui/desktop/src/components/ui/WorkflowWarningModal.tsx
+++ b/ui/desktop/src/components/ui/WorkflowWarningModal.tsx
@@ -102,7 +102,7 @@ export function WorkflowWarningModal({
             <Button variant="outline" onClick={onCancel}>
               Cancel
             </Button>
-            <Button onClick={onConfirm}>Trust and Execute</Button>
+            <Button onClick={onConfirm}>Trust and execute</Button>
           </DialogFooter>
         </DialogPrimitive.Content>
       </DialogPortal>

--- a/ui/desktop/src/components/workflows/WorkflowsView.test.tsx
+++ b/ui/desktop/src/components/workflows/WorkflowsView.test.tsx
@@ -342,3 +342,62 @@ describe('WorkflowsView on the settings visual vocabulary', () => {
     expect(await screen.findByTitle('Use workflow')).toBeInTheDocument();
   });
 });
+
+/**
+ * Defect 3.4. This is a MIS-ACTION risk, not missing copy: with two rows and
+ * two identically-titled "Add schedule" buttons, QA scheduled the wrong
+ * workflow on the first try. The dialog held the subject in state the whole
+ * time (`scheduleWorkflowManifest`) and simply never showed it, and
+ * `aria-describedby={undefined}` opted the dialog out of a description, so a
+ * screen reader heard "Add schedule" and nothing else either.
+ */
+describe('the schedule dialog names the workflow it is about to schedule', () => {
+  const rows = [
+    {
+      id: 'workflow-1',
+      file_path: '/tmp/one.yaml',
+      last_modified: '2026-07-11',
+      workflow: { title: 'Cohort review', description: 'one' },
+    },
+    {
+      id: 'workflow-2',
+      file_path: '/tmp/two.yaml',
+      last_modified: '2026-07-11',
+      workflow: { title: 'Variant calling nightly', description: 'two' },
+    },
+  ];
+
+  it('names the row the button belonged to, not merely "Add schedule"', async () => {
+    mocks.listSavedWorkflows.mockResolvedValue(rows);
+    render(
+      <MemoryRouter>
+        <WorkflowsView />
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Variant calling nightly');
+    const buttons = screen.getAllByTitle('Add schedule');
+    expect(buttons).toHaveLength(2);
+    fireEvent.click(buttons[1]);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/Variant calling nightly/)).toBeInTheDocument();
+    // The wrong subject must not be reachable from the dialog at all.
+    expect(within(dialog).queryByText(/Cohort review/)).not.toBeInTheDocument();
+  });
+
+  it('describes itself to assistive technology instead of opting out', async () => {
+    mocks.listSavedWorkflows.mockResolvedValue(rows);
+    render(
+      <MemoryRouter>
+        <WorkflowsView />
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Cohort review');
+    fireEvent.click(screen.getAllByTitle('Add schedule')[0]);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-describedby');
+  });
+});

--- a/ui/desktop/src/components/workflows/WorkflowsView.tsx
+++ b/ui/desktop/src/components/workflows/WorkflowsView.tsx
@@ -305,9 +305,14 @@ export default function WorkflowsView() {
         },
       });
 
+      // Named here too. The confirmation is the last chance to notice that the
+      // wrong row's button was pressed, and "Workflow will run ..." says
+      // nothing about WHICH workflow.
       toastSuccess({
         title: 'Schedule saved',
-        msg: `Workflow will run ${getReadableCron(scheduleCron)}`,
+        msg: `"${scheduleWorkflowManifest.workflow.title}" will run ${getReadableCron(
+          scheduleCron
+        )}`,
       });
 
       setShowScheduleDialog(false);
@@ -336,7 +341,7 @@ export default function WorkflowsView() {
 
       toastSuccess({
         title: 'Schedule removed',
-        msg: 'Workflow will no longer run automatically',
+        msg: `"${scheduleWorkflowManifest.workflow.title}" will no longer run automatically`,
       });
 
       setShowScheduleDialog(false);
@@ -807,15 +812,20 @@ export default function WorkflowsView() {
               desktop window and 448px only below the breakpoint. `MODAL_SIZE`
               is the ladder (V8: never a pixel literal for a dialog width), and
               its rungs are `sm:`-prefixed for exactly that reason. */}
-          <DialogContent
-            aria-describedby={undefined}
-            dismissible={!isSavingSchedule}
-            className={MODAL_SIZE.md}
-          >
+          {/* ⚠ No `aria-describedby={undefined}` here, and the description is
+              not decoration. Every row carries an identically-titled "Add
+              schedule" button, the dialog held its subject in state
+              (`scheduleWorkflowManifest`) and showed nothing, and QA scheduled
+              the WRONG workflow on the first try with two rows on screen. A
+              dialog that acts on one of several similar things has to name the
+              one it will act on — and opting out of the description meant a
+              screen reader heard "Add schedule" and nothing else either. */}
+          <DialogContent dismissible={!isSavingSchedule} className={MODAL_SIZE.md}>
             <DialogHeader>
               <DialogTitle>
                 {scheduleWorkflowManifest.schedule_cron ? 'Edit' : 'Add'} schedule
               </DialogTitle>
+              <DialogDescription>{scheduleWorkflowManifest.workflow.title}</DialogDescription>
             </DialogHeader>
             <div className="space-y-4">
               <CronPicker

--- a/ui/desktop/src/components/workflows/shared/InstructionsEditor.test.tsx
+++ b/ui/desktop/src/components/workflows/shared/InstructionsEditor.test.tsx
@@ -31,11 +31,11 @@ describe('InstructionsEditor', () => {
     }
 
     render(<Harness />);
-    expect(screen.getByText('Instructions Editor')).toBeInTheDocument();
+    expect(screen.getByText('Instructions editor')).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
 
-    await waitFor(() => expect(screen.queryByText('Instructions Editor')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Instructions editor')).not.toBeInTheDocument());
     expect(screen.getByText('Workflow editor')).toBeInTheDocument();
   });
 });

--- a/ui/desktop/src/components/workflows/shared/InstructionsEditor.tsx
+++ b/ui/desktop/src/components/workflows/shared/InstructionsEditor.tsx
@@ -65,7 +65,7 @@ Use {{parameter_name}} syntax for any user-provided values.`;
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleCancel()}>
       <DialogContent className="flex max-h-[90vh] w-[900px] max-w-[90vw] flex-col overflow-hidden sm:max-w-[90vw] lg:max-w-[900px]">
         <div className="mb-4 pr-8">
-          <DialogTitle>Instructions Editor</DialogTitle>
+          <DialogTitle>Instructions editor</DialogTitle>
         </div>
 
         <div className="flex-1 flex flex-col min-h-0">
@@ -79,7 +79,7 @@ Use {{parameter_name}} syntax for any user-provided values.`;
                 size="sm"
                 className="text-supporting"
               >
-                Insert Example
+                Insert example
               </Button>
             </div>
             <DialogDescription className="text-supporting text-text-muted mb-3">
@@ -105,7 +105,7 @@ Use {{parameter_name}} syntax for any user-provided values.`;
             Cancel
           </Button>
           <Button type="button" onClick={handleSave} variant="default">
-            Save Instructions
+            Save instructions
           </Button>
         </div>
       </DialogContent>

--- a/ui/desktop/src/components/workflows/shared/JsonSchemaEditor.tsx
+++ b/ui/desktop/src/components/workflows/shared/JsonSchemaEditor.tsx
@@ -98,7 +98,7 @@ export default function JsonSchemaEditor({
                 size="sm"
                 className="text-supporting"
               >
-                Insert Example
+                Insert example
               </Button>
             </div>
             <DialogDescription className="text-supporting text-text-muted mb-3">
@@ -136,7 +136,7 @@ export default function JsonSchemaEditor({
             Cancel
           </Button>
           <Button type="button" onClick={handleSave} variant="default">
-            Save Schema
+            Save schema
           </Button>
         </div>
       </DialogContent>

--- a/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
+++ b/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
@@ -358,7 +358,7 @@ export function WorkflowFormFields({
               <p className="text-text-danger text-body mt-1">{field.state.meta.errors[0]}</p>
             )}
 
-            {/* Instructions Editor Modal */}
+            {/* Instructions editor modal */}
             <InstructionsEditor
               isOpen={showInstructionsEditor}
               onClose={() => setShowInstructionsEditor(false)}

--- a/ui/desktop/src/hooks/chatStreamStore.test.ts
+++ b/ui/desktop/src/hooks/chatStreamStore.test.ts
@@ -595,6 +595,77 @@ describe('ChatStreamRegistry', () => {
     });
   });
 
+  /**
+   * Defect 3.1. Retry after "Connection dropped" took TWO presses, and the
+   * first press replaced the card with a scarier "Model turn ended
+   * unexpectedly".
+   *
+   * The pointer `ambiguousRetryTurnId` makes the first press an ATTACH, which
+   * returns before the resubmit. When the daemon answers that attach with its
+   * synthesized `stream_ended_without_terminal` — `TurnStream::close` for a
+   * turn with no writer — the ambiguity is RESOLVED: the turn is over and
+   * produced nothing. The press should carry on to the resubmit rather than
+   * paint an internal-scope failure and stop.
+   *
+   * ⚠ Only for that authoritative answer. An attach that could not be made at
+   * all (the daemon is unreachable) leaves the outcome genuinely ambiguous, and
+   * resubmitting there could double-run a turn that is still alive server-side.
+   * That path keeps its second press; see the case below it.
+   */
+  it('resubmits in ONE press when the daemon says the turn ended without a result', async () => {
+    const sessionId = 'retry-dead-turn';
+    const registry = new ChatStreamRegistry();
+    vi.mocked(resumeAgent).mockResolvedValue({ data: { session: session(sessionId) } } as never);
+    vi.mocked(reply)
+      // 1. the send whose response was lost after the daemon accepted it
+      .mockRejectedValueOnce(new TypeError('Response lost after accept'))
+      // 2. the attach: the daemon closes the turn with no result
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          yield {
+            type: 'Error',
+            error: 'The stream for this turn ended without a result. Please retry.',
+            code: 'stream_ended_without_terminal',
+            scope: 'internal',
+            retryable: true,
+          } as MessageEvent;
+        })(),
+      } as never)
+      // 3. the resubmit this press should reach on its own
+      .mockResolvedValueOnce({
+        stream: (async function* () {
+          yield { type: 'Finish', reason: 'done', token_state: tokenState } as MessageEvent;
+        })(),
+      } as never);
+
+    const controller = registry.getController(sessionId);
+    await controller.handleSubmit('do the thing');
+
+    await controller.retryTurn();
+
+    expect(reply).toHaveBeenCalledTimes(3);
+    expect(controller.getSnapshot().turnError).toBeUndefined();
+    expect(controller.getSnapshot().messages.filter((m) => m.role === 'user')).toHaveLength(1);
+  });
+
+  it('still takes a second press when the attach itself could not be made', async () => {
+    const sessionId = 'retry-attach-unreachable';
+    const registry = new ChatStreamRegistry();
+    vi.mocked(resumeAgent).mockResolvedValue({ data: { session: session(sessionId) } } as never);
+    vi.mocked(reply)
+      .mockRejectedValueOnce(new TypeError('Response lost after accept'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    const controller = registry.getController(sessionId);
+    await controller.handleSubmit('do the thing');
+
+    await controller.retryTurn();
+
+    // Two calls, not three: the turn may still be alive on the daemon, and a
+    // blind resubmit would run it twice.
+    expect(reply).toHaveBeenCalledTimes(2);
+  });
+
   it('attaches to a still-running ambiguous turn instead of starting another one', async () => {
     const sessionId = 'retry-running-attach';
     const registry = new ChatStreamRegistry();

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -3647,6 +3647,43 @@ class ChatStreamController {
       const ambiguousLease =
         this.continuationLeaseTurnId === ambiguousTurnId ? this.continuationLease : null;
       const attached = await this.attachToTurn(ambiguousTurnId);
+
+      // ⚠ **The daemon can resolve the ambiguity, and when it does, this press
+      // finishes the job.**
+      //
+      // Retry after "Connection dropped" took TWO presses, and the first press
+      // replaced the card with a scarier "Model turn ended unexpectedly". The
+      // reason is here: the pointer makes press one an ATTACH, which returns
+      // before the resubmit below. If that attach reaches a turn with no writer,
+      // `TurnStream::close` answers with `stream_ended_without_terminal` — the
+      // daemon stating that the turn is over and produced nothing. That is an
+      // authoritative answer, not a transport guess: the ambiguity the pointer
+      // exists for is gone, and the user's press should carry on to the
+      // resubmit instead of being spent on a round trip that reports a failure
+      // the model never had. (Same reading as `reframeStoppedTurnError`: the
+      // daemon describes the SHAPE of an ending, never its cause.)
+      //
+      // ⚠ And ONLY for that answer. An attach that could not be made at all —
+      // the POST threw, the daemon is unreachable — leaves the turn's fate
+      // genuinely unknown, and it may still be running server-side; resubmitting
+      // there would run the user's work twice. That path keeps its second press,
+      // which is a confirmation, not a bug.
+      if (attached && this.snapshot.turnError?.code === STREAM_ENDED_WITHOUT_TERMINAL) {
+        this.ambiguousRetryTurnId = null;
+        // Cleared BEFORE the next await so the internal-scope card cannot paint
+        // for a frame on its way out.
+        this.updateSnapshot((prev) => ({ ...prev, turnError: undefined }));
+        await this.abandonContinuationIfOwned(ambiguousLease);
+        // Re-read the tail: the attach ran a stream, and `last` was captured
+        // before it. Resubmitting a message that is no longer the trailing turn
+        // would append a duplicate.
+        const tail = this.messagesRef[this.messagesRef.length - 1];
+        if (!this.hasLiveTurn() && this.canSubmitMessage() && tail && tail.role === 'user') {
+          await this.submitPreparedMessage(tail, [...this.messagesRef], false);
+        }
+        return;
+      }
+
       if (!attached && this.ambiguousRetryTurnId === ambiguousTurnId) {
         this.ambiguousRetryTurnId = null;
         await this.abandonContinuationIfOwned(ambiguousLease);

--- a/ui/desktop/src/hooks/useSameRouteReset.ts
+++ b/ui/desktop/src/hooks/useSameRouteReset.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * "Take me back to the top of the page I am already on."
+ *
+ * Clicking a sidebar item you are already on was a dead click. React Router
+ * reconciles a same-path navigation rather than remounting the route element,
+ * so a page holding sub-state — a schedule's run detail, and the session
+ * history nested inside it — stayed exactly where it was, and the only escape
+ * was the in-page Back. The row is lit the whole time, which is the app telling
+ * the user "this is the destination"; pressing it should get them the
+ * destination.
+ *
+ * ⚠ **This is a window event, not route state, and that is deliberate.**
+ * Navigating to the same path with a fresh `state` object would work, but the
+ * cost is paid somewhere unrelated: several routes read `location.state` as
+ * their view options with a `|| window.history.state` fallback
+ * (`App.tsx`'s Settings and Extensions routes both do), and a truthy state
+ * object shadows that fallback. A reset is also not a navigation — it adds no
+ * destination worth a history entry — so an event models it honestly and
+ * touches no router behaviour at all.
+ */
+export const SAME_ROUTE_RESET_EVENT = 'biorouter:same-route-reset';
+
+export interface SameRouteResetDetail {
+  /** The route path the user re-selected. */
+  path: string;
+}
+
+/** Announce that the user re-selected the route they are already on. */
+export function announceSameRouteReset(path: string): void {
+  window.dispatchEvent(
+    new CustomEvent<SameRouteResetDetail>(SAME_ROUTE_RESET_EVENT, { detail: { path } })
+  );
+}
+
+/**
+ * Run `onReset` when the user re-selects `path` from the rail.
+ *
+ * For a page that drills into a sub-view it owns in local state. A page whose
+ * every view is a URL has nothing to do here and should not call this.
+ */
+export function useSameRouteReset(path: string, onReset: () => void): void {
+  // The callback is read from a ref so a caller passing an inline arrow — which
+  // is every caller — does not tear the listener down and rebuild it on each
+  // render.
+  const handler = useRef(onReset);
+  handler.current = onReset;
+
+  useEffect(() => {
+    const listener = (event: Event) => {
+      if ((event as CustomEvent<SameRouteResetDetail>).detail?.path !== path) return;
+      handler.current();
+    };
+    window.addEventListener(SAME_ROUTE_RESET_EVENT, listener);
+    return () => window.removeEventListener(SAME_ROUTE_RESET_EVENT, listener);
+  }, [path]);
+}

--- a/ui/desktop/src/test/spellingVariants.ts
+++ b/ui/desktop/src/test/spellingVariants.ts
@@ -34,6 +34,7 @@ const IZE_STEMS = [
   'formali',
   'generali',
   'initiali',
+  'internali',
   'maximi',
   'minimi',
   'moderni',
@@ -139,6 +140,8 @@ const OTHER_PAIRS: VariantPair[] = [
   ['signaling', 'signalling'],
   ['skillful', 'skilful'],
   ['traveled', 'travelled'],
+  ['trialed', 'trialled'],
+  ['trialing', 'trialling'],
   ['traveling', 'travelling'],
   // one-offs
   ['aging', 'ageing'],
@@ -147,6 +150,11 @@ const OTHER_PAIRS: VariantPair[] = [
   ['artifacts', 'artefacts'],
   ['catalog', 'catalogue'],
   ['catalogs', 'catalogues'],
+  // ⚠ The matcher is `(?<![A-Za-z])catalogue(?![A-Za-z])`, so the pair above
+  // does NOT cover `catalogued`/`cataloguing` — the trailing letter defeats the
+  // boundary. One shipped skill said "catalogued" for months because of it.
+  ['cataloged', 'catalogued'],
+  ['cataloging', 'cataloguing'],
   ['dialog', 'dialogue'],
   ['dialogs', 'dialogues'],
   ['gray', 'grey'],

--- a/ui/desktop/src/utils/extensionErrorUtils.test.ts
+++ b/ui/desktop/src/utils/extensionErrorUtils.test.ts
@@ -4,6 +4,7 @@ import {
   setFocusedChatSession,
   resetExtensionToastState,
 } from './extensionErrorUtils';
+import { resetExtensionLoadFailuresForTests } from './extensionLoadFailures';
 import { toastService } from '../toasts';
 
 vi.mock('../toasts', () => ({
@@ -21,6 +22,10 @@ describe('showExtensionLoadResults — multi-chat toast rules', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetExtensionToastState();
+    // The standing failure record is persistent BY DESIGN and deliberately
+    // survives `resetExtensionToastState` — that is the whole fix — so it has
+    // to be cleared explicitly or one case's failure silences the next one's.
+    resetExtensionLoadFailuresForTests();
     vi.mocked(toastService.isExtensionToastActive).mockReturnValue(false);
   });
 
@@ -234,5 +239,34 @@ describe('showExtensionLoadResults — multi-chat toast rules', () => {
     const [statuses, , , builtinFailures] = vi.mocked(toastService.extensionLoading).mock.calls[0];
     expect(statuses.map((s) => s.name)).toEqual(['cdwagent']);
     expect(builtinFailures).toEqual(['knowledge']);
+  });
+});
+
+/**
+ * Defect 1 (2026-09-12). "1 of 2 extensions loaded / Failed: Cdwagent"
+ * reappeared after EVERY renderer load once dismissed. The only caller of
+ * `showExtensionLoadResults` is `/agent/resume`, which a renderer load always
+ * performs — so the toast announced something the user did not do, and
+ * announced it again every time. The failure is real news exactly once; after
+ * that it belongs on a persistent surface, not in the transient layer.
+ */
+describe('a failure is announced once, not on every renderer load', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetExtensionToastState();
+    resetExtensionLoadFailuresForTests();
+  });
+
+  it('stays silent for a failure the user has already been shown', () => {
+    showExtensionLoadResults([ok('medcp'), bad('cdwagent')], 'chat-a');
+    expect(toastService.extensionLoading).toHaveBeenCalledTimes(1);
+
+    // A renderer reload: every module-level toast latch is fresh, and
+    // `/agent/resume` reports the same failure again.
+    vi.clearAllMocks();
+    resetExtensionToastState();
+    showExtensionLoadResults([ok('medcp'), bad('cdwagent')], 'chat-a');
+
+    expect(toastService.extensionLoading).not.toHaveBeenCalled();
   });
 });

--- a/ui/desktop/src/utils/extensionErrorUtils.ts
+++ b/ui/desktop/src/utils/extensionErrorUtils.ts
@@ -5,6 +5,10 @@
 import { ExtensionLoadResult } from '../api/types.gen';
 import { toastService, ExtensionLoadingStatus } from '../toasts';
 import { isCapabilityExtension } from '../components/settings/capabilities/capabilities';
+import {
+  markExtensionLoadFailuresAnnounced,
+  recordExtensionLoadResults,
+} from './extensionLoadFailures';
 
 export const MAX_ERROR_MESSAGE_LENGTH = 70;
 
@@ -84,6 +88,12 @@ export function resetExtensionToastState(): void {
  *     broken tool call, so it must not be swallowed — and since the grouped
  *     toast reuses one toast id, four chats hitting the same broken extension
  *     coalesce into one toast rather than stacking four.
+ *  3. **…but a failure is announced ONCE.** The only caller is `/agent/resume`,
+ *     which every renderer load performs, so rule 2 on its own re-announced the
+ *     same failure after every reload — a notification for something the user
+ *     did not do. `extensionLoadFailures` keeps the standing record across
+ *     reloads and answers what is actually new; anything the user has already
+ *     been shown is recorded silently and read on the Extensions page instead.
  *
  * @param results - Array of extension load results from the backend
  * @param sessionId - The chat these results belong to. Omit for non-chat callers
@@ -119,6 +129,22 @@ export function showExtensionLoadResults(
   const shipsWithBiorouter = (name: string) => isCapabilityExtension({ name });
   const results = allResults.filter((r) => !shipsWithBiorouter(r.name));
   const shippedFailures = allResults.filter((r) => shipsWithBiorouter(r.name) && !r.success);
+
+  // Rule 3. Record FIRST, unconditionally, and BEFORE any early return: the
+  // standing surface must learn of a failure whether or not the transient one
+  // is about to speak, and — the half that is easy to miss — a clean load has
+  // to CLEAR a record that is no longer true, including the all-shipped load
+  // the next line returns on. What comes back is only what the user has not
+  // already been shown.
+  const unannounced = recordExtensionLoadResults(
+    allResults.map((r) => ({
+      name: r.name,
+      success: r.success,
+      error: r.error,
+      builtin: shipsWithBiorouter(r.name),
+    }))
+  );
+
   if (results.length === 0 && shippedFailures.length === 0) {
     return;
   }
@@ -128,6 +154,13 @@ export function showExtensionLoadResults(
   // below: it must not be silenced as a background success, and it must not be
   // overwritten by a later clean run. It is only excluded from the *ratio*.
   const anyFailure = failedExtensions.length > 0 || shippedFailures.length > 0;
+
+  if (anyFailure && unannounced.length === 0) {
+    // Every failure here has already had its one announcement. Repeating it is
+    // the recurrence this rule exists to stop; the Extensions page still shows
+    // it, with the error text and something to do about it.
+    return;
+  }
 
   if (!anyFailure) {
     // Rule 1: a background chat's clean load is silent.
@@ -158,6 +191,9 @@ export function showExtensionLoadResults(
       traceback: errorMsg,
       recoverHints,
     });
+    // Only now — a failure that was never rendered has not been announced, and
+    // must keep its one announcement for the load that does render it.
+    markExtensionLoadFailuresAnnounced([failed.name]);
     return;
   }
 
@@ -177,4 +213,5 @@ export function showExtensionLoadResults(
     true,
     shippedFailures.map((r) => r.name)
   );
+  markExtensionLoadFailuresAnnounced(unannounced.map((entry) => entry.name));
 }

--- a/ui/desktop/src/utils/extensionLoadFailures.test.ts
+++ b/ui/desktop/src/utils/extensionLoadFailures.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  dismissExtensionLoadFailure,
+  getExtensionLoadFailures,
+  markExtensionLoadFailuresAnnounced,
+  recordExtensionLoadResults,
+  resetExtensionLoadFailuresForTests,
+  subscribeExtensionLoadFailures,
+} from './extensionLoadFailures';
+
+describe('the standing extension-failure record', () => {
+  beforeEach(() => {
+    resetExtensionLoadFailuresForTests();
+  });
+
+  it('survives a renderer reload — the in-memory cache is not the record', () => {
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }]);
+    markExtensionLoadFailuresAnnounced(['cdwagent']);
+
+    // A reload drops every module-level cache but not localStorage.
+    resetInMemoryCacheOnly();
+
+    const [failure] = getExtensionLoadFailures();
+    expect(failure.name).toBe('cdwagent');
+    expect(failure.announced).toBe(true);
+  });
+
+  it('answers "nothing new" for a failure already announced', () => {
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }]);
+    markExtensionLoadFailuresAnnounced(['cdwagent']);
+
+    expect(
+      recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }])
+    ).toHaveLength(0);
+  });
+
+  // A different failure is different news, even from the same extension.
+  it('treats a CHANGED error as new', () => {
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }]);
+    markExtensionLoadFailuresAnnounced(['cdwagent']);
+
+    const fresh = recordExtensionLoadResults([
+      { name: 'cdwagent', success: false, error: 'connection refused' },
+    ]);
+    expect(fresh.map((f) => f.name)).toEqual(['cdwagent']);
+  });
+
+  it('drops the record when the extension later loads cleanly', () => {
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }]);
+    recordExtensionLoadResults([{ name: 'cdwagent', success: true }]);
+
+    expect(getExtensionLoadFailures()).toHaveLength(0);
+  });
+
+  it('does not consume the announcement when nothing was rendered', () => {
+    const fresh = recordExtensionLoadResults([
+      { name: 'cdwagent', success: false, error: 'spawn ENOENT' },
+    ]);
+    expect(fresh).toHaveLength(1);
+    // No `markExtensionLoadFailuresAnnounced` — the toast never rendered.
+    expect(
+      recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }])
+    ).toHaveLength(1);
+  });
+
+  it('notifies subscribers on record and on dismissal', () => {
+    const seen: number[] = [];
+    const unsubscribe = subscribeExtensionLoadFailures((failures) => seen.push(failures.length));
+
+    recordExtensionLoadResults([{ name: 'cdwagent', success: false, error: 'spawn ENOENT' }]);
+    dismissExtensionLoadFailure('cdwagent');
+    unsubscribe();
+    recordExtensionLoadResults([{ name: 'medcp', success: false, error: 'spawn ENOENT' }]);
+
+    expect(seen).toEqual([1, 0]);
+  });
+
+  it('reads an unparseable record as an empty one instead of throwing', () => {
+    localStorage.setItem('biorouter.extensions.loadFailures', '{not json');
+    resetInMemoryCacheOnly();
+    expect(getExtensionLoadFailures()).toEqual([]);
+  });
+});
+
+/**
+ * Simulate a renderer load: the module's in-memory cache is gone, localStorage
+ * is not. `resetExtensionLoadFailuresForTests` clears BOTH, so it cannot stand
+ * in for this — and the distinction is the entire point of the module.
+ */
+function resetInMemoryCacheOnly(): void {
+  const saved = localStorage.getItem('biorouter.extensions.loadFailures');
+  resetExtensionLoadFailuresForTests();
+  if (saved !== null) {
+    localStorage.setItem('biorouter.extensions.loadFailures', saved);
+  }
+}

--- a/ui/desktop/src/utils/extensionLoadFailures.ts
+++ b/ui/desktop/src/utils/extensionLoadFailures.ts
@@ -1,0 +1,189 @@
+/**
+ * The standing record of extensions that failed to load.
+ *
+ * ⚠ **Why this module exists.** `showExtensionLoadResults` has exactly one
+ * caller — `/agent/resume` in `hooks/chatStreamStore.tsx` — and a renderer load
+ * always resumes. So the extension-failure toast announced something the user
+ * did not do, and announced it again on every reload; dismissing it bought one
+ * page load of quiet. That is precisely the "never notify for what the user did
+ * not do" rule, and the fix is not a shorter dwell time: a failure that is still
+ * true tomorrow is a STANDING CONDITION, and standing conditions belong on a
+ * persistent surface (the Extensions page's `Note`), not in the transient layer.
+ *
+ * So the split is:
+ *   · the record here is authoritative and survives reloads,
+ *   · the toast fires **once per distinct failure** (name + error text) and
+ *     never again for the same one,
+ *   · an extension that later loads cleanly has its record dropped, so a fixed
+ *     extension stops being reported without anyone dismissing anything.
+ *
+ * The `announced` flag is persisted rather than held in memory for the same
+ * reason the record is: in-memory state is exactly what a renderer load resets,
+ * and resetting it is what produced the recurrence.
+ */
+
+const STORAGE_KEY = 'biorouter.extensions.loadFailures';
+
+export interface ExtensionLoadFailure {
+  /** The extension's name as the daemon reported it. */
+  name: string;
+  /** The full error text, as reported. Never truncated here. */
+  error: string;
+  /** A shipped capability rather than something the user installed. */
+  builtin: boolean;
+  /** ms epoch of the most recent observation of this failure. */
+  at: number;
+  /** True once the transient layer has announced this exact failure. */
+  announced: boolean;
+}
+
+/** One load result, reduced to what the record cares about. */
+export interface ExtensionLoadOutcome {
+  name: string;
+  success: boolean;
+  error?: string | null;
+  builtin?: boolean;
+}
+
+type Listener = (failures: ExtensionLoadFailure[]) => void;
+
+const listeners = new Set<Listener>();
+let cache: ExtensionLoadFailure[] | null = null;
+
+function isFailure(value: unknown): value is ExtensionLoadFailure {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.name === 'string' && typeof record.error === 'string';
+}
+
+function read(): ExtensionLoadFailure[] {
+  if (cache) return cache;
+  let parsed: unknown = null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    parsed = raw ? JSON.parse(raw) : null;
+  } catch {
+    // A private window, cleared site data, or a document written by a build
+    // that shaped this differently. An unreadable record is an empty one — it
+    // must never take the page down with it.
+    parsed = null;
+  }
+  cache = Array.isArray(parsed)
+    ? parsed.filter(isFailure).map((entry) => ({
+        name: entry.name,
+        error: entry.error,
+        builtin: entry.builtin === true,
+        at: typeof entry.at === 'number' ? entry.at : 0,
+        announced: entry.announced === true,
+      }))
+    : [];
+  return cache;
+}
+
+function write(next: ExtensionLoadFailure[]): void {
+  cache = next;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Storage is full or unavailable. The in-memory cache still serves this
+    // page load; the record simply does not survive the next one.
+  }
+  for (const listener of listeners) listener(next);
+}
+
+/** The standing failures, newest observation first. */
+export function getExtensionLoadFailures(): ExtensionLoadFailure[] {
+  return [...read()].sort((a, b) => b.at - a.at);
+}
+
+/**
+ * Subscribe to the record. Fires on every change made in this renderer, and on
+ * a `storage` event so a second window showing the Extensions page follows a
+ * failure recorded in the first.
+ */
+export function subscribeExtensionLoadFailures(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('storage', (event) => {
+    if (event.key !== null && event.key !== STORAGE_KEY) return;
+    cache = null;
+    const next = read();
+    for (const listener of listeners) listener(next);
+  });
+}
+
+/**
+ * Fold one load report into the record and answer what is NEW.
+ *
+ * A failure is new when nothing has been announced for that extension, or when
+ * the error text has changed since it was (a different failure is different
+ * news). Successes drop any record for that extension.
+ *
+ * @returns the failures worth announcing. Empty means "nothing the user has not
+ *          already been told", which is the caller's cue to stay silent.
+ */
+export function recordExtensionLoadResults(
+  results: readonly ExtensionLoadOutcome[]
+): ExtensionLoadFailure[] {
+  const existing = read();
+  const byName = new Map(existing.map((entry) => [entry.name, entry]));
+  const fresh: ExtensionLoadFailure[] = [];
+  let changed = false;
+
+  for (const result of results) {
+    if (result.success) {
+      if (byName.delete(result.name)) changed = true;
+      continue;
+    }
+    const error = result.error || 'Unknown error';
+    const previous = byName.get(result.name);
+    const alreadyAnnounced = previous?.announced === true && previous.error === error;
+    const entry: ExtensionLoadFailure = {
+      name: result.name,
+      error,
+      builtin: result.builtin === true,
+      at: Date.now(),
+      announced: alreadyAnnounced,
+    };
+    byName.set(result.name, entry);
+    changed = true;
+    if (!alreadyAnnounced) fresh.push(entry);
+  }
+
+  if (changed) write([...byName.values()]);
+  return fresh;
+}
+
+/**
+ * Mark these failures as announced, so no later renderer load repeats them.
+ * Called only once a toast has actually been rendered — a suppressed report
+ * must not consume the one announcement its failure is owed.
+ */
+export function markExtensionLoadFailuresAnnounced(names: readonly string[]): void {
+  const wanted = new Set(names);
+  const current = read();
+  if (!current.some((entry) => wanted.has(entry.name) && !entry.announced)) return;
+  write(current.map((entry) => (wanted.has(entry.name) ? { ...entry, announced: true } : entry)));
+}
+
+/** Drop one extension's record — the Dismiss control on the standing notice. */
+export function dismissExtensionLoadFailure(name: string): void {
+  const current = read();
+  const next = current.filter((entry) => entry.name !== name);
+  if (next.length !== current.length) write(next);
+}
+
+/** Test seam — the record is persistent by design, so it must be cleared explicitly. */
+export function resetExtensionLoadFailuresForTests(): void {
+  cache = null;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Nothing to clear.
+  }
+}

--- a/ui/desktop/src/utils/sessionListCache.ts
+++ b/ui/desktop/src/utils/sessionListCache.ts
@@ -44,17 +44,56 @@ type ListListener = () => void;
 const listChangeListeners = new Set<ListListener>();
 let listChannel: BroadcastChannel | null = null;
 
+/**
+ * What changed, when the change is more specific than "something did".
+ *
+ * M11: a plain "re-read now" nudge is enough to ADD a session and not enough to
+ * remove one. The sidebar Recents merges each re-read into what it already holds
+ * (`appendSessionPage` appends and replaces by id, and has no removal branch),
+ * so a deleted chat survived every refresh and cleared only on a renderer
+ * reload. Removals are therefore announced BY ID rather than inferred from a
+ * refetch — `loadPage(true)` re-reads only the first page, and an entry can drop
+ * out of that window because other chats were touched rather than because it was
+ * deleted, so inference would evict live chats.
+ */
+export interface SessionListChange {
+  /** The id of a session that no longer exists. */
+  removed?: string;
+}
+
+type RemovalListener = (sessionId: string) => void;
+const removalListeners = new Set<RemovalListener>();
+
+function fanOutRemoval(sessionId: string | undefined): void {
+  if (!sessionId) return;
+  for (const l of removalListeners) l(sessionId);
+}
+
 function getListChannel(): BroadcastChannel | null {
   if (listChannel) return listChannel;
   if (typeof BroadcastChannel === 'undefined') return null;
   listChannel = new BroadcastChannel('biorouter:session-list');
-  listChannel.onmessage = () => {
+  listChannel.onmessage = (event: MessageEvent) => {
     // Another window changed the set. Refresh this window's own cache (so its
     // See-all/Home update) and fan out to hooks that fetch their own way.
+    fanOutRemoval((event.data as SessionListChange | undefined)?.removed);
     void refreshSessionList().catch(() => undefined);
     for (const l of listChangeListeners) l();
   };
   return listChannel;
+}
+
+/**
+ * Subscribe to session REMOVALS specifically, by id. For a surface that keeps
+ * its own merged list and cannot discover a deletion by re-reading — see
+ * {@link SessionListChange}.
+ */
+export function subscribeSessionRemoved(listener: RemovalListener): () => void {
+  getListChannel();
+  removalListeners.add(listener);
+  return () => {
+    removalListeners.delete(listener);
+  };
 }
 
 /**
@@ -75,10 +114,14 @@ export function subscribeSessionListChanges(listener: ListListener): () => void 
  * delete or import. Refreshes this window's cache immediately and notifies every
  * other window to do the same.
  */
-export function notifySessionListChanged(): void {
+export function notifySessionListChanged(change: SessionListChange = {}): void {
+  // Removals go out FIRST and synchronously. The nudge below is debounced by
+  // most subscribers, so a listener that splices by id must not be racing a
+  // re-read that would merge the doomed row straight back in.
+  fanOutRemoval(change.removed);
   void refreshSessionList().catch(() => undefined);
   for (const l of listChangeListeners) l();
-  getListChannel()?.postMessage({ at: Date.now() });
+  getListChannel()?.postMessage({ at: Date.now(), ...change });
 }
 
 export function getCachedSessionList(): Session[] | null {


### PR DESCRIPTION
Nine commits, one per defect (plus one follow-on), so any single fix can be reverted alone.

Every defect below records its **fail-before** measurement. Where a claim is visual, it is
asserted at the source and the visual half is listed on the live checklist at the end. Two of
the reported symptoms turned out **not to exist where they were said to be**; that is reported
rather than papered over.

---

## 1. MEDIUM — the extension-failure toast recurs, and points at a dead end

**Symptom.** "1 of 2 extensions loaded / Failed: Cdwagent" reappears after every renderer load
once dismissed; the Extensions page it points at says "No extensions yet".

**Mechanism.** `showExtensionLoadResults` has exactly **one** caller — `ensureAgentLoaded`'s
`/agent/resume` in `hooks/chatStreamStore.tsx` — and a renderer load always resumes. So the
toast announced something the user did not do and announced it again each time. Every
suppression latch it had (`extensionToastIsFailure`, the react-toastify id) is module-level,
i.e. exactly the state a reload clears.

**Fail-before.** New case in `extensionErrorUtils.test.ts` → `Tests 1 failed | 16 passed (17)`,
failing on `expect(toastService.extensionLoading).not.toHaveBeenCalled()` with
`Number of calls: 1`.

**Fix.** A failure that is still true tomorrow is a *standing condition*, so it moves out of
the transient layer:

- `utils/extensionLoadFailures.ts` — the standing record, persisted in `localStorage`, with the
  `announced` flag persisted too (in-memory state is what a reload resets, and resetting it is
  what produced the recurrence). A success drops the record, so a fixed extension stops being
  reported without anyone dismissing anything; a changed error text counts as new news.
- `extensionErrorUtils.ts` records first, unconditionally, **before every early return** (so a
  clean load can clear a record that is no longer true), then stays silent for anything already
  announced. The announcement is marked only where a toast actually rendered.
- `components/extensions/ExtensionLoadFailureNotice.tsx`, mounted above the list on the
  Extensions page: a persistent `Note` (Banner tier, not Toast) per failed extension carrying
  the name, the **full** error (not the toast's 70-char truncation) and three actions — Ask
  Biorouter, Copy error, Dismiss. That is the half that stops the destination denying the
  extension exists.

---

## 2. MEDIUM — a deleted chat survives in the sidebar Recents (M11)

**Symptom.** The row leaves History, the tab strip and the database at once; only the sidebar
Recents entry survives, clearing on a renderer reload.

**Mechanism — two independent breaks, both required.**
1. `SessionListView.handleConfirmDelete` updated its own state and the `sessionListCache`
   contents but never called `notifySessionListChanged()`. Create, diverge and import all
   announce on that channel; delete was the one membership mutation that did not.
2. Even with the nudge, Recents could not act on it. It reads a *different* endpoint
   (`GET /sessions/sidebar`) and merges every re-read into what it holds via
   `appendSessionPage`, which appends and replaces by id and has **no removal branch**.

Inferring removals from a refetch is unsafe: `loadPage(true)` re-reads only the **first** page,
and an entry can fall out of that window because other chats were touched rather than because
it was deleted — so inference would evict live chats, and the existing "refreshes … without
discarding pages already loaded by scrolling" test forbids the naive version.

**Fail-before.** Two new cases in `useSidebarSessions.test.ts` → `Tests 2 failed | 3 passed (5)`;
the second failed on `toHaveLength(19)` receiving `20` — the announced removal changed nothing.

**Fix.** Removals are announced **by id**. `notifySessionListChanged(change?: { removed })`,
a `subscribeSessionRemoved` listener set, and the id carried across the existing
`BroadcastChannel` so a sibling window follows. Removals fan out first and synchronously, ahead
of the debounced re-read. `useSidebarSessions` splices by id and moves `nextOffsetRef` down with
it (the server's list lost the same row; leaving the offset alone would make the next
`loadMore` skip one).

No re-fetch was added on the delete path, so neither the reissued-session-id trap nor
`GET /sessions`' INNER JOIN is in play. **Known remaining gap:** a session deleted *outside*
the renderer (CLI, daemon) still needs a reload — there is no announcement to carry. Already
true; out of scope.

---

## 3. LOW — the cluster of five

### 3.1 Retry after "Connection dropped" needs two presses — FIXED

**Mechanism.** A dropped stream sets `ambiguousRetryTurnId` and finishes `stream_interrupted` /
`transport`, which titles "Connection dropped". While that pointer is set, `retryTurnOnce`
spends the press on `attachToTurn(...)` and `return`s — it never reaches
`submitPreparedMessage`. The scarier title is a **different error raised by the retry itself**:
the attach reaches a turn with no writer, the daemon's `TurnStream::close` answers
`stream_ended_without_terminal` (`scope: internal`), and the client's `Error` case clears the
pointer, so only press two resubmits.

**Fail-before.** `expected "vi.fn()" to be called 3 times, but got 2 times`.

**Fix, deliberately narrow.** When the attach comes back with `stream_ended_without_terminal`
the daemon has *authoritatively* said the turn is over and produced nothing — the ambiguity the
pointer exists for is resolved — so the same press clears the error (before the next `await`, so
the internal card cannot paint on its way out) and carries on to the resubmit. Same reading as
the existing `reframeStoppedTurnError`: the daemon describes the *shape* of an ending, never its
cause.

⚠ An attach that could not be **made** (POST threw, daemon unreachable) is untouched and still
takes a second press — the turn may be running server-side and a blind resubmit would run the
user's work twice. A second test pins that. The trailing message is also re-read after the
attach so a resubmit can never append a duplicate user turn.

### 3.2 A window resize scrolls the active tab off-screen — FIXED

**Mechanism.** One `scrollIntoView` in `ChatTabStrip.tsx`, in an effect keyed on
`[activeTabId, tabs.length]` — no size input. The strip is a CSS scroll box whose `clientWidth`
and left gutter both move on a resize (the gutter flips when `AppLayout` auto-collapses the
sidebar) and the browser preserves `scrollLeft`. `useTabStripOverflow` observes the strip but
only sets a boolean for the ▾ menu. And the documented escape was itself a no-op:
`handleOverflowSelect` relied on "the effect above", whose deps are both unchanged when you pick
the tab you are already on.

**Fail-before.** New `ChatTabStrip.reveal.test.tsx` → `2 failed (2)`, verified against the
pre-fix component specifically (checked the file out at HEAD, re-ran, `2 failed`, restored) so
the failure is the component's and not a selector artefact.

**Fix.** One `revealActiveTab`, reached from three places: the content effect, a new
`ResizeObserver` on the strip, and a shared `handleSelect` that reveals when the selected tab is
already active. No feedback loop — `scrollIntoView` moves `scrollLeft`, which is not a size.

⚠ The tests assert the reveal is **requested** on the active tab on both previously-silent
paths. jsdom computes no layout and has no `scrollIntoView`; "the tab is visible after a
drag-resize" is on the live checklist.

### 3.3 Clicking a sidebar item you are already on is a dead click — FIXED

**Mechanism.** React Router reconciles a same-path navigation rather than remounting the route
element, and the run detail is *local* state: `SchedulesView.viewingScheduleId` and the
`selectedSession` nested inside `ScheduleDetailView`. `SchedulesView` reads `useLocation()` but
its one effect is keyed on `location.state`, `undefined` before and after, and its body
early-returns while a detail is open.

**Fail-before.** New case in `AppSidebar.test.tsx` → `Tests 1 failed | 9 passed (10)`, `[]`
where `['/schedules']` was expected.

**Fix.** `hooks/useSameRouteReset.ts` — a window event carrying the path, announced when the
clicked path equals `currentPath`, consumed by `SchedulesView` to drop `viewingScheduleId`
(which unmounts the detail view and takes its session selection with it). Other pages opt in
with one hook call.

⚠ An event, **not** route state: several routes read `location.state` as their view options with
a `|| window.history.state` fallback (App's Settings and Extensions routes both do), and a
truthy state object silently shadows it. A reset is also not a navigation and deserves no
history entry.

### 3.4 "Add schedule" never names the workflow — FIXED

A mis-action risk, not missing copy: two rows, two identically-titled buttons, and QA scheduled
the wrong workflow on the first try. The subject was in `scheduleWorkflowManifest` state the
whole time and never rendered, and `aria-describedby={undefined}` opted the dialog out of a
description so a screen reader heard the same two words.

**Fail-before.** Two new cases → `Tests 2 failed | 11 passed (13)`; the a11y one failed on
`expect(dialog).toHaveAttribute('aria-describedby')` receiving `null`.

**Fix.** `DialogDescription` carries the workflow title; the opt-out is gone. Both confirmation
toasts name it too — the toast is the last chance to notice the wrong row's button was pressed.

### 3.5 A directory named in prose is not offered as an artifact — FIXED

Confirmed collection-only, as briefed. `looksLikePreviewableFile` already accepts a folder, the
main process stats the path and answers `kind: 'directory'`, and the panel dispatches to
`DirectoryTreePreview`. The gap is `PREVIEWABLE_TEXT_ARTIFACT_RE`, which requires a literal `.`
plus an extension from a closed allowlist. **The tool-call side was not broken** —
`fileArtifactPathsFromToolCall` applies no extension filter to a write tool's path argument — so
one change sufficed, and a pinning test keeps it that way.

**Fail-before.** Three new cases in `BaseChat.artifacts.test.ts` → `Tests 2 failed | 65 passed
(67)`, both `[]` where a `/work/results` artifact was expected.

**Fix.** A second regex branch: a path ending in a separator is a directory (file branch first,
so `/work/out/plot.png` is never truncated to `/work/out/`). ⚠ Deliberately **not** "any
extensionless path" — `/usr/bin`, `/dev/null` and half the command lines in a transcript are
indistinguishable from an extensionless file and each would become a tab. The separator is then
stripped from the resolved path: only the absolute branch kept it (the resolver normalises the
relative one), so `/work/out/` and `/work/out` were two artifacts naming one folder.

---

## 4. LOW, copy — Title Case and British-English drift

### ⚠ Two named claims are not reproducible

**"The Auto Visualiser writes COLOUR as a table header."** Measured case-sensitively across all
26 templates, `_common.js` and every `.rs` in `crates/biorouter-mcp/src/autovisualiser/`, and
whole-repo: **there is no `COLOUR` or `Colour` in the autovisualiser at all.** The rendered
legend copy is already American ("Colors distinguish top-level branches"). The only whole-repo
`COLOUR` hits are shouted-for-emphasis words inside code comments. Nothing pins such a literal
because it does not exist.

What **is** there and is fixed: twelve lowercase `colour`/`coloured`/`colouring` in user- and
model-facing strings — tool descriptions, `///` schema field docs (which become the JSON-schema
`description`), the kind list in the server instructions, and one error message returned to the
caller. No Rust test asserts any of them (grepped `crates/biorouter-mcp/tests/` and the
`autovisualiser/tests*.rs` files; the only `colour` there is a local pixel variable).

**"Knowledge copy uses randomised / summarise."** No **user-facing** instance exists, in
`ui/desktop/src/components/knowledge/` or `crates/biorouter-mcp/src/knowledge/` — every
occurrence is a code comment or test fixture. `ui/desktop/src/test/uiCopySpelling.test.ts`
already enforces American English over `ui/desktop/src` plus the shipped skills. The real drift
in Knowledge is the two credibility `reason` strings returned in kb tool results and
`instructions.md`'s "visualisation"; both fixed.

### The find worth keeping: three gaps in the copy guard

Three shipped skills said "catalogued", "trialled" and "internalising" **inside** the guard's
governed root. `catalogued` slips because the matcher is `(?<![A-Za-z])catalogue(?![A-Za-z])`
and the trailing letter defeats the boundary. Fixed the strings **and** closed the gap:
`spellingVariants.ts` gains the `internali` stem and the `cataloged/cataloguing` and
`trialed/trialling` pairs.

**Fail-before for the gap fix.** With the extended list in place, `catalogued` was put back and
the guard re-run: `Tests 1 failed | 5 passed (6)`, reporting
`SKILL.md:73 "catalogued" → "cataloged"`. Before the list change the same file passed.

### Title Case → sentence case

Named: `ModelsBottomBar`'s "Change Model" and "Lead/Worker Settings". Swept its destination
dialog and 22 more across settings, tunnel, dictation, permissions, diagnostics, workflows and
the search bar; 8 pinned assertions updated.

**Left alone on purpose:** `text-caps` strings (the CSS renders them ALL CAPS, so their case is
invisible), proper nouns and product names ("Auto Visualiser" is formally exempt in the copy
guard's `ALLOWED_PHRASES`), and `components/settings/extensions/`, documented as outside this
sweep. `ToolCallConfirmation`'s "Allow Once"/"Always Allow" are a named permission affordance
referenced across docs and security tests — renaming them is a product decision, not a typo fix.

### Ruling on "Manage extensions (0 enabled)"

**Kept the scope, changed the verb: `Manage extensions (N added)`.**

The string is the `aria-label` on the chip's trigger — the visible chip is a bare digit and the
tooltip carries no count — so the person who hears "0 enabled" is a screen-reader user, and what
they hear is "you have no tools".

The count is not wrong. `activeCount` excludes shipped capabilities because it must count the
same population as the menu the button opens: the same invariant the extension-load toast's
denominator was fixed to honour. Widening the scope would make the digit disagree with the list
beneath it and turn the number into a constant plus a small offset.

So the verb is the fault. Every chat *has* those capabilities, so "enabled" names a state they
share and the number cannot be read against it. "Added" names the act the number actually
measures — which is what the code's own docblock already says it means — so zero of them becomes
a true statement instead of a false one about capability.

---

## Verification

| Gate | Result |
|---|---|
| `npm run lint:check` | **exit 0** (typecheck + eslint + themes + 332 contrast assertions + token mirrors) |
| `npm run format:check` | **All matched files use Prettier code style** |
| `npm run test:run` | **5038 passed, 1 skipped, 0 failed**, exit 1 |
| `npx tsc --noEmit` | clean |

The `test:run` exit 1 with **zero failing tests** is the documented pre-existing teardown hang
in `src/utils/artifactCdnAssets.browser.test.ts` (`afterAll` → `browser?.close()` exceeding the
hook timeout). It fails the same way on pristine `main` and is unrelated to this branch.

**No `cargo` was run** — the machine was under several cold Rust builds. The crate changes are
string literals and `///` doc comments only (18 lines, verified by reading the whole diff), with
no structural edits and no raw-string delimiters touched.

## Claims that can only be settled in the running app

1. **3.2** — that the active tab is genuinely *visible* after a drag-resize, and that the ▾
   menu's "already active" entry now scrolls it back. jsdom has no layout engine and no
   `scrollIntoView`.
2. **3.1** — that the real "Connection dropped" card now resolves on the **first** press against
   a live daemon, and that no "Model turn ended unexpectedly" flashes on its way out.
3. **1** — that the toast no longer reappears across real renderer reloads, and that the
   Extensions page shows the standing notice above "No extensions yet".
4. **2** — that the Recents row disappears the instant a chat is deleted from History, including
   from a second window.
5. **3.3** — that re-clicking Scheduler from inside a run detail returns to the schedule list.
6. **4** — that the Auto Visualiser's figure and report output reads "color" everywhere (needs a
   `cargo` build plus a rendered figure).
