### PR TITLE
test(agent_drafter): an unobservable descendant is not a dead one, and the reaper diagnostic must be reachable

### DIFF
--- a/crates/biorouter-mcp/src/agent_drafter/bundle.rs
+++ b/crates/biorouter-mcp/src/agent_drafter/bundle.rs
@@ -1772,12 +1772,32 @@ mod tests {
         /// Reaped: the pid no longer resolves.
         Gone,
         /// Dead, but not yet reaped by whoever inherited it. Only Linux can
-        /// name this state (see `zombie_aware_state`), so elsewhere the variant
-        /// is matched but never constructed.
-        #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+        /// name this state in a running poll (see `zombie_aware_state`);
+        /// `state_from_proc_read`'s own test constructs it on every unix.
         Zombie,
         /// Still a live process.
         Alive,
+        /// The pid resolves, but its state could not be *read*: the procfs
+        /// entry was there a moment ago (`kill(pid, 0)` succeeded) and the read
+        /// failed for a reason other than the entry being absent -- descriptor
+        /// exhaustion, `ENOMEM`, `EACCES`, or no `/proc` mounted at all.
+        ///
+        /// A failure to observe is not a death. This state differs from `Alive`
+        /// only in what it prints: neither satisfies `proves_death`, so both
+        /// keep the poll running and then fail on its deadline.
+        Unobservable,
+    }
+
+    #[cfg(unix)]
+    impl DescendantState {
+        /// The only two states that are evidence the reaper worked.
+        ///
+        /// The poll below and the assertion at the end of the reaper test both
+        /// ask this one question, so what stops the poll and what satisfies the
+        /// assertion cannot drift apart.
+        fn proves_death(self) -> bool {
+            matches!(self, DescendantState::Gone | DescendantState::Zombie)
+        }
     }
 
     /// Pull the state letter out of one `/proc/<pid>/stat` line.
@@ -1799,20 +1819,49 @@ mod tests {
             .next()
     }
 
