### PR TITLE
fix(workflow): a workflow captured from a chat can be saved (D12), and the KB card says when it will have no default (D14)

### DIFF
--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -12299,10 +12299,24 @@ impl Agent {
             workflow_builder = workflow_builder.parameters(parameters);
         }
 
-        let workflow = workflow_builder.build().map_err(|e| {
+        let mut workflow = workflow_builder.build().map_err(|e| {
             tracing::error!("Failed to build workflow: {}", e);
             anyhow!("Workflow build failed: {}", e)
         })?;
+
+        // A parameter the document refers to nowhere makes the whole workflow
+        // unsavable: `workflow::service::validate` refuses it either way round
+        // — with no default as "Optional parameters missing default values", with
+        // one as "Unnecessary parameter definitions" — so a capture that emitted
+        // one could not be saved from any surface. Models produce them routinely,
+        // because `workflow.md` asks for parameters and for their `{{ key }}`
+        // references as two separate instructions.
+        //
+        // Pruned HERE rather than in each of the three capture surfaces: the
+        // route, the CLI's `/workflow` and the model's own `generate` all come
+        // through this function, which is the whole reason
+        // `tests/workflow_capture_parity.rs` exists.
+        crate::workflow::service::drop_unreferenced_parameters(&mut workflow);
 
         tracing::info!("Workflow creation completed successfully");
         Ok(workflow)

--- a/crates/biorouter/src/workflow/service.rs
+++ b/crates/biorouter/src/workflow/service.rs
@@ -333,6 +333,86 @@ pub fn validate(workflow: &Workflow) -> Result<()> {
         .map_err(|err| anyhow::anyhow!("{err}"))
 }
 
+/// Drop the parameters no part of the document refers to, and return their keys.
+///
+/// [`validate`] refuses a parameter that appears in no `{{ key }}` anywhere in
+/// the document ("Unnecessary parameter definitions"), and separately refuses an
+/// `optional` parameter with no `default` ("Optional parameters missing default
+/// values"). Both rules are right on their own, and together they leave an
+/// unreferenced `optional` parameter with no accepted form at all: removing its
+/// default trades one refusal for the other. A generator that emits one
+/// therefore produces a workflow the user cannot save by any route — which is
+/// what "Create workflow from this chat" did, because `workflow.md` asks for
+/// parameters and for `{{ key }}` references as two separate instructions and a
+/// model routinely obeys only the first.
+///
+/// So the generated document is normalised instead of the rules being relaxed. A
+/// parameter nothing refers to is a value the run would collect and discard, and
+/// dropping it is the same stance `Agent::create_workflow` already takes towards
+/// a parameter list that does not parse: keep the expensive part, lose the part
+/// that cannot work, say so in the log.
+///
+/// ⚠ **The reference set is read the way [`validate`] reads it** — every
+/// `{{ … }}` in the serialized document, not just the ones in `prompt` and
+/// `instructions` — so the two can never disagree about what "referenced"
+/// means. A serialization failure drops nothing: an unpruned document still has
+/// a chance of being valid, and a silently emptied `parameters` list does not.
+pub fn drop_unreferenced_parameters(workflow: &mut Workflow) -> Vec<String> {
+    let Some(parameters) = workflow.parameters.as_ref() else {
+        return Vec::new();
+    };
+    if parameters.is_empty() {
+        return Vec::new();
+    }
+
+    let yaml = match workflow.to_yaml() {
+        Ok(yaml) => yaml,
+        Err(err) => {
+            tracing::warn!(
+                "Keeping the generated parameters: the workflow would not serialize \
+                 for a reference check: {err}"
+            );
+            return Vec::new();
+        }
+    };
+    let referenced = match crate::workflow::template_workflow::parse_workflow_content(&yaml, None) {
+        Ok((_, variables)) => variables,
+        Err(err) => {
+            tracing::warn!(
+                "Keeping the generated parameters: the workflow would not parse \
+                 for a reference check: {err}"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut dropped = Vec::new();
+    let kept: Vec<_> = parameters
+        .iter()
+        .filter(|parameter| {
+            if referenced.contains(&parameter.key) {
+                return true;
+            }
+            dropped.push(parameter.key.clone());
+            false
+        })
+        .cloned()
+        .collect();
+
+    if dropped.is_empty() {
+        return dropped;
+    }
+    tracing::warn!(
+        "Dropping generated workflow parameters the document never refers to: {}",
+        dropped.join(", ")
+    );
+    // `None`, not an empty list: `skip_serializing_if` keeps an empty `Vec` out
+    // of the YAML anyway, and `None` is what every other "there is nothing to
+    // say" path in this module means by it.
+    workflow.parameters = if kept.is_empty() { None } else { Some(kept) };
+    dropped
+}
+
 /// Substitute parameter values into a workflow template.
 ///
 /// `Ok(None)` means required parameters are still missing — the caller is

--- a/crates/biorouter/src/workflow/validate_workflow.rs
+++ b/crates/biorouter/src/workflow/validate_workflow.rs
@@ -103,24 +103,34 @@ fn validate_parameters_in_template(
     let mut message = String::new();
 
     if !missing_keys.is_empty() {
+        // Sorted, like the arm below: both sides come out of a `HashSet`
+        // difference, so an unsorted join gives the same fault a different
+        // message on each run.
+        let mut names: Vec<String> = missing_keys.iter().map(|s| s.to_string()).collect();
+        names.sort();
         message.push_str(&format!(
             "Missing definitions for parameters in the workflow file: {}.",
-            missing_keys
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
+            names.join(", ")
         ));
     }
 
     if !extra_keys.is_empty() {
+        // The prefix is load-bearing — it is what the messages users and tests
+        // have already matched on say. What follows it is new: the old message
+        // named the parameter and stopped, leaving "unnecessary" to be guessed
+        // at, and the obvious guess (remove its `default`) trades this refusal
+        // for `validate_optional_parameters`' one. Naming the fix rather than
+        // only the fault is the difference between a rule and a dead end.
+        let mut names: Vec<String> = extra_keys.iter().map(|s| s.to_string()).collect();
+        names.sort();
         message.push_str(&format!(
-            "\nUnnecessary parameter definitions: {}.",
-            extra_keys
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
+            "\nUnnecessary parameter definitions: {}. Nothing in the workflow \
+             refers to {}, so a value for it would be collected and then \
+             discarded — write {{{{ {} }}}} into `prompt` or `instructions`, or \
+             remove the definition. Giving it a `default` does not help.",
+            names.join(", "),
+            if names.len() == 1 { "it" } else { "them" },
+            names[0]
         ));
     }
     Err(anyhow::anyhow!("{}", message.trim_end()))

--- a/crates/biorouter/tests/workflow_capture_parity.rs
+++ b/crates/biorouter/tests/workflow_capture_parity.rs
@@ -61,7 +61,9 @@ fn sandbox_config_root_for_this_test_binary() {
 /// the two documents below therefore came from the capture path, which is
 /// exactly the fault being tested for.
 #[derive(Clone)]
-struct FixedWorkflowProvider;
+struct FixedWorkflowProvider {
+    json: &'static str,
+}
 
 const GENERATED_JSON: &str = r#"{
   "title": "Gene association summary",
@@ -98,7 +100,7 @@ impl Provider for FixedWorkflowProvider {
         _tools: &[Tool],
     ) -> Result<(Message, ProviderUsage), ProviderError> {
         Ok((
-            Message::assistant().with_text(GENERATED_JSON),
+            Message::assistant().with_text(self.json),
             ProviderUsage::new("fixed-model".to_string(), Usage::default()),
         ))
     }
@@ -115,6 +117,10 @@ struct Harness {
 }
 
 async fn harness() -> Harness {
+    harness_generating(GENERATED_JSON).await
+}
+
+async fn harness_generating(json: &'static str) -> Harness {
     let dir = TempDir::new().unwrap();
     let data_dir = dir.path().to_path_buf();
     let session_manager = Arc::new(SessionManager::new(data_dir.clone()));
@@ -136,7 +142,7 @@ async fn harness() -> Harness {
         .unwrap();
 
     agent
-        .update_provider(Arc::new(FixedWorkflowProvider), &session.id)
+        .update_provider(Arc::new(FixedWorkflowProvider { json }), &session.id)
         .await
         .expect("bind the fixed provider");
 
@@ -352,4 +358,164 @@ async fn the_settings_pin_names_the_bound_provider_and_never_panics() {
         "the pin must name the provider this session is BOUND to"
     );
     assert_eq!(settings.biorouter_model.as_deref(), Some("fixed-model"));
+}
+
+/// A generation whose optional parameter the document never refers to.
+///
+/// Models emit these constantly — `workflow.md` asks for parameters and for
+/// `{{ key }}` references separately, and a model that obeys the first half and
+/// forgets the second produces exactly this. `output_format` below is declared
+/// and then never used.
+const GENERATED_JSON_WITH_AN_UNREFERENCED_PARAMETER: &str = r#"{
+  "title": "Gene association summary",
+  "description": "Looks a gene up and summarises its disease associations.",
+  "instructions": "Query the graph and report the strongest associations first.",
+  "activities": ["Summarise APOE"],
+  "prompt": "Summarise the disease associations for {{ gene_symbol }}.",
+  "parameters": [
+    {
+      "key": "gene_symbol",
+      "input_type": "string",
+      "requirement": "user_prompt",
+      "description": "HGNC gene symbol"
+    },
+    {
+      "key": "output_format",
+      "input_type": "select",
+      "requirement": "optional",
+      "description": "How to format the summary",
+      "default": "markdown",
+      "options": ["markdown", "table"]
+    }
+  ],
+  "skills": []
+}"#;
+
+/// A workflow captured from a chat must be SAVABLE.
+///
+/// The two parameter validators are individually reasonable and jointly closed
+/// over a parameter the document never refers to:
+///
+///   * `optional` with no `default` → "Optional parameters missing default
+///     values in the workflow: output_format."
+///   * any requirement, referenced nowhere → "Unnecessary parameter
+///     definitions: output_format."
+///
+/// So there was no `default` — present or absent — for which `POST
+/// /workflows/save` accepted the generated document, and "Create workflow from
+/// this chat" could not complete at all.
+///
+/// Measured 2026-09-12. The refusal below, run against `origin/main`'s
+/// validator, read exactly `\nUnnecessary parameter definitions:
+/// output_format.` and nothing else; posting the same two documents to a
+/// running daemon answered **400** both times.
+///
+/// The generator is the half that is wrong. A parameter nothing refers to is a
+/// question the run would ask and then discard, so it is dropped at capture
+/// time — next to the existing rule that a parameter list which does not even
+/// parse is dropped rather than losing the whole document.
+#[tokio::test]
+async fn a_captured_workflow_never_declares_a_parameter_the_document_does_not_use() {
+    let h = harness_generating(GENERATED_JSON_WITH_AN_UNREFERENCED_PARAMETER).await;
+    let knowledge = biorouter_mcp::knowledge::service::KnowledgeService::new_default()
+        .expect("a knowledge service in the sandboxed root");
+    let session = h
+        .agent
+        .config
+        .session_manager
+        .get_session(&h.session_id, true)
+        .await
+        .unwrap();
+
+    let mut workflow = h
+        .agent
+        .create_workflow(session.conversation.clone().unwrap())
+        .await
+        .expect("the capture");
+    // The save path validates the ENRICHED document — the same one the modal
+    // posts — so the enrichment runs here too.
+    let enrichment = service::session_enrichment(&h.agent, &knowledge, &h.session_id, None)
+        .await
+        .expect("the route's enrichment");
+    service::apply_session_enrichment(&mut workflow, enrichment);
+
+    let keys: Vec<String> = workflow
+        .parameters
+        .iter()
+        .flatten()
+        .map(|parameter| parameter.key.clone())
+        .collect();
+    assert_eq!(
+        keys,
+        vec!["gene_symbol".to_string()],
+        "the referenced parameter is kept and the unreferenced one dropped"
+    );
+
+    // The whole point: what the capture produced is what `POST /workflows/save`
+    // will accept. `service::validate` is the function that route calls.
+    service::validate(&workflow).unwrap_or_else(|err| {
+        panic!(
+            "a workflow captured from a chat must save: {err}\n\n{}",
+            workflow.to_yaml().unwrap_or_default()
+        )
+    });
+}
+
+/// The two messages that closed the gap, pinned as a pair.
+///
+/// Read together they are the specification the generator now satisfies: a
+/// parameter must be referenced, and an `optional` one must also carry a
+/// default. Neither is relaxed — the "unnecessary" arm is the only thing that
+/// catches a key typo (`{{ gene }}` in the prompt beside a parameter keyed
+/// `gene_symbol` reports both halves of the mismatch), and a parameter nothing
+/// reads is dead weight in a document meant to be shared. What changed is that
+/// the message now says what to do about it.
+#[test]
+fn an_unreferenced_parameter_is_still_refused_and_the_refusal_says_why() {
+    let unreferenced_with_a_default = r#"
+version: 1.0.0
+title: Test
+description: Test
+instructions: Nothing refers to the parameter below.
+parameters:
+  - key: output_format
+    input_type: string
+    requirement: optional
+    description: How to format the summary
+    default: markdown
+"#;
+    let err = service::validate(
+        &biorouter::workflow::Workflow::from_content(unreferenced_with_a_default).unwrap(),
+    )
+    .expect_err("a parameter the document never refers to is refused");
+    let message = err.to_string();
+    assert!(
+        message.contains("Unnecessary parameter definitions: output_format."),
+        "the refusal still names the parameter: {message}"
+    );
+    assert!(
+        message.contains("{{ output_format }}"),
+        "and now says how to fix it, naming the key: {message}"
+    );
+
+    let unreferenced_without_a_default = r#"
+version: 1.0.0
+title: Test
+description: Test
+instructions: Nothing refers to the parameter below.
+parameters:
+  - key: output_format
+    input_type: string
+    requirement: optional
+    description: How to format the summary
+"#;
+    let message = service::validate(
+        &biorouter::workflow::Workflow::from_content(unreferenced_without_a_default).unwrap(),
+    )
+    .expect_err("dropping the default does not help")
+    .to_string();
+    assert!(
+        message.contains("Optional parameters missing default values"),
+        "the other half of the pair, unchanged: {message}"
+    );
 }

--- a/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
+++ b/ui/desktop/src/components/workflows/shared/WorkflowFormFields.tsx
@@ -689,6 +689,18 @@ export function WorkflowFormFields({
                   onSelectedIdsChange={onKnowledgeBaseIdsChange}
                   defaultId={defaultKnowledgeBaseId}
                   onDefaultIdChange={onDefaultKnowledgeBaseIdChange}
+                  // A chat with no pinned primary is captured as `default: null`,
+                  // and the daemon never infers one from `visible`
+                  // (`plan_knowledge_selection`) — so the workflow really will
+                  // have no default, and every chat it starts will have no write
+                  // target. That is the intent, not a bug, and the card said
+                  // nothing about it while its own description promised "which
+                  // one is focused by default": the reader had no way to tell
+                  // which of the two they were looking at.
+                  noDefaultText={
+                    'No default — this workflow will not focus one. Chats it starts search ' +
+                    'every base above, and a write that names no base asks which one to use.'
+                  }
                   notice={knowledgeBaseNotice}
                   emptyText="No knowledge bases found"
                   searchPlaceholder="Search knowledge bases..."

--- a/ui/desktop/src/components/workflows/shared/WorkflowResourcePicker.tsx
+++ b/ui/desktop/src/components/workflows/shared/WorkflowResourcePicker.tsx
@@ -20,6 +20,19 @@ interface WorkflowResourcePickerProps {
   onSelectedIdsChange: (ids: string[]) => void;
   defaultId?: string | null;
   onDefaultIdChange?: (id: string | null) => void;
+  /**
+   * What "no default" MEANS here, shown on the card whenever a default could be
+   * named and none is.
+   *
+   * The rows — and with them the only mark of which item is the default — live
+   * inside a closed popover, so a card with a default and a card with none read
+   * identically from outside it. That is fine for a control whose unset state is
+   * obvious and wrong for one whose description promises a default: the reader
+   * cannot tell a captured "this chat has no primary base" from a bug. The
+   * wording belongs to the caller because what the absence costs is
+   * domain-specific.
+   */
+  noDefaultText?: string;
   /** A standing condition the selection is subject to, shown under the label. */
   notice?: string;
   emptyText: string;
@@ -41,6 +54,7 @@ export function WorkflowResourcePicker({
   onSelectedIdsChange,
   defaultId,
   onDefaultIdChange,
+  noDefaultText,
   notice,
   emptyText,
   searchPlaceholder,
@@ -49,6 +63,20 @@ export function WorkflowResourcePicker({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const selected = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  // Named by id, labelled by label: the id is what is saved, and a picker whose
+  // items have not loaded yet must still be able to say a default is set.
+  const defaultLabel = defaultId
+    ? (items.find((item) => item.id === defaultId)?.label ?? defaultId)
+    : null;
+  // Nothing selected already says its own thing on the trigger ("No KBs
+  // selected"), and "no default" on top of it is noise about a set that is empty.
+  const defaultSummary =
+    !onDefaultIdChange || selectedIds.length === 0
+      ? null
+      : defaultLabel
+        ? `Default: ${defaultLabel}`
+        : (noDefaultText ?? null);
 
   const filteredItems = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -91,6 +119,14 @@ export function WorkflowResourcePicker({
         <div>
           <label className="text-label text-text-default">{label}</label>
           {description && <p className="mt-0.5 text-supporting text-text-muted">{description}</p>}
+          {defaultSummary && (
+            <p
+              className="mt-0.5 text-supporting text-text-muted"
+              data-testid="resource-picker-default-summary"
+            >
+              {defaultSummary}
+            </p>
+          )}
         </div>
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>

--- a/ui/desktop/src/components/workflows/shared/__tests__/WorkflowFormFields.test.tsx
+++ b/ui/desktop/src/components/workflows/shared/__tests__/WorkflowFormFields.test.tsx
@@ -847,4 +847,48 @@ describe('WorkflowFormFields', () => {
       expect(result).toEqual(['user_name', 'user_id', 'email_address', 'app_name']);
     });
   });
+
+  /**
+   * A chat with no pinned primary base is captured as `default: null`, and the
+   * daemon never infers a primary from `visible`
+   * (`plan_knowledge_selection`) — so the workflow really will have no default.
+   * The card promised "which one is focused by default" and then said nothing at
+   * all about not having one, leaving the correct capture indistinguishable from
+   * a bug.
+   */
+  describe('Knowledge bases card', () => {
+    const renderKnowledgeCard = (defaultKnowledgeBaseId: string | null) =>
+      render(
+        <TestWrapper
+          knowledgeBaseItems={[
+            { id: 'lab-notes', label: 'lab-notes' },
+            { id: 'soul', label: 'soul' },
+          ]}
+          selectedKnowledgeBaseIds={['lab-notes', 'soul']}
+          onKnowledgeBaseIdsChange={vi.fn()}
+          defaultKnowledgeBaseId={defaultKnowledgeBaseId}
+          onDefaultKnowledgeBaseIdChange={vi.fn()}
+        />
+      );
+
+    it('says the workflow will have no default when none is named', async () => {
+      const user = userEvent.setup();
+      renderKnowledgeCard(null);
+      await expandAdvancedSection(user);
+
+      const summary = screen.getByTestId('resource-picker-default-summary');
+      expect(summary).toHaveTextContent(/no default/i);
+      expect(summary).toHaveTextContent(/this workflow will not focus one/i);
+    });
+
+    it('names the default when one is named', async () => {
+      const user = userEvent.setup();
+      renderKnowledgeCard('lab-notes');
+      await expandAdvancedSection(user);
+
+      expect(screen.getByTestId('resource-picker-default-summary')).toHaveTextContent(
+        'Default: lab-notes'
+      );
+    });
+  });
 });

--- a/ui/desktop/src/components/workflows/shared/__tests__/WorkflowResourcePicker.test.tsx
+++ b/ui/desktop/src/components/workflows/shared/__tests__/WorkflowResourcePicker.test.tsx
@@ -6,12 +6,15 @@ import { WorkflowResourcePicker } from '../WorkflowResourcePicker';
 function renderPicker({
   selectedIds,
   defaultId,
+  noDefaultText,
+  onDefaultIdChange = vi.fn(),
 }: {
   selectedIds: string[];
   defaultId: string | null;
+  noDefaultText?: string;
+  onDefaultIdChange?: (id: string | null) => void;
 }) {
   const onSelectedIdsChange = vi.fn();
-  const onDefaultIdChange = vi.fn();
   render(
     <WorkflowResourcePicker
       label="Knowledge bases"
@@ -23,6 +26,7 @@ function renderPicker({
       onSelectedIdsChange={onSelectedIdsChange}
       defaultId={defaultId}
       onDefaultIdChange={onDefaultIdChange}
+      noDefaultText={noDefaultText}
       emptyText="No knowledge bases found"
       searchPlaceholder="Search knowledge bases..."
       noun="KB"
@@ -30,6 +34,9 @@ function renderPicker({
   );
   return { onSelectedIdsChange, onDefaultIdChange };
 }
+
+const NO_DEFAULT =
+  'No default — this workflow will not focus one. Chats it starts search every base above.';
 
 /**
  * The knowledge-base picker's default becomes the workflow's `default`, which
@@ -118,5 +125,64 @@ describe('WorkflowResourcePicker default', () => {
 
     await user.click(current);
     expect(onDefaultIdChange).toHaveBeenLastCalledWith(null);
+  });
+});
+
+/**
+ * Whether a default is set is only ever *marked* on a row, and the rows live
+ * inside a closed popover — so a captured "this chat has no primary base", which
+ * is the correct capture for a chat that pinned none, looked exactly like a card
+ * whose default had gone missing. The card has to say it.
+ */
+describe('WorkflowResourcePicker default summary', () => {
+  it('says there is no default, on the card, without opening the popover', () => {
+    renderPicker({
+      selectedIds: ['lab-notes', 'soul'],
+      defaultId: null,
+      noDefaultText: NO_DEFAULT,
+    });
+
+    expect(screen.getByTestId('resource-picker-default-summary')).toHaveTextContent(NO_DEFAULT);
+    // Still closed: the rows, and the Default control that marks one, are not
+    // rendered at all.
+    expect(screen.queryByRole('button', { name: 'Default KB: lab-notes' })).toBeNull();
+  });
+
+  it('names the default on the card when one is set', () => {
+    renderPicker({
+      selectedIds: ['lab-notes', 'soul'],
+      defaultId: 'lab-notes',
+      noDefaultText: NO_DEFAULT,
+    });
+
+    expect(screen.getByTestId('resource-picker-default-summary')).toHaveTextContent(
+      'Default: lab-notes'
+    );
+  });
+
+  // An empty selection already says so on the trigger, and "no default" on top
+  // of it is a statement about a set with nothing in it.
+  it('says nothing about a default when nothing is selected', () => {
+    renderPicker({ selectedIds: [], defaultId: null, noDefaultText: NO_DEFAULT });
+
+    expect(screen.queryByTestId('resource-picker-default-summary')).toBeNull();
+  });
+
+  // Skills and extensions have no default at all; the line must not appear for
+  // a picker that cannot name one.
+  it('says nothing for a picker with no default control', () => {
+    render(
+      <WorkflowResourcePicker
+        label="Skills"
+        items={[{ id: 'single-cell', label: 'single-cell' }]}
+        selectedIds={['single-cell']}
+        onSelectedIdsChange={vi.fn()}
+        emptyText="No skills found"
+        searchPlaceholder="Search skills..."
+        noun="skill"
+      />
+    );
+
+    expect(screen.queryByTestId('resource-picker-default-summary')).toBeNull();
   });
 });


### PR DESCRIPTION
## D12 — a workflow created from a chat could not be saved at all

`workflow::validate` (the function `POST /workflows/save` calls) applies two parameter rules:

* an `optional` parameter must carry a `default` — *"Optional parameters missing default values in the workflow: X. Please provide defaults."*
* every parameter must be referenced by a `{{ … }}` somewhere in the document — *"Unnecessary parameter definitions: X."*

Each is right on its own. Together they close over a parameter the document refers to nowhere: with no default the first arm fires, with a default the second does. There is no value of that parameter for which the save succeeds.

"Create workflow from this chat" emitted exactly that. `crates/biorouter/src/prompts/workflow.md` asks for `parameters` and for their `{{ key }}` references as **two separate instructions**, and a model that obeys the first and forgets the second produces an unsavable document.

**Measured, 2026-09-12.** Posting the two documents to a running daemon (`POST /workflows/save`, desktop dev build):

| document | before | after |
|---|---|---|
| unreferenced `optional`, no `default` | HTTP 400 `Optional parameters missing default values in the workflow: output_format. Please provide defaults.` | unchanged — still 400 |
| unreferenced `optional`, with `default` | HTTP 400 `\nUnnecessary parameter definitions: output_format.` | 400, and the message now says what to do |
| the same two parameters, one of them referenced from `prompt` | — | **saved** |

The pre-fix text of the second message was read off `origin/main`'s validator directly: the new test `an_unreferenced_parameter_is_still_refused_and_the_refusal_says_why` failed on it with `Unnecessary parameter definitions: output_format.` and nothing after the period.

### Which half I changed, and why

**The generator.** `Agent::create_workflow` now drops parameters the document refers to nowhere. A parameter nothing reads is a question the run would ask and then discard, so keeping it is misleading even where it is accepted; and this is the same stance the function already takes towards a parameter list that does not parse — keep the expensive part, lose the part that cannot work, say so in the log. "Referenced" is read exactly the way the validator reads it (every `{{ … }}` in the serialized document, via `parse_workflow_content`), so the two cannot disagree about what the word means. The prune lives in the generator, not in each of the three capture surfaces, because the HTTP route, the CLI's `/workflow` and the model's own `generate` all come through that one function — which is what `tests/workflow_capture_parity.rs` exists to hold.

**Not the validator.** I did check whether the second message is too strict, as asked. I kept it, for two reasons. It is the only thing that catches a key typo, and it catches it as a *pair*: `{{ gene }}` in the prompt beside a parameter keyed `gene_symbol` reports "Missing definitions … gene" **and** "Unnecessary … gene_symbol", which together name both halves of the mismatch; permitting a defaulted-but-unreferenced parameter would silence the half that names the typo'd definition. And a workflow is a shared document — an accepted dead parameter is dead weight in every copy of it.

What did change is the message. It named the fault and stopped, and the obvious guess at a fix — give the parameter a default — is precisely the move that trades one refusal for the other. It now names the fix:

```
Unnecessary parameter definitions: output_format. Nothing in the workflow refers to it,
so a value for it would be collected and then discarded — write {{ output_format }} into
`prompt` or `instructions`, or remove the definition. Giving it a `default` does not help.
```

Both arms also sort their names now. They come out of a `HashSet` difference, so an unsorted join gave the same fault a different message on each run.

## D14 — the Knowledge bases card never said the workflow would have no default

Which base is the default is marked **only** on a row inside a *closed* popover. So a chat with no pinned primary — captured as `default: null`, correctly, and #256's rule which this does not change — produced a card indistinguishable from one whose default had gone missing, while its own description promised "which one is focused by default".

The picker now states it on the card itself, without opening anything: `Default: <base>` when one is named, and otherwise the sentence the caller supplies. For knowledge bases that is

> No default — this workflow will not focus one. Chats it starts search every base above, and a write that names no base asks which one to use.

The line is suppressed when nothing is selected (the trigger already says "No KBs selected") and for pickers that have no default control at all (Skills, Extensions).

## Fail-before tests

| test | defect | fails on `origin/main` with |
|---|---|---|
| `crates/biorouter/tests/workflow_capture_parity.rs::a_captured_workflow_never_declares_a_parameter_the_document_does_not_use` | D12, generator | `left: ["gene_symbol", "output_format"] right: ["gene_symbol"]` |
| `crates/biorouter/tests/workflow_capture_parity.rs::an_unreferenced_parameter_is_still_refused_and_the_refusal_says_why` | D12, refusal text | `and now says how to fix it, naming the key: \nUnnecessary parameter definitions: output_format.` |
| `WorkflowResourcePicker.test.tsx` › "says there is no default, on the card, without opening the popover" | D14, component | no `resource-picker-default-summary` node |
| `WorkflowResourcePicker.test.tsx` › "names the default on the card when one is set" | D14, component | same |
| `WorkflowFormFields.test.tsx` › Knowledge bases card › "says the workflow will have no default when none is named" | D14, wiring + wording | same |
| `WorkflowFormFields.test.tsx` › Knowledge bases card › "names the default when one is named" | D14, wiring | same |

The frontend four were confirmed red by checking `WorkflowResourcePicker.tsx` and `WorkflowFormFields.tsx` back out from `origin/main` and re-running: **2 failed | 6 passed** in the picker file, **2 failed | 39 passed** in the form-fields file. With the fix, all 8 and all 41 pass.

## Verified in the running app, not only by unit test

Dev GUI on this branch's own `biorouterd`, sandboxed config, real chat on `versa_azure` / `gpt-5.5-2026-04-24`:

1. a chat asking for APOE's disease associations;
2. Chat summary → **Make workflow** — the card read `Default: Soul`, and after clearing the Default control it read the no-default sentence above;
3. **Create workflow** → saved;
4. Workflows → **Use workflow** → Trust and execute → the parameter dialog asked for `gene_symbol` and offered `detail_level` at its default `brief` → the prompt rendered as *"Summarise the disease associations for the gene TP53 at a brief level of detail…"* and the run returned the three bullets the instructions demand.

The YAML that now saves (trimmed to the parts at issue; the `extensions` block and the rest are unchanged):

```yaml
version: 1.0.0
title: Brief gene disease association summary
description: Generates a short markdown summary of disease associations for a named gene from general biomedical knowledge. Useful for quick orientation before deeper sourced lookup.
instructions: |-
  Summarise the disease associations for the requested gene at the requested level of detail, using concise biomedical language. If the user asks for a brief summary, return exactly three short markdown bullets, prioritising the best-established disease links and noting important allele, variant, or mechanism context when relevant.

  Do not use tools unless the user explicitly asks for sourced, current, or database-backed evidence. If answering from general knowledge, avoid fabricating certainty: state when an association is indirect, risk-modifying, or context-dependent.
prompt: Summarise the disease associations for the gene {{gene_symbol}} at a {{detail_level}} level of detail, as a short markdown bullet list. Do not use tools unless I ask for sourced evidence.
knowledge_bases:
  visible:
  - soul
settings:
  biorouter_provider: versa_azure
  biorouter_model: gpt-5.5-2026-04-24
  temperature: 0.0
activities:
- Summarise a gene
- Three bullet summary
- List major diseases
- Explain variant effects
author:
  contact: wgu
parameters:
- key: gene_symbol
  input_type: string
  requirement: user_prompt
  description: HGNC gene symbol to summarise, for example APOE, TP53, or BRCA1
- key: detail_level
  input_type: select
  requirement: optional
  description: How much detail the summary should include
  default: brief
  options:
  - brief
  - standard
  - detailed
```

Note `knowledge_bases` carries `visible` and **no** `default` — the exact state D14 is about, now stated on the card.

## Found in passing, not fixed here

A second, independent way the same modal loses its parameters, watched live on the second capture: the model wrote `"default": 80` for a `number` parameter, `WorkflowParameter.default` is `Option<String>`, and serde failed the **whole array** —

```
WARN biorouter::agents::agent: Dropping generated workflow parameters that did not parse:
invalid type: integer `80`, expected a string
```

— so every parameter was dropped, not just the offending one. Out of scope for this change and filed as a separate task; it has a trap of its own (a dropped-but-still-referenced parameter lands on the validator's *other* arm, "Missing definitions").

## Gates run

* `cargo fmt --check` — clean
* `./scripts/clippy-lint.sh` — all baseline checks pass
* `cargo test -p biorouter --lib` — **4014 passed, 0 failed**
* `cargo test -p biorouter-server --lib` — **665 passed, 0 failed**
* `cargo test -p biorouter --test workflow_capture_parity` — **4 passed** (2 of them red on `origin/main`)
* `npx vitest run src/components/workflows` — **139 passed** across 8 files
* `npm run lint:check` — typecheck, eslint, themes, 332 contrast assertions, token mirrors — all pass
* `npx prettier --check` on the four files touched — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
