### PR TITLE
test(server): pin the process session store before any test can move it

### DIFF
--- a/crates/biorouter-server/src/auth.rs
+++ b/crates/biorouter-server/src/auth.rs
@@ -49,8 +49,8 @@ pub fn install_user_action_digest(digest: Option<[u8; 32]>) {
 ///
 /// Pure, so the whole rule is testable without a process global or a server —
 /// which matters here because the alternative home for these assertions is an
-/// `AppState`-backed HTTP test, and `AppState::new()` opens the developer's REAL
-/// session database (see `routes::agent::working_dir_lock_tests`).
+/// `AppState`-backed HTTP test, and `AppState::new()` opens the ONE session DB this
+/// binary shares (see `routes::agent::working_dir_lock_tests`).
 ///
 /// `expected: None` is "this daemon was handed no key" and fails closed: `just
 /// run-server`, a hand-run `biorouterd agent` and every headless deployment land

--- a/crates/biorouter-server/src/routes/agent.rs
+++ b/crates/biorouter-server/src/routes/agent.rs
@@ -253,7 +253,7 @@ impl PrivacyBarrierBody {
 /// How `/agent/update_provider` failed, at the granularity the client needs.
 ///
 /// Split out of the handler so the mapping can be tested without an
-/// `AppState`: `AppState::new()` opens the REAL user session database (see the
+/// `AppState`: `AppState::new()` opens the ONE shared session database (see the
 /// note in `routes/session.rs`), so a route test must never go through it.
 #[derive(Debug)]
 pub(crate) enum ProviderBindFailure {
@@ -1981,7 +1981,7 @@ const CROSS_AFFILIATION_GRANT_CHAT_NOT_LOADED: &str =
 ///
 /// ⚠ **Extracted so the claim "only the user may grant" is asserted rather than
 /// grepped for.** The handler it belongs to cannot be driven from a test —
-/// `AppState::new()` opens the developer's REAL session database — so every
+/// `AppState::new()` opens the ONE session DB this binary shares — so every
 /// other fact about this route is a source scan, and a scan for
 /// `user_action_proof(` keeps passing against a match whose `Unproven` arm was
 /// refactored into `=> {}`. This mapping is pure, so
@@ -2035,7 +2035,7 @@ const CROSS_AFFILIATION_GRANT_AUTH_SUBJECT: &str = "one cross-institution connec
 ///
 /// ⚠ **Extracted for [`refuse_grant_unless_user`]'s reason, which is the same
 /// reason.** This handler cannot be driven from a test — `AppState::new()` opens
-/// the developer's REAL session database — so every other fact about the route
+/// the ONE session DB this binary shares — so every other fact about the route
 /// is a source scan, and a scan cannot tell "prompts in strict" from "prompts in
 /// every mode" or from "prompts in none". Taking the policy and the prompter as
 /// arguments makes all three modes assertions about the real decision path, with
@@ -2720,7 +2720,7 @@ async fn read_resource(
 /// of this process.
 ///
 /// Extracted so the mapping can be tested without `AppState`, which builds the
-/// process-global `AgentManager` and opens the REAL user session database. It
+/// process-global `AgentManager` and opens the ONE shared session database. It
 /// is the resource-path sibling of [`dispatch_failure_response`], and it exists
 /// for the same reason: `.map_err(|_e| INTERNAL_SERVER_ERROR)` threw Gate C's
 /// sibling refusal away and told the caller Biorouter had crashed. A privacy
@@ -2785,8 +2785,8 @@ mod read_resource_route_tests {
     //! properties below are the ones nothing asserted while it had a caller.
     //!
     //! The behaviour is asserted through [`read_resource_failure`] rather than
-    //! over HTTP because `AppState::new()` opens the developer's REAL session
-    //! database — the same reason `cross_affiliation_grant_route_tests` states.
+    //! over HTTP because `AppState::new()` opens the ONE session DB this binary
+    //! shares — the same reason `cross_affiliation_grant_route_tests` states.
     //! The capability the route hands the extension manager cannot be reached
     //! that way at all, so it is pinned at the source, and the refusal it
     //! produces is proved end-to-end by building the REAL refusal rather than a
@@ -2970,7 +2970,7 @@ mod read_resource_route_tests {
 /// server fault that keeps its 500.
 ///
 /// Extracted so the mapping can be tested without `AppState`, which builds the
-/// process-global `AgentManager` and opens the REAL user session database. It
+/// process-global `AgentManager` and opens the ONE shared session database. It
 /// mirrors the agent loop, which downcasts to `ErrorData` to avoid
 /// double-wrapping and hands the model the message.
 ///
@@ -4858,7 +4858,7 @@ mod cross_affiliation_grant_route_tests {
     //! silently.
     //!
     //! The behaviour these guard is not testable at the HTTP layer here —
-    //! `AppState::new()` opens the developer's REAL session database (see
+    //! `AppState::new()` opens the ONE session DB this binary shares (see
     //! `working_dir_lock_tests`) — so the copy is asserted directly, the way
     //! `routes::session`'s `the_refusals_say_different_things` asserts the
     //! declassification pair.
@@ -5335,7 +5335,7 @@ mod privacy_barrier_tests {
     //!
     //! Exercised through [`classify_provider_bind_failure`] — the exact mapping
     //! the handler applies — rather than through `AppState`, which opens the
-    //! REAL user session database.
+    //! ONE shared session database.
 
     use super::{classify_provider_bind_failure, PrivacyBarrierBody, ProviderBindFailure};
     use axum::http::StatusCode;
@@ -5741,7 +5741,7 @@ mod gate_c_call_tool_tests {
     //!
     //! Exercised through [`dispatch_failure_response`] — the exact mapping the
     //! handler applies — rather than through `AppState`, which builds the
-    //! process-global `AgentManager` and opens the REAL user session database.
+    //! process-global `AgentManager` and opens the ONE shared session database.
     //! That is the same shape `privacy_barrier_tests` above uses for Gate A's
     //! route half, and the same reason.
 
@@ -5862,7 +5862,7 @@ mod working_dir_lock_tests {
     //! rule (#44), exercised through [`apply_working_dir_update`] — the exact
     //! validation + guard + update path the handler runs before restarting the
     //! agent. A hermetic tempdir-backed [`SessionManager`] stands in for the
-    //! real one: `AppState::new()` opens the REAL user session database (see
+    //! real one: `AppState::new()` opens the ONE shared session database (see
     //! the note in `routes/session.rs`), so a mutating route test must never
     //! go through it.
 

--- a/crates/biorouter-server/src/routes/apps.rs
+++ b/crates/biorouter-server/src/routes/apps.rs
@@ -6438,7 +6438,7 @@ mod tests {
     use serde_json::json;
 
     // NOTE — the four `run_bounded_turn` tests below call `AppState::new()`,
-    // which opens the developer's REAL session database (via
+    // which opens the ONE session DB this binary shares (via
     // `AgentManager::instance()` → `SessionManager::instance()`), exactly as the
     // `workspace::turn` tests warn. They create rows named "worker",
     // "worker-text", "worker-abandoned" and "worker-cancelled". Keep the names
@@ -9921,11 +9921,13 @@ mod tests {
         #[tokio::test]
         #[serial_test::serial]
         async fn the_app_capability_report_follows_the_manifests_provider_not_the_global_one() {
-            // Warm the process-global `SessionManager` against the REAL path root
-            // BEFORE the env lock relocates it — otherwise this test could be the
-            // one that creates the session database inside a `TempDir` that is
-            // then unlinked, breaking every sibling test in the binary.
-            let _warm = crate::state::AppState::new().await.unwrap();
+            // This test used to warm the process-global `SessionManager` here,
+            // before the env lock relocates the path root, so that it could not
+            // be the one that creates the session database inside a `TempDir`
+            // that is then unlinked. `src/test_sandbox.rs` now freezes that path
+            // in a `#[ctor]` for the whole binary — the same fix, without having
+            // to be remembered at each new call site, which is why the flake
+            // outlived the warm-up.
 
             // Both inversions, because each is silent on its own and a fix that
             // hardcodes either literal passes one of them. In each row the agent
@@ -10397,11 +10399,13 @@ mod tests {
         #[tokio::test]
         #[serial_test::serial]
         async fn an_apps_skill_grant_is_bounded_to_search_and_load() {
-            // Warm the process-global `SessionManager` against the REAL path
-            // root BEFORE the env lock relocates it — otherwise this test could
+            // This test used to warm the process-global `SessionManager` here,
+            // before the env lock relocates the path root, so that it could not
             // be the one that creates the session database inside a `TempDir`
-            // that is then unlinked, breaking every sibling test in the binary.
-            let _warm = crate::state::AppState::new().await.unwrap();
+            // that is then unlinked. `src/test_sandbox.rs` now freezes that path
+            // in a `#[ctor]` for the whole binary — the same fix, without having
+            // to be remembered at each new call site, which is why the flake
+            // outlived the warm-up.
 
             let world = skill_world(&["app-skill"]);
             let dir = world.path();
@@ -10733,10 +10737,13 @@ mod tests {
         /// Run the real arming step against a sandboxed root and return what it
         /// refused to arm.
         async fn withheld(manifest: &Manifest) -> Vec<String> {
-            // Warm the process-global `SessionManager` against the REAL path
-            // root before the env lock relocates it — same reason as
-            // `an_apps_skill_grant_is_bounded_to_search_and_load`.
-            let _warm = crate::state::AppState::new().await.unwrap();
+            // This test used to warm the process-global `SessionManager` here,
+            // before the env lock relocates the path root, so that it could not
+            // be the one that creates the session database inside a `TempDir`
+            // that is then unlinked. `src/test_sandbox.rs` now freezes that path
+            // in a `#[ctor]` for the whole binary — the same fix, without having
+            // to be remembered at each new call site, which is why the flake
+            // outlived the warm-up.
             let root = tempfile::TempDir::new().unwrap();
             let _env = lock_env_for(root.path(), PUBLIC_HOST);
             let state = crate::state::AppState::new_with_knowledge_root(root.path().join("kb"))
@@ -11519,11 +11526,13 @@ mod tests {
         #[tokio::test]
         #[serial_test::serial]
         async fn configure_main_provider_cannot_raise_a_live_app_sessions_capability() {
-            // Warm the process-global `SessionManager` against the REAL path root
-            // BEFORE the env lock relocates it — otherwise this test could be the
-            // one that creates the session database inside a `TempDir` that is
-            // then unlinked, breaking every sibling test in the binary.
-            let _warm = crate::state::AppState::new().await.unwrap();
+            // This test used to warm the process-global `SessionManager` here,
+            // before the env lock relocates the path root, so that it could not
+            // be the one that creates the session database inside a `TempDir`
+            // that is then unlinked. `src/test_sandbox.rs` now freezes that path
+            // in a `#[ctor]` for the whole binary — the same fix, without having
+            // to be remembered at each new call site, which is why the flake
+            // outlived the warm-up.
             let dir = tempfile::TempDir::new().unwrap();
             let _env = lock_env_for(dir.path(), PRIVATE_HOST);
 

--- a/crates/biorouter-server/src/routes/config_management.rs
+++ b/crates/biorouter-server/src/routes/config_management.rs
@@ -2513,7 +2513,7 @@ mod affiliation_wire_tests {
 /// `POST /privacy/disclosure/ack`.
 ///
 /// ⚠ **Handlers, not `oneshot` over a `Router`.** These two routes take no
-/// `AppState`, and building one opens the developer's REAL session database
+/// `AppState`, and building one opens the ONE session DB this binary shares
 /// (`routes::agent::working_dir_lock_tests`). Calling the handlers directly is
 /// how the rest of this file's tests reach `read_config` and
 /// `get_detectable_providers`, and it exercises the same guard the router would.

--- a/crates/biorouter-server/src/routes/mod.rs
+++ b/crates/biorouter-server/src/routes/mod.rs
@@ -403,7 +403,7 @@ pub(crate) fn secret_matches(candidate: &str, expected: &str) -> bool {
 ///
 /// It is the ONE span a structural assertion about a handler is allowed to read.
 /// Several route facts in this crate cannot be asserted behaviourally —
-/// `AppState::new()` opens the developer's REAL session database — and the
+/// `AppState::new()` opens the ONE session DB this binary shares — and the
 /// failure mode of a whole-file `contains` is that it finds the fact in the
 /// handler *next door*. A second copy of this extractor is how two scans start
 /// disagreeing about where a function ends, so there is one, and every test

--- a/crates/biorouter-server/src/routes/session.rs
+++ b/crates/biorouter-server/src/routes/session.rs
@@ -1772,6 +1772,31 @@ pub fn routes(state: Arc<AppState>) -> Router {
 // second module and takes this one instead.
 #[cfg(test)]
 pub(crate) mod diverge_tests {
+    //! ⚠ **If a test in here fails with a 500 where it asserted a 200, suspect
+    //! the session store's PATH before you suspect this file.**
+    //!
+    //! Several of these are read-only route tests over one process-global
+    //! session store, and they were the rotating victims of a
+    //! `test (windows-latest)` flake: `activity_clamps_an_absurd_window`
+    //! answering 500 on one run, `sidebar_route_…` or a `/usage` route on the
+    //! next, and — measured in one job of PR #240 — the same test `... ok` in the
+    //! `biorouter_server` lib binary and `... FAILED` in the `biorouterd` bin
+    //! binary 61 s later, off identical source (`main.rs` and `lib.rs` both
+    //! declare `mod routes`).
+    //!
+    //! The 500 is honest: `get_activity(..).map_err(|_| INTERNAL_SERVER_ERROR)`
+    //! reporting a real database error. The database had been moved out from
+    //! under the process — a sibling test relocated `BIOROUTER_PATH_ROOT` under a
+    //! `TempDir`, won the race to be the first to touch the store, and then
+    //! unlinked it. The already-open connection kept answering, so it only bit
+    //! when the pool had to open a *second* one: `(code: 14) unable to open
+    //! database file`.
+    //!
+    //! `src/test_sandbox.rs` now freezes the store's directory before any test
+    //! runs, and `tests/session_store_survives_a_relocated_path_root.rs` holds
+    //! that closed. Read the pinning section of the first before changing
+    //! anything that relocates the path root.
+
     use super::*;
     use axum::body::{to_bytes, Body};
     use axum::http::Request;
@@ -1934,7 +1959,7 @@ pub(crate) mod diverge_tests {
     /// `/sessions/activity` must not be swallowed by the `/sessions/{session_id}`
     /// wildcard registered next to it, and the payload must be camelCase.
     ///
-    /// NOTE: `AppState::new()` opens the REAL user session database, so a route
+    /// NOTE: `AppState::new()` opens the ONE shared session database, so a route
     /// test here must be READ-ONLY. The behaviour of the activity aggregation is
     /// covered by `session_manager`'s unit tests, which use a `TempDir`.
     #[tokio::test(flavor = "multi_thread")]
@@ -2117,7 +2142,7 @@ pub(crate) mod diverge_tests {
     /// totalTokens, turns}`, with the unknown bucket carrying `null`.
     ///
     /// This is a pure serialization assertion rather than a live round-trip:
-    /// `AppState::new()` opens the REAL shared session DB, whose token-ledger
+    /// `AppState::new()` opens the ONE shared session DB, whose token-ledger
     /// contents (and, across parallel worktrees, whose schema) are not stable
     /// enough for a write-then-read route test. The aggregation SQL itself is
     /// covered by `session_manager`'s `TempDir` unit tests.
@@ -2206,6 +2231,44 @@ pub(crate) mod diverge_tests {
 
         let (status, _) = get_usage(state, "29990101_99999").await;
         assert_eq!(status, axum::http::StatusCode::FORBIDDEN);
+    }
+
+    /// A genuine database failure on `/sessions/activity` is still a **500**.
+    ///
+    /// ⚠ This is here because of the flake in the module note, not in spite of
+    /// it. That 500 was *correct* — the store really had been moved out from
+    /// under the process — so the only legitimate fix was to make the store
+    /// sound. Making this route quieter instead (an empty `ActivityWindow`, a
+    /// 200 with zeroes, an `unwrap_or_default`) would have turned the same green
+    /// suite into a daemon that answers the Home heatmap with silence when its
+    /// database is unreadable. Nothing else asserts that mapping, because it
+    /// cannot be driven from here: the handler reads the process-global store,
+    /// and there is no seam to hand it a broken one.
+    ///
+    /// A source scan over the handler's own span, with the negative control
+    /// [`crate::routes::body_of`] requires of every caller.
+    #[test]
+    fn a_database_failure_on_activity_is_reported_as_500() {
+        const SOURCE: &str = include_str!("session.rs");
+        let handler = crate::routes::body_of(SOURCE, "async fn get_session_activity(");
+
+        // Two `contains`, not the whole line: the exact closure spelling is not
+        // the claim (`|_|` vs `|_e|` is a rename, not a behaviour change), and a
+        // test that fails on a rename gets relaxed rather than read. The claim is
+        // that the error is still MAPPED and that what it maps to is 500.
+        assert!(
+            handler.contains(".map_err("),
+            "the activity route stopped mapping its database error:\n{handler}"
+        );
+        assert!(
+            handler.contains("StatusCode::INTERNAL_SERVER_ERROR"),
+            "the activity route stopped reporting a database failure as 500:\n{handler}"
+        );
+        assert!(
+            !handler.contains("SessionModelUsageResponse"),
+            "body_of over-read past get_session_activity into the /usage route, so \
+             the assertion above may have matched a different handler"
+        );
     }
 
     /// `days` is attacker-controlled; the server clamps it rather than building a
@@ -2652,10 +2715,19 @@ pub(crate) mod diverge_tests {
     /// route test, so the structural assertion is what stands in for it.
     #[test]
     fn both_copy_handlers_take_the_second_read() {
-        let src = std::fs::read_to_string("src/routes/session.rs").unwrap();
+        // `include_str!`, not `read_to_string("src/routes/session.rs")`. A
+        // relative read resolves against the process's working directory, which
+        // is ambient state no test owns: `cargo test` happens to set it to the
+        // package root, so the relative form works under cargo and fails with
+        // `NotFound` the moment the same binary is run any other way — under a
+        // debugger, from a load harness, or from a wrapper that runs the binary
+        // directly. That is the same class of bug as the session-store path this
+        // module's note describes, and `include_str!` closes it by resolving at
+        // compile time relative to THIS file.
+        let src = include_str!("session.rs");
         for signature in ["async fn diverge_session(", "async fn edit_message("] {
             assert!(
-                fn_body(&src, signature).contains("minted_capability_without_proof"),
+                fn_body(src, signature).contains("minted_capability_without_proof"),
                 "{signature} gates on the source it read before the copy and never \
                  re-checks the child it minted"
             );
@@ -2665,7 +2737,7 @@ pub(crate) mod diverge_tests {
         // `edit_in_place` truncates the LIVE session and copies nothing, so it
         // mints no capability and must not be carrying this gate.
         assert!(
-            !fn_body(&src, "async fn edit_in_place(").contains("minted_capability_without_proof"),
+            !fn_body(src, "async fn edit_in_place(").contains("minted_capability_without_proof"),
             "fn_body is not returning one function's body"
         );
     }
@@ -2795,7 +2867,7 @@ pub(crate) mod diverge_tests {
 /// LIVE session. These pin the preconditions that make that safe — the same
 /// discipline `/reply` applies to `conversation_so_far`.
 ///
-/// NOTE: `AppState::new()` opens the REAL user session database, so each test
+/// NOTE: `AppState::new()` opens the ONE shared session database, so each test
 /// creates its own session and deletes it again, exactly like `diverge_tests`.
 #[cfg(test)]
 mod edit_message_tests {

--- a/crates/biorouter-server/src/routes/session_reach.rs
+++ b/crates/biorouter-server/src/routes/session_reach.rs
@@ -478,7 +478,7 @@ impl From<SessionClassification> for TargetTier {
 ///
 /// ⚠ **Extracted so the claim is asserted rather than grepped for.** None of the
 /// gated handlers can be driven from a unit test cheaply — `AppState::new()`
-/// opens the developer's REAL session database — so a scan for
+/// opens the ONE session DB this binary shares — so a scan for
 /// `session_reach(` would keep passing against a call whose result was
 /// discarded. This mapping is pure, so every corner of it is driven for real by
 /// the `tests` module below (not linked: it is `#[cfg(test)]`, so rustdoc cannot
@@ -1443,8 +1443,8 @@ mod tests {
     /// that the gate is earlier in the body than that.
     ///
     /// A source scan because none of these handlers can be driven cheaply from a
-    /// unit test — `AppState::new()` opens the developer's REAL session
-    /// database. Every route on the list is also driven over HTTP by
+    /// unit test — `AppState::new()` opens the ONE session DB this binary
+    /// shares. Every route on the list is also driven over HTTP by
     /// [`super::bypass_tests`] except `POST /agent/add_extension` (whose admitted
     /// arm mints a real agent), `GET|POST /knowledge/active` (a middleware, which
     /// a body scan cannot see and
@@ -2249,11 +2249,13 @@ mod bypass_tests {
     /// transcript came back" is an assertion rather than an impression.
     ///
     /// ⚠ **Unmistakably a fixture, and deliberately not shaped like a record.**
-    /// These tests seed into the developer's REAL session database —
-    /// `AppState::new()` opens it — so a row that ever escapes [`SeededChat`]'s
-    /// cleanup lands in their own sidebar. A marker that read like a patient
-    /// identifier would then be a privacy incident invented by the test suite of
-    /// the privacy feature.
+    /// These tests seed into the ONE session DB this binary shares —
+    /// `AppState::new()` opens it — so a row that escapes [`SeededChat`]'s
+    /// cleanup is read by every sibling test after it. `src/test_sandbox.rs`
+    /// keeps that store off the developer's own sidebar, so a leak is no longer
+    /// a privacy incident invented by the privacy feature's own suite — but a
+    /// marker shaped like a patient identifier is still the wrong thing to write
+    /// down, and a distinctive one is what a reader greps for when a row leaks.
     const MARKER_IN_THE_TRANSCRIPT: &str = "task58-transcript-marker-not-real-data";
 
     async fn get_session_with(
@@ -2617,9 +2619,9 @@ mod bypass_tests {
     /// ends — **including on a panic**, which a `delete_session` at the end of
     /// the test body cannot do.
     ///
-    /// ⚠ The store here is the developer's REAL session database, so a row that
-    /// outlives a failing assertion is a chat in their own sidebar, forever, with
-    /// no obvious provenance. `block_in_place` is what lets an async delete run
+    /// ⚠ The store here is the ONE session DB this binary shares, so a row that
+    /// outlives a failing assertion is one every later test reads, with no
+    /// obvious provenance. `block_in_place` is what lets an async delete run
     /// from `Drop`, and it is only legal on a multi-threaded runtime — so
     /// `#[tokio::test(flavor = "multi_thread")]` on every test below is a
     /// requirement of this type, not a habit.

--- a/crates/biorouter-server/src/routes/status.rs
+++ b/crates/biorouter-server/src/routes/status.rs
@@ -270,7 +270,7 @@ mod tests {
     /// *sends* what `refusal_body` composes.
     ///
     /// A source scan, and for the reason `session_reach`'s own census gives —
-    /// `AppState::new()` opens the developer's REAL session database, so this
+    /// `AppState::new()` opens the ONE session DB this binary shares, so this
     /// handler cannot be driven from a unit test. Driving it over HTTP does not
     /// help either: the keyless arm is reached only when `USER_ACTION_DIGEST` was
     /// never set, and it is a `OnceLock` that any other serial test in this crate

--- a/crates/biorouter-server/src/test_sandbox.rs
+++ b/crates/biorouter-server/src/test_sandbox.rs
@@ -1,5 +1,6 @@
 //! Points a test binary's Biorouter data/config/state dirs at a throwaway
-//! directory, before the first line of test code runs.
+//! directory, before the first line of test code runs — and pins the
+//! process-global session store to it, so no later test can move it.
 //!
 //! Without this, `AppState::new()` — and every test that goes through it —
 //! opens the **developer's real** `sessions.db`. Tests then create, rename and
@@ -10,7 +11,7 @@
 //!
 //! The mechanism already exists — `biorouter::config::Paths::get_dir` honours
 //! `BIOROUTER_PATH_ROOT` — but it is read through a `LazyLock`
-//! (`session_manager::SESSION_STORAGE`) and a `OnceCell`
+//! (`session_manager::SHARED_STORE_ROOT`) and a `OnceCell`
 //! (`AgentManager::instance`), so a test that sets it *from inside* a `#[test]`
 //! fn only wins if it happens to be the first test to touch the singleton. That
 //! is why it has to be a `#[ctor]`: constructors run before `main`, before the
@@ -24,6 +25,40 @@
 //!
 //! An externally supplied `BIOROUTER_PATH_ROOT` is left alone, so a harness that
 //! already sandboxes the process keeps its own root.
+//!
+//! ## Setting the variable is not enough — the store has to be PINNED
+//!
+//! Redirecting the variable closed the cross-process half and left a
+//! within-process half open, which is the Windows CI flake that rotated through
+//! the route tests (`activity_clamps_an_absurd_window` and friends answering 500
+//! where the test wanted 200).
+//!
+//! `BIOROUTER_PATH_ROOT` is process-global, and a `#[test]` may legitimately
+//! relocate it under a `TempDir` to get its own config/skills/knowledge root —
+//! `routes::apps`'s `lock_env_for` and `routes::config_management`'s privacy
+//! tests both do. Whichever test first reaches the session store decides where
+//! the whole process's `sessions.db` lives, and the tests run in parallel, so
+//! that test could be one holding such a lock. Its `TempDir` then drops, the
+//! directory is unlinked, and the pool is pinned to a path that no longer
+//! exists.
+//!
+//! What happens next looks nothing like its cause. The connection the pool
+//! already opened keeps answering, because SQLite on POSIX does not care that
+//! its inode lost its name — so a serial query still returns 200. It is the
+//! first moment two tasks want the pool at once, forcing it to open a **second**
+//! connection, that fails with `(code: 14) unable to open database file`, and
+//! every route that touches the store turns that into a 500. The victim is
+//! whichever test queried next, which is why the failing name rotates and why
+//! the same test can pass in the `biorouter_server` lib binary and fail in the
+//! `biorouterd` bin binary minutes apart.
+//!
+//! So the ctor also calls `SessionManager::shared_store_root()`, whose side
+//! effect is to freeze that path here, at a root this module owns and only the
+//! `#[dtor]` deletes. It resolves one environment variable into a `PathBuf` —
+//! no pool, no disk, no async runtime — which is what makes it safe to run
+//! before `main`. The ad-hoc warm-ups (`AppState::new()` before the env lock)
+//! that four `routes::apps` tests carried for this are no longer needed, and
+//! four out of ~25 relocating sites is why the flake outlived them.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -41,15 +76,19 @@ fn sandbox_root() -> PathBuf {
 
 #[ctor::ctor]
 fn redirect_biorouter_dirs_into_a_sandbox() {
-    if std::env::var("BIOROUTER_PATH_ROOT").is_ok_and(|v| !v.trim().is_empty()) {
-        return;
+    if !std::env::var("BIOROUTER_PATH_ROOT").is_ok_and(|v| !v.trim().is_empty()) {
+        let root = sandbox_root();
+        if std::fs::create_dir_all(&root).is_ok() {
+            OWNED.store(true, Ordering::SeqCst);
+            std::env::set_var("BIOROUTER_PATH_ROOT", &root);
+        }
     }
-    let root = sandbox_root();
-    if std::fs::create_dir_all(&root).is_err() {
-        return;
-    }
-    OWNED.store(true, Ordering::SeqCst);
-    std::env::set_var("BIOROUTER_PATH_ROOT", &root);
+    // Freeze the session store's directory at whatever root is now in force,
+    // before any test can relocate `BIOROUTER_PATH_ROOT` under a `TempDir` it
+    // later unlinks. Unconditional: an externally supplied root needs the same
+    // protection, and so does the fallback where the sandbox could not be
+    // created — a stable directory, even the real one, beats a doomed one.
+    let _ = biorouter::session::session_manager::SessionManager::shared_store_root();
 }
 
 #[ctor::dtor]
@@ -62,6 +101,7 @@ fn remove_the_sandbox() {
 #[cfg(test)]
 mod tests {
     use biorouter::config::paths::Paths;
+    use biorouter::session::session_manager::SessionManager;
 
     /// The point of the whole module: the session database a test opens must not
     /// be the developer's. `Paths::data_dir()` is what
@@ -93,6 +133,31 @@ mod tests {
             data_dir.starts_with(super::sandbox_root()),
             "expected the per-process sandbox, got {}",
             data_dir.display()
+        );
+    }
+
+    /// Asserting the *pinned* root rather than the environment variable is what
+    /// makes this meaningful, and it is a strictly stronger claim than the test
+    /// above. `Paths::data_dir()` re-reads the environment on every call, so it
+    /// answers correctly even in a binary where some earlier test had already
+    /// pinned the store somewhere else. `shared_store_root()` is the value a
+    /// query actually follows, frozen for the life of the process.
+    ///
+    /// It fails if a future edit drops the pin from the `#[ctor]`, or if
+    /// anything in this crate reaches the session store before `main` under a
+    /// different root.
+    #[test]
+    #[serial_test::serial]
+    fn the_session_store_is_pinned_inside_the_sandbox() {
+        let pinned = SessionManager::shared_store_root();
+        assert!(
+            pinned.starts_with(super::sandbox_root()),
+            "the process session store is pinned at {}, outside the sandbox at {}. \
+             Something resolved it before the ctor did, so a test that relocates \
+             BIOROUTER_PATH_ROOT can move this binary's sessions.db into a TempDir \
+             it then deletes.",
+            pinned.display(),
+            super::sandbox_root().display()
         );
     }
 }

--- a/crates/biorouter-server/src/workspace/services.rs
+++ b/crates/biorouter-server/src/workspace/services.rs
@@ -678,16 +678,22 @@ mod tests {
     /// NOTE — what these tests share with the rest of this crate's unit tests,
     /// and what they deliberately do not.
     ///
-    /// * `AppState::new()` opens the **REAL user session database** (through
+    /// * `AppState::new()` opens the **ONE shared session database** (through
     ///   `AgentManager::instance()` → `SessionManager::instance()`, both
     ///   process-global `OnceCell`s with no path seam). `workspace/turn.rs`,
     ///   `routes/session.rs`, `routes/session_events.rs` and `state.rs` all
-    ///   carry the same warning: these tests create rows in the developer's own
-    ///   history. Keep session names unique and never assert on row counts.
-    ///   Relocating it would mean `BIOROUTER_PATH_ROOT` being set before the
-    ///   `LazyLock<SESSION_STORAGE>` resolves `Paths::data_dir()`
-    ///   (`session_manager.rs`), i.e. before whichever test touches the manager
-    ///   first — which libtest's parallel scheduling does not let a test decide.
+    ///   carry the same warning: every test in the binary creates rows in the
+    ///   same store. Keep session names unique and never assert on row counts.
+    ///
+    ///   It is **not** the developer's own history. This bullet used to argue
+    ///   relocating it was impossible — "`BIOROUTER_PATH_ROOT` being set before
+    ///   the `LazyLock` resolves `Paths::data_dir()` … which libtest's parallel
+    ///   scheduling does not let a test decide" — which is right about a
+    ///   `#[test]` and wrong about a constructor. `src/test_sandbox.rs`'s
+    ///   `#[ctor]` runs before `main`, so it cannot lose that race: it points
+    ///   the data root at a throwaway directory and freezes the store there.
+    ///   Leaving the claim standing cost a Windows CI flake; read that file's
+    ///   pinning section before touching anything that relocates the path root.
     ///   Fixing that is a crate-wide change (a path seam on `SessionManager`),
     ///   not a Task 9 one.
     /// * **Extensions are always passed explicitly**, never `None`. `None`

--- a/crates/biorouter-server/src/workspace/turn.rs
+++ b/crates/biorouter-server/src/workspace/turn.rs
@@ -1347,11 +1347,13 @@ mod tests {
 
     /// NOTE — two things about every test in this module:
     ///
-    /// 1. `AppState::new()` opens the **REAL user session database** (it goes
+    /// 1. `AppState::new()` opens the **ONE shared session database** (it goes
     ///    through `AgentManager::instance()` → `SessionManager::instance()`;
-    ///    `routes/session.rs:1122` and `:1414` carry the same warning). These
-    ///    tests create rows in the developer's own history. Keep session names
-    ///    unique and never assert on total row counts.
+    ///    `routes/session.rs` carries the same warning). Every test in the
+    ///    binary creates rows in the same store, so keep session names unique and
+    ///    never assert on total row counts. It is a throwaway root rather than
+    ///    the developer's own history — `src/test_sandbox.rs` pins it there
+    ///    before the first test runs.
     /// 2. The `TempDir` is the session's **working dir**, not a database.
     ///    `create_session`'s first parameter is `working_dir`
     ///    (`session_manager.rs:1191-1196`). An earlier draft did

--- a/crates/biorouter-server/tests/session_store_survives_a_relocated_path_root.rs
+++ b/crates/biorouter-server/tests/session_store_survives_a_relocated_path_root.rs
@@ -1,0 +1,115 @@
+//! A test that relocates `BIOROUTER_PATH_ROOT` must not be able to move this
+//! binary's `sessions.db` into a directory it then deletes.
+//!
+//! This is the regression test for a `test (windows-latest)` flake that rotated
+//! through the `routes::session` tests — `activity_clamps_an_absurd_window`
+//! answering `500` where it wanted `200`, `sidebar_route_…` and the `/usage`
+//! routes on other runs. Every one of them is a read-only route test, and the
+//! 500 is `get_activity(..).map_err(|_| INTERNAL_SERVER_ERROR)`: a genuine
+//! database error, reported correctly, from a database that had been moved out
+//! from under the process.
+//!
+//! The sequence this file reproduces:
+//!
+//! 1. `BIOROUTER_PATH_ROOT` is process-global, and a test may relocate it under
+//!    a `TempDir` to get its own config/skills/knowledge root — `routes::apps`'s
+//!    `lock_env_for` and `routes::config_management`'s privacy tests do exactly
+//!    that, for good reasons.
+//! 2. The process-global session store resolves its directory the first time
+//!    anything touches it. The tests run in parallel, so that first touch could
+//!    be made by a test holding such a lock — and then the whole binary's
+//!    `sessions.db` lives inside that test's `TempDir`.
+//! 3. The `TempDir` drops and the directory is unlinked.
+//! 4. **Nothing breaks yet.** The connection the pool already opened keeps
+//!    answering: SQLite on POSIX does not care that its inode lost its name. A
+//!    serial query still returns 200, which is why this hid for so long.
+//! 5. The first time two tasks want the pool at once it must open a *second*
+//!    connection — and that fails with `(code: 14) unable to open database
+//!    file`. Whichever test was querying then fails, so the name rotates, and
+//!    the same test can pass in the `biorouter_server` lib binary and fail in
+//!    the `biorouterd` bin binary a minute later.
+//!
+//! The fix is in `src/test_sandbox.rs`: the `#[ctor]` freezes the store's
+//! directory at the sandbox root before any test runs, so step 2 can no longer
+//! pick a doomed one. This file asserts steps 1–5 are now harmless, and it fails
+//! (15 of 16 concurrent queries erroring) if that pin is removed.
+
+#[path = "../src/test_sandbox.rs"]
+mod test_sandbox;
+
+use biorouter::session::session_manager::SessionManager;
+
+/// Stand in for a sibling test that relocates the path root: pin the store from
+/// inside the lock, unlink the directory, then use the store the way the routes
+/// do — including concurrently, which is what forces a second connection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_relocated_path_root_cannot_move_the_session_store() {
+    // Read the sandbox from the ENVIRONMENT, not from `shared_store_root()`:
+    // calling that here would freeze the store at the right answer even with the
+    // ctor's pin removed, and the test would pass while proving nothing.
+    let sandbox = std::path::PathBuf::from(
+        std::env::var("BIOROUTER_PATH_ROOT").expect("the ctor sandboxes this binary"),
+    )
+    .join("data");
+    let temp = tempfile::TempDir::new().unwrap();
+    let temp_root = temp.path().to_path_buf();
+
+    {
+        let _env = env_lock::lock_env([(
+            "BIOROUTER_PATH_ROOT",
+            Some(temp_root.to_str().expect("utf-8 temp path")),
+        )]);
+
+        // The relocation is real — an unpinned resolver would follow it.
+        assert!(
+            biorouter::config::paths::Paths::data_dir().starts_with(&temp_root),
+            "the env lock did not take, so this test proves nothing"
+        );
+
+        // …but the store does not, and it is the store a query follows.
+        assert_eq!(
+            SessionManager::shared_store_root(),
+            sandbox.as_path(),
+            "a test that relocates BIOROUTER_PATH_ROOT moved the process session store"
+        );
+
+        SessionManager::instance()
+            .get_activity(30)
+            .await
+            .expect("a query made while the path root is relocated");
+    }
+
+    drop(temp);
+    assert!(
+        !temp_root.exists(),
+        "the temp root outlived its TempDir, so the unlink half is untested"
+    );
+
+    // Serial first: this half passed even before the fix, and saying so here is
+    // what stops a future reader from deleting the concurrent half as redundant.
+    SessionManager::instance()
+        .get_activity(30)
+        .await
+        .expect("a serial query after the relocated root was unlinked");
+
+    // Concurrent: the pool has `max_connections(4)`, so this is the half that
+    // actually needs to OPEN a connection against the pinned directory. Pinned
+    // to an unlinked TempDir, 15 of these 16 fail with SQLITE_CANTOPEN.
+    let mut tasks = tokio::task::JoinSet::new();
+    for _ in 0..16 {
+        tasks.spawn(async { SessionManager::instance().get_activity(30).await });
+    }
+    let mut failures = Vec::new();
+    while let Some(joined) = tasks.join_next().await {
+        if let Err(e) = joined.expect("task panicked") {
+            failures.push(e.to_string());
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of 16 concurrent queries failed after a sibling's path root was \
+         unlinked — the session store is pinned outside the sandbox. First: {}",
+        failures.len(),
+        failures.first().map(String::as_str).unwrap_or("")
+    );
+}

--- a/crates/biorouter/src/execution/manager.rs
+++ b/crates/biorouter/src/execution/manager.rs
@@ -146,7 +146,18 @@ impl AgentManager {
                 let max_sessions = Config::global()
                     .get_biorouter_max_active_agents()
                     .unwrap_or(DEFAULT_MAX_SESSION);
-                let schedule_file_path = Paths::data_dir().join("schedule.json");
+                // The SAME data directory the process-global session store uses,
+                // asked for once rather than resolved a second time. In the
+                // daemon the two reads agree — nothing moves
+                // `BIOROUTER_PATH_ROOT` while it runs — so this is a no-op
+                // there. In a test binary a second read of a process-global
+                // variable at an instant nobody owns is the bug documented in
+                // `AgentManager::new` below (PR #191) and the one that made
+                // `sessions.db` land in a `TempDir` a sibling test deleted; see
+                // `SHARED_STORE_ROOT` in `session_manager.rs`. `schedule.json`
+                // and `sessions/sessions.db` are meant to be siblings, so taking
+                // the store's own answer is also the more honest statement.
+                let schedule_file_path = SessionManager::shared_store_root().join("schedule.json");
                 let session_manager = Arc::new(SessionManager::instance());
                 let manager =
                     Self::new(session_manager, schedule_file_path, Some(max_sessions)).await?;

--- a/crates/biorouter/src/scheduler.rs
+++ b/crates/biorouter/src/scheduler.rs
@@ -4483,8 +4483,9 @@ mod tests {
 /// ⚠ SCOPE, because the plan's sketch of the first test reads
 /// `tick(&job).await` and this one does not. `execute_job` builds its agent with
 /// `Agent::new()`, whose session manager is the process-wide
-/// `SessionManager::instance()` — the developer's REAL `~/.config/biorouter`
-/// store — and then drives a real `Agent::reply` against a real provider built
+/// `SessionManager::instance()` — the ONE store this whole test binary shares
+/// (a throwaway root, pinned by `crate::test_sandbox`, but shared) — and then
+/// drives a real `Agent::reply` against a real provider built
 /// from the registry (`versa_azure` needs a UCSF credential). A unit test cannot
 /// tick a job without writing sessions into the user's own history and calling a
 /// paid endpoint. What it CAN do, and what C2 is actually about, is the two

--- a/crates/biorouter/src/session/session_manager.rs
+++ b/crates/biorouter/src/session/session_manager.rs
@@ -426,8 +426,42 @@ impl std::str::FromStr for SessionType {
     }
 }
 
+/// The data directory the process-global session store lives under, resolved
+/// **once** per process.
+///
+/// Split out of [`SESSION_STORAGE`] on purpose, and the split is the whole fix
+/// for a Windows CI flake that rotated through the route tests. Resolving the
+/// path and building the pool used to be one `LazyLock`, so the path was frozen
+/// at the instant the first caller touched the store — an instant nothing owns,
+/// because the tests run in parallel. A test that relocates
+/// `BIOROUTER_PATH_ROOT` under a `TempDir` (for config/skills isolation) could
+/// therefore win that race and pin the whole process's `sessions.db` inside a
+/// directory that is unlinked when its `TempDir` drops.
+///
+/// The symptom is nothing like the cause. After the unlink the pool's already
+/// open connection keeps answering — SQLite on POSIX does not care that its
+/// inode has no name any more — so a *serial* query still succeeds. It is the
+/// moment two tasks want the pool at once, and it has to open a **second**
+/// connection, that the vanished directory bites: `(code: 14) unable to open
+/// database file`. Every caller turns that into its own failure, and
+/// `GET /sessions/activity` turns it into a 500, which is what
+/// `activity_clamps_an_absurd_window` measured as `left: 500 right: 200`. The
+/// victim is whichever test queried next, so the failing name rotates and the
+/// same test can pass in one binary and fail in another.
+///
+/// Freezing the path separately lets a test binary pin it — cheaply, with no
+/// pool, no I/O and no runtime — *before* the first test runs, via
+/// [`SessionManager::shared_store_root`]. See `src/test_sandbox.rs` in this
+/// crate and in `biorouter-server`.
+///
+/// Production behaviour is unchanged: nothing outside a test mutates
+/// `BIOROUTER_PATH_ROOT` after start, so this resolves to the same directory it
+/// always did, and it was already effectively frozen — only the instant it is
+/// captured moved earlier.
+static SHARED_STORE_ROOT: LazyLock<PathBuf> = LazyLock::new(Paths::data_dir);
+
 static SESSION_STORAGE: LazyLock<Arc<SessionStorage>> =
-    LazyLock::new(|| Arc::new(SessionStorage::new(Paths::data_dir())));
+    LazyLock::new(|| Arc::new(SessionStorage::new(SHARED_STORE_ROOT.clone())));
 
 pub const DEFAULT_SESSION_NAME: &str = "New chat";
 
@@ -1577,6 +1611,23 @@ impl SessionManager {
         Self {
             storage: Arc::clone(&SESSION_STORAGE),
         }
+    }
+
+    /// The data directory [`SessionManager::instance`]'s store resolves
+    /// `sessions/sessions.db` under, resolved once per process (see
+    /// [`SHARED_STORE_ROOT`]).
+    ///
+    /// Reading it is what *freezes* it, and that side effect is the point of the
+    /// call in a test binary's `#[ctor]`: it costs one environment read and a
+    /// `PathBuf`, builds no pool, touches no disk and needs no async runtime, so
+    /// it is safe to run before `main`. Once frozen, no later relocation of
+    /// `BIOROUTER_PATH_ROOT` can move the process's session database into a
+    /// directory that test owns and then deletes.
+    ///
+    /// In production this is a plain accessor — the daemon's data dir does not
+    /// move while it runs.
+    pub fn shared_store_root() -> &'static Path {
+        &SHARED_STORE_ROOT
     }
 
     pub fn storage(&self) -> &Arc<SessionStorage> {
@@ -16194,13 +16245,15 @@ mod tests {
         fn no_copy_path_hand_rolls_its_own_builder_any_more() {
             // The enumeration test, aimed at the three functions that matter
             // rather than at all 104 `create_session` call sites.
-            let src = std::fs::read_to_string("src/session/session_manager.rs").unwrap();
+            // `include_str!` rather than a relative `read_to_string`: the latter
+            // resolves against the process working directory, which no test owns.
+            let src = include_str!("session_manager.rs");
             for f in [
                 "copy_session",
                 "diverge_session_for_edit",
                 "diverge_session",
             ] {
-                let body = fn_body(&src, f);
+                let body = fn_body(src, f);
                 assert!(
                     body.contains("create_derived_session"),
                     "{f} does not use the shared helper"
@@ -16451,7 +16504,9 @@ mod tests {
         /// **values**, and the scan below pins that those four **names** are what
         /// the function hands to `info!`.
         fn fn_body(name: &str) -> String {
-            let src = std::fs::read_to_string("src/session/session_manager.rs").unwrap();
+            // `include_str!` rather than a relative `read_to_string`: the latter
+            // resolves against the process working directory, which no test owns.
+            let src = include_str!("session_manager.rs");
             let start = src
                 .find(&format!("fn {name}("))
                 .unwrap_or_else(|| panic!("no `fn {name}(` in the file"));
@@ -17030,9 +17085,11 @@ mod tests {
             // out of this string — the cut below, and the `\n            }`
             // that closes a match arm in the caller — is written with `\n`. A
             // raw read therefore fails on Windows alone, which is what it did.
-            let src = std::fs::read_to_string("src/session/session_manager.rs")
-                .unwrap()
-                .replace("\r\n", "\n");
+            // `include_str!` rather than a relative `read_to_string`: the latter
+            // resolves against the process working directory, which no test owns.
+            // The CRLF normalisation below is a separate concern and still needed —
+            // `include_str!` hands back whatever the checkout holds.
+            let src = include_str!("session_manager.rs").replace("\r\n", "\n");
             let cut = src
                 .find("\n#[cfg(test)]\nmod tests {")
                 .expect("this file's main test module moved");

--- a/crates/biorouter/src/test_sandbox.rs
+++ b/crates/biorouter/src/test_sandbox.rs
@@ -28,17 +28,29 @@
 /// An outer `BIOROUTER_PATH_ROOT` wins: the Task 33 gate exports its own
 /// `mktemp -d` root, and a harness that wants to inspect what a run wrote must
 /// be able to choose where it lands.
+///
+/// ⚠ Setting the variable is only half of it. `BIOROUTER_PATH_ROOT` is
+/// process-global and dozens of tests here relocate it under a `TempDir` of
+/// their own (`env_lock::lock_env`), so whichever test first reaches the session
+/// store still decides where this binary's `sessions.db` lives — and if that was
+/// a test holding such a lock, the store is pinned inside a directory that is
+/// unlinked moments later. The already-open connection keeps answering, so it
+/// stays invisible until two tasks want the pool at once and it has to open a
+/// second connection: `(code: 14) unable to open database file`, surfacing as
+/// whatever the *next* test was asserting. So the ctor also freezes the store's
+/// root here, which costs one environment read and a `PathBuf` — no pool, no
+/// disk, no runtime.
 #[ctor::ctor]
 fn sandbox_config_root_for_the_lib_test_binary() {
-    if std::env::var_os("BIOROUTER_PATH_ROOT").is_some() {
-        return;
+    if std::env::var_os("BIOROUTER_PATH_ROOT").is_none() {
+        let root = tempfile::TempDir::new().expect("scratch config root for the lib test binary");
+        std::env::set_var("BIOROUTER_PATH_ROOT", root.path());
+        // Leaked deliberately: a `static` is never dropped, which is exactly the
+        // lifetime the sandbox needs — it must outlive the last test in the binary.
+        static ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+        let _ = ROOT.set(root);
     }
-    let root = tempfile::TempDir::new().expect("scratch config root for the lib test binary");
-    std::env::set_var("BIOROUTER_PATH_ROOT", root.path());
-    // Leaked deliberately: a `static` is never dropped, which is exactly the
-    // lifetime the sandbox needs — it must outlive the last test in the binary.
-    static ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
-    let _ = ROOT.set(root);
+    let _ = crate::session::session_manager::SessionManager::shared_store_root();
 }
 
 #[cfg(test)]
@@ -59,6 +71,29 @@ mod tests {
             "Config::global() resolved to {path}, outside the sandbox at {root}. \
              Something reached Config::global() before the sandbox was installed, so \
              config writes from this binary land in the developer's real config."
+        );
+    }
+
+    /// The same claim for the session store, and it needs its own test because
+    /// the two singletons are frozen by different calls.
+    ///
+    /// `Paths::data_dir()` re-reads the environment on every call, so it answers
+    /// correctly even in a binary whose store was already pinned somewhere else.
+    /// `shared_store_root()` is the frozen value, and it is the one that decides
+    /// whether this binary's `sessions.db` can end up inside a `TempDir` a test
+    /// deletes underneath it.
+    #[test]
+    fn the_lib_test_binary_session_store_is_sandboxed() {
+        let root = std::env::var("BIOROUTER_PATH_ROOT")
+            .expect("BIOROUTER_PATH_ROOT must be sandboxed before any test in this binary runs");
+        let pinned = crate::session::session_manager::SessionManager::shared_store_root();
+        assert!(
+            pinned.starts_with(&root),
+            "the process session store is pinned at {}, outside the sandbox at {root}. \
+             Something resolved it before the ctor did, so a test that relocates \
+             BIOROUTER_PATH_ROOT can move this binary's sessions.db into a TempDir it \
+             then deletes.",
+            pinned.display()
         );
     }
 }


### PR DESCRIPTION
## The brief's mechanism was wrong, and the stale doc it came from is fixed here too

The handoff said these route tests "open the developer's **REAL** shared session
database", and diagnosed SQLITE_BUSY after the 5 s busy handler expired. Both
halves are false, and I checked before building anything:

- `crates/biorouter-server/src/test_sandbox.rs` has redirected the data/config/
  state dirs at a throwaway root in a `#[ctor]` since **2026-08-06** (`69a4825a`),
  for both the lib and the `biorouterd` bin test binary. No test in this crate has
  touched the developer's real `sessions.db` since. What the brief read were the
  doc comments in `routes/session.rs`, which still said otherwise — 24 of them
  across the tree did.
- The 221 `AppState::new()` call sites do **not** each get their own pool. They
  share one: `AgentManager::instance()` is a `OnceCell` holding one
  `SessionManager::instance()`, which is one `LazyLock<Arc<SessionStorage>>` with
  `max_connections(4)`. The count of 221 is right; "each with its own pool" is not.
- The error is not SQLITE_BUSY (code 5). It is **SQLITE_CANTOPEN (code 14)**, so
  raising `busy_timeout` would have changed nothing.

## What actually happens

`BIOROUTER_PATH_ROOT` is process-global, and **~25 sites** in this crate's tests
relocate it under a `TempDir` to get their own config/skills/knowledge root
(`routes::apps`'s `lock_env_for`, `routes::config_management`'s privacy tests,
`routes::audio`). The session store resolved its directory *inside the same
`LazyLock` that built the pool*, so the path was frozen at whatever the **first
toucher** saw — and with tests running in parallel, that could be a test holding
one of those locks.

Then its `TempDir` drops and the directory is unlinked. **Nothing breaks yet** —
the connection the pool already opened keeps answering, because SQLite on POSIX
does not care that its inode lost its name. A *serial* query still returns 200.
The first moment two tasks want the pool at once, it must open a **second**
connection, and that fails.

That two-stage shape explains every measurement in the brief: why the victim
rotates (whoever queried next), why the same test passes in one binary and fails
in another 61 s later (two processes, two independent races), and why
`activity_route_is_not_shadowed_by_the_session_id_wildcard` passed moments before
`activity_clamps_an_absurd_window` failed on the same handler and the same router
— the first got the surviving connection, the second needed a new one.

## Mechanism, measured

A probe (`tests/zz_probe_pin.rs`, not committed): relocate the path root to a
`TempDir`, touch `SessionManager::instance()` so the store pins there, query once,
drop the `TempDir`, then query serially and concurrently.

| | pin removed (pre-fix shape) | pin in place (this PR) |
|---|---|---|
| A) query inside the temp root | `ok` | `ok` |
| B) `TempDir` dropped, dir gone | `false` | `false` |
| C) **serial** `get_activity` after the unlink | **`Ok`** | `Ok` |
| D) **16 concurrent** `get_activity` | **15 of 16 failed** | **0 of 16 failed** |

First error in D: `error returned from database: (code: 14) unable to open
database file`. `get_session_activity` maps any `Err` to 500, which is exactly
`assert_eq! left: 500 right: 200` at the failing assertion.

Same binary, same machine, same probe code — the only difference is the ctor's
pin.

## The fix

Split the path out of the pool's `LazyLock` (`crates/biorouter/src/session/session_manager.rs`):

```rust
static SHARED_STORE_ROOT: LazyLock<PathBuf> = LazyLock::new(Paths::data_dir);
static SESSION_STORAGE: LazyLock<Arc<SessionStorage>> =
    LazyLock::new(|| Arc::new(SessionStorage::new(SHARED_STORE_ROOT.clone())));
```

and have **both** test-sandbox `#[ctor]`s (`biorouter` and `biorouter-server`)
freeze it at the sandbox root before `main`, via the new
`SessionManager::shared_store_root()`.

Freezing only the *path* is what makes this legal in a constructor: it is one
environment read and a `PathBuf`. Forcing the **pool** there would panic —
`SqlitePoolOptions` defaults leave `max_lifetime`/`idle_timeout` set, so
`spawn_maintenance_tasks` calls `sqlx::rt::spawn`, which is `panic!("this
functionality requires a Tokio context")` outside a runtime
(`sqlx-core-0.8.0/src/pool/inner.rs`, `src/rt/mod.rs`).

Why not the alternatives the brief listed:

- **`busy_timeout`** — rejected on evidence: the error is CANTOPEN, not BUSY.
- **`#[serial]` everywhere** — would not even work. Probe row D fails with a
  *single* test running: the concurrency that forces the second connection is
  inside one `get_activity` call's siblings, not only across tests.
- **A temp store per `AppState`** — would mean dismantling the `AGENT_MANAGER`
  `OnceCell` that holds the one `SessionManager`, across 221 call sites, and would
  change production. The env var that redirects the store already exists; the bug
  was that nothing pinned it in time.

### A fix that only touched the failing test was already in the tree, and it lost

`routes/apps.rs` carried an ad-hoc `let _warm = AppState::new()` before its env
lock, with a comment naming this exact hazard. When the flake was first seen it
was at **one** site; it is now at **four**, while ~25 sites relocate the variable.
Removed — the `#[ctor]` covers every site, including ones not yet written.

## Guards added

- `crates/biorouter-server/tests/session_store_survives_a_relocated_path_root.rs` —
  reproduces the whole sequence and requires all 16 concurrent queries to succeed.
  **Falsified twice**: with the ctor's pin removed it fails, naming the pinned root
  (`…/.tmpJahWif/data`) against the sandbox (`…/biorouter-test-root-44272/data`).
  It reads the expected root from the *environment*, not from
  `shared_store_root()`, precisely so removing the pin cannot make it pass.
- `test_sandbox::tests::the_session_store_is_pinned_inside_the_sandbox` (both
  crates) — asserts the **pinned** root, which is strictly stronger than the
  existing assertion on `Paths::data_dir()`: that function re-reads the
  environment and answers correctly even in a binary whose store was already
  pinned elsewhere.
- `routes::session::diverge_tests::a_database_failure_on_activity_is_reported_as_500`
  — see below.
- A module note on `diverge_tests` telling the next reader to suspect the store's
  path, not the file.

## Production behaviour unchanged

The whole code-only diff (comments stripped) is: the `SHARED_STORE_ROOT` split,
the `shared_store_root()` accessor, one line in `AgentManager::instance()`, and
test-only code. **No route handler is touched.**

`Paths::data_dir()` is a pure function of the environment and nothing in a daemon
mutates `BIOROUTER_PATH_ROOT` after start, so the value is identical; and the old
`LazyLock` already froze it — only the instant of capture moved earlier.

The route's error path is now pinned rather than asserted by inspection:
`a_database_failure_on_activity_is_reported_as_500` scans
`get_session_activity`'s own span (via `routes::body_of`, with the negative
control that helper requires) for `.map_err(` and
`StatusCode::INTERNAL_SERVER_ERROR`. **Falsified**: replacing the `map_err` with
an `unwrap_or_else` fails it. It is deliberately two `contains` rather than the
whole line, so `|_|` → `|_e|` is not a failure.

That test exists because the flake was a **correct** 500. Making the route quieter
— an empty `ActivityWindow`, a 200 with zeroes — would have turned the same green
suite into a daemon that answers the Home heatmap with silence when its database
is unreadable.

## Repeated runs, under load

`BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter-server --lib --bins`, run
alongside deliberate contention: **6 concurrent extra copies** of the same two
test binaries (`--test-threads=8`, bounded loops) plus a `dd`+`sync` disk writer
on the `$TMPDIR` volume, on a 16-core machine.

On the final tree (rebased onto `origin/main` @ `35a67843`):

| batch | result |
|---|---|
| plain run | 662 + 647 ok |
| 8 runs under contention, full logs captured | **8/8 ok** |
| 6 runs under contention (harsher harness) | **6/6 ok** |
| 8 runs under contention (package-root-CWD load) | **8/8 ok** |
| 7 runs under contention, full logs | **7/7 ok** |

Plus, on the same tree: `cargo test -p biorouter --lib` 4014 ok; `cargo test -p
biorouter-cli --lib` 475 ok (isolated `HOME`, literal `CARGO_HOME`/`RUSTUP_HOME`);
`--test every_test_binary_is_sandboxed` 3, `--test
session_store_survives_a_relocated_path_root` 3, `--test knowledge_routes` 62,
`--test memory_routes` 16, `--test memory_routes_auth` 5, `--test
privacy_toggle_config` 16, `--test llamacpp_routes` 8 — all ok. Earlier batches on
the two previous bases were 6/6 and 6/6.

No orphaned load processes and no leaked sandbox roots after any batch (the
`#[dtor]` removes them).

### One failure I chased down rather than re-running past

An early batch had **1 failing test in run 4 of 6**. I did not accept it as noise.
Hunting it under the same harness reproduced
`routes::session::diverge_tests::both_copy_handlers_take_the_second_read` failing
with `Os { code: 2, NotFound }` at `session.rs:2718`:
`std::fs::read_to_string("src/routes/session.rs")` — a **CWD-relative** read of
its own source. That works under `cargo test` only because cargo sets the CWD to
the package root, and fails the moment the same binary runs any other way. It is
the same class of bug as this PR's subject: a test depending on process state
nobody owns.

Fixed here (four such sites → `include_str!`, which resolves at compile time). The
measurable result: the `biorouter-server` lib test binary now passes **from any
working directory**, which it did not before. The harness that produced the run-4
failure is 6/6 clean afterwards.

Honest caveat: I could not prove that this test was *the* one that failed in run 4
(that run's output was truncated before the name), only that it is the sole
failure the harness reproduces and that it is now gone. 29 further full suite runs
have been clean.

## Related things found and deliberately NOT fixed

- `crates/biorouter/src/agents/script_call_gate.rs:1220` has the same
  CWD-dependence in a different shape — its script does `text_editor view
  Cargo.toml`, so run from the workspace root it reads the *workspace* manifest
  and the assertion fails. Pre-existing, untouched by this PR, and a different
  subsystem; it only misbehaves when the binary is run outside cargo.
- `biorouter-cli` has **no** test sandbox at all, so its one remaining
  "developer's REAL session database" comment is still true and is left standing.
  Giving that crate the same `#[ctor]` would also address the known
  `cargo test -p biorouter-cli` hang on real config, but it is its own change.

## Note on the instrument

Two clippy "failures" during this work (`result_large_err` in `routes/reply.rs`,
`too_many_lines` in `workspace_extension.rs`) were ghosts from a `cp -Rc`-cloned
`target/` dir taken from an older commit: the reported line numbers pointed at
code that is not there on this tree. Both cleared after `rm -rf
target/debug/.fingerprint/biorouter*`. `cargo fmt --all --check` and
`./scripts/clippy-lint.sh` are clean on this branch, and I verified the same on
pristine `origin/main` before believing either.

## CI on this PR

All 15 checks pass on the first run (`rust.yml` run 34685594542):

- **`test (windows-latest)`: success** — the flake's own job, with its `cargo test
  (workspace, lib + bins)` step green. One clean run does not by itself disprove a
  ~1-in-15 flake, which is why the mechanism proof and the 29 local runs above are
  the load-bearing evidence; this is the confirmation that nothing regressed on the
  platform that was failing.
- **`test (ubuntu-latest)`: success**, including `cargo test (integration binaries,
  no network)` — the step that picks up the new
  `session_store_survives_a_relocated_path_root` binary. Confirmed it is
  discovered by that step's `cargo metadata` enumeration and is not in the
  exclusion table, so it runs from the day it lands.
- `test (macos-latest)`, both `cross-check` targets, `guards`, `serve`,
  `no-ai-coauthor` and all six frontend checks: success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