-    /// Linux exposes the state letter directly, so a zombie is nameable even
-    /// where nothing ever reaps it -- a container whose pid 1 is not a
-    /// subreaper never turns the orphan below into `Gone`.
-    #[cfg(all(unix, target_os = "linux"))]
-    fn zombie_aware_state(pid: i32) -> DescendantState {
-        match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+    /// Map one attempt to read `/proc/<pid>/stat` onto a descendant state.
+    ///
+    /// Reached only once `kill(pid, 0)` has just succeeded, so the pid resolved
+    /// a moment ago. `ENOENT` is therefore the single error that means what it
+    /// looks like: procfs has no entry any more, i.e. the pid was reaped between
+    /// that `kill()` and this read. Every other error is a failure to OBSERVE
+    /// the process, and for an assertion whose whole job is to prove deadness
+    /// that must not read as dead -- see `Unobservable`.
+    ///
+    /// Deliberately compiled on every unix, for the same reason
+    /// `proc_stat_state` is -- the one decision here that can be wrong in a way
+    /// no platform's absence should hide.
+    #[cfg(unix)]
+    fn state_from_proc_read(read: io::Result<String>) -> DescendantState {
+        match read {
             // Z is "zombie", X is "dead": terminated, awaiting a reaper.
             Ok(stat) => match proc_stat_state(&stat) {
                 Some('Z' | 'X') => DescendantState::Zombie,
                 _ => DescendantState::Alive,
             },
             // Reaped between the kill() and this read.
-            Err(_) => DescendantState::Gone,
+            Err(error) if error.raw_os_error() == Some(libc::ENOENT) => DescendantState::Gone,
+            // EMFILE/ENFILE, ENOMEM, EACCES, ... : we failed to look.
+            Err(_) => DescendantState::Unobservable,
         }
+    }
+
+    /// Linux exposes the state letter directly, so a zombie is nameable even
+    /// where nothing ever reaps it -- a container whose pid 1 is not a
+    /// subreaper never turns the orphan below into `Gone`.
+    #[cfg(all(unix, target_os = "linux"))]
+    fn zombie_aware_state(pid: i32) -> DescendantState {
+        let read = std::fs::read_to_string(format!("/proc/{pid}/stat"));
+        // An absent entry means "reaped" only where procfs is mounted to have
+        // an entry in. Without this, a sandbox with no `/proc` answers ENOENT
+        // for every pid -- indistinguishable, to the arm above, from a reaper
+        // that worked -- and reports every live descendant as dead. Checked
+        // only on the error path, and against our OWN entry, which exists on
+        // any host where the read above can be believed.
+        if read.is_err() && std::fs::metadata("/proc/self/stat").is_err() {
+            return DescendantState::Unobservable;
+        }
+        state_from_proc_read(read)
     }
 
     /// Everywhere else, a pid that still resolves is reported as alive.
@@ -1847,7 +1896,7 @@ mod tests {
         let started = Instant::now();
         loop {
             let state = descendant_state(pid);
-            if state != DescendantState::Alive || started.elapsed() >= deadline {
+            if state.proves_death() || started.elapsed() >= deadline {
                 return state;
             }
             std::thread::sleep(Duration::from_millis(5));
@@ -1869,6 +1918,63 @@ mod tests {
         // Nothing parseable must not be reported as a state.
         assert_eq!(proc_stat_state("garbage"), None);
         assert_eq!(proc_stat_state("42 (sleep)"), None);
+    }
+
+    /// A `/proc` read that failed for any reason but `ENOENT` is a failure to
+    /// OBSERVE the descendant, and must never be reported as its death.
+    ///
+    /// The direction is the whole point: this poll exists to PROVE a descendant
+    /// died, so "I could not look" has to keep polling and then fail, never
+    /// satisfy the assertion. Mapping every `Err` onto `Gone` -- which is what
+    /// this did before the arm was split -- passed the reaper test with a live
+    /// `sleep 30` grandchild on any host that had run out of file descriptors,
+    /// was short of memory, or had no `/proc` mounted at all.
+    #[cfg(unix)]
+    #[test]
+    fn a_proc_read_that_failed_for_anything_but_enoent_is_not_evidence_of_death() {
+        // ENOENT is the one error that means what the old arm assumed of all of
+        // them: procfs no longer has an entry, so the pid really was reaped.
+        let gone = state_from_proc_read(Err(io::Error::from_raw_os_error(libc::ENOENT)));
+        assert_eq!(gone, DescendantState::Gone);
+        assert!(gone.proves_death());
+
+        // Every other errno: the pid resolved a moment ago and we failed to
+        // read it. Descriptor exhaustion, ENOMEM, EACCES, EIO.
+        for errno in [
+            libc::EMFILE,
+            libc::ENFILE,
+            libc::ENOMEM,
+            libc::EACCES,
+            libc::EIO,
+        ] {
+            let state = state_from_proc_read(Err(io::Error::from_raw_os_error(errno)));
+            assert_eq!(
+                state,
+                DescendantState::Unobservable,
+                "errno {errno} is a failed observation, not a reported state"
+            );
+            assert!(
+                !state.proves_death(),
+                "errno {errno} must not satisfy an assertion that the descendant died"
+            );
+        }
+
+        // An error carrying no errno at all is just as unobservable.
+        let synthetic = state_from_proc_read(Err(io::Error::other("procfs unavailable")));
+        assert_eq!(synthetic, DescendantState::Unobservable);
+        assert!(!synthetic.proves_death());
+
+        // A readable entry still decides on its state letter, and an entry that
+        // does not parse is not a death either.
+        assert_eq!(
+            state_from_proc_read(Ok("42 (sleep) Z 1 42".to_owned())),
+            DescendantState::Zombie
+        );
+        assert_eq!(
+            state_from_proc_read(Ok("42 (sleep) S 1 42".to_owned())),
+            DescendantState::Alive
+        );
+        assert!(!state_from_proc_read(Ok("garbage".to_owned())).proves_death());
     }
 
     #[cfg(unix)]
@@ -1935,7 +2041,7 @@ mod tests {
         const DEADLINE: Duration = Duration::from_secs(2);
         let state = await_descendant_death(pid, DEADLINE);
         assert!(
-            matches!(state, DescendantState::Gone | DescendantState::Zombie),
+            state.proves_death(),
             "the compiler's descendant (pid {pid}) was still {state:?} {DEADLINE:?} after \
              terminate_esbuild returned; the SIGKILL to the process group must leave it \
              dead (Zombie, awaiting its new parent's wait) or reaped (Gone)"

--- a/crates/biorouter-mcp/src/agent_drafter/bundle.rs
+++ b/crates/biorouter-mcp/src/agent_drafter/bundle.rs
@@ -1997,55 +1997,128 @@ mod tests {
         let entry = dir.path().join("main.ts");
         let out = dir.path().join("app.js");
         std::fs::write(&entry, "const ok = true;").unwrap();
+
+        /// The compiler's own limit, so the reaper runs about a second in.
+        const TIMEOUT: Duration = Duration::from_secs(1);
+        /// How long the whole attempt gets -- the pid being recorded, and the
+        /// call returning after its limit expired. This BOUNDS the call rather
+        /// than waiting on it, which is what lets the descendant be inspected
+        /// while it is still held; see the comment on the spawn below.
+        const BUDGET: Duration = Duration::from_secs(3);
+        /// How long after that the descendant gets to stop being a live
+        /// process.
+        const DEADLINE: Duration = Duration::from_secs(2);
         // Under load the shim can be killed before it reaches its
         // `echo "$!" > "$pidfile"`, leaving that file absent or truncated. Such
         // an attempt established no descendant at all, so it proves nothing in
         // either direction -- it is a harness miss, not a reaper failure. Retry
         // it instead of reading a pid that was never written.
         const ATTEMPTS: usize = 5;
-        let mut descendant = None;
+        let mut attempt = None;
         for _ in 0..ATTEMPTS {
             let _ = std::fs::remove_file(&descendant_pid);
-            let started = Instant::now();
-            let error = run_esbuild_with_timeout(
-                shim.to_str().unwrap(),
-                &[descendant_pid.to_string_lossy().into_owned()],
-                &entry,
-                &out,
-                Duration::from_secs(1),
-            )
-            .expect_err("the hung compiler must time out");
+            // The call runs on its own thread and the descendant is watched
+            // from this one, because a descendant that SURVIVES holds the
+            // call open: it inherited the shim's piped stdout/stderr, so
+            // `join_output`'s `read_to_end` cannot return until it exits --
+            // 30 s for `sleep 30`. Waiting for the call to return before
+            // looking at the pid would therefore look at a `sleep` that had
+            // long since exited on its own and report the reaper as healthy,
+            // and bounding only the call's WALL TIME (as this test did) makes
+            // that bound, not the descendant, the assertion a regression
+            // trips -- 30 s of waiting for `elapsed() < 3s`, which names
+            // neither the descendant nor the reaper.
+            let (finished, call_returned) = std::sync::mpsc::channel();
+            let call = {
+                let shim = shim.clone();
+                let args = vec![descendant_pid.to_string_lossy().into_owned()];
+                let entry = entry.clone();
+                let out = out.clone();
+                std::thread::spawn(move || {
+                    let result = run_esbuild_with_timeout(
+                        shim.to_str().unwrap(),
+                        &args,
+                        &entry,
+                        &out,
+                        TIMEOUT,
+                    );
+                    // Only the error is inspected; `used` keeps the payload
+                    // Debug-printable for an unexpected success.
+                    let _ = finished.send(result.map(|report| report.used));
+                })
+            };
 
-            assert_eq!(error.kind(), io::ErrorKind::TimedOut);
-            assert!(started.elapsed() < Duration::from_secs(3));
-
-            descendant = std::fs::read_to_string(&descendant_pid)
-                .ok()
-                .and_then(|recorded| recorded.trim().parse::<i32>().ok());
-            if descendant.is_some() {
-                break;
+            let spawned = Instant::now();
+            // The shim records the pid milliseconds in, so this normally falls
+            // through at once.
+            let recorded = loop {
+                let recorded = std::fs::read_to_string(&descendant_pid)
+                    .ok()
+                    .and_then(|recorded| recorded.trim().parse::<i32>().ok());
+                if recorded.is_some() || spawned.elapsed() >= BUDGET {
+                    break recorded;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            };
+            let returned = call_returned.recv_timeout(BUDGET.saturating_sub(spawned.elapsed()));
+            match recorded {
+                Some(pid) => {
+                    attempt = Some((pid, returned, call));
+                    break;
+                }
+                // Nothing to observe. Leave a call that is still blocked to
+                // finish on its own rather than joining it for its descendant's
+                // full lifetime.
+                None => {
+                    if returned.is_ok() {
+                        let _ = call.join();
+                    }
+                }
             }
         }
-        let pid = descendant.unwrap_or_else(|| {
+        let (pid, returned, call) = attempt.unwrap_or_else(|| {
             panic!(
                 "the shim never recorded a descendant pid in {ATTEMPTS} attempts, so this run \
                  never observed a process group at all -- a harness failure, not a reaper one"
             )
         });
+
         // The descendant is a GRANDCHILD: the shim backgrounds `sleep` and
         // waits on it, so `terminate_esbuild`'s `child.wait()` reaps the shim
         // and nothing else. The grandchild is re-parented to init/launchd and
         // stays a zombie until that reaps it -- and `kill(pid, 0)` succeeds for
         // a zombie, so checking once, here, races the reaper. Poll for the pid
         // to actually stop being a live process instead.
-        const DEADLINE: Duration = Duration::from_secs(2);
+        //
+        // Asserted FIRST, before anything about the call: this is the property
+        // the test is named for, so it is the diagnostic a reaper regression
+        // must print.
         let state = await_descendant_death(pid, DEADLINE);
+        let call_state = if returned.is_ok() {
+            "had returned"
+        } else {
+            "had not returned"
+        };
         assert!(
             state.proves_death(),
             "the compiler's descendant (pid {pid}) was still {state:?} {DEADLINE:?} after \
-             terminate_esbuild returned; the SIGKILL to the process group must leave it \
-             dead (Zombie, awaiting its new parent's wait) or reaped (Gone)"
+             run_esbuild_with_timeout's {TIMEOUT:?} limit expired (the call itself {call_state} \
+             within {BUDGET:?}); the SIGKILL to the process group must leave it dead (Zombie, \
+             awaiting its new parent's wait) or reaped (Gone)"
         );
+        // Only then the call itself. Its return is what the old wall-clock
+        // bound measured, and a surviving descendant delays it, so it can only
+        // be judged once the descendant has been.
+        let result = returned.unwrap_or_else(|_| {
+            panic!(
+                "run_esbuild_with_timeout produced no result within {BUDGET:?} of being called \
+                 with a {TIMEOUT:?} limit, though its descendant (pid {pid}) is {state:?}: the \
+                 timeout path itself did not return"
+            )
+        });
+        let error = result.expect_err("the hung compiler must time out");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        let _ = call.join();
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #263 (merged as `7230a0a2`), fixing two defects an adversarial review found in the
**new** test machinery that PR added. Test-only: `git diff origin/main` touches nothing before the
`mod tests` line, so `terminate_esbuild` and the rest of production remain byte-identical.

## Defect 1 — any `/proc` read error but ENOENT reported a LIVE descendant as dead

`zombie_aware_state` is reached only after `libc::kill(pid, 0)` returned 0 — the kernel has just
said the pid resolves — and it then mapped **every** `Err` from reading `/proc/<pid>/stat` onto
`DescendantState::Gone`, "the reaper worked". The comment named the case it meant (reaped between
the `kill()` and the read, i.e. ENOENT), but the arm also swallowed `EMFILE`/`ENFILE` (descriptor
exhaustion), `ENOMEM`, `EACCES`, and a `/proc` that is not mounted at all. On any of those a live
`sleep 30` grandchild was classified `Gone`, `await_descendant_death` returned on its first poll, and
the assertion whose entire job is to prove deadness passed with the descendant still running. A new
path: the old test never consulted `/proc`, so on `main` before #263 a live descendant failed the
assertion on a descriptor-exhausted host as on any other.

The direction is backwards for such an assertion — "I could not observe it" must mean keep polling
and then fail, never pass. So:

- the mapping is split out of the filesystem access into a pure
  `state_from_proc_read(io::Result<String>) -> DescendantState`, compiled on **every** unix like the
  `proc_stat_state` parser it wraps, with its own test;
- `ENOENT` stays `Gone` — the one error that means what the arm assumed of all of them, and sound
  precisely because the pid resolved a moment ago;
- every other error becomes a new `DescendantState::Unobservable`, which prints differently from
  `Alive` (so a failure says why it could not conclude) and, like `Alive`, does not satisfy
  `proves_death()`;
- ENOENT is itself ambiguous where procfs is absent, since an unmounted `/proc` answers ENOENT for
  every pid, so the Linux reader confirms its own `/proc/self/stat` before believing an absent
  entry — on the error path only;
- `proves_death()` is the single definition of "counts as dead", asked by both the poll and the
  reaper test's final assertion, so what stops the poll and what satisfies the assertion cannot
  drift apart.

**Fail-before** (the mapping split out, the arm still at its merged `Err(_) => Gone`, only that arm
differing between red and green):

```
---- a_proc_read_that_failed_for_anything_but_enoent_is_not_evidence_of_death stdout ----
bundle.rs:1932: assertion `left == right` failed: errno 24 is a failed observation, not a reported state
  left: Gone
 right: Unobservable
test result: FAILED. 0 passed; 1 failed
```

errno 24 is `EMFILE`. The test also covers ENFILE, ENOMEM, EACCES, EIO and an `io::Error` carrying
no errno at all, plus both halves of the `Ok` mapping.

## Defect 2 — the new diagnostic was unreachable under the mutation cited as proof of it

#263's central "not weakened" evidence was a mutation of `terminate_esbuild` (`-pid` → `pid`, so only
the direct child is killed) said to print *"the compiler's descendant (pid …) was still Alive 2s
after terminate_esbuild returned"*. **The merged code cannot print that under that mutation.** The
surviving grandchild inherited the shim's piped stdout/stderr, so `join_output`'s `read_to_end`
(production, unchanged) cannot return until it exits — 30 s for `sleep 30`. The call returns at
~31 s, and control reaches the pre-existing `assert!(started.elapsed() < Duration::from_secs(3))`
before the pidfile is read and long before the poll. Measured here on the merged commit with only
that mutation applied:

```
bundle.rs:1914: assertion failed: started.elapsed() < Duration::from_secs(3)
test result: FAILED. 0 passed; 1 failed; ... finished in 30.43s
```

30.43 s matches #263's own "incidental finding" for the mutant's runtime, which is the
elapsed-assertion path — so the two claims in that PR body are mutually inconsistent and the quoted
message must have come from a different build than the one that merged. Consequence: the readable
failure message #263 exists to add would essentially never be printed by a real regression, which
would instead report `assertion failed: started.elapsed() < …` after half a minute, pointing at the
timeout path rather than at the reaper.

Reordering the poll ahead of the elapsed bound would have been **worse** than leaving it: by the
time a call held open by the descendant returns, `sleep 30` has exited on its own and been reaped, so
the poll would find `Gone` and the mutation would *pass*. So the **whole attempt is bounded** rather
than only its wall time — `run_esbuild_with_timeout` runs on its own thread, the recorded pid and
then the call's return are awaited under one 3 s budget, and the descendant is asserted on **while it
is still held**, before anything about the call. The `recv_timeout` budget is now the wall-clock bound
the `elapsed()` assert used to be, and the message reports whether the call itself had returned, so a
slow host and a leaking reaper are distinguishable.

**The same mutation against this test — the message this build actually printed:**

```
thread '...a_timed_out_esbuild_reaps_its_whole_process_group' (6272848) panicked at
crates/biorouter-mcp/src/agent_drafter/bundle.rs:2102:9:
the compiler's descendant (pid 18576) was still Alive 2s after run_esbuild_with_timeout's 1s limit
expired (the call itself had not returned within 3s); the SIGKILL to the process group must leave it
dead (Zombie, awaiting its new parent's wait) or reaped (Gone)
test result: FAILED. 0 passed; 1 failed; ... finished in 5.02s
```

30.43 s naming a clock → 5.02 s naming the descendant. Mutation reverted; nothing under it shipped.

## Nothing is weakened

A genuinely surviving descendant still fails on every platform — it now fails sooner and says why.
An unobservable pid fails instead of passing. A missing pidfile still panics as a harness miss rather
than passing vacuously, and that retry path still works (one of the timed runs below took 4.03 s,
which is the pre-existing miss recovering).

## Verification

- `BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter-mcp --lib -- agent_drafter::bundle` run
  **12 times: 12/12 ok**, 49 passed each (48 before — the new test is the 49th). 10 of those were a
  back-to-back loop. Suite wall times 1.02–10.29 s; the reaper test alone, 10 further runs,
  1.01–1.02 s in nine and 4.03 s in one (the harness-miss retry).
- `cargo clippy -p biorouter-mcp --tests -- -D warnings` — clean (CI lints `--all-targets`, so test
  code counts).
- `cargo fmt --all && cargo fmt --check` — clean.
- No compiler warnings; `Zombie`'s `#[cfg_attr(not(target_os = "linux"), allow(dead_code))]` is
  dropped because `state_from_proc_read`'s test constructs it on every unix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
