### PR TITLE
fix(privacy): a model-facing provider bind may lower a capability, never raise it

### DIFF
--- a/crates/biorouter/src/agents/workspace_extension.rs
+++ b/crates/biorouter/src/agents/workspace_extension.rs
@@ -657,6 +657,13 @@ struct WorkspaceSetToolsParams {
     remove_skills: Vec<String>,
     /// Switch the conversation's provider. Required whenever `model` is given —
     /// a model name alone is ambiguous across providers.
+    ///
+    /// It must be a provider at the conversation's OWN privacy level: you may
+    /// move a public chat between public models and a private chat between
+    /// private ones, but you may not move a chat across that line in either
+    /// direction. Raising a conversation to a private model is the user's
+    /// decision (DR-16) — ask them to make it in that conversation's model
+    /// picker rather than calling this.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     provider: Option<String>,
     /// Switch the conversation's model. Validated against the provider's
@@ -3801,6 +3808,34 @@ impl WorkspaceClient {
                 return Err(format!(
                     "failed to switch provider: {}",
                     crate::privacy::refusal::PrivacyRefusal::PublicModelOnPrivateSession {
+                        session_id: args.session_id.clone(),
+                        provider: provider.get_name().to_string(),
+                    }
+                ));
+            }
+            // DR-16's half, which Gate A's predicate deliberately does not
+            // carry. `bind_allowed` refuses only the DOWNWARD bind, so on its
+            // own it lets a model put a PRIVATE provider in front of a public
+            // conversation — granting that conversation Private capability
+            // (chatrecall over private chats, private knowledge bases, an
+            // unfiltered Gate E roster) and, on its next turn, ratcheting its
+            // stored `privacy_tier` to Private for good.
+            //
+            // DR-16 rules that raise the user's alone, and its three enforcement
+            // sites are all HTTP routes, where `X-User-Action` can prove a
+            // person asked. Nothing proves that of a tool call, so this is a
+            // refusal and not a proof check — see `privacy::tool_bind_allowed`,
+            // which composes the two rules, and `PrivacyRefusal::ToolTierRaise`,
+            // which explains why a question here would be one the caller has no
+            // way to answer.
+            //
+            // Reached only when `bind_allowed` already passed, so the only way
+            // this can be false is the raise; the branch above owns the other
+            // sentence.
+            if !crate::privacy::tool_bind_allowed(provider.tier(), classification) {
+                return Err(format!(
+                    "failed to switch provider: {}",
+                    crate::privacy::refusal::PrivacyRefusal::ToolTierRaise {
                         session_id: args.session_id.clone(),
                         provider: provider.get_name().to_string(),
                     }
@@ -12337,6 +12372,181 @@ pub(crate) mod tests {
             text_of(&result).contains("provider"),
             "got: {}",
             text_of(&result)
+        );
+    }
+
+    /// A provider the registry really builds and whose INSTANCE reports
+    /// `Private`, for the tier tests below.
+    ///
+    /// The instance, not the metadata: `llamacpp`'s tier is a property of what
+    /// the instance resolved (`None` external base = the loopback sidecar), and
+    /// a metadata-only check would pass on a machine where
+    /// `LLAMACPP_EXTERNAL_HOST` points somewhere public — i.e. exactly where the
+    /// test would stop testing a raise. It is resolved through
+    /// `providers::create`, the same call `resolve_provider_switch` makes, so
+    /// what the test asserts about is what the handler will see.
+    async fn a_private_provider() -> (
+        &'static str,
+        std::sync::Arc<dyn crate::providers::base::Provider>,
+    ) {
+        const NAME: &str = "llamacpp";
+        let registry = crate::providers::providers().await;
+        let metadata = registry
+            .iter()
+            .map(|(metadata, _)| metadata)
+            .find(|m| m.name == NAME)
+            .unwrap_or_else(|| panic!("'{NAME}' is no longer a registered provider"))
+            .clone();
+        let provider = crate::providers::create(
+            NAME,
+            crate::model::ModelConfig::new_or_fail(&metadata.default_model),
+        )
+        .await
+        .expect("the bundled local provider must construct with no credentials");
+        assert_eq!(
+            provider.tier(),
+            crate::privacy::ProviderTier::Private,
+            "'{NAME}' resolved PUBLIC, so nothing below is testing a tier raise. \
+             Unset LLAMACPP_EXTERNAL_HOST (or point it at loopback) and re-run."
+        );
+        (NAME, provider)
+    }
+
+    /// **DR-16 at the model-facing surface.** `workspace_set_tools` may LOWER a
+    /// conversation's capability, never RAISE it.
+    ///
+    /// Before this gate, `privacy::bind_allowed` was the only privacy predicate
+    /// on this path, and it answers `true` for every bind onto a public
+    /// conversation — it exists to refuse the DOWNWARD bind. So a model could
+    /// hand any conversation it can write to a private provider: Private
+    /// capability (chatrecall over private chats, private knowledge bases, an
+    /// unfiltered Gate E roster) and, on that conversation's next turn, a
+    /// PERMANENT ratchet of its stored `privacy_tier`, with no person having
+    /// asked for any of it.
+    ///
+    /// Asserted through `set_tools_preflight_refusal` — the function the
+    /// always-confirm inspector asks BEFORE it raises a card, and the same one
+    /// `handle_set_tools` runs — so a refusal here is also the proof that no
+    /// confirmation card is raised for a change that cannot happen (F4).
+    #[tokio::test]
+    #[serial_test::serial(workspace_services)]
+    async fn set_tools_refuses_to_raise_a_public_conversation_onto_a_private_model() {
+        let f = tier_fixture().await;
+        let sm = f.client.context.session_manager.clone();
+        let (name, _provider) = a_private_provider().await;
+        let args = |session_id: &str| -> rmcp::model::JsonObject {
+            serde_json::from_value(serde_json::json!({
+                "session_id": session_id, "provider": name
+            }))
+            .unwrap()
+        };
+
+        // The headline: a PUBLIC conversation may not be raised, and the caller's
+        // own tier does not buy the raise — a private caller is refused too,
+        // because the rule is about the target, not about who asked.
+        for (label, caller) in [("public", public_caller()), ("private", private_caller())] {
+            let refusal = WorkspaceClient::set_tools_preflight_refusal(
+                sm.clone(),
+                "tier-caller",
+                caller.capability,
+                &args(&f.public_id),
+            )
+            .await
+            .unwrap_or_else(|| {
+                panic!("a {label} caller raised a public conversation to a private model")
+            });
+            assert!(
+                refusal.contains(&f.public_id) && refusal.contains(name),
+                "the refusal names neither what it refused nor where: {refusal}"
+            );
+            assert!(
+                refusal.contains(crate::privacy::refusal::USER_ACTION_REFUSAL_MARKER),
+                "a DR-16 refusal must say whose decision it is: {refusal}"
+            );
+        }
+
+        // The ratchet is permanent, so a refused raise that had already written
+        // would be unrecoverable. It did not write.
+        assert_eq!(
+            sm.get_session(&f.public_id, false)
+                .await
+                .unwrap()
+                .privacy_tier,
+            crate::privacy::SessionClassification::Public,
+            "a refused raise moved the ratchet anyway"
+        );
+
+        // The SIDEWAYS bind is untouched: a private conversation may still be
+        // moved between private models. Asserted as the absence of THIS gate's
+        // sentence rather than as success — the pre-flight has later phases that
+        // are not what this test is about.
+        let sideways = WorkspaceClient::set_tools_preflight_refusal(
+            sm.clone(),
+            "tier-caller",
+            private_caller().capability,
+            &args(&f.private_id),
+        )
+        .await
+        .unwrap_or_default();
+        assert!(
+            !sideways.contains(crate::privacy::refusal::USER_ACTION_REFUSAL_MARKER),
+            "private → private is sideways, not a raise: {sideways}"
+        );
+
+        // DR-15: with the feature off there is no tier to raise, so this gate
+        // must be silent — the same opt-out the storage gate honours, honoured
+        // here because the check lives inside the `Some(classification)` arm.
+        let opted_out = WorkspaceClient::set_tools_preflight_refusal(
+            sm.clone(),
+            "tier-caller",
+            opted_out_caller().capability,
+            &args(&f.public_id),
+        )
+        .await
+        .unwrap_or_default();
+        assert!(
+            !opted_out.contains(crate::privacy::refusal::USER_ACTION_REFUSAL_MARKER),
+            "DR-15's opt-out must reach this gate too: {opted_out}"
+        );
+    }
+
+    /// The same refusal, through the real tool — and **this is the test that
+    /// covers the un-inspected boundary**, which is where the hole actually was.
+    ///
+    /// It drives `WorkspaceClient::call_tool` with no `ToolInspectionManager`
+    /// anywhere, which is exactly the shape of a call made from inside an
+    /// `execute_code` script: `code_execution_extension.rs` hands a script's
+    /// inner calls straight to `ExtensionManager::dispatch_tool_call`, so
+    /// `WorkspaceMutationInspector`'s always-confirm — the only control that
+    /// stood on the provider switch — never runs. That file's
+    /// `uninspected_boundary_refusal` re-asks four boundaries and this is not one
+    /// of them; `workspace_inspector::uninspected_crossing_refusal`, the closest,
+    /// returns `None` on its first line for a PUBLIC caller and is about a
+    /// first crossing rather than a bind.
+    ///
+    /// With the pre-flight check removed, this test reported the handler's own
+    /// SUCCESS message — *"Applied to session …: model=llamacpp/gemma4-12b"* —
+    /// i.e. a public-tier caller had bound a private provider to another of the
+    /// user's conversations with no card and no proof. That is why the gate lives
+    /// in the handler's resolve phase and not in a fifth boundary refusal: the
+    /// choke point cannot be missed by a sixth door.
+    #[tokio::test]
+    #[serial_test::serial(workspace_services)]
+    async fn the_tool_itself_refuses_the_raise() {
+        let f = tier_fixture().await;
+        let (name, _provider) = a_private_provider().await;
+        let result = call_as(
+            &f.client,
+            "workspace_set_tools",
+            serde_json::json!({ "session_id": f.public_id, "provider": name }),
+            public_caller(),
+        )
+        .await;
+        let text = text_of(&result);
+        assert_eq!(result.is_error, Some(true), "{text}");
+        assert!(
+            text.contains(crate::privacy::refusal::USER_ACTION_REFUSAL_MARKER),
+            "{text}"
         );
     }
 

--- a/crates/biorouter/src/privacy/mod.rs
+++ b/crates/biorouter/src/privacy/mod.rs
@@ -375,6 +375,43 @@ pub fn bind_allowed(incoming: ProviderTier, target: SessionClassification) -> bo
     }
 }
 
+/// Gate A's predicate **plus DR-16's**, for the surface where a MODEL asks for
+/// the bind: it may LOWER a conversation's capability, never RAISE it.
+///
+/// [`bind_allowed`] is deliberately asymmetric — it refuses only the *downward*
+/// bind, because putting a MORE private model in front of a conversation can
+/// never leak that conversation's contents. That reasoning is sound for the
+/// user's own act and incomplete for a model's: the raise is not dangerous to
+/// the conversation's *contents*, it is dangerous because of what the raised
+/// conversation may then **reach**. A session bound to a private provider has
+/// Private capability, which unlocks `chatrecall` over private conversations,
+/// private knowledge bases and an unfiltered Gate E roster — and, on its next
+/// turn, ratchets `sessions.privacy_tier` to Private permanently, locking the
+/// user's conversation out of every public model for good.
+///
+/// DR-16 rules that the raise "is the user's decision, not yours"
+/// ([`refusal::raise_needs_user_action`]). The three sites that enforce it are
+/// all HTTP routes, where `X-User-Action` can carry proof that a person asked;
+/// a model-facing tool has no person on the other end to supply that proof, so
+/// it gets the refusal rather than the question. See
+/// [`refusal::PrivacyRefusal::ToolTierRaise`].
+///
+/// What is left is the *sideways* bind, in both directions of the pair: the
+/// provider's tier must equal the target's classification. That is the two
+/// rules composed, not a third one — `capability(S) >= classification(S)` is
+/// the invariant, [`bind_allowed`] forbids dropping below the floor, and this
+/// forbids a model raising the ceiling above it.
+///
+/// ⚠ The baseline is the target's **stored classification**, not its currently
+/// bound provider's tier (which is what the HTTP sites compare). Two reasons:
+/// the classification is the value that ratchets, and is therefore the one a
+/// concurrent turn cannot move in the unsafe direction; and the pre-flight
+/// already holds it, where reading the target's live provider would mean
+/// reaching for its agent, which the pre-flight must not create.
+pub fn tool_bind_allowed(incoming: ProviderTier, target: SessionClassification) -> bool {
+    bind_allowed(incoming, target) && incoming.is_private() == target.is_private()
+}
+
 /// Gate D / the §7 matrix's VIS rule: a caller sees a target only when the
 /// target's classification does not exceed the caller's capability.
 pub fn visible_to(caller: ProviderTier, target: SessionClassification) -> bool {
@@ -384,6 +421,60 @@ pub fn visible_to(caller: ProviderTier, target: SessionClassification) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// DR-16 at the model-facing surface, as the predicate: all four
+    /// combinations, and the asymmetry `bind_allowed` carries on its own spelled
+    /// out beside the one this adds.
+    ///
+    /// The `Private → Public` row is the whole finding: `bind_allowed` answers
+    /// `true` there, because putting a MORE private model in front of a public
+    /// chat leaks nothing — and `tool_bind_allowed` answers `false`, because a
+    /// MODEL asking for it is granting that chat reach it did not have and
+    /// ratcheting it permanently. Both answers are correct for their own
+    /// caller; the bug was having only the first one on the tool path.
+    #[test]
+    fn a_model_may_lower_a_capability_but_never_raise_one() {
+        use ProviderTier::{Private, Public};
+        use SessionClassification as C;
+
+        // Sideways, both directions of the pair: the only binds a model may ask
+        // for, and the ones that must keep working.
+        assert!(tool_bind_allowed(Public, C::Public));
+        assert!(tool_bind_allowed(Private, C::Private));
+
+        // Downward. Gate A already refuses it, and this must not disagree —
+        // two predicates over the same four cells that differ anywhere except
+        // the raise cell would be two policies.
+        assert!(!bind_allowed(Public, C::Private));
+        assert!(!tool_bind_allowed(Public, C::Private));
+
+        // The raise. `bind_allowed` permits it on purpose; the model-facing
+        // surface must not.
+        assert!(
+            bind_allowed(Private, C::Public),
+            "Gate A's asymmetry is deliberate — if this flipped, `tool_bind_allowed` is now \
+             redundant and the change that flipped it needs a much harder look than this test"
+        );
+        assert!(
+            !tool_bind_allowed(Private, C::Public),
+            "a model just raised a public conversation's capability to Private"
+        );
+
+        // Stated as a rule rather than as four cells, so a fifth cell (a third
+        // tier) cannot be added while satisfying the cells above.
+        for (incoming, target) in [
+            (Public, C::Public),
+            (Public, C::Private),
+            (Private, C::Public),
+            (Private, C::Private),
+        ] {
+            assert_eq!(
+                tool_bind_allowed(incoming, target),
+                incoming.is_private() == target.is_private(),
+                "a model-facing bind is exactly the sideways one ({incoming:?} → {target:?})"
+            );
+        }
+    }
 
     #[test]
     fn capability_is_a_least_and_classification_is_a_max() {

--- a/crates/biorouter/src/privacy/refusal.rs
+++ b/crates/biorouter/src/privacy/refusal.rs
@@ -143,6 +143,41 @@ pub enum PrivacyRefusal {
     )]
     TierRaiseNeedsUser { requested: String },
 
+    /// DR-16 at the **model-facing tool** surface: `workspace_set_tools` was
+    /// asked to bind a private provider to a conversation classified public,
+    /// which raises that conversation's capability to Private.
+    ///
+    /// ⚠ **Refused outright, with no user-proof branch, and the difference from
+    /// [`Self::TierRaiseNeedsUser`] is the point.** That sibling guards an HTTP
+    /// route, where the very same request *can* arrive carrying `X-User-Action`
+    /// — so it asks a question the caller has a way to answer. This one guards
+    /// a tool the model calls: there is no person on the other end of a tool
+    /// call, so `is_user_action` is false on every one of them and a proof
+    /// check here could only ever refuse. A check that can only ever refuse is
+    /// a refusal wearing a question's clothes, and SD-8's ruling — *a control
+    /// that can never work here says so, before it is touched* — says to write
+    /// the refusal.
+    ///
+    /// It names the conversation because, unlike the HTTP sibling, it is about
+    /// a chat **other** than the caller's: "this chat is unchanged" would name
+    /// the wrong one, and a model told the wrong conversation was refused
+    /// retries against the right one. §14.4 is satisfied — an id and a provider
+    /// name, no conversation content — and the caller already held both (it
+    /// passed them in), so nothing is disclosed that it did not itself supply.
+    #[error(
+        "Conversation '{session_id}' is a public chat, and switching it to '{provider}' — a \
+         private model — would raise what that conversation is allowed to reach. That {}. It is \
+         unchanged and still on its current model. Do not retry; the same call will be refused \
+         again, and it is refused the same way through every workspace tool. If that \
+         conversation genuinely needs a private model, stop and ask the user to switch it \
+         themselves, in that conversation's own model picker.",
+        USER_ACTION_REFUSAL_MARKER
+    )]
+    ToolTierRaise {
+        session_id: String,
+        provider: String,
+    },
+
     /// DR-16 / Task 18A: `POST /agent/add_extension` was asked to attach a
     /// private extension to a session running on a public model.
     ///
