### PR TITLE
fix(models): the model controls say what they do (D6, D7, D4)

### DIFF
--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.chatBinding.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.chatBinding.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ModelsBottomBar from './ModelsBottomBar';
+import { __resetDisclosureStoreForTests } from '../../../privacy/disclosureCopy';
+
+/**
+ * D6 of the 2026-09-12 model-controls run, and the most dangerous of that batch.
+ *
+ * The "Change model" dialog opened from inside a chat is headed *"Select a
+ * provider and model for this chat."* and pre-filled the APP-WIDE selection, so
+ * pressing "Select model" without touching anything moved the chat to a model
+ * the user never chose. Model identity decides the privacy tier, so this is
+ * correctness, not cosmetics.
+ *
+ * Measured live against `origin/main` (dev GUI, sandboxed config, 2026-09-12):
+ * chat `20260610_28` — session row `provider_name = versa_azure`,
+ * `model_config_json.model_name = gpt-5.2-2025-12-11`, `privacy_tier = private`
+ * — with `BIOROUTER_MODEL = gpt-5.5-2026-04-24` and
+ * `BIOROUTER_PROVIDER = versa_azure`. The composer chip read
+ * `gpt-5.2-2025-12-11`; the dialog opened beneath it read
+ * `Select a provider and model for this chat.` over **`gpt-5.5-2026-04-24`**.
+ *
+ * The dialog is stubbed here and its props are the assertion. That is
+ * deliberate: what the dialog OPENS ON is a property of the hand-off, and the
+ * real modal's two selects load asynchronously from a provider catalog whose
+ * absence would make a passing test say nothing about which pair was passed.
+ */
+
+const mocks = vi.hoisted(() => ({
+  read: vi.fn(async (_key: string, _isSecret: boolean) => '' as unknown),
+  getProviders: vi.fn(async () => [] as unknown[]),
+  getPrivacyDisclosure: vi.fn(),
+  ackPrivacyDisclosure: vi.fn(),
+  switchModelProps: [] as Record<string, unknown>[],
+}));
+
+vi.mock('../../../../api', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getPrivacyDisclosure: mocks.getPrivacyDisclosure,
+  ackPrivacyDisclosure: mocks.ackPrivacyDisclosure,
+}));
+vi.mock('../../../../utils/userAction', () => ({
+  userActionHeaders: async () => ({ 'X-User-Action': 'test-key' }),
+}));
+
+vi.mock('../../../ConfigContext', () => ({
+  useConfig: () => ({ read: mocks.read, getProviders: mocks.getProviders }),
+  usePrivacyTiersEnabled: () => true,
+}));
+
+/** The app-wide selection — what the chip used to state everywhere. */
+const SELECTION = { model: 'gpt-5.5-2026-04-24', provider: 'versa_azure' };
+/** What chat `20260610_28`'s own row named, and what it really runs on. */
+const CHAT_BINDING = { model: 'gpt-5.2-2025-12-11', provider: 'versa_azure' };
+
+vi.mock('../../../ModelAndProviderContext', () => ({
+  useModelAndProvider: () => ({
+    currentModel: SELECTION.model,
+    currentProvider: SELECTION.provider,
+    getCurrentModelAndProviderForDisplay: async () => ({
+      model: SELECTION.model,
+      provider: 'Versa API Azure',
+    }),
+    getCurrentModelDisplayName: async () => SELECTION.model,
+    getCurrentProviderDisplayName: async () => 'Versa API Azure',
+  }),
+}));
+
+vi.mock('../subcomponents/SwitchModelModal', () => ({
+  SwitchModelModal: (props: Record<string, unknown>) => {
+    mocks.switchModelProps.push(props);
+    return <div data-testid="switch-model-modal" />;
+  },
+}));
+vi.mock('../subcomponents/LeadWorkerSettings', () => ({ LeadWorkerSettings: () => null }));
+
+const dropdownRef = { current: null } as unknown as React.RefObject<HTMLDivElement>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.switchModelProps = [];
+  __resetDisclosureStoreForTests();
+  mocks.getProviders.mockResolvedValue([
+    {
+      name: 'versa_azure',
+      is_configured: true,
+      provider_type: 'Builtin',
+      metadata: {
+        name: 'versa_azure',
+        display_name: 'Versa API Azure',
+        tier: 'private',
+        runs_locally: false,
+      },
+      affiliation: null,
+      resolved_tier: 'private',
+    },
+  ]);
+  mocks.getPrivacyDisclosure.mockResolvedValue({
+    data: { title_template: '{provider}', long: 'LONG', short: 'SHORT', acknowledged: true },
+  });
+  // No lead/worker pair configured, so nothing else competes for the chip.
+  mocks.read.mockImplementation(async (key: string) =>
+    key === 'BIOROUTER_MODEL' ? SELECTION.model : ''
+  );
+});
+
+/**
+ * `ModelsBottomBar` renders the dialog only from its own dropdown, and Radix's
+ * trigger opens on `pointerdown`, not on `click` — the same gesture
+ * `ModelsBottomBar.browserSurface.test.tsx` uses on this chip.
+ */
+async function openChangeModel() {
+  await screen.findByRole('button', { name: /Current model:/ });
+  fireEvent.pointerDown(screen.getByLabelText(/Current model/), { button: 0, ctrlKey: false });
+  fireEvent.click(await screen.findByRole('menuitem', { name: /Change model/ }));
+  await screen.findByTestId('switch-model-modal');
+  return mocks.switchModelProps[mocks.switchModelProps.length - 1];
+}
+
+describe('the Change model dialog opened from a chat', () => {
+  it("opens on the chat's own binding, not the app-wide selection", async () => {
+    render(
+      <ModelsBottomBar
+        sessionId="20260610_28"
+        privacyTier="private"
+        effectiveModel={CHAT_BINDING}
+        dropdownRef={dropdownRef}
+        setView={vi.fn()}
+        alerts={[]}
+      />
+    );
+    // The chip already states the binding; the dialog has to agree with it.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Current model:/ })).toHaveAccessibleName(
+        /gpt-5\.2-2025-12-11/
+      )
+    );
+
+    const props = await openChangeModel();
+    expect(props.sessionId).toBe('20260610_28');
+    expect(props.initialProvider).toBe(CHAT_BINDING.provider);
+    expect(props.initialModel).toBe(CHAT_BINDING.model);
+    // Without this the case above passes for a dialog handed a hard-coded pair.
+    expect(props.initialModel).not.toBe(SELECTION.model);
+  });
+
+  /**
+   * A chat whose binding agrees with the selection, or which has none of its own,
+   * arrives with `effectiveModel` unset (`usePinnedModel` sets it only on a
+   * difference). Passing `undefined` through is correct there — the modal's own
+   * fallback resolves to the same pair — and asserting it stops the fix from
+   * being written as a hard-coded value.
+   */
+  it('passes nothing through for a chat that runs the selection', async () => {
+    render(
+      <ModelsBottomBar
+        sessionId="20260610_29"
+        privacyTier="public"
+        dropdownRef={dropdownRef}
+        setView={vi.fn()}
+        alerts={[]}
+      />
+    );
+    const props = await openChangeModel();
+    expect(props.sessionId).toBe('20260610_29');
+    expect(props.initialProvider).toBeUndefined();
+    expect(props.initialModel).toBeUndefined();
+  });
+});

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.leadWorker.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.leadWorker.test.tsx
@@ -1,24 +1,36 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ModelsBottomBar from './ModelsBottomBar';
 import { __resetDisclosureStoreForTests } from '../../../privacy/disclosureCopy';
 import { announceAppModelSelection } from '../../../../utils/sessionBindingSync';
 
 /**
- * The chip's lead/worker ROLE has to follow the app-wide selection, not just
- * its value.
+ * The chip's lead/worker statement has to follow the app-wide selection, not just
+ * its value — and it has to be TRUE.
  *
- * Measured live on 2026-09-12, two windows of one instance: Settings → Models →
- * Lead/worker, lead `gpt-5.5-2026-04-24`, worker `gpt-4.1-mini-2025-04-14`,
- * Save. Saving rewrites `BIOROUTER_MODEL` to the WORKER and announces it, so
- * BOTH windows' chips moved to `gpt-4.1-mini-2025-04-14` — but only the window
- * that saved said `(worker)`. The other kept the `isLeadWorkerActive: false` it
- * had read at mount and drew a bare name, with nothing to say a lead was
- * configured at all.
+ * # Two defects, one file
  *
- * The three reads behind the label are asserted as ONE refresh here, because
- * the failure this guards is a partial one: `isLeadWorkerActive` fresh and
- * `BIOROUTER_MODEL` stale puts `(lead)` on the worker.
+ * **#279.** Measured live on 2026-09-12, two windows of one instance: Settings →
+ * Models → Lead/worker, Save. Saving rewrites `BIOROUTER_MODEL` to the worker and
+ * announces it, so BOTH windows' chips moved — but only the window that saved
+ * said anything about a pair. The other kept the "no pair configured" it had read
+ * at mount and drew a bare name, with nothing to suggest a lead existed. The
+ * reads behind the label are asserted as ONE refresh, because the failure this
+ * guards is a partial one.
+ *
+ * **D7, 2026-09-12.** What the refreshed label SAID was wrong. Measured against
+ * `origin/main` with lead `claude_code / claude-opus-5`, worker `versa_azure /
+ * gpt-4.1-mini-2025-04-14` and `BIOROUTER_LEAD_TURNS: 3`, Home's chip read
+ * `Current model: gpt-4.1-mini-2025-04-14 (worker) (Public model)` — while
+ * `LeadWorkerProvider::get_active_provider` sends the first three turns of every
+ * new chat to the lead. `BIOROUTER_MODEL` **is** the worker while a pair is on, so
+ * the old role (that key compared against `BIOROUTER_LEAD_MODEL`) could only ever
+ * read `worker`.
+ *
+ * So the assertions here changed with the truth, and #279's mechanism did not:
+ * the label still moves on another window's announcement, and still moves because
+ * all four keys are re-read together. `leadWorkerLabel.ts` holds the rule and its
+ * arithmetic is tested beside it.
  */
 const mocks = vi.hoisted(() => ({
   read: vi.fn(async (_key: string, _isSecret: boolean) => '' as unknown),
@@ -44,6 +56,8 @@ vi.mock('../../../ConfigContext', () => ({
 // The app-wide selection this window believes in. After a lead/worker save it
 // is the WORKER — that is what the daemon writes to `BIOROUTER_MODEL`.
 const selection = { model: 'gpt-4.1-mini-2025-04-14', provider: 'versa_azure' };
+/** The other half of the measured pair. */
+const LEAD = 'claude-opus-5';
 
 vi.mock('../../../ModelAndProviderContext', () => ({
   useModelAndProvider: () => ({
@@ -58,7 +72,6 @@ vi.mock('../../../ModelAndProviderContext', () => ({
   }),
 }));
 
-vi.mock('../../../BaseChat', () => ({ useCurrentModelInfo: () => null }));
 vi.mock('../subcomponents/SwitchModelModal', () => ({ SwitchModelModal: () => null }));
 vi.mock('../subcomponents/LeadWorkerSettings', () => ({ LeadWorkerSettings: () => null }));
 
@@ -73,19 +86,36 @@ const providerEntry = (name: string, display: string, tier: 'private' | 'public'
   resolved_tier: tier,
 });
 
-/** What the daemon answers for the two keys the role is derived from. */
-function daemonHolds(leadModel: string, activeModel: string) {
+/** What the daemon answers for the keys the label is derived from. */
+function daemonHolds(
+  leadModel: string,
+  activeModel: string,
+  extra: { leadProvider?: string; leadTurns?: unknown } = {}
+) {
   mocks.read.mockImplementation(async (key: string) => {
     if (key === 'BIOROUTER_LEAD_MODEL') return leadModel;
+    if (key === 'BIOROUTER_LEAD_PROVIDER') return extra.leadProvider ?? 'claude_code';
     if (key === 'BIOROUTER_MODEL') return activeModel;
+    if (key === 'BIOROUTER_LEAD_TURNS') return extra.leadTurns ?? 3;
     return '';
   });
 }
 
-function renderBar() {
+/**
+ * The handover line lives in the chip's dropdown, and Radix's trigger opens on
+ * `pointerdown`, not on `click` — the gesture
+ * `ModelsBottomBar.browserSurface.test.tsx` uses on this chip.
+ */
+async function openChipMenu() {
+  await screen.findByRole('button', { name: /Current model:/ });
+  fireEvent.pointerDown(screen.getByLabelText(/Current model/), { button: 0, ctrlKey: false });
+  await screen.findByRole('menuitem', { name: /Change model/ });
+}
+
+function renderBar(sessionId: string | null = null) {
   return render(
     <ModelsBottomBar
-      sessionId={null}
+      sessionId={sessionId}
       privacyTier={undefined}
       dropdownRef={dropdownRef}
       setView={vi.fn()}
@@ -99,6 +129,7 @@ beforeEach(() => {
   __resetDisclosureStoreForTests();
   mocks.getProviders.mockResolvedValue([
     providerEntry('versa_azure', 'Versa API Azure', 'private'),
+    providerEntry('claude_code', 'Claude Code', 'public'),
   ]);
   mocks.getPrivacyDisclosure.mockResolvedValue({
     data: {
@@ -114,46 +145,121 @@ beforeEach(() => {
 });
 
 describe('a lead/worker pair saved in another window', () => {
-  it('labels the chip (worker) once the selection change is announced', async () => {
+  it('names the lead, as the lead, once the selection change is announced', async () => {
     renderBar();
     const trigger = await screen.findByRole('button', { name: /Current model:/ });
     await waitFor(() => expect(trigger).toHaveAccessibleName(/gpt-4\.1-mini-2025-04-14/));
-    expect(trigger).not.toHaveAccessibleName(/worker/);
+    expect(trigger).not.toHaveAccessibleName(/lead/);
 
     // The other window saved the pair: the daemon now holds a lead, and
     // `BIOROUTER_MODEL` names the worker.
-    daemonHolds('gpt-5.5-2026-04-24', selection.model);
+    daemonHolds(LEAD, selection.model);
     announceAppModelSelection();
 
-    await waitFor(() =>
-      expect(trigger).toHaveAccessibleName(/gpt-4\.1-mini-2025-04-14 \(worker\)/)
-    );
-  });
-
-  it('labels it (lead) when the selection names the lead half', async () => {
-    renderBar();
-    const trigger = await screen.findByRole('button', { name: /Current model:/ });
-    await waitFor(() => expect(trigger).toHaveAccessibleName(/gpt-4\.1-mini-2025-04-14/));
-
-    // A pair whose lead IS the selected model: the role must read `lead`, which
-    // is only derivable from BOTH keys being re-read together.
-    daemonHolds(selection.model, selection.model);
-    announceAppModelSelection();
-
-    await waitFor(() => expect(trigger).toHaveAccessibleName(/gpt-4\.1-mini-2025-04-14 \(lead\)/));
+    // Home's next message opens a new chat, and a new chat's first turns are the
+    // lead's — so this is the model that gets it.
+    await waitFor(() => expect(trigger).toHaveAccessibleName(/claude-opus-5 \(lead\)/));
     expect(trigger).not.toHaveAccessibleName(/worker/);
   });
 
-  it('drops the role again when the pair is turned off elsewhere', async () => {
-    daemonHolds('gpt-5.5-2026-04-24', selection.model);
+  it('drops the statement again when the pair is turned off elsewhere', async () => {
+    daemonHolds(LEAD, selection.model);
     renderBar();
     const trigger = await screen.findByRole('button', { name: /Current model:/ });
-    await waitFor(() => expect(trigger).toHaveAccessibleName(/\(worker\)/));
+    await waitFor(() => expect(trigger).toHaveAccessibleName(/\(lead\)/));
 
     daemonHolds('', selection.model);
     announceAppModelSelection();
 
-    await waitFor(() => expect(trigger).not.toHaveAccessibleName(/worker/));
+    await waitFor(() => expect(trigger).not.toHaveAccessibleName(/lead/));
     expect(trigger).toHaveAccessibleName(/gpt-4\.1-mini-2025-04-14/);
+  });
+
+  /**
+   * D7's other half. The role was derived by comparing `BIOROUTER_MODEL` against
+   * `BIOROUTER_LEAD_MODEL`, and `BIOROUTER_MODEL` IS the worker, so inside a chat
+   * the chip asserted `(worker)` over the whole of every chat — including the
+   * opening turns the lead serves. The turn count that would settle it is daemon
+   * state this component is never served, so the claim is dropped rather than
+   * flipped.
+   */
+  it('claims no role inside a chat, where the live half is not knowable', async () => {
+    daemonHolds(LEAD, selection.model);
+    renderBar('20260610_28');
+    const trigger = await screen.findByRole('button', { name: /Current model:/ });
+    await waitFor(() => expect(trigger).toHaveAccessibleName(/gpt-4\.1-mini-2025-04-14/));
+    expect(trigger).not.toHaveAccessibleName(/\(worker\)/);
+    expect(trigger).not.toHaveAccessibleName(/\(lead\)/);
+  });
+
+  /**
+   * What the chip cannot say, the dropdown can — and it is the same sentence on
+   * both surfaces, because the handover is true of both.
+   */
+  it('states the handover in the dropdown, on Home and in a chat alike', async () => {
+    daemonHolds(LEAD, selection.model, { leadTurns: 2 });
+    const { unmount } = renderBar();
+    await openChipMenu();
+    await waitFor(() =>
+      expect(screen.getByTestId('lead-worker-handover-note')).toHaveTextContent(
+        'Lead/worker mode. claude-opus-5 answers the first 2 turns of a chat; gpt-4.1-mini-2025-04-14 takes the rest.'
+      )
+    );
+    unmount();
+
+    renderBar('20260610_28');
+    await openChipMenu();
+    await waitFor(() =>
+      expect(screen.getByTestId('lead-worker-handover-note')).toHaveTextContent(
+        /claude-opus-5 answers the first 2 turns/
+      )
+    );
+  });
+
+  it('says nothing about a pair when none is configured', async () => {
+    renderBar();
+    await openChipMenu();
+    expect(screen.queryByTestId('lead-worker-handover-note')).toBeNull();
+  });
+
+  /**
+   * The badges beside the name are read off ONE catalog row, for whichever
+   * provider the chip is naming. Naming the lead while still resolving the
+   * worker's provider put the worker's Private padlock on a public lead — the
+   * cross-provider pairing `ModelsBottomBar`'s own comments warn about, and the
+   * demotion case the tier exists to catch.
+   */
+  it("takes the lead PROVIDER's tier, not the worker's", async () => {
+    daemonHolds(LEAD, selection.model);
+    renderBar();
+    const trigger = await screen.findByRole('button', { name: /Current model:/ });
+    await waitFor(() => expect(trigger).toHaveAccessibleName(/claude-opus-5 \(lead\)/));
+    // `claude_code` is Public; `versa_azure` — the worker's provider, and what
+    // the app-wide selection names — is Private.
+    await waitFor(() => expect(trigger).toHaveAccessibleName(/Public model/));
+    expect(trigger).not.toHaveAccessibleName(/Private model/);
+  });
+
+  /**
+   * A chat with its own binding runs the single provider its row names, so no
+   * half of a globally configured pair is in play: no role, no handover line.
+   */
+  it('says nothing about a pair for a chat with its own binding', async () => {
+    daemonHolds(LEAD, selection.model);
+    render(
+      <ModelsBottomBar
+        sessionId="20260610_28"
+        privacyTier={undefined}
+        effectiveModel={{ provider: 'versa_azure', model: 'gpt-5.2-2025-12-11' }}
+        dropdownRef={dropdownRef}
+        setView={vi.fn()}
+        alerts={[]}
+      />
+    );
+    const trigger = await screen.findByRole('button', { name: /Current model:/ });
+    await waitFor(() => expect(trigger).toHaveAccessibleName(/gpt-5\.2-2025-12-11/));
+    expect(trigger).not.toHaveAccessibleName(/lead|worker/);
+    await openChipMenu();
+    expect(screen.queryByTestId('lead-worker-handover-note')).toBeNull();
   });
 });

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -11,7 +11,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '../../../ui/dropdown-menu';
-import { useCurrentModelInfo } from '../../../BaseChat';
 import { useConfig } from '../../../ConfigContext';
 import { getProviderMetadata } from '../modelInterface';
 import { Alert } from '../../../alerts';
@@ -32,6 +31,13 @@ import { isBrowserSurface } from '../../../../utils/surface';
 import type { ProviderTier, SessionClassification } from '../../../../api/types.gen';
 import type { PinnedModelView } from '../../../../hooks/chatStreamStore';
 import { subscribeAppModelSelectionChanges } from '../../../../utils/sessionBindingSync';
+import {
+  DEFAULT_LEAD_TURNS,
+  leadWorkerChip,
+  leadWorkerHandoverNote,
+  readLeadTurns,
+  type LeadWorkerChip,
+} from './leadWorkerLabel';
 
 /**
  * Round 3 / N1 — the one line explaining why the chip may not name the model the
@@ -124,13 +130,11 @@ export default function ModelsBottomBar({
     getCurrentModelDisplayName,
     getCurrentProviderDisplayName,
   } = useModelAndProvider();
-  const currentModelInfo = useCurrentModelInfo();
   const { read, getProviders } = useConfig();
   const [displayProvider, setDisplayProvider] = useState<string | null>(null);
   const [displayModelName, setDisplayModelName] = useState<string>('Select Model');
   const [isAddModelModalOpen, setIsAddModelModalOpen] = useState(false);
   const [isLeadWorkerModalOpen, setIsLeadWorkerModalOpen] = useState(false);
-  const [isLeadWorkerActive, setIsLeadWorkerActive] = useState(false);
   const [providerDefaultModel, setProviderDefaultModel] = useState<string | null>(null);
   /**
    * Task 30A (issue #56, DR-17 requirement 3). Does the model bound to this
@@ -192,46 +196,45 @@ export default function ModelsBottomBar({
    */
   const hostManaged = isBrowserSurface();
 
-  /**
-   * Issue #56 Gate B. What actually runs in THIS chat: the pin when there is
-   * one, the app's global selection otherwise.
-   *
-   * ⚠ The chat's own binding outranks lead/worker below. Such a chat runs the
-   * single provider its session row names, so a lead/worker pair configured
-   * globally is not what answers here, and labelling the chip `(lead)` would
-   * name a mechanism that is not in play.
-   */
-  const effectiveProvider = effectiveModel?.provider ?? currentProvider;
-
-  // Which half of a lead/worker pair the app-wide selection names.
-  // `BIOROUTER_MODEL` IS the worker while the pair is on, so the role has to be
-  // derived by comparing it against `BIOROUTER_LEAD_MODEL` — there is no
-  // "which half" key to read.
+  // The app-wide lead/worker selection, as its three config keys state it.
+  // `BIOROUTER_MODEL` IS the worker while a pair is on, so there is no
+  // "which half is live" key to read — see `leadWorkerLabel.ts` for what that
+  // leaves knowable, and for the false `(worker)` it used to produce.
   const [leadModelName, setLeadModelName] = useState<string>('');
+  const [leadProviderName, setLeadProviderName] = useState<string>('');
   const [currentActiveModel, setCurrentActiveModel] = useState<string>('');
+  const [leadTurns, setLeadTurns] = useState<number>(DEFAULT_LEAD_TURNS);
 
   /**
-   * One read for the whole lead/worker question: is a pair configured, what is
-   * the lead, and which of the two does `BIOROUTER_MODEL` currently name.
+   * One read for the whole lead/worker question: is a pair configured, what are
+   * the lead's model and provider, what does `BIOROUTER_MODEL` name, and how many
+   * turns the lead opens with.
    *
-   * ⚠ **The three answers move together or not at all.** They used to be three
-   * reads across two effects and a modal-close handler, so `isLeadWorkerActive`
-   * could be refreshed while `currentActiveModel` stayed behind — and that
-   * comparison is the whole of `modelMode`. A half-refreshed chip puts the
-   * wrong role on the right model, which is worse than carrying no role.
+   * ⚠ **The answers move together or not at all.** They used to be three reads
+   * across two effects and a modal-close handler, so "is a pair configured" could
+   * be refreshed while `currentActiveModel` stayed behind — and a half-refreshed
+   * chip puts the wrong role on the right model, which is worse than carrying no
+   * role. D7's two new answers joined the same `Promise.all` for that reason
+   * rather than taking reads of their own.
    */
   const refreshLeadWorker = useCallback(async () => {
     try {
-      const [leadModel, activeModel] = await Promise.all([
+      const [leadModel, leadProvider, activeModel, turns] = await Promise.all([
         read('BIOROUTER_LEAD_MODEL', false),
+        read('BIOROUTER_LEAD_PROVIDER', false),
         read('BIOROUTER_MODEL', false),
+        read('BIOROUTER_LEAD_TURNS', false),
       ]);
-      setIsLeadWorkerActive(!!leadModel);
       setLeadModelName((leadModel as string) || '');
+      setLeadProviderName((leadProvider as string) || '');
       setCurrentActiveModel((activeModel as string) || '');
+      setLeadTurns(readLeadTurns(turns));
     } catch (error) {
       console.error('Error reading the lead/worker selection:', error);
-      setIsLeadWorkerActive(false);
+      // A selection we could not read is not a pair, and must not leave a stale
+      // `(lead)` on a name from the last successful read.
+      setLeadModelName('');
+      setLeadProviderName('');
     }
   }, [read]);
 
@@ -275,23 +278,59 @@ export default function ModelsBottomBar({
     void refreshLeadWorker();
   };
 
-  // Determine the mode based on which model is currently active
-  const modelMode = isLeadWorkerActive
-    ? currentActiveModel === leadModelName
-      ? 'lead'
-      : 'worker'
-    : undefined;
+  /**
+   * D7 — the name and role a lead/worker pair earns on THIS surface. `sessionId`
+   * is the whole input: with no chat the next message opens a new session and the
+   * lead answers it, so the chip names the lead; inside a chat the live half
+   * depends on a turn count the renderer is never served, so no role is claimed.
+   * `leadWorkerLabel.ts` carries the measurement and the reasoning.
+   *
+   * A chat with its own binding runs a single provider, so the pair is not in
+   * play at all and is not asked about — the rule {@link effectiveProvider}
+   * below also records.
+   */
+  const pair = {
+    leadModel: leadModelName,
+    // `create_lead_worker_from_env` falls back to the default provider for an
+    // unset `BIOROUTER_LEAD_PROVIDER`, so the fallback is resolved here and
+    // nothing downstream has to know about it.
+    leadProvider: leadProviderName || currentProvider || '',
+    workerModel: currentActiveModel,
+    leadTurns,
+  };
+  const chipPair: LeadWorkerChip = effectiveModel ? {} : leadWorkerChip(pair, !!sessionId);
+  const handoverNote = effectiveModel ? null : leadWorkerHandoverNote(pair);
 
-  // Determine which model to display - activeModel takes priority when lead/worker is active
+  /**
+   * Issue #56 Gate B. What actually runs in THIS chat: the pin when there is
+   * one, then the half of a lead/worker pair the chip is naming, then the app's
+   * global selection.
+   *
+   * ⚠ The chat's own binding outranks lead/worker. Such a chat runs the single
+   * provider its session row names, so a lead/worker pair configured globally is
+   * not what answers here, and labelling the chip `(lead)` would name a mechanism
+   * that is not in play.
+   *
+   * ⚠ **It must follow the name the chip prints, not the app-wide selection.**
+   * Every other fact below — the tier padlock, the affiliation glyph, the
+   * disclosure line — is read off ONE catalog row for this provider. When the chip
+   * names the lead (D7, no chat) and this still named the worker's provider, the
+   * chip hung the worker's tier on the lead's name: a public lead wore the
+   * worker's Private padlock over turns that really go to a public endpoint.
+   */
+  const effectiveProvider = effectiveModel?.provider ?? chipPair.provider ?? currentProvider;
+
+  // Determine which model to display. The pair's own answer outranks the app-wide
+  // selection; a chat's own binding outranks both.
+  //
+  // ⚠ `useCurrentModelInfo()` is NOT consulted: `CurrentModelContext` is created
+  // and read in `BaseChat.tsx` and never provided, so the branch that used to sit
+  // here could not run on any surface. See `leadWorkerLabel.ts`.
   const displayModel =
     effectiveModel?.model ??
-    (isLeadWorkerActive && currentModelInfo?.model
-      ? currentModelInfo.model
-      : currentModel || providerDefaultModel || displayModelName);
-  const fullModelLabel =
-    !effectiveModel && isLeadWorkerActive && modelMode
-      ? `${displayModel} (${modelMode})`
-      : displayModel;
+    chipPair.model ??
+    (currentModel || providerDefaultModel || displayModelName);
+  const fullModelLabel = chipPair.role ? `${displayModel} (${chipPair.role})` : displayModel;
   const inlineModelLabel =
     fullModelLabel.length > MAX_INLINE_MODEL_LABEL_CHARS
       ? `${fullModelLabel.slice(0, MAX_INLINE_MODEL_LABEL_CHARS - 3)}...`
@@ -423,18 +462,23 @@ export default function ModelsBottomBar({
   const affiliationWords = affiliationPresentation(affiliation);
 
   /**
-   * The two names in the dropdown's "Current model" block, pinned binding first.
+   * The two names in the dropdown's "Current model" block, pinned binding first,
+   * then the lead the chip above is naming, then the app's global selection.
    *
    * Layered here rather than inside the effects that fill `displayModelName` /
    * `displayProvider`: those two describe the app's GLOBAL selection, which is
    * still the right answer for every chat that is not pinned, and having two
    * effects race to own one state was how the earlier drafts of this went
    * wrong.
+   *
+   * ⚠ **The same model as the chip, always.** The note under these names says
+   * "New chats in every window start on this model" — so with a pair configured
+   * it had to name the lead too, or that sentence pointed at the worker, which
+   * is not what a new chat starts on.
    */
-  const shownModelName = effectiveModel?.model ?? displayModelName;
-  const shownProviderName = effectiveModel
-    ? (pinnedProviderName ?? effectiveModel.provider)
-    : displayProvider;
+  const shownModelName = effectiveModel?.model ?? chipPair.model ?? displayModelName;
+  const shownProviderName =
+    effectiveModel || chipPair.model ? (pinnedProviderName ?? effectiveProvider) : displayProvider;
 
   // What is true of the MODEL, as one clause: its tier, then who covers it.
   // Both axes come off one sample of one endpoint, so they can be said in one
@@ -566,6 +610,23 @@ export default function ModelsBottomBar({
                 {NEW_CHATS_MODEL_NOTE}
               </div>
             )}
+            {/*
+              D7 — the pair's whole truth, in the one surface with room for a
+              sentence. The chip above can name one half and (off Home) cannot
+              even say which half is live, because the turn count that decides it
+              is daemon state the renderer is never served. This line states the
+              HANDOVER instead of claiming a side of it, so it is true of every
+              chat and every surface — the same split this block already uses for
+              the tier word, the affiliation word and `CHAT_KEEPS_ITS_MODEL_NOTE`.
+            */}
+            {handoverNote && (
+              <div
+                data-testid="lead-worker-handover-note"
+                className="mt-1 text-[11px] leading-4 text-text-muted [overflow-wrap:anywhere]"
+              >
+                {handoverNote}
+              </div>
+            )}
             {/* Under the heading "Current model", so it must be about the
                 model. It used to be `privacyLine`. */}
             {modelTierWords && (
@@ -666,9 +727,32 @@ export default function ModelsBottomBar({
       </DropdownMenu>
 
       {isAddModelModalOpen ? (
+        /*
+          D6 — the dialog is headed "Select a provider and model for this chat",
+          so it must OPEN on that chat's own binding. Left to its own fallback it
+          pre-fills `ModelAndProviderContext`'s app-wide selection, and pressing
+          "Select model" without touching anything then moved the chat to a model
+          the user never chose.
+
+          Measured (dev GUI, 2026-09-12): chat `20260610_28`, row
+          `provider_name = versa_azure`, `model_name = gpt-5.2-2025-12-11`,
+          `privacy_tier = private`; `BIOROUTER_MODEL = gpt-5.5-2026-04-24`. The
+          chip read `gpt-5.2-2025-12-11`, the dialog opened on
+          `gpt-5.5-2026-04-24`. Model identity decides the privacy tier, so a
+          silent move is a correctness bug, not a cosmetic one.
+
+          ⚠ `effectiveModel` is the right source and `undefined` is the right
+          pass-through. `usePinnedModel` sets it exactly when the chat's binding
+          DIFFERS from the selection; where it is unset the two agree (or the chat
+          has no binding of its own and genuinely runs the selection), and the
+          modal's own fallback to `currentProvider`/`currentModel` is then the
+          same pair.
+        */
         <SwitchModelModal
           sessionId={sessionId}
           privacyTier={privacyTier}
+          initialProvider={effectiveModel?.provider}
+          initialModel={effectiveModel?.model}
           setView={setView}
           onClose={() => setIsAddModelModalOpen(false)}
         />

--- a/ui/desktop/src/components/settings/models/bottom_bar/leadWorkerLabel.test.ts
+++ b/ui/desktop/src/components/settings/models/bottom_bar/leadWorkerLabel.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_LEAD_TURNS,
+  leadWorkerActive,
+  leadWorkerChip,
+  leadWorkerHandoverNote,
+  readLeadTurns,
+  type LeadWorkerPair,
+} from './leadWorkerLabel';
+
+/**
+ * D7 of the 2026-09-12 model-controls run, as arithmetic.
+ *
+ * React-free and DOM-free on purpose, the rule `utils/messageClamp.ts` and
+ * `styles/measures.test.ts` already record: a threshold you can only exercise by
+ * rendering a component is one nobody re-tests. The rendered half — that the chip
+ * prints what this returns — is `ModelsBottomBar.leadWorker.test.tsx`.
+ *
+ * Measured live against `origin/main` (dev GUI, sandboxed config, 2026-09-12):
+ * lead `claude_code / claude-opus-5`, worker `versa_azure /
+ * gpt-4.1-mini-2025-04-14`, `BIOROUTER_LEAD_TURNS: 3`. Home's chip read
+ * `Current model: gpt-4.1-mini-2025-04-14 (worker) (Public model)` — the half
+ * that does not answer the next message, under the word that says it does.
+ */
+
+const PAIR: LeadWorkerPair = {
+  leadModel: 'claude-opus-5',
+  leadProvider: 'claude_code',
+  workerModel: 'gpt-4.1-mini-2025-04-14',
+  leadTurns: 3,
+};
+const NO_PAIR: LeadWorkerPair = {
+  leadModel: '',
+  leadProvider: '',
+  workerModel: 'gpt-5.5-2026-04-24',
+  leadTurns: DEFAULT_LEAD_TURNS,
+};
+
+describe('leadWorkerChip', () => {
+  it('names the lead, as the lead, where there is no chat yet', () => {
+    // `/agent/start` opens the session at `turn_count: 0` and `lead_turns >= 1`,
+    // so this is the one answer the renderer can give with certainty.
+    expect(leadWorkerChip(PAIR, false)).toEqual({
+      model: 'claude-opus-5',
+      provider: 'claude_code',
+      role: 'lead',
+    });
+  });
+
+  it('claims no role inside a chat, where the live half is not knowable', () => {
+    // The turn count that decides it is daemon state this component is never
+    // served. `{}` keeps the app-wide selection on the chip — the name it always
+    // had — and drops the `(worker)` that was false for every chat's opening
+    // turns.
+    expect(leadWorkerChip(PAIR, true)).toEqual({});
+  });
+
+  it('says nothing at all when no pair is configured', () => {
+    expect(leadWorkerChip(NO_PAIR, false)).toEqual({});
+    expect(leadWorkerChip(NO_PAIR, true)).toEqual({});
+  });
+
+  /**
+   * At `lead_turns: 0` the worker takes turn 1 (`turn_count < 0` never holds) and
+   * the lead is reached only by the failure fallback, so the app-wide selection is
+   * already the right name and `(lead)` would be false on Home too.
+   */
+  it('claims nothing at zero lead turns, where the worker takes turn 1', () => {
+    expect(leadWorkerChip({ ...PAIR, leadTurns: 0 }, false)).toEqual({});
+    expect(leadWorkerHandoverNote({ ...PAIR, leadTurns: 0 })).toBe(
+      'Lead/worker mode. gpt-4.1-mini-2025-04-14 answers every turn; claude-opus-5 is the fallback model.'
+    );
+  });
+
+  // The provider travels with the model or the chip hangs the worker provider's
+  // tier, affiliation and disclosure on the lead's name.
+  it('never returns a model without its provider', () => {
+    for (const hasChat of [false, true]) {
+      const chip = leadWorkerChip(PAIR, hasChat);
+      expect(!!chip.model).toBe(!!chip.provider);
+    }
+  });
+});
+
+describe('leadWorkerActive', () => {
+  it('is the lead model and nothing else', () => {
+    expect(leadWorkerActive(PAIR)).toBe(true);
+    expect(leadWorkerActive(NO_PAIR)).toBe(false);
+    // A worker alone is just the app-wide selection, which every machine has.
+    expect(leadWorkerActive({ ...NO_PAIR, workerModel: 'anything' })).toBe(false);
+  });
+});
+
+describe('readLeadTurns', () => {
+  it('takes a saved number', () => {
+    expect(readLeadTurns(5)).toBe(5);
+    expect(readLeadTurns('2')).toBe(2);
+  });
+
+  it('falls back to the daemon default for what a usize parse rejects', () => {
+    // `/config/read` answers an unset key with `null`; a config file can hold
+    // anything. Each of these is what `get_param::<usize>` would reject, so each
+    // must resolve to what the daemon would then use.
+    for (const raw of [null, undefined, '', 'three', {}, NaN, -4, 2.5]) {
+      expect(readLeadTurns(raw)).toBe(DEFAULT_LEAD_TURNS);
+    }
+  });
+
+  /**
+   * ⚠ `0` is ACCEPTED by `get_param::<usize>`, so it must survive here. Treating
+   * it as unusable and defaulting to 3 would make the chip claim `(lead)` for a
+   * pair whose lead never answers the first turn — D7 with the halves swapped.
+   * It is reachable through the shipped CLI: `configure.rs`'s `prompt_turns`
+   * validator accepts any `u32::parse`, and `"0"` parses.
+   */
+  it('keeps a zero, which the daemon accepts', () => {
+    expect(readLeadTurns(0)).toBe(0);
+    expect(readLeadTurns('0')).toBe(0);
+  });
+
+  it('matches the Rust default', () => {
+    // `DEFAULT_LEAD_TURNS` in crates/biorouter/src/providers/factory.rs.
+    expect(DEFAULT_LEAD_TURNS).toBe(3);
+  });
+});
+
+describe('leadWorkerHandoverNote', () => {
+  it('states the handover, which is true of every surface', () => {
+    expect(leadWorkerHandoverNote(PAIR)).toBe(
+      'Lead/worker mode. claude-opus-5 answers the first 3 turns of a chat; gpt-4.1-mini-2025-04-14 takes the rest.'
+    );
+  });
+
+  it('reads as English at one turn', () => {
+    expect(leadWorkerHandoverNote({ ...PAIR, leadTurns: 1 })).toContain('the first turn of a chat');
+  });
+
+  it('names only what it knows when the worker key is unset', () => {
+    expect(leadWorkerHandoverNote({ ...PAIR, workerModel: '' })).toBe(
+      'Lead/worker mode. claude-opus-5 answers the first 3 turns of a chat.'
+    );
+  });
+
+  it('is null with no pair, so nothing renders', () => {
+    expect(leadWorkerHandoverNote(NO_PAIR)).toBeNull();
+  });
+});

--- a/ui/desktop/src/components/settings/models/bottom_bar/leadWorkerLabel.ts
+++ b/ui/desktop/src/components/settings/models/bottom_bar/leadWorkerLabel.ts
@@ -1,0 +1,171 @@
+/**
+ * What the composer's model chip may say about a lead/worker pair.
+ *
+ * # The defect (D7 of the 2026-09-12 model-controls run)
+ *
+ * The chip's one job is to say where the next message goes. With a pair
+ * configured it named the WORKER and labelled it `(worker)` — on Home, where the
+ * next message starts a new chat and the **lead** answers it.
+ *
+ * Measured live (dev GUI, sandboxed config, 2026-09-12): lead
+ * `claude_code / claude-opus-5`, worker `versa_azure / gpt-4.1-mini-2025-04-14`,
+ * `BIOROUTER_LEAD_TURNS: 3`. Home's chip read
+ * `Current model: gpt-4.1-mini-2025-04-14 (worker) (Public model)` — the model
+ * that does not get the first three turns, under the one word that says so.
+ *
+ * # Why the role was always `worker`
+ *
+ * `BIOROUTER_MODEL` **is** the worker while a pair is on (`LeadWorkerSettings`
+ * writes the worker to it; `providers::factory::create_lead_worker_from_env`
+ * reads it as the worker's model). The role was derived by comparing that key
+ * against `BIOROUTER_LEAD_MODEL`, so it could only ever read `lead` for a
+ * degenerate pair whose two halves name the same model. Every real pair read
+ * `worker`, in every chat and on Home.
+ *
+ * ⚠ The `useCurrentModelInfo()` branch that looked like it rescued this is dead:
+ * `CurrentModelContext` in `BaseChat.tsx` is created and read and **never
+ * provided**, so the hook returns `null` on every surface. Do not reason from it.
+ *
+ * # What the renderer can actually know
+ *
+ * `LeadWorkerProvider::get_active_provider` routes to the lead while
+ * `turn_count < lead_turns`, and `turn_count` is daemon state the renderer is
+ * never served. So there are exactly two answers:
+ *
+ * - **No chat yet** (Home, a chat not started). `/agent/start` opens a session at
+ *   `LeadWorkerRoutingState::default()` — `turn_count: 0` — so with `lead_turns`
+ *   at 1 or more the lead answers the next message, with certainty. The chip
+ *   names the lead and labels it `(lead)`.
+ * - **Inside a chat.** Which half is live depends on that chat's turn count, and
+ *   nothing tells this component what it is. So the chip claims **no role at
+ *   all** rather than asserting the one that is false for every chat's opening
+ *   turns. It still names what `BIOROUTER_MODEL` holds, which is what it named
+ *   before.
+ *
+ * ⚠ **`lead_turns` of 0 is a real configuration, and it inverts the first
+ * answer.** `turn_count < 0` never holds, so the WORKER takes turn 1 and the lead
+ * is only ever reached through `handle_completion_result`'s failure fallback. It
+ * is not merely hand-editable: `configure.rs`'s `prompt_turns` validator accepts
+ * any `u32::parse`, and `"0"` parses — so the shipped CLI will write it while
+ * telling the user it wants a positive number. Claiming `(lead)` there would be
+ * D7 again, with the halves swapped.
+ *
+ * Dropping a claim is the point, not a loss: the pair's whole truth goes to
+ * {@link leadWorkerHandoverNote}, in the dropdown, which has room for a sentence
+ * — the same split this chip already uses for the tier word, the affiliation
+ * word and `CHAT_KEEPS_ITS_MODEL_NOTE`.
+ *
+ * A chat with its OWN binding is not this module's business: it runs the single
+ * provider its session row names, so no half of a globally configured pair is in
+ * play and `ModelsBottomBar` never asks.
+ */
+
+/**
+ * `DEFAULT_LEAD_TURNS` in `crates/biorouter/src/providers/factory.rs`. A copy,
+ * because the renderer reads the config key itself and the daemon's fallback is
+ * not served anywhere; {@link readLeadTurns} is the one place it is applied.
+ */
+export const DEFAULT_LEAD_TURNS = 3;
+
+/** The app-wide lead/worker selection, as its config keys state it. */
+export interface LeadWorkerPair {
+  /** `BIOROUTER_LEAD_MODEL`. Empty when no pair is configured. */
+  leadModel: string;
+  /**
+   * `BIOROUTER_LEAD_PROVIDER`, falling back to `BIOROUTER_PROVIDER` — which is
+   * exactly what `create_lead_worker_from_env` does with an unset key. Resolve
+   * the fallback before building this, so nothing downstream has to.
+   */
+  leadProvider: string;
+  /** `BIOROUTER_MODEL` — the WORKER's model while a pair is on. */
+  workerModel: string;
+  /** `BIOROUTER_LEAD_TURNS`, already defaulted by {@link readLeadTurns}. */
+  leadTurns: number;
+}
+
+/**
+ * `BIOROUTER_LEAD_TURNS` as the count the daemon will use.
+ *
+ * ⚠ **This mirrors `get_param::<usize>(…).unwrap_or(DEFAULT_LEAD_TURNS)` and
+ * nothing else.** `/config/read` answers an unset key with `null`, a saved number
+ * as a number, and a config file can hold anything; what the daemon's `usize`
+ * parse REJECTS falls back to its default, and what it accepts is kept as-is.
+ * `0` is accepted there, so it is kept here — see the header. Treating it as
+ * "unusable, so default to 3" was the first draft, and it would have put `(lead)`
+ * on a pair whose lead does not answer the first turn.
+ */
+export function readLeadTurns(raw: unknown): number {
+  if (raw === null || raw === undefined || raw === '') return DEFAULT_LEAD_TURNS;
+  const parsed = typeof raw === 'number' ? raw : Number(raw);
+  // A `usize` parse takes neither a fraction nor a negative nor a non-number.
+  if (!Number.isInteger(parsed) || parsed < 0) return DEFAULT_LEAD_TURNS;
+  return parsed;
+}
+
+/** Is a lead/worker pair configured at all? */
+export function leadWorkerActive(pair: LeadWorkerPair): boolean {
+  return !!pair.leadModel;
+}
+
+/** What the chip says about the pair. */
+export interface LeadWorkerChip {
+  /**
+   * The model the chip must name, or `undefined` to keep naming the app-wide
+   * selection (which is the worker, and is what the chip named before).
+   */
+  model?: string;
+  /**
+   * The provider that model belongs to, and it is set exactly when `model` is.
+   *
+   * ⚠ **The two travel together or the chip lies about a third thing.** Every
+   * other fact the chip states — the tier padlock, the affiliation glyph, the
+   * disclosure line — is read off ONE catalog row for the provider named here. A
+   * `model` without its provider would hang the worker's provider's tier on the
+   * lead's name, which is the cross-provider pairing `ModelsBottomBar`'s own
+   * comments warn about at length.
+   */
+  provider?: string;
+  /**
+   * The role parenthetical, or `undefined` when no role may be claimed — either
+   * because no pair is configured, or because the chip is inside a chat and the
+   * live half is not knowable here.
+   */
+  role?: 'lead';
+}
+
+/**
+ * The chip's name, provider and role for a pair.
+ *
+ * `hasChat` is the whole of the distinction: with no chat the next message opens
+ * a new session and the lead answers it; inside a chat the turn count decides
+ * and the renderer is not told it.
+ */
+export function leadWorkerChip(pair: LeadWorkerPair, hasChat: boolean): LeadWorkerChip {
+  if (!leadWorkerActive(pair)) return {};
+  if (hasChat) return {};
+  // `lead_turns: 0` means the worker takes turn 1 and the lead is fallback-only,
+  // so the app-wide selection is already the right name and no role is claimable.
+  if (pair.leadTurns < 1) return {};
+  return { model: pair.leadModel, provider: pair.leadProvider, role: 'lead' };
+}
+
+/**
+ * The dropdown's one line about the pair, or `null` when none is configured.
+ *
+ * True of every chat and every surface, which is why it can stand where the
+ * chip's role cannot: it states the handover rather than claiming a side of it.
+ * The worker is omitted when the key is unset — a sentence that names only what
+ * it knows, rather than one with a hole in it.
+ */
+export function leadWorkerHandoverNote(pair: LeadWorkerPair): string | null {
+  if (!leadWorkerActive(pair)) return null;
+  // At 0 lead turns there is no handover to describe: the worker answers
+  // everything and the lead is reached only by the failure fallback.
+  if (pair.leadTurns < 1) {
+    const worker = pair.workerModel ? `${pair.workerModel} answers every turn; ` : '';
+    return `Lead/worker mode. ${worker}${pair.leadModel} is the fallback model.`;
+  }
+  const turns = pair.leadTurns === 1 ? 'the first turn' : `the first ${pair.leadTurns} turns`;
+  const opening = `Lead/worker mode. ${pair.leadModel} answers ${turns} of a chat`;
+  return pair.workerModel ? `${opening}; ${pair.workerModel} takes the rest.` : `${opening}.`;
+}

--- a/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
@@ -23,6 +23,64 @@ interface LeadWorkerSettingsProps {
   onClose: () => void;
 }
 
+/**
+ * A model row in either select.
+ *
+ * `unavailableReason` is the daemon's own sentence for a provider the user HAS
+ * set up that cannot run right now (`ProviderDetails.unavailable_reason`, from
+ * `ProviderReadiness::Unavailable`).
+ *
+ * # The defect (D4 of the 2026-09-12 model-controls run)
+ *
+ * This dialog built its options from `providers.filter((p) => p.is_configured)`
+ * and mapped them to `{ value, label, provider }`, dropping the row. The daemon
+ * serves an unavailable provider `is_configured: false` **with** a reason, so the
+ * filter deleted the one row the user most needs to see — and the option shape it
+ * mapped to had nowhere to carry the reason even if the row had survived.
+ *
+ * Measured live (dev GUI, sandboxed config, `CODEX_COMMAND: /nope/codex`,
+ * 2026-09-12): this dialog built **25** options, `anyCodex=false`,
+ * `anyUnavailable=false`, while `GET /config/providers` was serving
+ * `codex | is_configured=False | unavailable_reason='Codex is not installed, or is
+ * not on a path Biorouter searches' | 6 known models`. One menu item away, the
+ * Switch-models picker rendered that provider disabled with the same sentence on
+ * the row.
+ *
+ * So the reason is carried through, and rendered the way that picker already
+ * renders it: `aria-disabled` rows with the sentence beneath the label, plus the
+ * sentence beside a FIELD whose selection is barred — because a disabled row is
+ * not a disabled selection (a pair saved while the CLI worked reopens here after
+ * it moved, with nobody re-picking anything).
+ */
+type LeadWorkerModelOption = {
+  value: string;
+  label: string;
+  provider: string;
+  unavailableReason?: string;
+};
+
+/** The prefix the Switch-models picker uses, so the two surfaces read alike. */
+const unavailableLine = (reason: string) => `Unavailable: ${reason}`;
+
+/**
+ * A row's label, with the reason on a second line in the MENU only — the closed
+ * field has room for the name alone, and the reason is stated beside it instead.
+ */
+const renderLeadWorkerOption = (rawOption: unknown, meta: { context: 'menu' | 'value' }) => {
+  const option = rawOption as LeadWorkerModelOption;
+  if (meta.context === 'value' || !option.unavailableReason) {
+    return <span className="block max-w-full truncate">{option.label}</span>;
+  }
+  return (
+    <div className="min-w-0 py-0.5">
+      <div className="truncate text-sm font-medium text-current">{option.label}</div>
+      <div className="mt-0.5 line-clamp-2 text-xs leading-relaxed text-current opacity-70">
+        {unavailableLine(option.unavailableReason)}
+      </div>
+    </div>
+  );
+};
+
 export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps) {
   const { read, upsert, getProviders, getProviderModels, remove } = useConfig();
   const { currentModel } = useModelAndProvider();
@@ -37,9 +95,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
   const [failureThreshold, setFailureThreshold] = useState<number>(2);
   const [fallbackTurns, setFallbackTurns] = useState<number>(2);
   const [isEnabled, setIsEnabled] = useState(false);
-  const [modelOptions, setModelOptions] = useState<
-    { value: string; label: string; provider: string }[]
-  >([]);
+  const [modelOptions, setModelOptions] = useState<LeadWorkerModelOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   // Load current configuration
@@ -97,7 +153,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
         }
 
         // Load available models
-        const options: { value: string; label: string; provider: string }[] = [];
+        const options: LeadWorkerModelOption[] = [];
 
         if (shouldShowPredefinedModels()) {
           // Use predefined models if available
@@ -112,13 +168,21 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
         } else {
           // Fallback to provider-based models
           const providers = await getProviders(false);
-          const activeProviders = providers.filter((p) => p.is_configured);
+          // D4 — every usable provider, PLUS every provider the user set up that
+          // cannot run right now, which arrives `is_configured: false` with a
+          // reason. The reason rides the option from here to the row; a provider
+          // that was never set up stays out, exactly as before. Same predicate,
+          // same polarity, as `SwitchModelModal`'s provider list.
+          const listedProviders = providers.filter((p) => p.is_configured || p.unavailable_reason);
 
-          const results = await fetchModelsForProviders(activeProviders, getProviderModels);
+          const results = await fetchModelsForProviders(listedProviders, getProviderModels);
           results.forEach(({ provider: p, models, error }) => {
             if (error) {
               console.error(error);
             }
+            const unavailableReason = p.is_configured
+              ? undefined
+              : (p.unavailable_reason ?? undefined);
 
             if (models && models.length > 0) {
               models.forEach((modelName) => {
@@ -126,6 +190,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                   value: modelName,
                   label: `${modelName} (${p.metadata.display_name})`,
                   provider: p.name,
+                  unavailableReason,
                 });
               });
             }
@@ -135,6 +200,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                 value: `__custom__:${p.name}`,
                 label: 'Enter a model not listed...',
                 provider: p.name,
+                unavailableReason,
               });
             }
           });
@@ -171,8 +237,31 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
    */
   const hostManaged = isBrowserSurface();
 
+  /**
+   * D4's pre-flight: the reason each HALF cannot run, derived from the selection
+   * on every render.
+   *
+   * ⚠ **A disabled row is not a disabled selection** — the rule
+   * `SwitchModelModal.validation` records at length, and it bites harder here
+   * because nothing in this dialog picks anything on open: the two fields are
+   * filled from `BIOROUTER_LEAD_*` / `BIOROUTER_MODEL`, so a pair saved while a
+   * coding agent's CLI resolved reopens after it moved with a barred model in a
+   * field whose menu nobody will touch. Keyed on the PROVIDER, because that is
+   * what the reason belongs to, and read off the option list so it can never
+   * disagree with the row.
+   */
+  const unavailableReasonForProvider = (providerName: string) =>
+    modelOptions.find((option) => option.provider === providerName)?.unavailableReason ?? null;
+  const leadUnavailable = leadProvider ? unavailableReasonForProvider(leadProvider) : null;
+  const workerUnavailable = workerProvider ? unavailableReasonForProvider(workerProvider) : null;
+  // Only what is actually in force: the fields are inert while the pair is off.
+  const barred = isEnabled && !!(leadUnavailable || workerUnavailable);
+
   const handleSave = async () => {
     if (hostManaged) return;
+    // The button below is already disabled on this verdict; this is its
+    // post-click half, for a submit that arrives some other way.
+    if (barred) return;
     try {
       if (isEnabled && leadModel && workerModel) {
         // Save lead/worker configuration
@@ -279,6 +368,10 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                   }}
                   placeholder="Select lead model..."
                   isDisabled={!isEnabled}
+                  formatOptionLabel={renderLeadWorkerOption}
+                  isOptionDisabled={(rawOption: unknown) =>
+                    !!(rawOption as LeadWorkerModelOption).unavailableReason
+                  }
                 />
               ) : (
                 <Input
@@ -289,6 +382,15 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                   disabled={!isEnabled}
                 />
               )}
+              {/* D4 — beside the field, because a disabled row says nothing about
+                  a selection nobody re-picked. The custom-model input above
+                  bypasses the option list entirely and keeps its provider, so the
+                  same verdict has to be spoken here for both branches. */}
+              {isEnabled && leadUnavailable ? (
+                <p data-testid="lead-worker-lead-unavailable" className="text-sm text-text-danger">
+                  {unavailableLine(leadUnavailable)}
+                </p>
+              ) : null}
               <p className="text-xs text-text-muted">
                 Strong model for initial planning and fallback recovery
               </p>
@@ -330,6 +432,10 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                   }}
                   placeholder="Select worker model..."
                   isDisabled={!isEnabled}
+                  formatOptionLabel={renderLeadWorkerOption}
+                  isOptionDisabled={(rawOption: unknown) =>
+                    !!(rawOption as LeadWorkerModelOption).unavailableReason
+                  }
                 />
               ) : (
                 <Input
@@ -340,6 +446,14 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                   disabled={!isEnabled}
                 />
               )}
+              {isEnabled && workerUnavailable ? (
+                <p
+                  data-testid="lead-worker-worker-unavailable"
+                  className="text-sm text-text-danger"
+                >
+                  {unavailableLine(workerUnavailable)}
+                </p>
+              ) : null}
               <p className="text-xs text-text-muted">Fast model for routine execution tasks</p>
             </div>
 
@@ -400,7 +514,7 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
             </Button>
             <Button
               onClick={handleSave}
-              disabled={hostManaged || (isEnabled && (!leadModel || !workerModel))}
+              disabled={hostManaged || barred || (isEnabled && (!leadModel || !workerModel))}
               title={hostManaged ? HOST_MANAGED_MODEL_REASON : undefined}
             >
               Save settings

--- a/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.unavailable.test.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.unavailable.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderDetails } from '../../../../api';
+import { LeadWorkerSettings } from './LeadWorkerSettings';
+
+/**
+ * D4 of the 2026-09-12 model-controls run — a provider the user set up that
+ * cannot run must be EXPLAINED in these two selects, not omitted from them.
+ *
+ * Measured live (dev GUI, sandboxed config, `CODEX_COMMAND: /nope/codex`,
+ * 2026-09-12) against `origin/main`: Settings → the composer chip → Lead/worker
+ * settings, switch on, open the lead select — **25** options,
+ * `anyCodex=false`, `anyUnavailable=false`, while `GET /config/providers` served
+ * `codex | is_configured=False | unavailable_reason='Codex is not installed, or
+ * is not on a path Biorouter searches' | 6 known models`. One menu item away,
+ * the Switch-models picker rendered Codex disabled with that same sentence on
+ * the row. Same catalog, same machine, two different stories.
+ *
+ * The real `Select` (react-select) is used deliberately, exactly as
+ * `SwitchModelModal.unavailable.test.tsx` does: `role="option"` and
+ * `aria-disabled` are react-select's own output, and they are what this
+ * pre-flight has to produce. A stubbed Select can see no option at all.
+ */
+
+const mocks = vi.hoisted(() => ({
+  read: vi.fn(),
+  upsert: vi.fn(),
+  remove: vi.fn(),
+  getProviders: vi.fn(),
+  getProviderModels: vi.fn(),
+}));
+
+vi.mock('../predefinedModelsUtils', () => ({
+  shouldShowPredefinedModels: () => false,
+  getPredefinedModelsFromEnv: () => [],
+}));
+
+vi.mock('../../../ConfigContext', () => ({
+  useConfig: () => ({
+    read: mocks.read,
+    upsert: mocks.upsert,
+    remove: mocks.remove,
+    getProviders: mocks.getProviders,
+    getProviderModels: mocks.getProviderModels,
+  }),
+}));
+
+vi.mock('../../../ModelAndProviderContext', () => ({
+  useModelAndProvider: () => ({ currentModel: null }),
+}));
+
+/** The daemon's sentence for a coding agent whose CLI does not resolve. */
+const NOT_INSTALLED = 'Codex is not installed, or is not on a path Biorouter searches';
+
+function provider(
+  name: string,
+  displayName: string,
+  models: string[],
+  readiness: { is_configured: boolean; unavailable_reason?: string | null }
+): ProviderDetails {
+  return {
+    name,
+    provider_type: 'Builtin',
+    affiliation: null,
+    resolved_tier: null,
+    unavailable_reason: null,
+    ...readiness,
+    metadata: {
+      config_keys: [],
+      default_model: models[0] ?? '',
+      description: '',
+      display_name: displayName,
+      known_models: models.map((model) => ({ name: model })),
+      model_doc_link: '',
+      name,
+      tier: 'public',
+      runs_locally: false,
+    },
+  } as unknown as ProviderDetails;
+}
+
+/** Versa usable, Codex set up but unable to run, OpenAI never set up. */
+const ROWS = [
+  provider('versa_azure', 'Versa API Azure', ['gpt-5.5-2026-04-24'], { is_configured: true }),
+  provider('codex', 'Codex', ['gpt-6-astra'], {
+    is_configured: false,
+    unavailable_reason: NOT_INSTALLED,
+  }),
+  provider('openai', 'OpenAI', ['gpt-4o'], { is_configured: false }),
+];
+
+/** No pair configured, so the dialog opens with the worker on the selection. */
+function daemonHoldsNoPair() {
+  mocks.read.mockImplementation(async (key: string) => {
+    if (key === 'BIOROUTER_MODEL') return 'gpt-5.5-2026-04-24';
+    if (key === 'BIOROUTER_PROVIDER') return 'versa_azure';
+    return null;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getProviders.mockResolvedValue(ROWS);
+  mocks.getProviderModels.mockResolvedValue([]);
+  mocks.upsert.mockResolvedValue(undefined);
+  mocks.remove.mockResolvedValue(undefined);
+  daemonHoldsNoPair();
+});
+
+/** The switch gates both selects (`isDisabled={!isEnabled}`), so turn it on. */
+async function enablePair() {
+  const toggle = await screen.findByRole('switch', { name: 'Lead/worker mode' });
+  if (toggle.getAttribute('aria-checked') === 'false') fireEvent.click(toggle);
+}
+
+/** The lead select is the first combobox and the worker select the second. */
+async function openSelect(which: 'lead' | 'worker') {
+  await enablePair();
+  const boxes = await screen.findAllByRole('combobox');
+  fireEvent.keyDown(boxes[which === 'lead' ? 0 : 1], { key: 'ArrowDown', code: 'ArrowDown' });
+}
+
+describe('LeadWorkerSettings — a provider that cannot run', () => {
+  it.each(['lead', 'worker'] as const)(
+    'lists its models in the %s select, disabled, with the reason on the row',
+    async (which) => {
+      render(<LeadWorkerSettings isOpen onClose={vi.fn()} />);
+      await openSelect(which);
+
+      const codex = await screen.findByRole('option', { name: /gpt-6-astra/ });
+      expect(codex).toHaveAttribute('aria-disabled', 'true');
+      expect(codex).toHaveTextContent(`Unavailable: ${NOT_INSTALLED}`);
+    }
+  );
+
+  // Without this the case above passes for a picker that disables every row —
+  // and a picker that had simply stopped filtering would offer a provider the
+  // user never set up.
+  it('leaves a usable provider selectable, and still omits one never set up', async () => {
+    render(<LeadWorkerSettings isOpen onClose={vi.fn()} />);
+    await openSelect('lead');
+
+    const versa = await screen.findByRole('option', { name: /gpt-5\.5-2026-04-24/ });
+    expect(versa).toHaveAttribute('aria-disabled', 'false');
+    expect(versa).not.toHaveTextContent(/Unavailable/);
+    expect(screen.queryByRole('option', { name: /gpt-4o/ })).toBeNull();
+  });
+
+  /**
+   * The reason has to reach a field that is ALREADY filled: a pair saved while
+   * the CLI resolved reopens here after it moved, and nothing in this dialog
+   * re-picks anything on open. A disabled menu row says nothing about that.
+   */
+  it('explains a saved lead whose provider can no longer run, and refuses the save', async () => {
+    mocks.read.mockImplementation(async (key: string) => {
+      if (key === 'BIOROUTER_LEAD_MODEL') return 'gpt-6-astra';
+      if (key === 'BIOROUTER_LEAD_PROVIDER') return 'codex';
+      if (key === 'BIOROUTER_MODEL') return 'gpt-5.5-2026-04-24';
+      if (key === 'BIOROUTER_PROVIDER') return 'versa_azure';
+      return null;
+    });
+
+    render(<LeadWorkerSettings isOpen onClose={vi.fn()} />);
+
+    expect(await screen.findByTestId('lead-worker-lead-unavailable')).toHaveTextContent(
+      `Unavailable: ${NOT_INSTALLED}`
+    );
+    // The worker half is fine, so it says nothing — otherwise this passes for a
+    // dialog that shouts the reason at both fields.
+    expect(screen.queryByTestId('lead-worker-worker-unavailable')).toBeNull();
+
+    const save = screen.getByRole('button', { name: 'Save settings' });
+    expect(save).toBeDisabled();
+    fireEvent.click(save);
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  // The fields are inert while the pair is off, so a verdict about them would be
+  // a refusal of something nobody is doing.
+  it('says nothing about either half while the pair is switched off', async () => {
+    mocks.read.mockImplementation(async (key: string) => {
+      if (key === 'BIOROUTER_LEAD_MODEL') return 'gpt-6-astra';
+      if (key === 'BIOROUTER_LEAD_PROVIDER') return 'codex';
+      if (key === 'BIOROUTER_MODEL') return 'gpt-5.5-2026-04-24';
+      if (key === 'BIOROUTER_PROVIDER') return 'versa_azure';
+      return null;
+    });
+
+    render(<LeadWorkerSettings isOpen onClose={vi.fn()} />);
+    await screen.findByTestId('lead-worker-lead-unavailable');
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Lead/worker mode' }));
+
+    expect(screen.queryByTestId('lead-worker-lead-unavailable')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Save settings' })).toBeEnabled();
+  });
+});

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -149,6 +149,22 @@ const PUBLIC_MODEL_IN_PRIVATE_CHAT =
 type ProviderOption = { value: string; label: string; unavailableReason?: string };
 
 /**
+ * The one reason this dialog writes itself rather than quoting the daemon, for
+ * the one row that can arrive from outside the catalog.
+ *
+ * A chat's own binding may name a provider that is not set up here at all — a
+ * session bound to `xiaomi_mimo` on a machine that has never configured it — and
+ * since D6 the dialog OPENS on that binding. Such a provider is deliberately
+ * absent from the list (`is_configured || unavailable_reason` keeps out what was
+ * never set up), so without this row the field would sit blank while the model
+ * beside it named a real model, and the confirm would happily attempt the bind.
+ *
+ * It is written for a person, like every other sentence on this surface, and it
+ * names the repair that exists: the "Use other provider" row directly below.
+ */
+const PROVIDER_NOT_SET_UP = 'this provider is not set up in Biorouter';
+
+/**
  * F3 / privacy-tiers §14.3 P4 — what a switch from THIS dialog changes, said in
  * the dialog, before the user commits.
  *
@@ -612,14 +628,26 @@ export const SwitchModelModal = ({
         // a disabled row sits where it always sat instead of sinking to the
         // bottom — then "Use other provider". A provider that is simply not set
         // up stays out, as before.
+        const offered = providersResponse
+          .filter((provider) => provider.is_configured || provider.unavailable_reason)
+          .map(({ metadata, name, is_configured, unavailable_reason }) => ({
+            value: name,
+            label: metadata.display_name,
+            unavailableReason: is_configured ? undefined : (unavailable_reason ?? undefined),
+          }));
+        // D6's consequence: the provider this dialog OPENED on is always offered,
+        // even when the catalog would not list it. See `PROVIDER_NOT_SET_UP`.
+        if (initialProvider && !offered.some((option) => option.value === initialProvider)) {
+          offered.unshift({
+            value: initialProvider,
+            label:
+              providersResponse.find((row) => row.name === initialProvider)?.metadata
+                .display_name ?? initialProvider,
+            unavailableReason: PROVIDER_NOT_SET_UP,
+          });
+        }
         setProviderOptions([
-          ...providersResponse
-            .filter((provider) => provider.is_configured || provider.unavailable_reason)
-            .map(({ metadata, name, is_configured, unavailable_reason }) => ({
-              value: name,
-              label: metadata.display_name,
-              unavailableReason: is_configured ? undefined : (unavailable_reason ?? undefined),
-            })),
+          ...offered,
           {
             value: 'configure_providers',
             label: 'Use other provider',

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.unavailable.test.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.unavailable.test.tsx
@@ -139,4 +139,41 @@ describe('SwitchModelModal — a provider that cannot run', () => {
     fireEvent.click(confirm);
     expect(mocks.changeModel).not.toHaveBeenCalled();
   });
+
+  /**
+   * D6's consequence (2026-09-12). Since the dialog OPENS on the chat's own
+   * binding, `initialProvider` can name a provider that is not set up here at
+   * all — a session bound to `xiaomi_mimo` on a machine that has never configured
+   * it, which the sandbox measured on 2026-09-12 (`GET /config/providers` served
+   * `xiaomi_mimo | is_configured=False | unavailable_reason=None`, and eight
+   * sessions' rows named it).
+   *
+   * Such a provider is deliberately absent from the list — `is_configured ||
+   * unavailable_reason` keeps out what was never set up — so without a row of its
+   * own the provider field sat BLANK beside a real model name, and `validation`
+   * found no reason to refuse: the confirm stayed live and would attempt the bind.
+   */
+  it('offers the provider it opened on even when the catalog would not list it', async () => {
+    render(
+      <SwitchModelModal
+        sessionId="s1"
+        onClose={vi.fn()}
+        setView={vi.fn()}
+        initialProvider="xiaomi_mimo"
+        initialModel="mimo-v2.5-pro"
+      />
+    );
+
+    const reason = await screen.findByTestId('switch-model-provider-error');
+    expect(reason).toHaveTextContent('Unavailable: this provider is not set up in Biorouter');
+    const confirm = screen.getByRole('button', { name: 'Select model' });
+    expect(confirm).toBeDisabled();
+    fireEvent.click(confirm);
+    expect(mocks.changeModel).not.toHaveBeenCalled();
+
+    // And it is a real row in the menu, not only a sentence beside the field.
+    fireEvent.keyDown(screen.getAllByRole('combobox')[0], { key: 'ArrowDown', code: 'ArrowDown' });
+    const row = await screen.findByRole('option', { name: /xiaomi_mimo/ });
+    expect(row).toHaveAttribute('aria-disabled', 'true');
+  });
 });


### PR DESCRIPTION
Three defects from the 2026-09-12 model-controls run. All one shape: a control
that **states** one thing and **does** another. Each was found by driving the
real app against a sandboxed daemon, and every number below is from my own run.

---

## D6 (medium — the dangerous one). The "Change model" dialog pre-filled the app-wide selection

The dialog opened from inside a chat is headed *"Select a provider and model for
this chat."* and pre-filled the **app-wide** selection, not the chat's own
binding. Pressing "Select model" without touching anything silently moved the
chat to a model the user never chose. Model identity decides the privacy tier, so
a silent move can change which side of the private/public boundary the chat's
next turn lands on — correctness, not cosmetics.

**Measured on `origin/main`** (dev GUI, sandboxed config, CDP):

| | |
|---|---|
| session `20260610_28` row | `provider_name = versa_azure`, `model_config_json.model_name = gpt-5.2-2025-12-11`, `privacy_tier = private` |
| app-wide selection | `BIOROUTER_MODEL = gpt-5.5-2026-04-24`, `BIOROUTER_PROVIDER = versa_azure` |
| composer chip | `gpt-5.2-2025-12-11` |
| dialog, under "…for this chat." | **`gpt-5.5-2026-04-24`** |

**After**, same chat, same daemon: the dialog reads **`gpt-5.2-2025-12-11`**.

`ModelsBottomBar` now hands the chat's own binding (`effectiveModel`, which
`usePinnedModel` sets exactly when the binding differs from the selection) to the
dialog as `initialProvider`/`initialModel`. `undefined` passes straight through,
which is right: where it is unset the two already agree.

That exposed a second hole, so it is closed here too. A chat can be bound to a
provider the catalog would **not list at all** — eight sessions on this machine
name `xiaomi_mimo`, which `/config/providers` serves `is_configured=False`
with no reason, and the modal deliberately keeps un-set-up providers out. The
field then sat **blank** beside a real model name and `validation` found nothing
to refuse, so the confirm stayed live and would have attempted the bind. The
dialog now always offers the provider it opened on, disabled, with a sentence
written for a person.

## D7 (low). Home's chip named the worker; the lead answers the next message

With a lead/worker pair configured, Home's composer chip named the **worker** and
labelled it `(worker)`, while `LeadWorkerProvider::get_active_provider` sends the
first `BIOROUTER_LEAD_TURNS` turns of every new chat to the **lead**.

The cause is one line. `BIOROUTER_MODEL` **is** the worker while a pair is on
(`LeadWorkerSettings` writes it; `create_lead_worker_from_env` reads it as the
worker), and the role was that key compared against `BIOROUTER_LEAD_MODEL` — so
it could only ever read `worker` for any real pair. The `useCurrentModelInfo()`
branch that looked like it rescued this is **dead**: `CurrentModelContext` in
`BaseChat.tsx` is created, exported and **never provided**.

**Measured on `origin/main`**: lead `claude_code / claude-opus-5`, worker
`versa_azure / gpt-4.1-mini-2025-04-14`, `BIOROUTER_LEAD_TURNS: 3` →
`Current model: gpt-4.1-mini-2025-04-14 (worker) (Public model)`.

**After**, same config → `Current model: claude-opus-5 (lead) (Public model)`,
with the dropdown reading `claude-opus-5 · Claude Code` and one new line:
`Lead/worker mode. claude-opus-5 answers the first 3 turns of a chat;
gpt-4.1-mini-2025-04-14 takes the rest.`

### The label I chose, and why

The chip's one job is "where does the next message go", and the renderer can
answer that with certainty in exactly one state:

- **No chat yet** (Home, a chat not started) — `/agent/start` opens the session at
  `LeadWorkerRoutingState::default()`, `turn_count: 0`, so the lead answers. The
  chip names the **lead**, `(lead)`.
- **Inside a chat** — which half is live depends on that chat's turn count, which
  is daemon state the renderer is never served. So the claim is **dropped**, not
  flipped. The chip keeps naming what `BIOROUTER_MODEL` holds (unchanged) and
  stops asserting `(worker)`, which was false for every chat's opening turns.
- **A chat with its own binding** — untouched: it runs one provider, so no half of
  a global pair is in play.

What the chip cannot say, the dropdown does — the handover, which is true of
every surface. Same split this component already uses for the tier word, the
affiliation word and `CHAT_KEEPS_ITS_MODEL_NOTE`.

Two consequences worth calling out:

- **The badges follow the name the chip prints.** `effectiveProvider` now resolves
  to the lead's provider when the chip names the lead, because the tier padlock,
  the affiliation glyph and the disclosure line all come off **one** catalog row.
  Leaving it on the worker's provider would hang the worker's Private padlock on
  a public lead — the cross-provider pairing this file's own comments warn about.
- **`lead_turns: 0` inverts the first answer**, and it is not merely
  hand-editable: `configure.rs`'s `prompt_turns` validator accepts any
  `u32::parse` and `"0"` parses, so the shipped CLI writes it while asking for a
  positive number. `turn_count < 0` never holds, so the worker takes turn 1 —
  the chip claims nothing there, and the note says the lead is the fallback model.

`#279`'s cross-window `refreshLeadWorker` is built on, not around: the two new
answers joined its single `Promise.all` rather than taking reads of their own, and
its three scenarios still assert that the label moves on another window's
announcement. Only what the label *says* changed.

## D4 (low). A configured-but-unavailable coding agent vanished from both selects

`LeadWorkerSettings` built its options from
`providers.filter((p) => p.is_configured)` and mapped them to
`{ value, label, provider }`, dropping the row. The daemon serves such a provider
`is_configured: false` **with** an `unavailable_reason`
(`ProviderReadiness::Unavailable`), so the filter deleted the one row the user
most needs to see — and the option shape had nowhere to carry the reason anyway.

**Measured on `origin/main`** with `CODEX_COMMAND: /nope/codex`, while
`/config/providers` served
`codex | is_configured=False | unavailable_reason='Codex is not installed, or is not on a path Biorouter searches' | 6 known models`:

| | `origin/main` | after |
|---|---|---|
| options in the lead select | **25** | **36** |
| `anyCodex` | `false` | `true` |
| `anyUnavailable` | `false` | `true` |
| Codex rows `aria-disabled` | — | `true` × 7, each carrying the daemon's sentence |
| Versa row `aria-disabled` | `false` | `false` |

One menu item away, the Switch-models picker was already explaining the identical
state in a sentence. The reason is now carried through and rendered the way that
picker renders it — and, because **a disabled row is not a disabled selection**,
also beside a *field* whose selection is barred, with Save refused. That case is
not hypothetical: a pair saved while the CLI resolved reopens here after it moved,
and nothing in this dialog re-picks anything on open.

---

## Fail-before tests

Each fails on `origin/main` and passes after. Verified by checking out
`origin/main`'s copy of the source file under the new test and running it.

| Defect | Test | On `origin/main` |
|---|---|---|
| D6 | `ModelsBottomBar.chatBinding.test.tsx` | 1 of 2 fail (`expected undefined to be 'versa_azure'`); the passing one is the anti-overfit control |
| D6 | `SwitchModelModal.unavailable.test.tsx` → "offers the provider it opened on…" | 1 of 4 fail |
| D7 | `ModelsBottomBar.leadWorker.test.tsx` | 5 of 7 fail; the 2 passing are the "says nothing" controls |
| D7 | `leadWorkerLabel.test.ts` | the module does not exist on `main` |
| D4 | `LeadWorkerSettings.unavailable.test.tsx` | 4 of 5 fail; the passing one is the anti-overfit control |

Every one of these is written so it cannot pass vacuously: each defect's test is
paired with a control asserting the *working* case is still working (a usable
provider still selectable, a provider never set up still omitted, `undefined`
still passed through, no role claimed where none is claimable).

## Gates

- `npx vitest run --exclude "**/artifactCdnAssets.browser*"` — **473 files, 5318 passed, 1 skipped, 0 failed**. The exclusion is the known `browser.close()` teardown that exceeds 30 s on pristine `main` too.
- `npm run lint:check` — tsc + ESLint + themes + **332 contrast assertions** + token mirrors, all pass.
- `npx prettier --check` on all nine touched files — clean. (Nothing in CI runs Prettier.)
- `cargo fmt --check` — clean; `./scripts/clippy-lint.sh` — clean incl. the banned-TLS check. No Rust file is touched.
- Live re-verification of all three fixes in the dev GUI, same sandbox, same daemon.

## Note for review

`CurrentModelContext` / `useCurrentModelInfo` in `BaseChat.tsx` are now entirely
dead (this was their last consumer). I left them in place rather than widen the
diff — removing the export also means removing five now-pointless `vi.mock`s in
sibling specs — but a dead hook that looks like "how the chip learns the live
model" is exactly the trap that produced D7's dead branch, so it is worth a
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
