### PR TITLE
test: two CI flakes that were both unlocked reads of shared state (one test had also stopped testing its regression)

### DIFF
--- a/crates/biorouter-mcp/src/knowledge/service.rs
+++ b/crates/biorouter-mcp/src/knowledge/service.rs
@@ -3002,6 +3002,30 @@ impl KnowledgeService {
         Ok(staged)
     }
 
+    /// Is a base publication for `id` staged under this root **right now**?
+    ///
+    /// A base is built in a sibling directory (`.creating-<id>-<uuid>`, or
+    /// `.importing-…`) and moved into place with one rename, so `<root>/<id>`
+    /// appears only at the very END of the transaction. The two observables
+    /// therefore say opposite things, and mistaking one for the other is easy:
+    ///
+    /// * `paths::kb_root(root, id).exists()` — the publication has **finished**
+    ///   and the base is installed.
+    /// * `publication_in_progress(id)` — a publication holds the root lock
+    ///   right now and the base is **not installed yet**.
+    ///
+    /// This is the one a concurrent caller can wait on to be *inside* another
+    /// creation rather than after it, and it deliberately takes no lock: the
+    /// whole point is to observe while somebody else holds it. It costs one
+    /// `read_dir` of the knowledge root and never waits on a subprocess, so
+    /// waiting for it does not become a bet on how long `git init` takes —
+    /// which is what waiting for the installed base is.
+    pub fn publication_in_progress(&self, id: &str) -> bool {
+        self.staged_publication_paths_unlocked()
+            .map(|staged| staged.iter().any(|(staged_id, _)| staged_id == id))
+            .unwrap_or(false)
+    }
+
     fn session_primary_references_unlocked(&self, id: &str) -> Result<bool> {
         let dir = paths::primary_kb_sessions_dir(self.root());
         if !dir.exists() {
@@ -4972,6 +4996,88 @@ mod tests {
         let bases = svc.list_bases().unwrap();
         assert_eq!(bases.len(), 1);
         assert_eq!(bases[0].name, "MS Patient Analysis");
+    }
+
+    /// The two observables a concurrent caller can wait on mean OPPOSITE
+    /// things, and a test elsewhere in this repo waited on the wrong one for
+    /// three weeks.
+    ///
+    /// `create_base` builds the base in `.creating-<id>-<uuid>` and publishes
+    /// it with a single rename, so `<root>/<id>` exists only once the whole
+    /// transaction — `git init`, the initial commit, the graph cache, the
+    /// classification stamp, the registry row — is done and the root lock is
+    /// about to be released. A caller that waits for the base *directory* has
+    /// therefore waited for the creation to FINISH, and anything it does next
+    /// runs after the window, not inside it.
+    /// `KnowledgeService::publication_in_progress` is the marker that means
+    /// inside, and it is true from the first write of the transaction.
+    ///
+    /// Both halves are asserted from within the transaction itself, through the
+    /// creation's own checkpoints, because that is the only place the claim is
+    /// observable.
+    #[test]
+    fn a_creation_is_visible_as_staged_long_before_its_base_directory_exists() {
+        let (_dir, svc) = svc();
+        let kb_root = paths::kb_root(svc.root(), "midflight");
+        let mut seen: Vec<(CreateCheckpoint, bool, bool)> = Vec::new();
+        svc.create_base_as_with_checkpoint(
+            CreateBaseSpec {
+                id: "midflight",
+                name: "midflight",
+                color: None,
+                format: KbFormat::default(),
+            },
+            false,
+            &crate::knowledge::affiliation::CallerAffiliation::Unstated,
+            |checkpoint| {
+                seen.push((
+                    checkpoint,
+                    svc.publication_in_progress("midflight"),
+                    kb_root.exists(),
+                ));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        let before_publication = [
+            CreateCheckpoint::Files,
+            CreateCheckpoint::Repository,
+            CreateCheckpoint::GraphCache,
+            CreateCheckpoint::Classification,
+            CreateCheckpoint::Registry,
+        ];
+        for checkpoint in before_publication {
+            let (_, staged, installed) = seen
+                .iter()
+                .copied()
+                .find(|(seen, _, _)| *seen == checkpoint)
+                .unwrap_or_else(|| panic!("the creation must reach {checkpoint:?}"));
+            assert!(
+                staged,
+                "at {checkpoint:?} the creation holds the root lock and must read as staged, \
+                 or nothing can wait for the window it is in"
+            );
+            assert!(
+                !installed,
+                "at {checkpoint:?} the base directory must NOT exist yet — a caller waiting for \
+                 it would be waiting for this whole transaction to finish, subprocesses included"
+            );
+        }
+
+        let (_, staged, installed) = seen
+            .iter()
+            .copied()
+            .find(|(seen, _, _)| *seen == CreateCheckpoint::Published)
+            .expect("the creation must reach Published");
+        assert!(!staged, "publication consumes the staging directory");
+        assert!(
+            installed,
+            "publication is what makes the base directory exist"
+        );
+
+        assert!(!svc.publication_in_progress("midflight"));
+        assert!(kb_root.exists());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/biorouter-server/src/routes/agent.rs
+++ b/crates/biorouter-server/src/routes/agent.rs
@@ -6118,7 +6118,12 @@ mod knowledge_selection_tests {
                     "creating {id} neither published nor returned in {WEDGE:?}: the knowledge \
                      root lock is held by something that is not this creation"
                 );
-                std::thread::yield_now();
+                // Cheap polling, not a budget: the loop's exits are still the two
+                // events above. A bare `yield_now` here spun one core hot for the
+                // few ms the staging takes and issued thousands of `read_dir`s —
+                // measurable next door, because ~660 other tests in this binary
+                // share a session store and some of them are sensitive to load.
+                std::thread::sleep(std::time::Duration::from_micros(200));
             }
             if inside {
                 staged = Some(creator);

--- a/crates/biorouter-server/src/routes/agent.rs
+++ b/crates/biorouter-server/src/routes/agent.rs
@@ -6032,12 +6032,41 @@ mod knowledge_selection_tests {
     /// so a base created in that window was in nobody's hidden list and joined
     /// a workflow session the workflow had never mentioned.
     ///
-    /// The race is staged deterministically: the creator takes the root lock
-    /// first (`create_base` holds it for the whole git init), and the apply
-    /// starts a few ms later. `list_bases` takes no lock, so the old code read
-    /// its inventory straight through the creator's lock and missed `gamma`;
-    /// the locked write blocks until the base is fully installed and then hides
-    /// it like any other undeclared base.
+    /// The race is staged on an OBSERVABLE, never on the clock, and the
+    /// observable has to be the right one. `create_base` builds the base in
+    /// `.creating-<id>-<uuid>` and publishes it with a single rename, so the
+    /// base's own directory appears only at the END of the transaction —
+    /// `KnowledgeService::publication_in_progress` is what means "the creator
+    /// holds the root lock and the base is not installed yet", which is the
+    /// window the apply must survive. Listing the bases takes no lock, so the
+    /// old code read its inventory straight through the creator's lock and
+    /// missed the new base; the locked write blocks until it is fully installed
+    /// and then hides it like any other undeclared base.
+    ///
+    /// ⚠ Both previous stagings were wrong, in opposite directions, and the
+    /// second looked like a fix for the first:
+    ///
+    /// * A fixed 10 ms sleep staged the window correctly but bet the creator
+    ///   thread would be scheduled within it, which it is not on a loaded
+    ///   Windows runner.
+    /// * Waiting for the base DIRECTORY to exist waits for the publishing
+    ///   rename — i.e. for the creation to *finish*. That un-staged the race
+    ///   entirely (with the base already installed, the buggy unlocked
+    ///   inventory would have seen it too, so the test could no longer fail on
+    ///   the regression it is named for) and made the 5 s budget a bet on
+    ///   `git init` plus a commit plus a graph derive returning in time. It
+    ///   lost that bet on `main` on 2026-09-12 and failed a PR with no Rust
+    ///   changes the same day.
+    ///
+    /// So: no budget on anything legitimate. The stage loop ends when the
+    /// creation becomes observable (proceed) or when the creator thread finishes
+    /// (the window was missed — stage a fresh one, and never assert into an
+    /// unstaged run). Both conditions are events, so being starved for a whole
+    /// second only makes this slower, never red. The one clock left is
+    /// [`WEDGE`]: a creation that neither publishes nor returns is not a slow
+    /// runner, it is a held root lock, and that must be a sentence rather than
+    /// a hung job. `publication_in_progress`'s two halves are pinned in
+    /// `knowledge::service`, from inside the transaction.
     #[test]
     fn applying_a_workflow_hides_a_base_that_lands_mid_call() {
         let dir = tempfile::tempdir().unwrap();
@@ -6057,23 +6086,48 @@ mod knowledge_selection_tests {
             visible: ids(&["alpha"]),
         });
 
-        let creator = {
-            let svc = Arc::clone(&svc);
-            std::thread::spawn(move || svc.create_base("gamma", "gamma", None).unwrap())
-        };
-        // Wait for an observable write that happens only after `create_base`
-        // has taken the root lock. A fixed sleep lost this race on slower
-        // Windows runners: the apply could finish before the creator thread was
-        // scheduled, making `gamma` legitimately visible when it landed later.
-        let gamma_root = biorouter_mcp::knowledge::paths::kb_root(svc.root(), "gamma");
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        while !gamma_root.exists() {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "the creator must begin writing gamma while the test is waiting"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(1));
+        // Not a race budget: 100x the slowest whole `create_base` anyone has
+        // measured, and only reachable when the creation can neither finish nor
+        // publish — i.e. something else is holding the knowledge root lock.
+        const WEDGE: std::time::Duration = std::time::Duration::from_secs(600);
+
+        let mut staged = None;
+        for attempt in 0..8 {
+            let id = format!("gamma{attempt}");
+            let creator = {
+                let svc = Arc::clone(&svc);
+                let id = id.clone();
+                std::thread::spawn(move || svc.create_base(&id, &id, None).unwrap())
+            };
+            let wedged_at = std::time::Instant::now() + WEDGE;
+            let mut inside = false;
+            while !creator.is_finished() {
+                if svc.publication_in_progress(&id) {
+                    inside = true;
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < wedged_at,
+                    "creating {id} neither published nor returned in {WEDGE:?}: the knowledge \
+                     root lock is held by something that is not this creation"
+                );
+                std::thread::yield_now();
+            }
+            if inside {
+                staged = Some(creator);
+                break;
+            }
+            // The whole creation landed before this thread looked even once.
+            // Nothing is asserted against that run: it would be the vacuous
+            // pass this staging exists to stop. Its base stays installed and
+            // undeclared, so the assertion below covers it too.
+            creator.join().unwrap();
         }
+        let creator = staged.expect(
+            "every creation finished before the test could observe it mid-flight, so the \
+             mid-call window was never staged",
+        );
+
         apply_workflow_knowledge_selection(&svc, "s1", &workflow).unwrap();
         creator.join().unwrap();
 

--- a/crates/biorouter/src/agents/extension_manager_extension.rs
+++ b/crates/biorouter/src/agents/extension_manager_extension.rs
@@ -4000,9 +4000,18 @@ mod tests {
         }
     }
 
+    /// Hold `BIOROUTER_PATH_ROOT` still for the duration of a test, so the
+    /// fixture below and the uninstall path under test resolve
+    /// `extensions_root()` to the same directory every time either asks.
+    ///
+    /// ⚠ It pins the **sandbox** root, not the variable's current value. The
+    /// difference is the whole bug: reading the variable to decide what to pin
+    /// happens before the lock is taken, so the value read is whichever of this
+    /// binary's ~30 relocating tests is holding `env_lock` at that instant —
+    /// and by the time the pin acquires the lock, that test has finished and
+    /// deleted its `TempDir`. See `crate::test_sandbox::pin_sandbox_path_root`.
     fn pinned_path_root() -> env_lock::EnvGuard<'static> {
-        let current = std::env::var("BIOROUTER_PATH_ROOT").ok();
-        env_lock::lock_env([("BIOROUTER_PATH_ROOT", current.as_deref())])
+        crate::test_sandbox::pin_sandbox_path_root()
     }
 
     async fn install_deletion_fixture(registry_id: &str, label: &str) -> DeletionFixture {

--- a/crates/biorouter/src/security/global_memory.rs
+++ b/crates/biorouter/src/security/global_memory.rs
@@ -1203,11 +1203,18 @@ record_result(all);"#;
     ///
     /// The writers were never the problem and adding a lock to them would not
     /// help — `env_lock` serialises only the tasks that ASK for it, and the
-    /// reader here never did. Pinning to the variable's *current* value is
-    /// deliberate: the point is to hold the lock, not to change the root.
+    /// reader here never did.
+    ///
+    /// ⚠ It pins the **sandbox** root rather than the variable's current value,
+    /// and the version that pinned "current" was this same bug one level down:
+    /// the read that decides what to pin happens *before* the lock is acquired,
+    /// so when a relocating test holds the lock at that moment it is that
+    /// test's `TempDir` that gets pinned — restored and deleted a moment later,
+    /// while this test spends its whole life resolving under it. Holding the
+    /// lock was always the point; reading the environment to decide what to
+    /// hold was the hole. See `crate::test_sandbox::pin_sandbox_path_root`.
     fn pinned_store_root() -> env_lock::EnvGuard<'static> {
-        let current = std::env::var("BIOROUTER_PATH_ROOT").ok();
-        env_lock::lock_env([("BIOROUTER_PATH_ROOT", current.as_deref())])
+        crate::test_sandbox::pin_sandbox_path_root()
     }
 
     fn store_path_spellings() -> Vec<String> {

--- a/crates/biorouter/src/test_sandbox.rs
+++ b/crates/biorouter/src/test_sandbox.rs
@@ -16,6 +16,19 @@
 //! an editor's test runner emits. This makes the sandbox the default and lets
 //! the gate keep choosing its own root.
 
+/// This binary's sandbox root, recorded before any test could move it.
+///
+/// ⚠ **`std::env::var("BIOROUTER_PATH_ROOT")` is NOT a way to ask what the
+/// sandbox root is, at any point after `main` starts.** Around thirty tests in
+/// this binary legitimately point that variable at a `TempDir` of their own
+/// under `env_lock` and put it back (`logging`, `managed`, `providers::utils`,
+/// `session::diagnostics`, `agents::skills_extension`, `agents::agent`,
+/// `execution::manager`, `knowledge::conversation_ingest`, …), so a read taken
+/// at test time answers "whichever test is relocating it at this instant",
+/// which is a different directory on every run and is deleted moments later.
+/// This cell is the only stable answer, and it is why it exists.
+static SANDBOX_ROOT: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
 /// Run before `main`, because the placement is the whole point.
 ///
 /// `Config::global()`, `SessionManager::instance()` and `AGENT_MANAGER` are all
@@ -27,18 +40,74 @@
 ///
 /// An outer `BIOROUTER_PATH_ROOT` wins: the Task 33 gate exports its own
 /// `mktemp -d` root, and a harness that wants to inspect what a run wrote must
-/// be able to choose where it lands.
+/// be able to choose where it lands. Either way the value that ends up in
+/// effect is recorded in [`SANDBOX_ROOT`] — this is the one moment in the
+/// process's life at which reading the variable answers the right question,
+/// because no test has run yet.
 #[ctor::ctor]
 fn sandbox_config_root_for_the_lib_test_binary() {
-    if std::env::var_os("BIOROUTER_PATH_ROOT").is_some() {
+    if let Some(outer) = std::env::var_os("BIOROUTER_PATH_ROOT") {
+        record_sandbox_root(&outer);
         return;
     }
     let root = tempfile::TempDir::new().expect("scratch config root for the lib test binary");
     std::env::set_var("BIOROUTER_PATH_ROOT", root.path());
+    record_sandbox_root(root.path().as_os_str());
     // Leaked deliberately: a `static` is never dropped, which is exactly the
     // lifetime the sandbox needs — it must outlive the last test in the binary.
     static ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
     let _ = ROOT.set(root);
+}
+
+fn record_sandbox_root(root: &std::ffi::OsStr) {
+    // A root that is not valid UTF-8 cannot be pinned through `env_lock`
+    // (its API is `&str`), so it is left unrecorded rather than recorded
+    // lossily — a mangled root would be pinned as a *different* directory.
+    // `sandbox_path_root` then says so instead of silently relocating writes.
+    if let Some(root) = root.to_str() {
+        let _ = SANDBOX_ROOT.set(root.to_owned());
+    }
+}
+
+/// The config/data root every test in this binary resolves under, unless a test
+/// is deliberately relocating it.
+pub(crate) fn sandbox_path_root() -> &'static str {
+    SANDBOX_ROOT
+        .get()
+        .expect(
+            "the sandbox root was recorded before main; an absent value means either the ctor \
+             did not run or BIOROUTER_PATH_ROOT is not valid UTF-8 and cannot be pinned",
+        )
+        .as_str()
+}
+
+/// Hold `BIOROUTER_PATH_ROOT` **at the sandbox root** for as long as the guard
+/// lives, so a test whose subject resolves paths from that variable resolves
+/// the same root every time it asks.
+///
+/// ⚠ **Pin the recorded root, never the variable's current value.** Two call
+/// sites used to open with
+///
+/// ```ignore
+/// let current = std::env::var("BIOROUTER_PATH_ROOT").ok();
+/// env_lock::lock_env([("BIOROUTER_PATH_ROOT", current.as_deref())])
+/// ```
+///
+/// whose stated intent — "hold the lock, do not change the root" — is exactly
+/// right and which does the opposite whenever it matters. The read happens
+/// *before* the lock is acquired, so if any of the ~30 relocating tests holds
+/// the lock at that instant, `current` is **that test's `TempDir`**. The pin
+/// then blocks, the relocator finishes, its guard restores the sandbox root and
+/// its `TempDir` is deleted — and the pin wakes up and installs the deleted
+/// directory as this test's root for the whole test. Everything the test then
+/// resolves (`Config::global()`, `extensions_root()`, the global memory store)
+/// points outside its own sandbox at a path whose parent may be gone, which is
+/// how `a_removal_prunes_the_extension_from_every_stored_session_roster` came
+/// to fail a full-suite run inside `create_dir_all` with `EINVAL` while passing
+/// 3/3 in isolation. A writer's lock cannot protect an unlocked reader — this
+/// helper's job is to have no unlocked read to protect.
+pub(crate) fn pin_sandbox_path_root() -> env_lock::EnvGuard<'static> {
+    env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(sandbox_path_root()))])
 }
 
 #[cfg(test)]
@@ -51,14 +120,143 @@ mod tests {
     /// still pass if something had reached `Config::global()` before the ctor.
     #[test]
     fn the_lib_test_binary_config_root_is_sandboxed() {
-        let root = std::env::var("BIOROUTER_PATH_ROOT")
-            .expect("BIOROUTER_PATH_ROOT must be sandboxed before any test in this binary runs");
+        // The recorded root, not `std::env::var` — a read taken here answers
+        // "whichever test is relocating the variable right now", and this
+        // assertion would then blame the sandbox for a sibling's `TempDir`.
+        let root = super::sandbox_path_root();
         let path = crate::config::Config::global().path();
         assert!(
-            path.starts_with(&root),
+            path.starts_with(root),
             "Config::global() resolved to {path}, outside the sandbox at {root}. \
              Something reached Config::global() before the sandbox was installed, so \
              config writes from this binary land in the developer's real config."
         );
+    }
+
+    /// The pin must ignore the live variable, and this is the situation in which
+    /// they differ — the one that made `pinned_path_root` install another test's
+    /// soon-to-be-deleted `TempDir`.
+    ///
+    /// Staged with a thread that holds `env_lock` (so it is holding a foreign
+    /// root installed) and is released by a channel, not a sleep: every step is
+    /// an event, so a starved runner makes this slower and never red. Nothing
+    /// else in the binary can write the environment while that lock is held,
+    /// which is also what makes the bare `std::env::var` read below safe here.
+    ///
+    /// Before the fix, the pin's source was exactly that `std::env::var` read,
+    /// so the assertion below could not hold.
+    #[test]
+    fn the_pin_source_ignores_a_root_another_test_has_installed() {
+        let sandbox = super::sandbox_path_root();
+        let foreign = tempfile::TempDir::new().expect("a foreign root to install");
+        let foreign_value = foreign
+            .path()
+            .to_str()
+            .expect("a UTF-8 temp path")
+            .to_owned();
+
+        let (installed_tx, installed_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let held = foreign_value.clone();
+        let holder = std::thread::spawn(move || {
+            let _guard = env_lock::lock_env([("BIOROUTER_PATH_ROOT", Some(held.as_str()))]);
+            installed_tx.send(()).expect("the test is still waiting");
+            // Hold the foreign root — and the environment lock — until released.
+            let _ = release_rx.recv();
+        });
+        installed_rx.recv().expect("the holder installs its root");
+
+        let live = std::env::var("BIOROUTER_PATH_ROOT").ok();
+        let pinned = super::sandbox_path_root();
+        release_tx.send(()).expect("the holder is still parked");
+        holder.join().expect("the holder exits cleanly");
+
+        assert_eq!(
+            live.as_deref(),
+            Some(foreign_value.as_str()),
+            "precondition: the holder's root really is the live value right now, so a pin \
+             that reads the environment would install a directory it does not own"
+        );
+        assert_eq!(
+            pinned, sandbox,
+            "the pin followed another test's root instead of this binary's sandbox"
+        );
+    }
+
+    /// Nothing in this crate may ask the environment where the sandbox root is.
+    ///
+    /// This is the shared state itself rather than either symptom: both flakes
+    /// this guard comes from — a pin that installed another test's `TempDir`,
+    /// and a sandbox assertion that compared a frozen path against a sibling's
+    /// root — were an unlocked read of a variable ~30 tests in this binary
+    /// relocate. Adding a lock to the writers cannot close that; not reading
+    /// can. The resolver is the one place that must read it, because production
+    /// honours the relocation, and this module is where the answer is recorded.
+    #[test]
+    fn only_the_resolver_and_the_sandbox_read_the_path_root_variable() {
+        let crate_src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        assert!(
+            crate_src.is_dir(),
+            "the audit walks {}; if that path is wrong it passes for the wrong reason",
+            crate_src.display()
+        );
+        let needle = concat!("BIOROUTER_", "PATH_ROOT");
+        let allowed = ["config/paths.rs", "test_sandbox.rs"];
+
+        let mut offenders: Vec<String> = Vec::new();
+        let mut scanned = 0usize;
+        for entry in walkdir::WalkDir::new(&crate_src) {
+            let entry = entry.expect("the audit must not silently skip an unreadable directory");
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(&crate_src)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/");
+            scanned += 1;
+            if allowed.contains(&rel.as_str()) {
+                continue;
+            }
+            let body = std::fs::read_to_string(path).expect("a readable source file");
+            for (number, line) in body.lines().enumerate() {
+                let code = line.trim_start();
+                // Prose about the variable is fine; a read of it is not.
+                if code.starts_with("//") {
+                    continue;
+                }
+                if code.contains(needle) && (code.contains("env::var") || code.contains("var_os")) {
+                    offenders.push(format!("{rel}:{}", number + 1));
+                }
+            }
+        }
+        assert!(
+            scanned > 100,
+            "only {scanned} files scanned — the walk found nothing to audit"
+        );
+        assert!(
+            offenders.is_empty(),
+            "these read BIOROUTER_PATH_ROOT from the environment: {offenders:?}. After main \
+             starts, that answers 'whichever test is relocating it at this instant', not 'where \
+             is the sandbox'. Ask `test_sandbox::sandbox_path_root()`, or take \
+             `test_sandbox::pin_sandbox_path_root()` if the subject resolves paths itself. \
+             Setting it is still fine under `env_lock`."
+        );
+    }
+
+    /// …and the guard the helper hands out really does install that root, so a
+    /// subject resolving `BIOROUTER_PATH_ROOT` under it lands in the sandbox.
+    #[test]
+    fn the_pin_installs_the_sandbox_root_for_its_lifetime() {
+        let _pin = super::pin_sandbox_path_root();
+        assert_eq!(
+            std::env::var("BIOROUTER_PATH_ROOT").as_deref(),
+            Ok(super::sandbox_path_root())
+        );
+        assert!(crate::config::paths::Paths::config_dir().starts_with(super::sandbox_path_root()));
+        assert!(crate::extension_install::brxt::extensions_root()
+            .starts_with(super::sandbox_path_root()));
     }
 }


### PR DESCRIPTION
Two CI flake families, measured, both independent of the SQLite `busy_timeout`
contention and the `subagent_handle::HANDLES` deadlock being fixed elsewhere.
Neither turned out to be a production bug — both are test-isolation defects,
and **Family A's test had also stopped testing the regression it is named
for**, which is the more important finding of the two.

## Family A — `applying_a_workflow_hides_a_base_that_lands_mid_call`

### Measured before this branch

- **On `main` itself**: run 34679956636 (head `9096d371`), job `103516636542`,
  `test (windows-latest)` — `test result: FAILED. 608 passed; 1 failed`,
  `panicked at crates\biorouter-server\src\routes\agent.rs:5697:13: the creator
  must begin writing gamma while the test is waiting`.
- Earlier the same day on **PR #255, which has zero Rust changes**, while six
  other PRs passed the same job against the same `main`.

### What the race is

Nothing — the test stopped staging one on 2026-08-21.

`create_base` builds a base in `.creating-<id>-<uuid>` and publishes it with a
single `rename`, so `<root>/<id>` appears at the **very end** of the
transaction, after `git init`, the initial commit, the graph cache, the
classification stamp and the registry row. The barrier waited for exactly that
directory, which means:

1. **The 5 s budget was a bet on a whole `create_base` returning**, subprocesses
   included, on a Windows runner concurrently running 608 other tests. That is
   the assertion that fired: the staging barrier, not the invariant.
2. **The window was already over when the apply started.** With the base
   installed, the pre-fix unlocked inventory would have seen it too — so the
   test could no longer fail on its own regression.

Point 2, measured by reintroducing the pre-fix inversion in
`workflow::runtime::apply_knowledge_selection` (list unlocked → invert →
`set_selection` with a hidden list):

| barrier | result against the reintroduced bug |
| --- | --- |
| old — wait for `kb_root(root, "gamma").exists()` | **passes, 5/5** (vacuous) |
| new — wait for `publication_in_progress("gamma0")` | **fails on attempt 0**: `left: ["alpha", "gamma0"]`, `right: ["alpha"]` |

History: `76952512` ("stabilize Windows knowledge selection race test")
replaced a 10 ms sleep — which staged the window correctly but bet on the
creator thread being scheduled inside it — with a wait for the opposite event.
One flake was traded for a false pass *plus* a slower flake.

### Not a production bug

`KnowledgeService::set_visible_kbs` takes the root lock and inverts the
caller's **visible** set against the inventory read inside that lock; the
caller has no way to hand it a stale snapshot. The nondeterminism was entirely
in the harness.

### Fix

- `KnowledgeService::publication_in_progress(id)` — one `read_dir`, no lock, no
  subprocess — is the observable that means "a publication holds the root lock
  right now and the base is **not** installed yet".
- The stage loop now ends on an **event** either way: the creation becomes
  observable (proceed), or the creator thread finishes (the window was missed —
  stage a fresh one rather than assert into an unstaged run). A starved runner
  makes the test slower, never red.
- The one clock left is a 600 s wedge detector — ~100× the slowest whole
  `create_base` anyone has measured, reachable only when a creation can neither
  publish nor return, i.e. the root lock is held by something else — and it says
  that instead of hanging the job.
- `a_creation_is_visible_as_staged_long_before_its_base_directory_exists`
  (`biorouter-mcp`) pins both halves from **inside** the transaction via the
  creation's own checkpoints, which is the only place the claim is observable.

## Family B — `a_removal_prunes_the_extension_from_every_stored_session_roster`

### Measured before this branch

Full `-p biorouter --lib` suite on a merged integration tree: `4008 passed; 1
failed`, `panicked at crates/biorouter/src/agents/extension_manager_extension.rs:4266:79:
called Result::unwrap() on an Err value: Os { code: 22, kind: InvalidInput,
message: "Invalid argument" }` — i.e. `install_sideloaded_fixture`'s
`create_dir_all(install_dir.join("skills").join(&skill_slug))`. The same test
passes 3/3 in isolation.

### The shared state, and who writes it

`extensions_root()` → `Paths::config_dir()` → `Paths::get_dir` reads
`BIOROUTER_PATH_ROOT` **on every call**, uncached — deliberately, because
production honours the relocation. `test_sandbox`'s `#[ctor]` sets it to a
`TempDir` before `main`, and 29 further sites in the same binary then
legitimately relocate it to a `TempDir` of their own under `env_lock`:
`logging`, `managed` (×3), `providers::utils` (×5), `session::diagnostics` (×7),
`agents::skills_extension` (×6), `agents::agent` (×3), `agents::reply_parts`,
`execution::manager` (×2), `extension_install::claim`,
`knowledge::conversation_ingest` (×2).

### The bug: the pin read the variable before taking the lock

```rust
fn pinned_path_root() -> env_lock::EnvGuard<'static> {
    let current = std::env::var("BIOROUTER_PATH_ROOT").ok();   // unlocked
    env_lock::lock_env([("BIOROUTER_PATH_ROOT", current.as_deref())])
}
```

Both call sites (`agents::extension_manager_extension`,
`security::global_memory`) documented the intent as "hold the lock, do not
change the root", and both did the opposite exactly when it mattered:

1. A relocator holds `env_lock` with its own `TempDir`.
2. The pin's **unlocked** read returns *that* root, then blocks on the lock.
3. The relocator finishes: its guard restores the sandbox root, and its
   `TempDir` is deleted.
4. The pin wakes and installs the **deleted** directory as this test's root for
   the rest of the test.

So the fixture — and `Config::global()`, `extensions_root()`, the global memory
store — resolve outside the test's own sandbox, under a path whose owner has
just removed it. `the_lib_test_binary_config_root_is_sandboxed` was exposed the
same way (it compared a frozen `Config::global()` path against a live read of
the variable).

A writer's lock cannot protect an unlocked reader. The fix is to have no
unlocked read: `test_sandbox` records the root in effect **before `main`** — the
one moment at which reading the variable answers the right question — and
`pin_sandbox_path_root()` pins that.

### On the `EINVAL`

The isolation defect is proven and fixed; the specific errno is **not
reproduced**, and I would rather say so than invent a mechanism. Ruled out by
measurement on this machine (APFS):

| candidate path | actual errno |
| --- | --- |
| invalid UTF-8 name | 92 `EILSEQ` (and `std::env::var` cannot yield one) |
| component > 255 bytes / total > 1024 | 63 `ENAMETOOLONG` |
| `create_dir_all` inside a tree being `rm -rf`'d (3087 creates) | 0 failures |
| under a nonexistent `/var/folders/<hash>` | 13 `EACCES` |
| `/`-rooted (blank-home fallback) | 30 `EROFS` |
| relative `.config/biorouter/...` (blank-home fallback) | succeeds |

What is certain is that the fixture was writing somewhere it does not own. If
it recurs after this change, the root is provably the sandbox, which narrows it
to something other than the environment.

### Fix, with three tests that fail before and pass after

- `the_pin_source_ignores_a_root_another_test_has_installed` — a thread holds
  `env_lock` with a foreign root and is released by a **channel, not a sleep**
  (every step is an event, so a starved runner makes it slower, never red), and
  the test asserts the pin source is still the sandbox. Against the pre-fix
  source it fails naming both temp directories:
  `left: "…/.tmpejKell"`, `right: "…/.tmpEPxyAn"`.
- `the_pin_installs_the_sandbox_root_for_its_lifetime` — the guard really moves
  `Paths::config_dir()` and `extensions_root()` into the sandbox.
- `only_the_resolver_and_the_sandbox_read_the_path_root_variable` — walks
  `crates/biorouter/src` and permits the read only in the resolver and in
  `test_sandbox`. Verified non-vacuous: re-adding the old idiom makes it fail
  naming `agents/extension_manager_extension.rs:4014`. *Setting* the variable
  under `env_lock` stays fine; reading it to find out where the sandbox is does
  not.

No `#[serial]`, no retry of an assertion, no widened race budget, no narrowed
assertion, nothing `#[ignore]`d.

## Verification

Five consecutive runs of each affected suite, sequentially (concurrent cargo
runs in one worktree produce phantom failures), on this branch rebased onto
`35a67843`, with `BIOROUTER_DISABLE_KEYRING=true`. **15/15 exit 0, zero failures.**

| run | `-p biorouter --lib` | `-p biorouter-server --lib --bins` | `-p biorouter-mcp --lib` |
| --- | --- | --- | --- |
| 1 | 4016 passed, 0 failed — 54 s | 660 + 645 passed, 0 failed — 125 s | rc=0 — 127 s * |
| 2 | 4016 passed, 0 failed — 65 s | 660 + 645 passed, 0 failed — 26 s | 1686 passed, 0 failed — 100 s |
| 3 | 4016 passed, 0 failed — 46 s | 660 + 645 passed, 0 failed — 33 s | 1686 passed, 0 failed — 91 s |
| 4 | 4016 passed, 0 failed — 48 s | 660 + 645 passed, 0 failed — 26 s | 1686 passed, 0 failed — 101 s |
| 5 | 4016 passed, 0 failed — 70 s | 660 + 645 passed, 0 failed — 26 s | 1686 passed, 0 failed — 95 s |

\* run 1's `biorouter-mcp` log was deleted by a sibling process before the
counts could be read from it; the run itself exited 0, and runs 2-5 give the
count. Wall times include the build for the first run of each suite.

Plus, on the same tree: the rewritten race test 10x on its own (0.06-0.13 s
every time, so the window is staged on the first attempt and the restage path is
not being leaned on), and the four `test_sandbox` tests plus
`a_removal_prunes_the_extension_from_every_stored_session_roster` together.


- `cargo fmt --all -- --check`: clean.
- `./scripts/clippy-lint.sh`: clean — `-D warnings`, the `too_many_lines`
  baseline and the banned-TLS check all pass. (Worth recording: the same script
  was RED on `9096d371`, the commit this work started from, in files this branch
  does not touch — `clippy::result_large_err` in `routes/reply.rs`,
  `clippy::string_slice` in `commands/agent.rs` and two `too_many_lines`
  baseline violations. All four were fixed upstream in the 121 commits that
  landed while this branch was being written. CI would not have caught them:
  `rust.yml` runs clippy without `-D warnings`, "informational until warnings
  are burned down".)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