@@ -351,6 +386,12 @@ impl PrivacyRefusal {
         match self {
             Self::PublicModelOnPrivateSession { .. } => Some(SessionClassification::Private),
             Self::TierRaiseNeedsUser { .. }
+            // Same reasoning as its HTTP sibling directly above: DR-16 is about
+            // WHO may raise a tier, not about a stored transcript that collided
+            // with a model, so there is no (classification, tier) pair to put on
+            // a repair card — and a card offering to repair it would offer the
+            // model the very act the refusal exists to keep out of its hands.
+            | Self::ToolTierRaise { .. }
             | Self::PrivateExtensionOverHttp { .. }
             | Self::CapabilityConfigNeedsUser { .. }
             // A spawn refusal is about the CAPABILITY the parent has, not about
@@ -375,6 +416,7 @@ impl PrivacyRefusal {
             Self::PrivateChildOfPublicParent { requested }
             | Self::PublicChildOfPrivateParent { requested } => Some(*requested),
             Self::TierRaiseNeedsUser { .. }
+            | Self::ToolTierRaise { .. }
             | Self::PrivateExtensionOverHttp { .. }
             | Self::CapabilityConfigNeedsUser { .. }
             // The refused bind was necessarily private (a raise is the only
@@ -397,6 +439,12 @@ impl PrivacyRefusal {
     pub fn session_id(&self) -> Option<&str> {
         match self {
             Self::PublicModelOnPrivateSession { session_id, .. } => Some(session_id),
+            // The one DR-16 variant that HAS a session to name, because it is
+            // the one about a conversation other than the caller's. Reporting it
+            // seeds no card — `session_classification` above is `None`, and
+            // `routes/agent.rs`'s repair needs the pair — it just answers the
+            // question this accessor asks truthfully.
+            Self::ToolTierRaise { session_id, .. } => Some(session_id),
             Self::TierRaiseNeedsUser { .. }
             | Self::PrivateExtensionOverHttp { .. }
             | Self::CapabilityConfigNeedsUser { .. }
@@ -1391,6 +1439,63 @@ mod tests {
                 "a refusal the model will retry is a loop: {msg}"
             );
         }
+    }
+
+    /// The tool-surface raise refusal: it names what it refused, marks itself as
+    /// a DR-16 refusal, and deliberately does NOT end in
+    /// [`ASK_THE_USER_TO_SWITCH`].
+    ///
+    /// That constant reads *"ask the user to switch **this chat** to a private
+    /// model … with the model chip in the composer"*, and this is the one DR-16
+    /// refusal about a conversation **other** than the caller's. Ending on it
+    /// would send the user to the wrong composer — and, worse, send the model to
+    /// the one chat whose model it does not need changed, which is a retry loop
+    /// dressed as a way out. The equivalent sentence is written for the target
+    /// instead.
+    #[test]
+    fn the_tool_raise_refusal_names_the_target_and_sends_the_user_to_it() {
+        let refusal = PrivacyRefusal::ToolTierRaise {
+            session_id: "s-target".into(),
+            provider: "llamacpp".into(),
+        };
+        let msg = refusal.to_string();
+
+        // Names both halves of what it refused — the rule this repo states as
+        // "a refusal names what it refused".
+        assert!(msg.contains("s-target"), "{msg}");
+        assert!(msg.contains("llamacpp"), "{msg}");
+
+        // Same disclosure bound as its siblings: it may name what the caller
+        // itself passed in, and nothing else.
+        for other in ["versa_azure", "versa_bedrock", "ollama"] {
+            assert!(
+                !msg.contains(other),
+                "refusal leaked the classification of {other}"
+            );
+        }
+
+        assert!(msg.contains(USER_ACTION_REFUSAL_MARKER), "{msg}");
+        assert!(
+            msg.contains("Do not retry"),
+            "a refusal the model will retry is a loop: {msg}"
+        );
+        assert!(
+            !msg.contains(ASK_THE_USER_TO_SWITCH),
+            "that sentence points at THIS chat's composer, and the chat that needs switching is \
+             a different one: {msg}"
+        );
+        // The way out it does carry is the target's own picker.
+        assert!(
+            msg.contains("ask the user to switch it themselves"),
+            "a refusal with no way out is a dead end: {msg}"
+        );
+
+        // A raise is about who may act, not about a transcript that collided
+        // with a model, so there is no pair for `routes/agent.rs` to build a
+        // repair card from — but the session it IS about is still reportable.
+        assert_eq!(refusal.session_classification(), None);
+        assert_eq!(refusal.provider_tier(), None);
+        assert_eq!(refusal.session_id(), Some("s-target"));
     }
 
     /// R4's refusal, which Task 23's spawn gate is the only caller of. §14.4:

--- a/crates/biorouter/tests/privacy_guard_wiring.rs
+++ b/crates/biorouter/tests/privacy_guard_wiring.rs
@@ -607,9 +607,15 @@ const REGISTRY: &[Guard] = &[
             },
             Site {
                 file: "crates/biorouter/src/privacy/mod.rs",
-                counts: c(1, 0, 0),
+                counts: c(2, 0, 0),
                 kind: SiteKind::Guard,
-                what: "`SessionClassification::bind_allowed`'s inherent-method form",
+                what: "`SessionClassification::bind_allowed`'s inherent-method form, plus \
+                       `tool_bind_allowed` — the model-facing predicate — which COMPOSES this \
+                       one rather than re-spelling its cells. The second call is deliberate and \
+                       is the point of that predicate's shape: `tool_bind_allowed` is Gate A's \
+                       rule AND DR-16's, and if it restated Gate A's half instead of calling it, \
+                       the two would be free to drift and this census would see only one of \
+                       them. Its own row is below",
             },
             Site {
                 file: "crates/biorouter/src/workflow/privacy.rs",
@@ -627,9 +633,36 @@ const REGISTRY: &[Guard] = &[
                        is a pre-flight, not the gate — `Agent::update_provider`'s conditional \
                        `WHERE` still decides when the change is applied — and it asks this \
                        predicate by name rather than re-spelling it, only when the write gate \
-                       resolved a classification (i.e. under enforcement)",
+                       resolved a classification (i.e. under enforcement). \
+                       ⚠ It is ALSO the only privacy check on this tool's provider bind at \
+                       the dispatch boundaries no inspector reaches — an `execute_code` \
+                       script's inner call and `POST /agent/call_tool` both go straight to \
+                       `ExtensionManager::dispatch_tool_call`, so the always-confirm card \
+                       named above does not run for either. Do not weaken this on the \
+                       reasoning that a card backs it up: for two of its callers, nothing does",
             },
         ],
+    },
+    Guard {
+        ident: "tool_bind_allowed",
+        defined_in: "crates/biorouter/src/privacy/mod.rs",
+        decides: "Gate A's rule PLUS DR-16's, for the surface a MODEL asks the bind on: it may \
+                  LOWER a conversation's capability, never RAISE it",
+        status: Status::Wired,
+        sites: &[Site {
+            file: "crates/biorouter/src/agents/workspace_extension.rs",
+            counts: c(1, 0, 0),
+            kind: SiteKind::Guard,
+            what: "`workspace_set_tools`' pre-flight, beside its `bind_allowed` sibling and \
+                   after it, so the more specific refusal owns the downward case. This is the \
+                   predicate's ONLY caller by design and not by accident: `bind_allowed` \
+                   permits every bind onto a public conversation (Gate A refuses only the \
+                   downward one), which let a public-tier model hand any conversation it \
+                   could write to a private provider — Private capability, and a permanent \
+                   ratchet of that conversation's stored `privacy_tier` on its next turn. If \
+                   this row ever reads ZERO calls, that hole is open again and no behavioural \
+                   test elsewhere will say so, because the predicate itself is still correct",
+        }],
     },
     Guard {
         ident: "privacy_refusal",


### PR DESCRIPTION
> ## ⚠ SECURITY-SENSITIVE (privacy gate). Requires human review.
> `HOWTOAI.md` and `.github/copilot-instructions.md` both say auth/permission
> code needs human review regardless of AI assistance. **Do not merge on CI
> alone.**

## Corrected severity — this supersedes an earlier HIGH in circulation

An adversarial review reported this as *"`workspace_set_tools { provider }` lets a
model bind an arbitrary private provider with **no proof and no approval
card**"*. **The "no approval card" half is false**, and the corrected finding is
narrower and more specific:

| | |
|---|---|
| **Original claim** | HIGH — unauthenticated tier raise on every daemon |
| **Corrected** | **MEDIUM-HIGH** — a real, default-on, model-reachable privilege escalation, but only through the dispatch boundaries that no `ToolInspector` sees. The model's *ordinary* tool call is gated by a human-only card in every permission mode. |

### What is NOT wrong (measured, so it is not re-litigated)

A provider switch through `workspace_set_tools` raises a confirmation card on the
model's ordinary tool call, and that card is solid:

- `set_tools_confirmation_reason` returns `Some(…)` for **any** call carrying a
  `provider` argument — `workspace_inspector.rs:248-253`.
- `WorkspaceMutationInspector` has **no mode gate** (module doc `:1-14`;
  `// NOTE: deliberately no mode gate` in `inspect_with_pinned_capability`), and
  `apply_inspection_results_to_permissions` folds to the **strongest** verdict
  (`tool_inspection.rs:333-347`), so `RequireApproval` beats Auto mode's blanket
  `Allow` **and** a per-tool always-allow grant.
- The ask is `AskClass::HumanOnly` (`approval_relay.rs:99`, `:861-866`): not
  answerable by an Auto-mode ancestor (`:822-856`), and never memoized (`:973`).
- Registered unconditionally on every agent (`agent.rs:4781`, pinned at `:13676`),
  and the coding-agent MCP bridge shares that same stack (`agent.rs:7055`).
- A parked decision with **no human surface fails closed**:
  `UserActionOutcome::Cancelled`, leaving no card for a later turn to resurrect
  (`crates/biorouter-server/tests/call_tool_no_human_surface.rs`).

So there is no bypass on the path the review described, and the card cannot be
auto-answered or timed out into an allow.

### What IS wrong: `execute_code` reaches the same handler with no inspector

`code_execution_extension.rs:2290` hands a script's inner tool calls **straight to
`ExtensionManager::dispatch_tool_call`** — its own doc says so at `:2323-2330`. It
compensates with `uninspected_boundary_refusal` (`:2337-2386`), which re-asks
exactly **four** boundaries: global memory, the session store, `kb_delete_base`,
and the workspace **first-crossing** disclosure. `WorkspaceMutationInspector`'s
always-confirm — the only control on the provider switch — **is not among them**,
and the closest one cannot cover it:

```rust
// workspace_inspector::uninspected_crossing_refusal, first two lines
if !cap.enforced() || !cap.tier().is_private() { return None; }
```

A **public** caller is never refused by it, and its own doc says *"a same-tier
write is untouched"*. A public chat raising a public conversation misses on both
counts.

Both halves are **`default_enabled: true`**: `code_execution`
(`agents/extension.rs:135-137`, pinned at `:948`) and `workspace`
(`extension.rs:93`). `create_server_module` exports every tool of every loaded
server as a script import; only `platform` is excluded (`:144-149`).

`POST /agent/call_tool` is the second such boundary
(`UninspectedBoundary::AgentCallToolRoute`) — no card there either, though it
requires the proof-of-user digest, so a person is behind it.

### Why the raise matters at all

`privacy::bind_allowed` is Gate A's predicate and deliberately asymmetric:

```rust
match target {
    SessionClassification::Public => true,                 // <-- every bind onto a public chat
    SessionClassification::Private => incoming.is_private(),
}
```

It refuses the **downward** bind, because a *more* private endpoint cannot leak
the target's contents. Correct — and incomplete for a model, because the raise is
dangerous for what the raised conversation may then **reach**: Private capability
unlocks `chatrecall` over private conversations, private knowledge bases and an
unfiltered Gate E roster, and the target's next turn **ratchets
`sessions.privacy_tier` to Private permanently**, locking one of the user's own
conversations out of every public model for good.

## Fail-before evidence

With the new check removed, `the_tool_itself_refuses_the_raise` reports the
handler's own **success** message:

```
Applied to session 17ad32e2_2: model=llamacpp/gemma4-12b.
The model change applies to this conversation's NEXT turn.
```

A public-tier caller bound `llamacpp` (asserted `ProviderTier::Private` by the
fixture, on the *instance*, so `LLAMACPP_EXTERNAL_HOST` cannot make the test
vacuous) to a public-classified conversation. That test drives
`WorkspaceClient::call_tool` with **no `ToolInspectionManager` anywhere** — it *is*
the un-inspected boundary, which is why it is the one that proves the
`execute_code` path is closed.

## The fix, and why not the alternatives

`privacy::tool_bind_allowed(incoming, target) = bind_allowed(incoming, target) &&
incoming.is_private() == target.is_private()` — a model-facing bind must be
**sideways**. That is the two existing rules composed, not a third:
`capability(S) >= classification(S)` is the invariant, `bind_allowed` forbids
dropping below the floor, and this forbids a model raising the ceiling above it.
Asked in `preflight_set_tools`, the handler's own resolve phase.

**Rejected:**

- **Add `raise_needs_user_action` to the tool path.** `is_user_action` is false
  for every tool call by construction — there is no person on the other end of
  one — so the check could only ever refuse. A check that can only refuse is a
  refusal wearing a question's clothes; SD-8 (*a control that can never work here
  says so, before it is touched*) says write the refusal. It would also have moved
  a census count for a site that adds no decision. **Precedent:**
  `bind_app_provider` (`routes/apps.rs:1272-1291`) already refuses an app
  session's raise **outright** with `AppSessionTierFixed` and no user-proof
  branch, for the same reason (DR-21). This makes the workspace tool behave like
  the app socket.
- **Change `bind_allowed`.** Its asymmetry is load-bearing and shared: it is Gate
  A's predicate, it backs `visible_to` (Gate D, where `Private → Public` must stay
  `true`), and `the_sql_predicate_and_bind_allowed_agree_on_every_combination`
  pins it to the live `WHERE` clause of `bind_provider_if_allowed`. Tightening it
  would also refuse the user's own legitimate raise through the model picker —
  exactly what DR-16 permits.
- **Add a fifth `uninspected_boundary_refusal`.** Closes `execute_code` and leaves
  the defect at the next door: that file's own doc notes `dispatch_tool_call` "is
  reached from four places and only one of them runs the inspector stack". A gate
  at the choke point cannot be missed by a sixth door.
- **Only fix the card's wording.** The card says *"switches this conversation to
  provider 'X', which sends its whole history to that provider's endpoint"* — it
  names the provider and the history egress and says **nothing** about the privacy
  tier or the permanent ratchet, so a person clicking Allow has not been told what
  they are authorising. That is real, but it would leave `execute_code` wide open.
  Refusing the raise closes it **by construction**: no card is ever raised for a
  raise any more, so the card now only ever describes a *sideways* switch, where
  there is no tier change to name. One change closes both.

**The baseline** is the target's stored **classification**, not its currently bound
provider's tier (which is what the HTTP sites compare): the classification is the
value that ratchets, so a concurrent turn cannot move it in the unsafe direction,
and the pre-flight already holds it — reading the target's live provider would
mean reaching for its agent, which the pre-flight must not create.

**It breaks no human path.** `routes/workspace.rs` exposes no `set_tools`
endpoint, and the CLI's parity table maps `WorkspaceCapability::SetTools` to
`Surface::Tool("workspace_set_tools")` (`workspace_parity.rs:189`). There is no
person-facing door on this bind at all; the user's own route is the model picker →
`/agent/update_provider`, where `raise_needs_user_action` already lives and is
untouched.

## Sibling surfaces swept

| Surface | Verdict |
|---|---|
| `workspace_set_tools { provider, model }` | **the defect — fixed here** |
| `workspace_open { new: … }` | Clean — no `provider`/`model` field (`:750-793`); `start_session` takes none. The new session gets the operator's configured default, as a user's own "New chat" does. |
| other seven `workspace_*` tools | Clean — no provider/model arguments (`DISPATCHED_TOOL_NAMES`, `:1611`) |
| `subagent { settings: { provider } }` | Clean — `apply_settings_overrides` refuses `child_tier.is_private() && !parent_cap.is_private()` with `spawn_upgrade` (R4), `subagent_tool.rs:2092` |
| Agent Drafter profiles / routes / `ModelSelect` | Clean — `raw_bind` is private, `bind_app_provider` is the only door and is raise-gated (DR-21) |
| `extensionmanager__manage_extensions` | Clean — Gate F1 refuses a private extension on a public session outright |
| `platform__manage_schedule` | Clean — no model-supplied provider; `resolve_scheduled_provider` takes the creating chat's or the global default |
| `Workflow` tool | Clean — no provider/model parameters |
| **`platform__ingest_source { model: {provider, model} }`** | **NEEDS ITS OWN DECISION — not fixed here** ⬇ |

### Filed, not fixed: Gate H has the same asymmetry

`privacy::assert_alt_provider_allowed` (`alt_provider.rs:58-75`) also gates on
`bind_allowed` alone — its own test is named
`only_a_private_session_on_a_public_provider_is_refused`. It is reachable from a
model-facing tool argument (`knowledge_tool.rs:440` ←
`knowledge_source_tool.rs:155-170` ← the schema at `platform_tools.rs:339-346`),
so a **public** chat can run a knowledge ingest on a **private** provider.

Deliberately left alone, because it is not the same defect: it binds nothing to a
session, so no session tier ratchets; the KB *read* target is resolved against the
**chat's** capability, not the chosen provider's; the direction is data-safe; and
its two other call sites are a person's own act (the CLI, and a user-authored
hook). What it *does* do is pass `caller_capability: chosen.capability` into
`ingest_sources`, and a KB write is a tier choke point — so a public chat naming a
private model can ratchet a knowledge base to Private, permanently refusing it to
every public caller. Either pass the *chat's* capability as the write tier, or
refuse the raise as this PR does. Both are behaviour changes to the Knowledge
ratchet and belong to whoever owns `knowledge/tier*.rs`.

## Verification

| Command | Result |
|---|---|
| `cargo test -p biorouter --lib -- privacy:: agents::workspace_extension` | 398 passed, 0 failed |
| `cargo test -p biorouter --test privacy_capability` | 4 passed |
| `cargo test -p biorouter --test privacy_guard_wiring` | 3 passed |
| `cargo test -p biorouter --test privacy_toggle` | 4 passed |
| `cargo test -p biorouter --lib -- subagent` | 197 passed |
| `cargo fmt --all && cargo fmt --check` | clean |
| `./scripts/clippy-lint.sh` | one failure, **pre-existing and not from this branch**: `too_many_lines (101/100)` on `send_prompt_turn`, `workspace_extension.rs:3413`. This branch's three hunks in that file are at `:657`, `:3813`, `:12375` — none inside it. |

### Census movement — one delta, measured not guessed

`bind_allowed` in `privacy/mod.rs`, **calls 1 → 2**: the `bind_allowed(…)` call
inside `tool_bind_allowed`'s body. The **existing row was extended** (the census
aggregates per `(needle, file)` and compares against one tuple per row, so a
second row for the same file fails even when both counts are right), with the
justification that composing rather than restating is what stops the two
predicates drifting apart unseen.

Also added: a curated `Guard` row for `tool_bind_allowed` — `privacy/mod.rs` is
not a `COMPLETE_MODULES` entry, so nothing discovers it, and the module docs
instruct adding one by hand. Its value is that a future **zero**-call reading is
the signal this escalation is open again.

Checked by measurement rather than assumption: `occurrences()` enforces
identifier word boundaries, so `tool_bind_allowed(` does **not** score as a
`bind_allowed(` hit; comments are blanked, so the doc references score nothing;
`#[cfg(test)]` regions are excluded, so the new unit test's two calls score
nothing. No `privacy::floor(` was added, so that separate caller-count census is
untouched.

## Files touched (for merge sequencing)

- `crates/biorouter/src/privacy/mod.rs`
- `crates/biorouter/src/privacy/refusal.rs`
- `crates/biorouter/src/agents/workspace_extension.rs` — hunks at `:657`, `:3813`,
  `:12375`, deliberately clear of `send_prompt_turn`, which another agent is
  extracting
- `crates/biorouter/tests/privacy_guard_wiring.rs`

Two commits: the fix, then the census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
