### PR TITLE
fix(privacy): Gate H's ratcheting half, so a public chat cannot privatise its own knowledge base

### DIFF
--- a/crates/biorouter/src/agents/knowledge_source_tool.rs
+++ b/crates/biorouter/src/agents/knowledge_source_tool.rs
@@ -452,6 +452,162 @@ mod tests {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Gate H: the alternate provider a MODEL names
+    // -----------------------------------------------------------------------
+
+    fn public_session(id: &str) -> Session {
+        use crate::session::session_manager::SessionType;
+        Session {
+            id: id.to_string(),
+            working_dir: PathBuf::from("."),
+            name: "Gate H".to_string(),
+            user_set_name: false,
+            session_type: SessionType::User,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            extension_data: Default::default(),
+            total_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
+            accumulated_total_tokens: None,
+            accumulated_input_tokens: None,
+            accumulated_output_tokens: None,
+            schedule_id: None,
+            workflow: None,
+            user_workflow_values: None,
+            conversation: None,
+            message_count: 0,
+            provider_name: None,
+            model_config: None,
+            diverged_from: None,
+            branch_point_msg_uid: None,
+            parent_session_id: None,
+            privacy_tier: crate::privacy::SessionClassification::Public,
+            privacy_reason: None,
+        }
+    }
+
+    /// `ollama` resolved against a host, so `providers::create` builds a REAL
+    /// provider whose `tier()` is the production implementation reading the
+    /// resolved base URL. 127.0.0.1 is loopback, so it reads PRIVATE; port 1
+    /// refuses instantly, so nothing here waits on a model.
+    fn ollama_at(host: &str) -> std::collections::HashMap<String, String> {
+        std::collections::HashMap::from([("OLLAMA_HOST".to_string(), host.to_string())])
+    }
+    const A_PRIVATE_HOST: &str = "http://127.0.0.1:1";
+    const A_PUBLIC_HOST: &str = "https://api.example-saas.invalid";
+
+    async fn ingest_on(kb: &str, session: &Session, host: &str) -> ToolResult<Vec<Content>> {
+        crate::config::with_config_overrides(
+            ollama_at(host),
+            handle_ingest_source_with_provider(
+                serde_json::json!({
+                    "kb_id": kb,
+                    "text": "Ordinary public notes, ingested from a public chat.",
+                    "title": "note",
+                    "model": {"provider": "ollama", "model": "qwen3"},
+                }),
+                session,
+                None,
+                crate::privacy::CallCapability::for_test(ProviderTier::Public, true),
+                None,
+            ),
+        )
+        .await
+    }
+
+    /// **The finding, driven through the real handler.** A PUBLIC chat names a
+    /// PRIVATE model in `platform__ingest_source`'s `model` argument. The chosen
+    /// provider's tier — not the session's classification — is what
+    /// `SourceIngestArgs::caller_capability` carries into the knowledge base's
+    /// permanent ratchet, so before the fix this call privatised the base and
+    /// locked the chat that owns it out of its own notes.
+    ///
+    /// Measured on this branch before the gate changed, with exactly this test:
+    ///
+    /// ```text
+    /// --- handler outcome: Ok([… "Curated 0 of 1 source(s) into knowledge base
+    ///     'gate-h-exploit' on ollama/qwen3. …"])
+    /// --- tier::is_private after the call: true
+    /// --- a public caller can still reach it: false
+    /// ```
+    ///
+    /// i.e. the tool answered with an ordinary per-source report — not an error —
+    /// and the base was gone. Note the ratchet fires in `prepare_ingest_base`,
+    /// **before** the sub-agent runs, so a curation that failed outright still
+    /// cost the user the base.
+    #[tokio::test]
+    async fn a_public_chat_may_not_privatise_a_base_by_naming_a_private_model() {
+        use biorouter_mcp::knowledge::caller::KbCaller;
+        use biorouter_mcp::knowledge::tier;
+
+        let svc = KnowledgeService::new_default().expect("the lib binary's sandboxed root");
+        let kb = "gate-h-private-model-from-public-chat";
+        svc.create_base(kb, "Gate H", None).expect("create");
+        assert!(
+            !tier::is_private(svc.root(), kb) && KbCaller::restricted().can_reach(svc.root(), kb),
+            "precondition: the base starts public and its public owner can reach it"
+        );
+
+        let session = public_session("gate-h-public");
+        let err = ingest_on(kb, &session, A_PRIVATE_HOST)
+            .await
+            .expect_err("a public chat may not run an ingest on a private model")
+            .message
+            .to_string();
+        assert!(err.contains("private model"), "{err}");
+        assert!(
+            err.contains("`model` argument"),
+            "the refusal must name the knob that fixes it: {err}"
+        );
+        assert!(
+            err.contains("ollama"),
+            "a refusal names what it refused: {err}"
+        );
+
+        // The ratchet is permanent, so a refusal that had already written would be
+        // unrecoverable. It did not write, and the owner still has its base.
+        assert!(
+            !tier::is_private(svc.root(), kb),
+            "a refused ingest ratcheted the base to PRIVATE anyway"
+        );
+        assert!(
+            KbCaller::restricted().can_reach(svc.root(), kb),
+            "the public chat that owns this base can no longer read it"
+        );
+    }
+
+    /// The other direction, or the gate is not a barrier but an outage: the same
+    /// public chat naming a PUBLIC alternate model still runs, and the base stays
+    /// public.
+    ///
+    /// The ingest itself fails — the endpoint is unroutable — and that is the
+    /// point: it fails *past* the gate, with the per-source report the tool
+    /// answers with, having reached `prepare_ingest_base` and left the base
+    /// public.
+    #[tokio::test]
+    async fn the_same_chat_may_still_name_a_public_alternate_model() {
+        use biorouter_mcp::knowledge::caller::KbCaller;
+        use biorouter_mcp::knowledge::tier;
+
+        let svc = KnowledgeService::new_default().expect("the lib binary's sandboxed root");
+        let kb = "gate-h-public-model-from-public-chat";
+        svc.create_base(kb, "Gate H", None).expect("create");
+
+        let session = public_session("gate-h-public-sideways");
+        let report = ingest_on(kb, &session, A_PUBLIC_HOST)
+            .await
+            .expect("a public chat on a public alternate model is a sideways choice");
+        let text = format!("{report:?}");
+        assert!(
+            text.contains("ollama/qwen3"),
+            "the report must name the model that ran it: {text}"
+        );
+        assert!(!tier::is_private(svc.root(), kb));
+        assert!(KbCaller::restricted().can_reach(svc.root(), kb));
+    }
+
     /// Half a model reference is not a choice, so the chat's own model runs the
     /// ingest — never a partially-resolved provider.
     #[test]

--- a/crates/biorouter/src/agents/knowledge_tool.rs
+++ b/crates/biorouter/src/agents/knowledge_tool.rs
@@ -414,7 +414,7 @@ async fn build_model_ref_completer(
     Ok((Box::new(completer), tier, affiliation))
 }
 
-/// The provider behind a [`ModelRef`], past **Gate H**.
+/// The provider behind a [`ModelRef`], past **Gate H's ratcheting half**.
 ///
 /// Split out of [`build_model_ref_completer`] so a caller that needs the
 /// provider itself — a batch, which mints one completer per source from one
@@ -427,6 +427,27 @@ async fn build_model_ref_completer(
 /// to consult. `what` and `env_key_to_name` are Gate H's own two strings — the
 /// feature named in the refusal and the knob that fixes it — and they differ per
 /// caller, which is why they are arguments rather than constants here.
+///
+/// ⚠ **It asks [`crate::privacy::assert_alt_provider_matches_session`], not its
+/// laxer sibling, and that is the whole of the fix for the Gate H finding.** The
+/// tier of the provider built here does not stay in this process: it becomes
+/// `SourceIngestArgs::caller_capability` / `ConversationIngestArgs::caller_capability`,
+/// which crosses to `caller_is_private` and lands in
+/// `knowledge::tier::raise_unlocked` — a permanent, monotone ratchet on a
+/// knowledge base. So the upward choice `bind_allowed` waves through (a PRIVATE
+/// provider named by a PUBLIC chat) is not harmless here: it privatises that
+/// chat's own base for good, after which every KB read choke point refuses the
+/// chat with `tier::KB_PRIVATE_REFUSAL`. Measured before the fix: the tool
+/// returned an ordinary report (*"Curated 0 of 1 source(s) … on ollama/qwen3"*)
+/// while `tier::is_private` flipped to `true` and the public caller's
+/// `can_reach` to `false` — a base lost to a failed ingest.
+///
+/// This is the choke point rather than the tool's own handler because both
+/// knowledge paths reach an alternate provider through here: the `model`
+/// argument of `platform__ingest_source` (a name the MODEL wrote) and a base's
+/// stored `default_model` on a scheduled digest. Both end in the same ratchet,
+/// so both take the same rule, and a third knowledge path cannot be added
+/// without passing it.
 pub(crate) async fn build_model_ref_provider(
     model: &ModelRef,
     session: crate::privacy::SessionClassification,
@@ -437,7 +458,12 @@ pub(crate) async fn build_model_ref_provider(
     let provider = crate::providers::create(&model.provider, model_config).await?;
     // AFTER `create`: the tier belongs to the instance that was resolved, not to
     // the name the manifest asked for. Constructing it discloses nothing.
-    crate::privacy::assert_alt_provider_allowed(what, provider.as_ref(), session, env_key_to_name)?;
+    crate::privacy::assert_alt_provider_matches_session(
+        what,
+        provider.as_ref(),
+        session,
+        env_key_to_name,
+    )?;
     Ok(provider)
 }
 
@@ -887,6 +913,26 @@ mod tests {
         )
         .await
         .is_ok());
+
+        // The fourth cell, and the one this path needs the STRICTER half of Gate
+        // H for: a PUBLIC session on a PRIVATE default model. `bind_allowed`
+        // permits it — nothing leaks upward — but the tier that comes back is
+        // what ratchets the target base, so permitting it hands a public
+        // scheduled digest the power to privatise the base it writes into. It is
+        // refused here and the refusal names the base's own knob.
+        let raise = crate::config::with_config_overrides(
+            ollama_at("http://localhost:11434"),
+            build_model_ref_completer(&model, SessionClassification::Public, None),
+        )
+        .await
+        .err()
+        .expect("a public chat may not digest itself on the base's private default model")
+        .to_string();
+        assert!(raise.contains("private model"), "{raise}");
+        assert!(
+            raise.contains("knowledge base's default model"),
+            "the refusal must name the knob that fixes it: {raise}"
+        );
     }
 
     /// Issue #56 Gate H, the *wiring*. The test above proves

--- a/crates/biorouter/src/privacy/alt_provider.rs
+++ b/crates/biorouter/src/privacy/alt_provider.rs
@@ -15,11 +15,45 @@
 //!    (`agents/knowledge_tool.rs`) prefers a target KB's `default_model` over
 //!    the agent's own provider for scheduled jobs.
 //!
+//! Site 3 is reached through exactly one function, `build_model_ref_provider`,
+//! by BOTH knowledge paths: `platform__ingest_source`'s `model` argument (a
+//! provider name the MODEL wrote) and a base's stored `default_model` on a
+//! scheduled digest. That is deliberate — they end in the same knowledge-base
+//! ratchet, so a third knowledge path cannot be added without passing the gate.
+//!
 //! A fourth site, the HTTP knowledge macros (`routes/knowledge.rs`'s
-//! `build_completer`), is deliberately **not** here: it has a knowledge-base id
-//! and no session at all, so the predicate it needs is the KB-keyed one Task 10C
-//! installs, not this session-keyed one. Putting a `SessionClassification` check
-//! there would be a type error, not merely a misfiling.
+//! `build_completer`), is deliberately **not** here, and neither is its CLI twin
+//! (`biorouter-cli/src/commands/knowledge.rs`'s `build_completer`, whose
+//! provider comes from `--provider`): both have a knowledge-base id and no
+//! session at all, so the predicate they need is the KB-keyed one Task 10C
+//! installs (`assert_macro_target_reachable` → `knowledge::tier::assert_reachable`),
+//! not this session-keyed one. Putting a `SessionClassification` check there
+//! would be a type error, not merely a misfiling. The person who typed the
+//! provider name is also the one DR-16 rules may raise a tier, which is the
+//! substantive half of the distinction rather than the typing one.
+//!
+//! # How to re-derive this list rather than trust it
+//!
+//! Grep the workspace for `providers::create`, `create_from_persisted` and
+//! `create_with_named_model`, then keep only the calls where BOTH hold: the
+//! provider is *not* the one the session row records, and a session's content
+//! reaches it. Everything else falls out for a nameable reason, and the reasons
+//! are worth knowing because each looks like a Gate H site from the grep alone:
+//!
+//! * **It binds, so Gate A owns it** — `Agent::update_provider` and the turn
+//!   barrier, the CLI session builder, `routes/agent.rs`, `commands/web.rs`,
+//!   `biorouter-acp`, `scheduler.rs`, and `workspace_set_tools`' provider switch
+//!   (which additionally asks `tool_bind_allowed`, DR-16's half — see
+//!   [`assert_alt_provider_matches_session`], which asks the same predicate).
+//! * **It is the spawn**, whose own gate already refuses BOTH directions
+//!   (`subagent_tool::apply_settings_overrides`).
+//! * **No session content reaches it** — `config_management.rs`'s provider
+//!   validation and `auto_detect.rs`'s availability probe send a canned request.
+//! * **It is the app bind**, which DR-21 confines to `app_provider_bind` (see
+//!   the ⚠ note where `routes/apps.rs` deliberately does *not* import `create`).
+//!
+//! Re-derived this way on 2026-09-12: the three sites above, plus the two
+//! KB-keyed exemptions, are the whole list.
 //!
 //! # What this gate does NOT do: it never raises the floor
 //!
@@ -34,10 +68,38 @@
 //! is refused above — and it is the same class as the one-turn window
 //! `Agent::reply` documents at its ratchet (O5). Recorded here because Task 19
 //! did not close it and nothing else in this module would say so.
+//!
+//! # Two halves, because "harmless" depends on where the tier lands
+//!
+//! [`assert_alt_provider_allowed`] refuses only the DOWNWARD choice, because
+//! that is the only one that discloses anything: a MORE private provider cannot
+//! leak the session it is handed. Sites 1 and 2 above take that half, and it is
+//! the right one for them — plan mode's answer and a hook's output land in
+//! `self.messages`, where the residual is the under-classification recorded
+//! above and the provider was named by a person's own configuration.
+//!
+//! [`assert_alt_provider_matches_session`] is the STRICTER half, and site 3
+//! needs it: a knowledge ingest does not merely read the session, it writes into
+//! a **knowledge base**, whose tier is a permanent, monotone ratchet over the
+//! callers that write to it (`biorouter-mcp`'s `knowledge::tier`). The chosen
+//! provider's tier — not the session's classification — is what
+//! `SourceIngestArgs::caller_capability` carries into that ratchet, so the
+//! "harmless" upward choice permanently privatises a base a **public** chat
+//! owns, and that chat is then refused at every KB read choke point. The user
+//! loses a base to a decision nobody asked them about.
+//!
+//! So on that half the tiers must MATCH. It is the same ruling the spawn gate
+//! reached for the same reason (`subagent_tool::apply_settings_overrides`
+//! refuses `spawn_upgrade` AND `spawn_downgrade`): R4 says a public parent may
+//! not gain private reach, DR-19 supplies the initiator R4 never named, and a
+//! tool call has no person on the other end to consent. DR-16 rules the raise
+//! the user's decision, and SD-8 rules that a control which can never work here
+//! says so rather than asking — `is_user_action` is false for every tool call,
+//! so a proof check here could only ever refuse.
 
 use anyhow::{anyhow, Result};
 
-use super::{bind_allowed, SessionClassification};
+use super::{bind_allowed, tool_bind_allowed, SessionClassification};
 use crate::providers::base::Provider;
 
 /// Refuse to hand a session's content to a provider that is not the one bound to
@@ -64,7 +126,105 @@ pub fn assert_alt_provider_allowed(
     // DR-15's master opt-out, read INSIDE the gate. A direct read, not a
     // `CallCapability`: this gate fires where nothing is bound, so there is no
     // admitted tool call whose capability it could inherit.
-    if !super::privacy_tiers_enabled() || bind_allowed(provider.tier(), session) {
+    if !super::privacy_tiers_enabled() {
+        return Ok(());
+    }
+    refuse_downward(what, provider, session, env_key_to_name)
+}
+
+/// [`assert_alt_provider_allowed`] **plus** the upward half, for an alternate
+/// provider whose tier does not stay in this process: it becomes the ratchet
+/// input of a knowledge base's permanent classification.
+///
+/// The arguments and the downward sentence are the sibling's, unchanged and
+/// undoubled — this is that gate AND one more rule, not a second spelling of it,
+/// so the two can never disagree about the cell they share. What it adds is the
+/// raise: a provider more private than the session is refused, because
+/// `caller_capability` is what `knowledge::tier::raise_unlocked` ratchets on and
+/// a ratchet is not undoable. A public chat that names a private model would
+/// mark its own base private for good and then be refused at
+/// `knowledge::tier::assert_reachable` — a loss of access to the user's own
+/// notes that no one was asked about, delivered by a tool call.
+///
+/// ⚠ **Do not "simplify" this to the sibling.** The cell that differs —
+/// `(session = Public, provider = Private)` — is `Ok` there on purpose and is
+/// the whole finding here; `only_a_private_session_on_a_public_provider_is_refused`
+/// and [`the_upward_choice_is_refused_only_on_the_ratcheting_half`] pin both
+/// answers side by side.
+///
+/// It is also the same shape as `workspace_set_tools`' provider switch, which
+/// asks [`bind_allowed`] and then [`tool_bind_allowed`] for the same two
+/// sentences. That is not a coincidence to be tidied away later: both surfaces
+/// are a MODEL asking for a tier it was not given, so they must answer with one
+/// set of cells. This function therefore *calls* [`tool_bind_allowed`] rather
+/// than re-spelling `is_private() == is_private()`, and a change to DR-16's rule
+/// lands on both sites or neither.
+///
+/// [`the_upward_choice_is_refused_only_on_the_ratcheting_half`]: tests::the_upward_choice_is_refused_only_on_the_ratcheting_half
+pub fn assert_alt_provider_matches_session(
+    what: &str,
+    provider: &dyn Provider,
+    session: SessionClassification,
+    env_key_to_name: &str,
+) -> Result<()> {
+    // One read of DR-15's switch for both rules, for the same reason
+    // `tier::assert_reachable` reads it once for both of its axes.
+    //
+    // ⚠ It is a DIRECT read, and on one of this gate's two callers that is a
+    // departure from the house rule — measured, bounded and recorded rather than
+    // half-fixed. The rule (see `privacy::CallCapability`) is that a gate on a
+    // TOOL-CALL path asks the once-per-call `cap.enforced()` instead of
+    // re-reading the flag, because `privacy_tiers_enabled()` is a runtime
+    // `AtomicBool` that `POST /config/upsert`'s gated arm can flip mid-call.
+    // `platform__ingest_source` IS a tool call and does hold a sampled
+    // `CallCapability` (its `resolve_target_kb` already uses it), so this read is
+    // a second one; the scheduled-digest caller threads no capability at all, so
+    // it could only ever read directly.
+    //
+    // Why the residual is not worth the threading: the harmful outcome needs the
+    // switch OFF **here** (to admit the raise) and ON again at the write (to
+    // ratchet), because `knowledge::tier::raise_unlocked` asks
+    // `ratchets_are_live()` for itself. A flip in one direction produces no loss,
+    // and both directions inside one ingest means the user turned protection off
+    // and back on while a model was resolving a provider. Threading a capability
+    // through two callers where only one has one, to close that, is a larger
+    // change with a worse failure mode than the race it removes. If a future
+    // caller gives this gate a capability on BOTH paths, take it — do not add a
+    // parameter only the first path can fill.
+    if !super::privacy_tiers_enabled() {
+        return Ok(());
+    }
+    refuse_downward(what, provider, session, env_key_to_name)?;
+    // DR-16's half, asked through the predicate that already states it
+    // (`privacy::tool_bind_allowed`) instead of a second spelling of its cells.
+    // Reached only when `refuse_downward` — i.e. `bind_allowed` — already
+    // passed, so the only way this can be false is the RAISE; the sentence for
+    // the downward cell belongs to `refuse_downward` and is not repeated here.
+    if tool_bind_allowed(provider.tier(), session) {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "This chat is public, so {what} cannot run on `{}`, which is a private model: a \
+         knowledge base takes the tier of the most private model that writes to it, so this \
+         would mark the base private permanently and lock this public chat out of its own \
+         notes. Nothing was written. Do not retry with the same model; the answer will not \
+         change. Set {env_key_to_name} to a public model, or stop and ask the user to \
+         continue this work in a private chat.",
+        provider.get_name()
+    ))
+}
+
+/// Gate A's rule, and the one sentence that states it. Shared so both public
+/// entry points above refuse the downward choice in the same words — and so
+/// [`bind_allowed`] keeps exactly one caller in this file, which the guard
+/// census counts.
+fn refuse_downward(
+    what: &str,
+    provider: &dyn Provider,
+    session: SessionClassification,
+    env_key_to_name: &str,
+) -> Result<()> {
+    if bind_allowed(provider.tier(), session) {
         return Ok(());
     }
     Err(anyhow!(
@@ -130,8 +290,11 @@ mod tests {
         assert!(err.contains("BIOROUTER_PLANNER_PROVIDER"), "{err}");
 
         // ...and the other three are allowed, or this is not a barrier but an
-        // outage. A public session is unaffected in BOTH directions: upward is
-        // Gate A's business, not this one's.
+        // outage. A public session is unaffected in BOTH directions HERE: the
+        // upward choice discloses nothing, so on a path whose tier stops in this
+        // process it is Gate A's business and not this one's. Where that tier
+        // becomes a knowledge base's permanent classification it is refused, and
+        // the test below is the other half of this pair.
         for (session, tier) in [
             (Private, ProviderTier::Private),
             (Public, ProviderTier::Public),
@@ -141,6 +304,97 @@ mod tests {
                 assert_alt_provider_allowed("plan mode", &provider_at(tier), session, "KEY")
                     .is_ok(),
                 "{session:?} + {tier:?} must be allowed"
+            );
+        }
+    }
+
+    /// The ratcheting half. Three cells agree with the sibling above and the
+    /// fourth — a PUBLIC session naming a PRIVATE provider — is the finding:
+    /// allowed there, refused here.
+    ///
+    /// Stated as both the four cells and the rule, so a third tier cannot be
+    /// added while satisfying the cells.
+    #[test]
+    fn the_upward_choice_is_refused_only_on_the_ratcheting_half() {
+        use SessionClassification::{Private, Public};
+
+        let err = assert_alt_provider_matches_session(
+            "ingesting these sources",
+            &provider_at(ProviderTier::Private),
+            Public,
+            "this tool's `model` argument",
+        )
+        .expect_err("a public chat may not privatise its base by naming a private model")
+        .to_string();
+        // A refusal names what it refused, why, and the way out.
+        assert!(err.contains("public"), "{err}");
+        assert!(err.contains("private model"), "{err}");
+        assert!(err.contains("planner"), "the provider must be named: {err}");
+        assert!(err.contains("ingesting these sources"), "{err}");
+        assert!(err.contains("`model` argument"), "{err}");
+        assert!(
+            err.contains("Do not retry"),
+            "a refusal the model will retry is a loop: {err}"
+        );
+
+        // The downward cell is still the sibling's sentence, not a second one:
+        // one rule, one wording, whichever entry point asked.
+        let downward = assert_alt_provider_matches_session(
+            "ingesting these sources",
+            &provider_at(ProviderTier::Public),
+            Private,
+            "KEY",
+        )
+        .expect_err("a private chat on a public model must still be refused")
+        .to_string();
+        assert_eq!(
+            downward,
+            assert_alt_provider_allowed(
+                "ingesting these sources",
+                &provider_at(ProviderTier::Public),
+                Private,
+                "KEY"
+            )
+            .expect_err("the sibling refuses the same cell")
+            .to_string(),
+            "the two entry points must refuse the downward choice in the same words"
+        );
+
+        // Sideways, both directions of the pair: the only choices that remain,
+        // and the ones that must keep working.
+        for (session, tier) in [
+            (Private, ProviderTier::Private),
+            (Public, ProviderTier::Public),
+        ] {
+            assert!(
+                assert_alt_provider_matches_session(
+                    "ingesting these sources",
+                    &provider_at(tier),
+                    session,
+                    "KEY"
+                )
+                .is_ok(),
+                "{session:?} + {tier:?} is sideways, not a crossing"
+            );
+        }
+
+        // The rule, not the cells — and stated as the predicate rather than as a
+        // second spelling of its comparison. This gate admits exactly what the
+        // model-facing BIND predicate admits, because both surfaces are a model
+        // asking for a tier nobody granted it; `workspace_set_tools`' provider
+        // switch is the other caller. The four cells are pinned above, so this
+        // adds the thing the cells cannot say: that the two policies are one.
+        for (session, tier) in [
+            (Public, ProviderTier::Public),
+            (Public, ProviderTier::Private),
+            (Private, ProviderTier::Public),
+            (Private, ProviderTier::Private),
+        ] {
+            assert_eq!(
+                assert_alt_provider_matches_session("x", &provider_at(tier), session, "KEY")
+                    .is_ok(),
+                tool_bind_allowed(tier, session),
+                "{session:?} + {tier:?}"
             );
         }
     }

--- a/crates/biorouter/src/privacy/mod.rs
+++ b/crates/biorouter/src/privacy/mod.rs
@@ -47,7 +47,7 @@ pub mod system_auth_windows;
 pub mod visibility;
 
 pub use affiliation::{CrossAffiliation, ExtensionAffiliation, ModelAffiliation};
-pub use alt_provider::assert_alt_provider_allowed;
+pub use alt_provider::{assert_alt_provider_allowed, assert_alt_provider_matches_session};
 pub use capability::CallCapability;
 pub use config_keys::is_capability_key;
 pub use extensions::{

--- a/crates/biorouter/tests/privacy_guard_wiring.rs
+++ b/crates/biorouter/tests/privacy_guard_wiring.rs
@@ -597,6 +597,39 @@ const REGISTRY: &[Guard] = &[
         ],
     },
     Guard {
+        ident: "assert_alt_provider_matches_session",
+        defined_in: "crates/biorouter/src/privacy/alt_provider.rs",
+        decides: "Gate H's RATCHETING half: whether a provider named for a knowledge ingest may \
+                  differ in tier from the session whose content it will fold into a base",
+        status: Status::Wired,
+        sites: &[
+            Site {
+                file: "crates/biorouter/src/agents/knowledge_tool.rs",
+                counts: c(1, 0, 0),
+                kind: SiteKind::Guard,
+                what: "`build_model_ref_provider`, the ONE Gate H site both knowledge paths \
+                       share — `platform__ingest_source`'s `model` argument (a provider name \
+                       the MODEL wrote) and a base's stored `default_model` on a scheduled \
+                       digest. Its laxer sibling `assert_alt_provider_allowed` is what used to \
+                       be here, and it refuses only the DOWNWARD choice: the tier that comes \
+                       back becomes `caller_capability`, crosses to `caller_is_private` and \
+                       lands in `knowledge::tier::raise_unlocked`, a permanent monotone \
+                       ratchet — so the upward choice Gate A calls harmless let a PUBLIC chat \
+                       privatise its own base for good and then be refused at every KB read \
+                       choke point. If this row ever reads ZERO calls, that hole is open again \
+                       and no behavioural test elsewhere will say so, because the sibling \
+                       predicate is still correct for the two paths that keep it",
+            },
+            Site {
+                file: "crates/biorouter/src/privacy/mod.rs",
+                counts: c(0, 0, 1),
+                kind: SiteKind::Guard,
+                what: "the `pub use` beside its sibling's, so `crate::privacy::` is the one \
+                       path both halves of Gate H are called through",
+            },
+        ],
+    },
+    Guard {
         ident: "bind_allowed",
         defined_in: "crates/biorouter/src/privacy/mod.rs",
         decides: "Gate A: whether a provider of tier P may be bound to a session classified T",
@@ -666,20 +699,37 @@ const REGISTRY: &[Guard] = &[
         decides: "Gate A's rule PLUS DR-16's, for the surface a MODEL asks the bind on: it may \
                   LOWER a conversation's capability, never RAISE it",
         status: Status::Wired,
-        sites: &[Site {
-            file: "crates/biorouter/src/agents/workspace_extension.rs",
-            counts: c(1, 0, 0),
-            kind: SiteKind::Guard,
-            what: "`workspace_set_tools`' pre-flight, beside its `bind_allowed` sibling and \
-                   after it, so the more specific refusal owns the downward case. This is the \
-                   predicate's ONLY caller by design and not by accident: `bind_allowed` \
-                   permits every bind onto a public conversation (Gate A refuses only the \
-                   downward one), which let a public-tier model hand any conversation it \
-                   could write to a private provider — Private capability, and a permanent \
-                   ratchet of that conversation's stored `privacy_tier` on its next turn. If \
-                   this row ever reads ZERO calls, that hole is open again and no behavioural \
-                   test elsewhere will say so, because the predicate itself is still correct",
-        }],
+        sites: &[
+            Site {
+                file: "crates/biorouter/src/agents/workspace_extension.rs",
+                counts: c(1, 0, 0),
+                kind: SiteKind::Guard,
+                what: "`workspace_set_tools`' pre-flight, beside its `bind_allowed` sibling and \
+                       after it, so the more specific refusal owns the downward case. \
+                       `bind_allowed` permits every bind onto a public conversation (Gate A \
+                       refuses only the downward one), which let a public-tier model hand any \
+                       conversation it could write to a private provider — Private capability, \
+                       and a permanent ratchet of that conversation's stored `privacy_tier` on \
+                       its next turn. If this row ever reads ZERO calls, that hole is open \
+                       again and no behavioural test elsewhere will say so, because the \
+                       predicate itself is still correct",
+            },
+            Site {
+                file: "crates/biorouter/src/privacy/alt_provider.rs",
+                counts: c(1, 0, 1),
+                kind: SiteKind::Guard,
+                what: "`assert_alt_provider_matches_session`, Gate H's ratcheting half, plus \
+                       its import. ⚠ This row is why the sibling row above no longer claims to \
+                       be this predicate's only caller: DR-16's rule now has TWO model-facing \
+                       surfaces, a bind (`workspace_set_tools`' provider switch) and a \
+                       construction that binds nothing (a knowledge ingest's `model` argument, \
+                       whose tier ratchets a knowledge base instead of a session). Both CALL \
+                       this predicate rather than re-spelling `is_private() == is_private()`, \
+                       so the two can never answer the raise cell differently. A new site that \
+                       inlines the comparison would satisfy every behavioural test and be \
+                       invisible here, which is exactly the drift this census exists to see",
+            },
+        ],
     },
     Guard {
         ident: "privacy_refusal",

--- a/crates/biorouter/tests/privacy_toggle.rs
+++ b/crates/biorouter/tests/privacy_toggle.rs
@@ -709,6 +709,19 @@ async fn the_master_toggle_governs_every_gate_in_both_directions() {
         "BIOROUTER_PLANNER_PROVIDER",
     )
     .is_err());
+    // 10b H's RATCHETING half — the same gate on the path where the chosen
+    //     provider's tier does not stop in this process but becomes a knowledge
+    //     base's permanent classification. It has its OWN toggle read (it must:
+    //     it refuses a cell the sibling allows), so the sibling's assertion above
+    //     says nothing about it, and the cell tested here is exactly the one they
+    //     disagree on — a PRIVATE provider named by a PUBLIC chat.
+    assert!(biorouter::privacy::assert_alt_provider_matches_session(
+        "ingesting these sources",
+        private_provider().as_ref(),
+        SessionClassification::Public,
+        "this tool's `model` argument",
+    )
+    .is_err());
 
     // 13 spawn (Task 23) — the spawn matrix's THREE decisions, all hanging off
     //          one toggle read inside `apply_settings_overrides`.
@@ -862,6 +875,16 @@ async fn the_master_toggle_governs_every_gate_in_both_directions() {
         public_provider().as_ref(),
         SessionClassification::Private,
         "BIOROUTER_PLANNER_PROVIDER",
+    )
+    .is_ok());
+    // 10b: the ratcheting half goes quiet too. Its early return is its own line
+    //      of code, so a gate that read the switch once for the pair — or not at
+    //      all on this half — would still pass the assertion above it.
+    assert!(biorouter::privacy::assert_alt_provider_matches_session(
+        "ingesting these sources",
+        private_provider().as_ref(),
+        SessionClassification::Public,
+        "this tool's `model` argument",
     )
     .is_ok());
     // 13 spawn: all three decisions go quiet, and the third is the one a flipped

--- a/docs/security/privacy-tiers.md
+++ b/docs/security/privacy-tiers.md
@@ -211,14 +211,50 @@ this section is the ledger.
      are reached only by the `subagent` tool. This is the exact route DR-19's own refusal names —
      *"they can start a new chat on it and give it the task directly"* — with the model, rather than
      the user, taking it.
-  3. **DR-16's upward capability raise is HTTP-only.** `raise_needs_user_action` is called from
-     `routes/agent.rs` and `routes/apps.rs` and nowhere else, while
-     `workspace_set_tools { provider, model }` performs the same bind in-process through
-     `Agent::update_provider`. Gate A refuses the *downward* bind there, so a private chat cannot be
-     moved onto a public model; nothing on that path asks for the user proof DR-16 requires to move
-     a chat **up**. `workspace_set_tools` also has no self-target guard — only
-     `workspace_send_prompt` refuses `session_id == caller` — so the target may be the caller's own
-     conversation.
+  3. **DR-16's upward capability raise was HTTP-only. Both model-facing halves are now closed —
+     as refusals, not as proof checks.** ⚠ **This item asserted the opposite until 2026-09-12 and
+     was, by then, wrong twice over**; it is kept rather than deleted because the *shape* of the
+     finding is the reusable part and because a reader who greps `raise_needs_user_action` still
+     finds only the two HTTP callers and would draw the old conclusion.
+
+     What was true, and still is: `raise_needs_user_action` is called from `routes/agent.rs` and
+     `routes/apps.rs` and nowhere else, and [`bind_allowed`](../../crates/biorouter/src/privacy/mod.rs)
+     refuses only the *downward* bind — so on its own it lets a MODEL move a public conversation
+     **up** onto a private provider, granting it Private capability and ratcheting its stored
+     `privacy_tier` permanently on the next turn.
+
+     What is no longer true is that nothing asks. The instrument argument below is why it could
+     never be a proof check — a tool call is by definition the model and can never carry proof of a
+     human — so both sites answer with a **refusal** instead of a question, and both ask ONE
+     predicate, `privacy::tool_bind_allowed` (Gate A's rule AND DR-16's, composed rather than
+     re-spelled):
+
+     - the **bind**: `workspace_set_tools { provider, model }`, in `workspace_extension.rs`'s
+       pre-flight, beside its `bind_allowed` sibling and after it, so the more specific refusal
+       owns the raise and the downward sentence stays Gate A's. That pre-flight also now refuses
+       `session_id == caller_session_id` outright, so the other half of this item's old last
+       sentence — that the target may be the caller's own conversation — is closed too.
+     - the **construction that binds nothing**: Gate H's ratcheting half,
+       `privacy::assert_alt_provider_matches_session`, called from `build_model_ref_provider` in
+       `agents/knowledge_tool.rs`. This is the same raise arriving by a road that has no bind for
+       Gate A to watch: an alternate provider named in `platform__ingest_source`'s `model` argument
+       (a name the model wrote), or a base's stored `default_model` on a scheduled digest. Nothing
+       ratchets the *session* there, so the old reasoning that "the upward choice discloses
+       nothing" held — but the chosen provider's tier is what
+       `SourceIngestArgs::caller_capability` carries into `knowledge::tier::raise_unlocked`, a
+       permanent monotone ratchet on a **knowledge base**. A public chat naming a private model
+       therefore marked its own base private for good and was then refused at every KB read choke
+       point, losing the user a base to a decision nobody was asked about. Measured before the fix:
+       the tool answered with an ordinary per-source report while `tier::is_private` flipped to
+       `true`.
+
+     Two consequences worth carrying forward. The census rows in
+     `crates/biorouter/tests/privacy_guard_wiring.rs` are what keep the two sites asking the same
+     predicate: a third surface that inlined `is_private() == is_private()` would satisfy every
+     behavioural test and be invisible, which is the drift that census exists to see. And Gate H's
+     **laxer** entry point, `assert_alt_provider_allowed`, is still correct for CLI plan mode and
+     prompt hooks, whose provider is named by a person's own configuration and whose tier stops in
+     this process — so the two halves are a deliberate pair, not a migration that stalled.
 
   What is unchanged is the reasoning about the **instrument**: none of this is fixable with the
   daemon's user-action proof, because a tool call is by definition the model and can never carry


### PR DESCRIPTION
## What Gate H closes, and the half that was open

Gate H (issue #56) is the **alternate-provider barrier**: the production paths that hand a session's content to a provider the session row never records, and which therefore pass neither `Agent::update_provider` (Gate A) nor `Agent::reply` (Gate B).

`bind_allowed` is asymmetric on purpose — Gate A refuses only the **downward** bind, because putting a *more* private model in front of a conversation cannot leak that conversation. Gate H inherited that predicate at every site. On one site the premise does not hold.

`build_model_ref_provider` (`crates/biorouter/src/agents/knowledge_tool.rs`) builds a provider whose tier **does not stop in this process**. It becomes `SourceIngestArgs::caller_capability` / `ConversationIngestArgs::caller_capability`, crosses to `caller_is_private`, and lands in `knowledge::tier::raise_unlocked` — a permanent, monotone ratchet on a **knowledge base**.

So the "harmless" upward choice let a **public** chat name a **private** model in `platform__ingest_source`'s `model` argument and privatise its own base for good, after which every KB read choke point refused that chat. Two details make it worse than it sounds:

- the ratchet fires in `prepare_ingest_base`, **before** the sub-agent runs, so a curation that failed outright still cost the user the base;
- the tool answered with an ordinary per-source report, not an error. Measured before the fix, with the test now in the tree: `Ok([… "Curated 0 of 1 source(s) into knowledge base 'gate-h-exploit' on ollama/qwen3"])`, `tier::is_private` → `true`, public caller's `can_reach` → `false`.

### The fix

`build_model_ref_provider` now asks `privacy::assert_alt_provider_matches_session` — Gate A's rule **and** DR-16's, i.e. the tiers must match. It is the one function **both** knowledge paths reach an alternate provider through (`platform__ingest_source`'s `model` argument, a name the *model* wrote; and a base's stored `default_model` on a scheduled digest), so a third knowledge path cannot be added without passing it.

The laxer `assert_alt_provider_allowed` stays, and stays correct, for CLI plan mode and prompt hooks: their provider is named by a person's own configuration and its tier stops in this process, where the residual is the under-classification the module already records. The two halves are a deliberate pair, not a stalled migration.

**It composes main's predicate rather than re-spelling it.** `tool_bind_allowed` landed on `main` after this work was written, for the same reason on the sibling surface (`workspace_set_tools`' provider switch). DR-16's rule must not have two sets of cells, so the new gate *calls* it — `refuse_downward` answers Gate A's half, then `tool_bind_allowed` answers exactly the raise. The census rows are what keep the two sites asking one predicate: a third surface that inlined `is_private() == is_private()` would satisfy every behavioural test and be invisible.

## Which construction sites were enumerated, and how

Re-derived rather than assumed. Grep the workspace for `providers::create`, `create_from_persisted` and `create_with_named_model`, then keep only calls where **both** hold: the provider is not the one the session row records, **and** a session's content reaches it.

| Site | Gate | Verdict |
|---|---|---|
| CLI plan mode — `get_reasoner`, `biorouter-cli/src/session/mod.rs:2488` | `assert_alt_provider_allowed` | correct as-is; tier stops in-process |
| Prompt hooks — `resolve_prompt_provider`, `hooks/mod.rs:945` | `assert_alt_provider_allowed` | correct as-is; same reason |
| Knowledge alternate model — `build_model_ref_provider`, `knowledge_tool.rs:461` | **`assert_alt_provider_matches_session`** | **the fix**; both knowledge paths funnel here |
| HTTP knowledge macros — `routes/knowledge.rs:1320` | KB-keyed `assert_macro_target_reachable` | exempt: base id, no session; the *person* typed the model |
| CLI knowledge macros — `biorouter-cli/src/commands/knowledge.rs:109` | KB-keyed, same | exempt: `--provider` is typed by a person |

Everything else the grep returns falls out for a nameable reason, and each one looks like a Gate H site from the grep alone:

- **it binds, so Gate A owns it** — `Agent::update_provider` + the turn barrier, `biorouter-cli/src/session/builder.rs`, `routes/agent.rs`, `commands/web.rs`, `biorouter-acp/src/server.rs`, `scheduler.rs`, and `workspace_set_tools`' provider switch (which additionally asks `tool_bind_allowed`);
- **it is the spawn**, whose own gate already refuses **both** directions (`subagent_tool::apply_settings_overrides`, `spawn_upgrade` + `spawn_downgrade`);
- **no session content reaches it** — `config_management.rs`'s provider validation and `auto_detect.rs`'s availability probe send a canned request;
- **it is the app bind**, which DR-21 confines to `app_provider_bind` (`routes/apps.rs` deliberately does not import `create`);
- `br.kb`'s ingest takes `url`/`text` only and calls `add_raw_source` — no LLM, no alternate provider.

The method is written into the module doc so the next reader can redo it instead of trusting this table.

**Why the invariant is worth having:** Gate B ratchets the session from the bound provider's tier at the top of `Agent::reply`, so on the *chat-provider* ingest path `caller_capability` already equals `session.privacy_tier`. The alternate-provider path was the one door where they could diverge upward. The fix makes both paths agree.

## Verification

Every command under `BIOROUTER_DISABLE_KEYRING=true`, on this branch merged with `main` at `9096d371`.

| Command | Result |
|---|---|
| `cargo check -p biorouter --lib --tests` | clean, **0 warnings** |
| `cargo test -p biorouter --lib privacy::` | **246 passed**, 0 failed |
| `cargo test -p biorouter --test privacy_capability --test privacy_guard_wiring --test privacy_toggle --test privacy_disclosure_toggle` | **4 / 3 / 4 / 1 passed**, 0 failed |
| `cargo test -p biorouter-mcp --lib knowledge::tier` | **31 passed**, 0 failed |
| `cargo test -p biorouter --lib -- knowledge_source_tool knowledge_tool` | **25 passed**, 0 failed |
| `cargo fmt --check` | clean — see note below |
| `./scripts/clippy-lint.sh` | strict clippy **clean** on `-p biorouter -p biorouter-mcp`; workspace run blocked by a pre-existing `main` error, below |

### The instrument was verified, not trusted

Three sabotages, each restored:

1. neutered the new predicate (`if true { return Ok(()) }`) → `the_master_toggle_governs_every_gate_in_both_directions` **FAILED at privacy_toggle.rs:718** (the armed assertion);
2. removed the new gate's master-switch read → the same test **FAILED at privacy_toggle.rs:883** (the quiet assertion);
3. reverted the call site to `assert_alt_provider_allowed` → **both** behavioural tests FAILED (`a_public_chat_may_not_privatise_a_base_by_naming_a_private_model`, `the_knowledge_default_model_obeys_the_barrier`).

## What the WIP got wrong, beyond being unverified

The predecessor commit said its ~419 insertions were "NOT compiled or tested". They did in fact compile and pass, but three things were genuinely wrong or missing:

1. **`cargo fmt --check` failed** in three places in its own additions — it would have failed CI's fmt gate.
2. **The new gate was absent from `privacy_toggle.rs`.** It has its *own* `privacy_tiers_enabled()` read (it must — it refuses a cell the sibling allows), so the sibling's Gate H assertion said nothing about it. Added in both directions; sabotage 2 above proves it bites.
3. **It re-spelled DR-16's rule** instead of calling `tool_bind_allowed`, which `main` had since landed. Converged.

Also corrected: `docs/security/privacy-tiers.md`'s "Did not ship" item 3 claimed DR-16's raise was HTTP-only and that `workspace_set_tools` had no self-target guard. **Both were already false on `main`** — that PR landed the code and left the record behind. Item 3 now states what is closed, by which predicate, at both surfaces, with this finding as the second half of the same story.

## One residual, recorded rather than half-fixed

`assert_alt_provider_matches_session` reads `privacy_tiers_enabled()` directly. On the `platform__ingest_source` path that is a departure from the house rule (a gate on a tool-call path should ask the once-per-call `cap.enforced()`), because that handler does hold a sampled `CallCapability`. The scheduled-digest caller threads none, so it could only ever read directly.

The harmful outcome needs the switch **OFF** at the gate (to admit the raise) and **ON** again at the write (to ratchet), because `knowledge::tier::raise_unlocked` asks `ratchets_are_live()` for itself. A flip in one direction loses nothing; both directions inside one ingest means the user turned protection off and back on while a model was resolving a provider. Adding a parameter only one of two callers can fill is a worse change than the race it removes. Written into the code with the condition under which to take it.

## Pre-existing `main` breakage found on the way

`./scripts/clippy-lint.sh` fails the workspace on `result_large_err` at `crates/biorouter-server/src/routes/reply.rs:1863` (`authorize_steer`, from SD-11's `5c399eb7`). **Not this branch:** the file is byte-identical to `origin/main`, this branch touches no server code, and the identical error was reproduced on a detached control worktree at `9096d371`. CI's clippy step passes no `-D warnings` and is labelled "informational until warnings are burned down", which is how `main` carries it while the documented local gate is red. Two `too_many_lines` baseline warnings (`code_execution_extension.rs:1837`, `session_manager.rs:4960`) are pre-existing the same way. Filed separately; deliberately not fixed here.

## Notes for the reviewer

- History was collapsed to **one commit on top of `main`**. The merge of `origin/main` (`9096d371`) was performed first and was **conflict-free**; only `privacy/mod.rs` and `privacy_guard_wiring.rs` overlapped and both auto-merged, after which the censuses were re-run and re-measured by hand rather than trusted.
- `privacy_guard_wiring.rs` counts *occurrences* per `(needle, file)` and compares an aggregate against one tuple per row. The `tool_bind_allowed` row gained a **second file** (`alt_provider.rs`, `c(1, 0, 1)` — one call plus the shared `use super::{…}` import) and its sibling row's "this predicate's ONLY caller" claim was retired with it. No file appears twice in any row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
