### PR TITLE
Four smaller live findings: D8 blast radius, D9 notice persistence, D13 dead string, D11 flake

### DIFF
--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -712,10 +712,15 @@ fn skill_already_loaded_pointer() -> &'static str {
 /// [`Agent::decide_turn_stop`], acted on by the reply loop.
 enum TurnStop {
     /// Let the turn end, after showing the user `notices`.
-    Finish { notices: Vec<String> },
+    Finish { notices: Vec<Message> },
     /// Keep working: `feedback` goes to the model as a hidden steer, `notice`
     /// to the user.
-    KeepWorking { feedback: String, notice: String },
+    ///
+    /// Rows rather than strings, because whether a notice is written to the
+    /// transcript is decided per notice by [`Agent::decide_turn_stop`] — see
+    /// [`Agent::durable_notice`] — and the generator that yields them should not
+    /// have to know which kind it is holding.
+    KeepWorking { feedback: String, notice: Message },
 }
 
 /// Context needed for the reply function
@@ -9245,6 +9250,43 @@ impl Agent {
         }
     }
 
+    /// A user-visible notice that OUTLIVES the stream it was yielded on.
+    ///
+    /// ⚠ **Most inline notices in this loop are deliberately live-only, and stay
+    /// that way.** They narrate something the user is watching happen —
+    /// "Compacting to continue the chat…", "Retrying (2/3)…", "Hook denied
+    /// permission for X" — and replaying them on every reload would be noise
+    /// about a moment that has passed.
+    ///
+    /// A turn-level VERDICT is not narration. "The checklist still has 2
+    /// unfinished item(s); asking the agent to finish them or say why not" is the
+    /// only record that the turn was sent back at all: the feedback it produced is
+    /// model-only, so without this row a reload, History and a shared session all
+    /// show a turn with an extra unexplained round-trip and no reason for it. The
+    /// planning gate's stop check is also the half that fires in practice — a live
+    /// drive measured its redirect never firing against real models — so this is
+    /// in effect the gate's only visible output.
+    ///
+    /// The row that comes back carries the uid it was stored under (#41), so the
+    /// copy the caller yields and the stored row are the same message rather than
+    /// two.
+    ///
+    /// A failed write degrades to the live-only notice instead of failing the
+    /// turn: the user still sees it now, which is strictly better than losing a
+    /// turn's work over a notice.
+    async fn durable_notice(&self, session_id: &str, text: String) -> Message {
+        let mut notice = inline_notice_user_only(text);
+        if let Err(e) = self
+            .config
+            .session_manager
+            .add_message_adopting_uid(session_id, &mut notice)
+            .await
+        {
+            warn!("could not persist a turn notice; it stays live-only this turn: {e}");
+        }
+        notice
+    }
+
     /// Everything that decides whether a turn may end, in order: the planning
     /// gate's checklist check, then the Stop hooks (a `/goal` judge is one).
     ///
@@ -9264,14 +9306,17 @@ impl Agent {
         conversation: &Conversation,
         active_goal: Option<crate::agents::goal::GoalState>,
     ) -> TurnStop {
-        let mut notices = Vec::new();
+        let mut notices: Vec<Message> = Vec::new();
         if active_goal.is_none() {
             match self.checklist_stop(session_id, conversation).await {
                 crate::agents::planning_gate::ChecklistStop::Block { feedback, notice } => {
-                    return TurnStop::KeepWorking { feedback, notice };
+                    return TurnStop::KeepWorking {
+                        feedback,
+                        notice: self.durable_notice(session_id, notice).await,
+                    };
                 }
                 crate::agents::planning_gate::ChecklistStop::GiveUp { notice } => {
-                    notices.push(notice);
+                    notices.push(self.durable_notice(session_id, notice).await);
                 }
                 crate::agents::planning_gate::ChecklistStop::Clear => {}
             }
@@ -9288,10 +9333,10 @@ impl Agent {
                 // clear it and tell the user.
                 if let Some(goal) = active_goal {
                     self.clear_goal(session_id).await;
-                    notices.push(format!(
+                    notices.push(inline_notice_user_only(format!(
                         "🎯 Goal met and cleared: {}",
                         crate::agents::goal::ellipsize(&goal.condition, 200)
-                    ));
+                    )));
                 }
                 TurnStop::Finish { notices }
             }
@@ -9301,11 +9346,11 @@ impl Agent {
                 } else {
                     ""
                 };
-                notices.push(format!(
+                notices.push(inline_notice_user_only(format!(
                     "Stop hook block limit ({}) reached; finishing anyway.{}",
                     crate::hooks::STOP_HOOK_BLOCK_CAP,
                     goal_hint
-                ));
+                )));
                 TurnStop::Finish { notices }
             }
             crate::hooks::StopHookVerdict::Blocked { reason } => {
@@ -9313,7 +9358,10 @@ impl Agent {
                 let (feedback, notice) = self
                     .stop_hook_block_feedback(session_id, &reason, active_goal.is_some())
                     .await;
-                TurnStop::KeepWorking { feedback, notice }
+                TurnStop::KeepWorking {
+                    feedback,
+                    notice: inline_notice_user_only(notice),
+                }
             }
         }
     }
@@ -11430,7 +11478,7 @@ impl Agent {
                     ).await {
                         TurnStop::Finish { notices } => {
                             for notice in notices {
-                                yield AgentEvent::Message(inline_notice_user_only(notice));
+                                yield AgentEvent::Message(notice);
                             }
                             break;
                         }
@@ -11446,7 +11494,7 @@ impl Agent {
                                 yield published;
                             }
                             conversation.push(feedback);
-                            yield AgentEvent::Message(inline_notice_user_only(notice));
+                            yield AgentEvent::Message(notice);
                             // Keep looping: the model sees the feedback next turn.
                             // After a goal gives up it is cleared, so the next stop
                             // proceeds once the agent delivers its wrap-up.

--- a/crates/biorouter/src/agents/planning_gate.rs
+++ b/crates/biorouter/src/agents/planning_gate.rs
@@ -1555,6 +1555,19 @@ mod agent_loop_tests {
             .collect()
     }
 
+    /// The notices the DURABLE transcript holds — what a reload, History and a
+    /// shared session show, as opposed to what the live stream yielded.
+    async fn persisted_notices(fixture: &Fixture) -> Vec<String> {
+        let session = fixture
+            .agent
+            .config
+            .session_manager
+            .get_session(&fixture.session_id, true)
+            .await
+            .unwrap();
+        notices(session.conversation.unwrap_or_default().messages())
+    }
+
     async fn checklist(fixture: &Fixture) -> TodoState {
         let session = fixture
             .agent
@@ -1745,6 +1758,66 @@ mod agent_loop_tests {
                 .iter()
                 .any(|notice| notice.contains("finishing anyway")),
             "{shown:?}"
+        );
+    }
+
+    /// **The stop check's notice survives a reload.**
+    ///
+    /// It is the gate's only visible output in practice — the live drive measured
+    /// the redirect half never firing against real models (16 turns armed, 0
+    /// redirected, across eight prompt shapes on two models) while the stop check
+    /// does fire — so a notice that exists only in the live stream means a turn
+    /// that was sent back to finish its checklist leaves no trace at all in
+    /// History or after a reload.
+    #[tokio::test]
+    async fn the_stop_check_notices_are_in_the_durable_transcript() {
+        let mut script = vec![call(
+            "plan",
+            "todo__todo_write",
+            serde_json::json!({"content": "- [ ] one\n- [ ] two"}),
+        )];
+        // Stop unnamed until the cap lets the turn go, so BOTH notices are
+        // produced in one run: the blocks, then the give-up.
+        for n in 0..(crate::hooks::STOP_HOOK_BLOCK_CAP + 1) {
+            script.push(call(
+                &format!("work-{n}"),
+                "fixture__step",
+                serde_json::json!({"n": n}),
+            ));
+            script.push(Message::assistant().with_text("All finished."));
+        }
+        let fixture = fixture(true, ScriptedProvider::new(script)).await;
+
+        let yielded = notices(&turn(&fixture, FOUR_STEPS).await);
+        let stored = persisted_notices(&fixture).await;
+
+        let planning = |notices: &[String]| -> Vec<String> {
+            notices
+                .iter()
+                .filter(|notice| notice.contains("📋"))
+                .cloned()
+                .collect()
+        };
+        assert!(
+            !planning(&yielded).is_empty(),
+            "the run must produce the notices in the first place: {yielded:?}"
+        );
+        assert_eq!(
+            planning(&stored),
+            planning(&yielded),
+            "every 📋 notice the stream showed must also be in the stored transcript"
+        );
+        assert!(
+            planning(&stored)
+                .iter()
+                .any(|notice| notice.contains("asking the agent to finish")),
+            "{stored:?}"
+        );
+        assert!(
+            planning(&stored)
+                .iter()
+                .any(|notice| notice.contains("finishing anyway")),
+            "{stored:?}"
         );
     }
 }

--- a/crates/biorouter/src/security/sensitive_ops.rs
+++ b/crates/biorouter/src/security/sensitive_ops.rs
@@ -553,12 +553,14 @@ pub fn screen_or_control_call(
 /// A sensitive **write** in a shell command line: any redirect target (`>` /
 /// `>>`), or the path argument of a mutating binary. Returns the finding phrase,
 /// or `None` for a read.
-fn command_writes_sensitively(command: &str, env: &EnvFacts) -> Option<String> {
+fn command_writes_sensitively(command: &str, env: &EnvFacts, found: &mut Findings) {
     // Redirects are unconditional writes, wherever in the line they appear.
     for rt in redirect_targets(command) {
         let tp = normalize_for(env.platform, &rt, env);
         if let Some(reason) = sensitivity_reason(&tp, env) {
-            return Some(write_finding(&tp.norm, reason));
+            if found.push(write_finding(&tp.norm, reason)) {
+                return;
+            }
         }
     }
     // Mutating binaries: their (already classified) path/redirect targets.
@@ -569,11 +571,12 @@ fn command_writes_sensitively(command: &str, env: &EnvFacts) -> Option<String> {
         }
         for hit in &seg.targets {
             if let Some(reason) = sensitivity_reason(&hit.path, env) {
-                return Some(write_finding(&hit.path.norm, reason));
+                if found.push(write_finding(&hit.path.norm, reason)) {
+                    return;
+                }
             }
         }
     }
-    None
 }
 
 /// The finding phrase for criteria 1-4, which all describe a write to a
@@ -581,6 +584,115 @@ fn command_writes_sensitively(command: &str, env: &EnvFacts) -> Option<String> {
 /// be destroyed, not which rule matched).
 fn write_finding(path: &str, reason: &str) -> String {
     format!("writes to {path} ({reason})")
+}
+
+/// How many sensitive operations one tool call is graded for.
+///
+/// Not a display limit — [`Findings::describe`] shows fewer than this. It is the
+/// **work** limit: criterion 5 spends a bounded directory walk per target, so a
+/// script naming a thousand deletes would otherwise put a thousand walks on the
+/// agent's critical path. At the cap the card says "at least N", which is the
+/// honest thing to say about a list that was not finished.
+const MAX_GRADED_FINDINGS: usize = 32;
+
+/// How many of them the approval card names.
+///
+/// A card the user cannot read is not consent either, so the list is short and
+/// the remainder is counted rather than printed.
+const SHOWN_FINDINGS: usize = 6;
+
+/// The sensitive operations found in one tool call.
+///
+/// ⚠ **Ordered and de-duplicated, and both matter.** The order is the order the
+/// call would perform them, so the first entry is still the one the old
+/// single-finding card named — that is what keeps every existing expectation
+/// about *which* operation is reported intact. De-duplication is not cosmetic:
+/// an `execute_code` body is scanned twice (string literals as command lines,
+/// then inner tool calls), so the same write can be reached down both paths and
+/// would otherwise be counted twice in a number the user is asked to trust.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Findings {
+    reasons: Vec<String>,
+    /// The grading stopped at [`MAX_GRADED_FINDINGS`], so `reasons.len()` is a
+    /// lower bound on how many operations the call really performs.
+    capped: bool,
+}
+
+impl Findings {
+    /// Record one finding. Returns `true` once the budget is spent, so a scanning
+    /// loop can stop rather than keep paying for probes it will not report.
+    fn push(&mut self, reason: String) -> bool {
+        if self.capped {
+            return true;
+        }
+        if !self.reasons.contains(&reason) {
+            self.reasons.push(reason);
+        }
+        if self.reasons.len() >= MAX_GRADED_FINDINGS {
+            self.capped = true;
+        }
+        self.capped
+    }
+
+    fn is_full(&self) -> bool {
+        self.capped
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.reasons.is_empty()
+    }
+
+    pub fn into_reasons(self) -> Vec<String> {
+        self.reasons
+    }
+
+    /// The clause naming what the call would affect, for the approval card and
+    /// for the [`InspectionResult::reason`] beside it.
+    ///
+    /// One finding reads as a sentence, because that is the overwhelmingly common
+    /// case and a one-item bulleted list is worse prose than a clause. Several
+    /// read as a counted list: the count first, so the user learns the blast
+    /// radius before the paths, and the tail summarised rather than printed.
+    pub fn describe(&self) -> String {
+        match self.reasons.as_slice() {
+            [] => String::new(),
+            [only] => format!("This tool call {only}."),
+            many => {
+                let at_least = if self.capped { "at least " } else { "" };
+                let mut out = format!(
+                    "This tool call affects {at_least}{} places on this machine:",
+                    many.len()
+                );
+                for reason in many.iter().take(SHOWN_FINDINGS) {
+                    out.push_str("\n  • it ");
+                    out.push_str(reason);
+                }
+                if many.len() > SHOWN_FINDINGS {
+                    out.push_str(&format!(
+                        "\n  • …and {} more, not listed here.",
+                        many.len() - SHOWN_FINDINGS
+                    ));
+                }
+                out
+            }
+        }
+    }
+
+    /// The short form for logs and for the finding's own `reason` field.
+    fn summary(&self) -> String {
+        match self.reasons.as_slice() {
+            [] => String::new(),
+            [only] => format!("Sensitive file operation ({only})"),
+            many => {
+                let at_least = if self.capped { "at least " } else { "" };
+                format!(
+                    "Sensitive file operations at {at_least}{} paths (first: {})",
+                    many.len(),
+                    many[0]
+                )
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1280,30 +1392,42 @@ fn established_directory_probe(
     Some(probe)
 }
 
-/// A recursive delete in `command` that criterion 5 escalates, if any.
+/// Every recursive delete in `command` that criterion 5 escalates.
+///
+/// ⚠ **All of them, not the first.** The approval card names what it found, and a
+/// script that clears six established directories must not be described by one of
+/// them — the user would approve five deletions the card never mentioned. That is
+/// what makes each target worth its own bounded probe; [`Findings`] caps how many
+/// probes one call can cost.
 fn command_deletes_established_directory(
     command: &str,
     env: &EnvFacts,
     session: &CallSession<'_>,
-) -> Option<String> {
-    let targets = recursive_delete_targets(command, env);
-    if targets.is_empty() {
-        return None;
+    found: &mut Findings,
+) {
+    for target in recursive_delete_targets(command, env) {
+        if let Some(reason) = established_directory_reason(&target, session, env) {
+            if found.push(reason) {
+                return;
+            }
+        }
     }
-    targets
-        .iter()
-        .find_map(|target| established_directory_reason(target, session, env))
 }
 
 /// Every criterion a shell command line can trip: the four path-classification
-/// ones (via [`command_writes_sensitively`]) and criterion 5.
-fn command_is_sensitive(
+/// ones (via [`command_writes_sensitively`]) and criterion 5 — and every hit of
+/// each, not the first.
+fn command_findings(
     command: &str,
     env: &EnvFacts,
     session: &CallSession<'_>,
-) -> Option<String> {
-    command_writes_sensitively(command, env)
-        .or_else(|| command_deletes_established_directory(command, env, session))
+    found: &mut Findings,
+) {
+    command_writes_sensitively(command, env, found);
+    if found.is_full() {
+        return;
+    }
+    command_deletes_established_directory(command, env, session, found);
 }
 
 /// Read the JS string / template literal that opens at `chars[start]` (a `"`,
@@ -1550,13 +1674,14 @@ fn extract_inner_calls(code: &str) -> Vec<InnerCall> {
 /// inner calls recovered from an `execute_code` body, so an inner call is graded
 /// **exactly** as the same call made directly would be, and the two can never
 /// drift apart.
-fn mutating_path_write(
+fn mutating_path_writes(
     tool_name: &str,
     args: &Map<String, Value>,
     env: &EnvFacts,
-) -> Option<String> {
+    found: &mut Findings,
+) {
     if !operation_is_mutating(tool_name, args) {
-        return None;
+        return;
     }
     for raw in path_values(args) {
         if raw.trim().is_empty() {
@@ -1564,10 +1689,11 @@ fn mutating_path_write(
         }
         let tp = normalize_for(env.platform, &raw, env);
         if let Some(reason) = sensitivity_reason(&tp, env) {
-            return Some(write_finding(&tp.norm, reason));
+            if found.push(write_finding(&tp.norm, reason)) {
+                return;
+            }
         }
     }
-    None
 }
 
 /// Scan an `execute_code` JS body for a sensitive operation. Two independent
@@ -1582,7 +1708,7 @@ fn mutating_path_write(
 ///     (`const cmd = "… >> ~/.ssh/config"; shell({command: cmd})`) and would
 ///     escape a call-scoped scan.
 ///  2. *Inner tool calls.* Each `callee({…})` site is graded by
-///     [`mutating_path_write`], i.e. exactly as the same tool call made directly
+///     [`mutating_path_writes`], i.e. exactly as the same tool call made directly
 ///     would be: the callee must read as a mutation, and only its own
 ///     path-keyed arguments are candidate targets.
 ///
@@ -1592,18 +1718,19 @@ fn mutating_path_write(
 /// target. A KB page write (`kb_write_page`, whose name contains "write") beside
 /// an unrelated `page.path.split("/")` therefore normalized the utility literal
 /// `"/"` to the filesystem root and parked Auto mode on an approval prompt.
-fn code_is_sensitive(code: &str, env: &EnvFacts, session: &CallSession<'_>) -> Option<String> {
+fn code_findings(code: &str, env: &EnvFacts, session: &CallSession<'_>, found: &mut Findings) {
     for lit in extract_string_literals(code) {
-        if let Some(hit) = command_is_sensitive(&lit, env, session) {
-            return Some(hit);
+        command_findings(&lit, env, session, found);
+        if found.is_full() {
+            return;
         }
     }
     for call in extract_inner_calls(code) {
-        if let Some(hit) = mutating_path_write(&call.callee, &call.args, env) {
-            return Some(hit);
+        mutating_path_writes(&call.callee, &call.args, env, found);
+        if found.is_full() {
+            return;
         }
     }
-    None
 }
 
 /// Classify a tool call: `Some(reason)` when it is an extremely sensitive
@@ -1624,31 +1751,45 @@ pub fn sensitive_file_operation(
     args: &Map<String, Value>,
     session: &CallSession<'_>,
 ) -> Option<String> {
+    sensitive_file_operations(tool_name, args, session)
+        .into_reasons()
+        .into_iter()
+        .next()
+}
+
+/// [`sensitive_file_operation`], but EVERY sensitive operation the call would
+/// perform, in the order the call performs them.
+///
+/// This is what the approval card is built from. The singular form above is the
+/// yes/no question — "must this call be approved at all" — and stays because
+/// dozens of tests, and the criteria's own documentation, are phrased that way.
+pub fn sensitive_file_operations(
+    tool_name: &str,
+    args: &Map<String, Value>,
+    session: &CallSession<'_>,
+) -> Findings {
     let env = EnvFacts::host(&session.working_dir().to_string_lossy());
+    let mut found = Findings::default();
 
     // 1. File-editor / file-tool path arguments (mutations only).
-    if let Some(finding) = mutating_path_write(tool_name, args, &env) {
-        return Some(finding);
-    }
+    mutating_path_writes(tool_name, args, &env, &mut found);
 
     // 2. Shell command lines (developer/shell and any command-bearing tool).
-    if let Some(command) = command_text_from(tool_name, args) {
-        if let Some(finding) = command_is_sensitive(&command, &env, session) {
-            return Some(finding);
+    if !found.is_full() {
+        if let Some(command) = command_text_from(tool_name, args) {
+            command_findings(&command, &env, session, &mut found);
         }
     }
 
     // 3. code_execution/execute_code JS body — its inner tool calls bypass every
     //    agent-layer inspector, so scan the script itself.
-    if is_execute_code(tool_name) {
+    if !found.is_full() && is_execute_code(tool_name) {
         if let Some(code) = args.get("code").and_then(Value::as_str) {
-            if let Some(finding) = code_is_sensitive(code, &env, session) {
-                return Some(finding);
-            }
+            code_findings(code, &env, session, &mut found);
         }
     }
 
-    None
+    found
 }
 
 /// This inspector's name, as it appears on an [`InspectionResult`]. Named so
@@ -1785,22 +1926,31 @@ impl SensitiveOpsInspector {
             let Some(args) = tool_call.arguments.as_ref() else {
                 continue;
             };
-            if let Some(reason) = sensitive_file_operation(&tool_call.name, args, &call_session) {
+            let found = sensitive_file_operations(&tool_call.name, args, &call_session);
+            if !found.is_empty() {
+                let summary = found.summary();
                 tracing::warn!(
                     counter.biorouter.sensitive_op_escalated = 1,
                     tool_name = %tool_call.name,
                     tool_request_id = %request.id,
+                    %summary,
                     "Sensitive file operation escalated to approval in Auto mode"
                 );
+                // The card names EVERY operation it found, not the first. A script
+                // that recursively deletes six directories used to be described by
+                // one of them, so the user approved five deletions the card had not
+                // mentioned — an approval that does not describe its own blast
+                // radius is not consent.
+                let affected = found.describe();
                 results.push(InspectionResult {
                     tool_request_id: request.id.clone(),
                     action: InspectionAction::RequireApproval(Some(format!(
                         "🔒 Sensitive system operation in Fully-Automatic mode.\n\
-                         This tool call {reason}.\n\
+                         {affected}\n\
                          Approve it to continue, or deny it. Ordinary file changes \
                          run without a prompt in this mode."
                     ))),
-                    reason: format!("Sensitive file operation ({reason})"),
+                    reason: summary,
                     confidence: 1.0,
                     inspector_name: self.name().to_string(),
                     finding_id: Some(format!("SENS-{}", Uuid::new_v4().simple())),
@@ -3070,10 +3220,45 @@ record_result("ok");"#;
         SystemTime::now() + Duration::from_secs(600)
     }
 
+    /// The single-finding forms these tests are written against. Production reads
+    /// [`Findings`] so an approval card can name every operation a call performs;
+    /// the yes/no question — "does this call have to be approved at all" — is what
+    /// almost every test below is really asking, and it stays spelled that way.
+    fn command_writes_sensitively(command: &str, env: &EnvFacts) -> Option<String> {
+        let mut found = Findings::default();
+        super::command_writes_sensitively(command, env, &mut found);
+        found.into_reasons().into_iter().next()
+    }
+
+    fn code_is_sensitive(code: &str, env: &EnvFacts, session: &CallSession<'_>) -> Option<String> {
+        code_findings_of(code, env, session)
+            .into_reasons()
+            .into_iter()
+            .next()
+    }
+
+    /// [`code_is_sensitive`], keeping every hit.
+    fn code_findings_of(code: &str, env: &EnvFacts, session: &CallSession<'_>) -> Findings {
+        let mut found = Findings::default();
+        code_findings(code, env, session, &mut found);
+        found
+    }
+
     /// Run the shell-command half of the classifier against the host filesystem.
     fn shell_finding(command: &str, session: &CallSession<'_>) -> Option<String> {
+        shell_findings(command, session)
+            .into_reasons()
+            .into_iter()
+            .next()
+    }
+
+    /// [`shell_finding`], keeping every hit — what the approval card is built
+    /// from.
+    fn shell_findings(command: &str, session: &CallSession<'_>) -> Findings {
         let env = EnvFacts::host(&session.working_dir().to_string_lossy());
-        command_is_sensitive(command, &env, session)
+        let mut found = Findings::default();
+        command_findings(command, &env, session, &mut found);
+        found
     }
 
     /// A session that began *before* the fixtures were written — the shape a
@@ -3862,6 +4047,156 @@ record_result("ok");"#;
         );
     }
 
+    // --- D8: the card names its whole blast radius -------------------------
+
+    #[cfg(not(target_os = "windows"))] // POSIX-dialect fixture; see the note above the module.
+    /// **The card must name every directory the script destroys, not the first.**
+    ///
+    /// A script that clears six established trees used to produce a card naming
+    /// one of them, so a user who read the card and approved it approved five
+    /// deletions it never mentioned. An approval that does not describe its own
+    /// blast radius is not consent.
+    #[test]
+    fn a_script_deleting_many_directories_names_all_of_them() {
+        let scratch = Scratch::new();
+        let victims: Vec<PathBuf> = ["alpha", "beta", "gamma"]
+            .iter()
+            .map(|name| scratch.populated(name, 2))
+            .collect();
+        let session = CallSession::new(scratch.path(), started_after_fixtures(), &[], &[]);
+        let env = EnvFacts::host(&scratch.path().to_string_lossy());
+        let code = victims
+            .iter()
+            .map(|v| format!("shell({{ command: `rm -rf {}` }});", v.display()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let found = code_findings_of(&code, &env, &session);
+        let reasons = found.clone().into_reasons();
+        assert_eq!(
+            reasons.len(),
+            3,
+            "every established directory the script clears is a finding: {reasons:?}"
+        );
+        let described = found.describe();
+        for victim in &victims {
+            assert!(
+                described.contains(&victim.to_string_lossy().to_string()),
+                "the card must name {}, got: {described}",
+                victim.display()
+            );
+        }
+        assert!(
+            described.contains("affects 3 places"),
+            "the card must lead with how many, got: {described}"
+        );
+    }
+
+    /// The same rule for one shell command line naming several targets — the
+    /// shape `rm -rf a b c` arrives in.
+    #[cfg(not(target_os = "windows"))] // POSIX-dialect fixture; see the note above the module.
+    #[test]
+    fn one_delete_command_with_several_operands_names_all_of_them() {
+        let scratch = Scratch::new();
+        let a = scratch.populated("one", 2);
+        let b = scratch.repo("two");
+        let session = CallSession::new(scratch.path(), started_after_fixtures(), &[], &[]);
+
+        let found = shell_findings(&format!("rm -rf {} {}", a.display(), b.display()), &session);
+        let described = found.describe();
+        assert!(
+            described.contains(&a.to_string_lossy().to_string())
+                && described.contains(&b.to_string_lossy().to_string()),
+            "both operands must be named, got: {described}"
+        );
+        // The repository clause still rides its own entry, so the more serious of
+        // the two is not flattened into a count.
+        assert!(
+            described.contains("contains a git repository"),
+            "the card must keep what makes each target serious, got: {described}"
+        );
+    }
+
+    /// A long list is summarised rather than dumped: the user is told how many,
+    /// shown enough to recognise a mistake, and told what was left out. A card
+    /// nobody can read is not consent either.
+    #[cfg(not(target_os = "windows"))] // POSIX-dialect fixture; see the note above the module.
+    #[test]
+    fn a_very_long_list_is_counted_and_truncated_rather_than_dumped() {
+        let scratch = Scratch::new();
+        let victims: Vec<PathBuf> = (0..10)
+            .map(|i| scratch.populated(&format!("v{i}"), 1))
+            .collect();
+        let session = CallSession::new(scratch.path(), started_after_fixtures(), &[], &[]);
+        let command = format!(
+            "rm -rf {}",
+            victims
+                .iter()
+                .map(|v| v.display().to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+
+        let described = shell_findings(&command, &session).describe();
+        assert!(
+            described.contains("affects 10 places"),
+            "the count is the part the user needs first, got: {described}"
+        );
+        assert_eq!(
+            described.matches("  • ").count(),
+            SHOWN_FINDINGS + 1,
+            "six findings plus the one line accounting for the rest: {described}"
+        );
+        assert!(
+            described.contains("…and 4 more, not listed here."),
+            "the tail must be accounted for, not dropped, got: {described}"
+        );
+    }
+
+    /// One finding still reads as the sentence it always was. The overwhelming
+    /// majority of these calls trip exactly one criterion, and a one-item bullet
+    /// list is worse prose than a clause.
+    #[test]
+    fn a_single_finding_still_reads_as_one_sentence() {
+        let mut found = Findings::default();
+        found.push("writes to /etc/passwd (a protected system directory)".into());
+        assert_eq!(
+            found.describe(),
+            "This tool call writes to /etc/passwd (a protected system directory)."
+        );
+    }
+
+    /// An `execute_code` body is scanned twice — string literals as command
+    /// lines, then inner tool calls — so the same write is reachable down both
+    /// paths. Counting it twice would put a number in front of the user that the
+    /// script does not support.
+    #[test]
+    fn the_same_operation_found_twice_is_counted_once() {
+        let mut found = Findings::default();
+        assert!(!found.push("writes to /etc/hosts (a protected system directory)".into()));
+        assert!(!found.push("writes to /etc/hosts (a protected system directory)".into()));
+        assert_eq!(found.into_reasons().len(), 1);
+    }
+
+    /// The grading budget is a work limit, and at it the card says "at least" —
+    /// a number that stopped counting must not be presented as a total.
+    #[test]
+    fn a_capped_scan_says_at_least_rather_than_an_exact_count() {
+        let mut found = Findings::default();
+        for i in 0..MAX_GRADED_FINDINGS {
+            let full = found.push(format!(
+                "writes to /etc/f{i} (a protected system directory)"
+            ));
+            assert_eq!(full, i + 1 == MAX_GRADED_FINDINGS);
+        }
+        assert!(found.is_full());
+        let described = found.describe();
+        assert!(
+            described.contains(&format!("affects at least {MAX_GRADED_FINDINGS} places")),
+            "got: {described}"
+        );
+    }
+
     // --- the inspector, end to end ----------------------------------------
 
     fn shell_request(id: &str, command: &str) -> ToolRequest {
@@ -3884,6 +4219,75 @@ record_result("ok");"#;
             created_at,
             ..Session::default()
         }
+    }
+
+    #[cfg(not(target_os = "windows"))] // POSIX-dialect fixture; see the note above the module.
+    /// D8, end to end: the card an `execute_code` script gets is the card that
+    /// names what the script does — all of it.
+    ///
+    /// The same run is the regression test for the defect: on the single-finding
+    /// card only `first` appeared, and approving it also approved `second` and
+    /// `third` without their ever being shown.
+    #[tokio::test]
+    async fn an_execute_code_card_names_every_directory_the_script_clears() {
+        let scratch = Scratch::new();
+        let workspace = scratch.dir("workspace");
+        let victims: Vec<PathBuf> = ["first", "second", "third"]
+            .iter()
+            .map(|name| scratch.populated(name, 2))
+            .collect();
+        let code = victims
+            .iter()
+            .map(|v| format!("shell({{ command: `rm -rf {}` }});", v.display()))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let results = SensitiveOpsInspector::unbound()
+            .inspect(
+                &[ToolRequest {
+                    id: "req_code".into(),
+                    tool_call: Ok(CallToolRequestParams {
+                        task: None,
+                        name: "code_execution__execute_code".into(),
+                        arguments: Some(args(json!({ "code": code }))),
+                        meta: None,
+                    }),
+                    metadata: None,
+                    tool_meta: None,
+                }],
+                &[],
+                BioRouterMode::Auto,
+                &session_at(
+                    &workspace,
+                    chrono::Utc::now() + chrono::Duration::seconds(600),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let result = results
+            .iter()
+            .find(|r| r.tool_request_id == "req_code")
+            .expect("the script must be escalated");
+        let InspectionAction::RequireApproval(Some(prompt)) = &result.action else {
+            panic!("expected an approval prompt, got {:?}", result.action);
+        };
+        for victim in &victims {
+            assert!(
+                prompt.contains(&victim.to_string_lossy().to_string()),
+                "the card must name {}, got: {prompt}",
+                victim.display()
+            );
+        }
+        assert!(
+            prompt.contains("affects 3 places"),
+            "the card must lead with the blast radius, got: {prompt}"
+        );
+        assert!(
+            result.reason.contains("at 3 paths"),
+            "the logged reason must carry the count too, got: {}",
+            result.reason
+        );
     }
 
     #[cfg(not(target_os = "windows"))] // POSIX-dialect fixture; see the note above the module.

--- a/crates/biorouter/tests/subagent_delegation.rs
+++ b/crates/biorouter/tests/subagent_delegation.rs
@@ -52,31 +52,112 @@ fn shared_session_manager() -> Arc<SessionManager> {
         .clone()
 }
 
-struct PausedParentProvider {
-    inner: Arc<ScriptedSubagentProvider>,
-    parent_calls: AtomicUsize,
-    pause: Duration,
+/// The steer `steering_mid_delegation_costs_no_subagent_results` sends. A const
+/// because both the test and the provider watching for it in context have to
+/// spell it the same way.
+const STEER: &str = "also summarise what each of them found";
+
+/// The rendezvous a [`ParkedParentProvider`] gives the test driving it: the
+/// parent announces that it has reached the boundary after its spawn batch, and
+/// does not proceed until the test releases it.
+///
+/// ⚠ **This replaces a wall-clock `sleep`, and the difference is the whole
+/// point.** A steer is only accepted while the turn's interrupt queue is open,
+/// and the loop closes that queue in `close_and_drain` the moment it commits to
+/// exiting — which is BEFORE it waits for its children. So a test that wants to
+/// steer mid-delegation has to establish two things at once: the children are in
+/// flight, and the parent has not yet reached its exit check. The old harness
+/// tried to buy that window by sleeping 250 ms inside the parent's second
+/// provider call, i.e. by out-running the loop. Under load the two detached
+/// child tasks are not scheduled inside 250 ms, the parent reaches
+/// `close_and_drain` first, and `try_queue_soft_interrupt` answers `TurnEnded`
+/// — a failure that is about scheduler luck and not about the product.
+/// Measured on `origin/main` at `1b199445`: 7 failures in 18 runs of this binary
+/// with six copies of it running at once.
+///
+/// A `Notify` permit is stored when nothing is waiting yet, so neither half of
+/// the handshake depends on which side arrives first.
+struct ParentRendezvous {
+    /// Signalled once, when the parent parks after its spawn batch.
+    parked: tokio::sync::Notify,
+    /// Awaited by that parked call; the test signals it after queueing a steer.
+    release: tokio::sync::Notify,
 }
 
-impl PausedParentProvider {
-    async fn pause_after_spawn(&self, system_prompt: &str) {
-        if !system_prompt.contains("You are a specialized subagent")
-            && self.parent_calls.fetch_add(1, Ordering::SeqCst) > 0
-        {
-            tokio::time::sleep(self.pause).await;
+impl ParentRendezvous {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            parked: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        })
+    }
+
+    /// Wait for the parent to reach the post-spawn boundary. The timeout is a
+    /// liveness guard for a hung turn, never the thing that makes the ordering
+    /// hold — that is the handshake itself.
+    async fn await_parked(&self) {
+        tokio::time::timeout(Duration::from_secs(30), self.parked.notified())
+            .await
+            .expect("the parent reaches the boundary after its spawn batch");
+    }
+
+    fn release(&self) {
+        self.release.notify_one();
+    }
+}
+
+/// A parent provider that PARKS at the boundary after the spawn batch instead of
+/// sleeping there. See [`ParentRendezvous`].
+struct ParkedParentProvider {
+    inner: Arc<ScriptedSubagentProvider>,
+    parent_calls: AtomicUsize,
+    rendezvous: Arc<ParentRendezvous>,
+    /// Set once a PARENT call is shown [`STEER`] in its context.
+    ///
+    /// Recorded here rather than counted as "one extra parent call", because the
+    /// number of calls a turn makes after a steer is not a property of the steer:
+    /// native supervision adds one of its own when the children report. What the
+    /// test actually claims is that the model SAW the steer during this turn, and
+    /// that is exactly what this observes.
+    saw_steer: std::sync::atomic::AtomicBool,
+}
+
+impl ParkedParentProvider {
+    /// Park the parent's FIRST post-spawn call, and only that one: the loop makes
+    /// further calls once it consumes the steer and once the children report, and
+    /// parking either would hang the turn on a release nobody sends.
+    async fn park_after_spawn(&self, system_prompt: &str) {
+        if system_prompt.contains("You are a specialized subagent") {
+            return;
         }
+        if self.parent_calls.fetch_add(1, Ordering::SeqCst) != 1 {
+            return;
+        }
+        self.rendezvous.parked.notify_one();
+        self.rendezvous.release.notified().await;
+    }
+
+    fn saw_steer(&self) -> bool {
+        self.saw_steer.load(Ordering::SeqCst)
     }
 }
 
 #[async_trait]
-impl Provider for PausedParentProvider {
+impl Provider for ParkedParentProvider {
     async fn complete(
         &self,
         system_prompt: &str,
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<(Message, ProviderUsage), ProviderError> {
-        self.pause_after_spawn(system_prompt).await;
+        if !system_prompt.contains("You are a specialized subagent")
+            && messages
+                .iter()
+                .any(|message| message.as_concat_text().contains(STEER))
+        {
+            self.saw_steer.store(true, Ordering::SeqCst);
+        }
+        self.park_after_spawn(system_prompt).await;
         self.inner.complete(system_prompt, messages, tools).await
     }
 
@@ -99,18 +180,29 @@ impl Provider for PausedParentProvider {
     }
 
     fn get_name(&self) -> &str {
-        "paused-parent-scripted-subagent"
+        "parked-parent-scripted-subagent"
     }
 }
 
 async fn harness(batch: Vec<(String, Call)>) -> Harness {
-    harness_with_parent_pause(batch, None).await
+    let (harness, parked) = build_harness(batch, false).await;
+    assert!(parked.is_none(), "a plain harness parks nothing");
+    harness
 }
 
-async fn harness_with_parent_pause(
+/// A harness whose parent parks at the boundary after its spawn batch, plus the
+/// handle that releases it and counts its calls.
+async fn harness_with_parked_parent(
     batch: Vec<(String, Call)>,
-    parent_pause: Option<Duration>,
-) -> Harness {
+) -> (Harness, Arc<ParkedParentProvider>) {
+    let (harness, parked) = build_harness(batch, true).await;
+    (harness, parked.expect("the parked parent was requested"))
+}
+
+async fn build_harness(
+    batch: Vec<(String, Call)>,
+    park_parent: bool,
+) -> (Harness, Option<Arc<ParkedParentProvider>>) {
     std::env::set_var("BIOROUTER_SUBAGENT_MAX_TURNS", "3");
 
     let work_dir = TempDir::new().expect("test working directory");
@@ -132,12 +224,16 @@ async fn harness_with_parent_pause(
         .expect("parent session is created");
     let scripted = Arc::new(ScriptedSubagentProvider::new(batch));
     let ledger = scripted.ledger.clone();
-    let provider: Arc<dyn Provider> = match parent_pause {
-        Some(pause) => Arc::new(PausedParentProvider {
-            inner: scripted,
+    let parked = park_parent.then(|| {
+        Arc::new(ParkedParentProvider {
+            inner: Arc::clone(&scripted),
             parent_calls: AtomicUsize::new(0),
-            pause,
-        }),
+            rendezvous: ParentRendezvous::new(),
+            saw_steer: std::sync::atomic::AtomicBool::new(false),
+        })
+    });
+    let provider: Arc<dyn Provider> = match parked.clone() {
+        Some(parked) => parked,
         None => scripted,
     };
     agent
@@ -156,12 +252,15 @@ async fn harness_with_parent_pause(
         .await
         .expect("developer extension registers");
 
-    Harness {
-        agent: Arc::new(agent),
-        session_id: session.id,
-        ledger,
-        work_dir,
-    }
+    (
+        Harness {
+            agent: Arc::new(agent),
+            session_id: session.id,
+            ledger,
+            work_dir,
+        },
+        parked,
+    )
 }
 
 #[derive(Debug)]
@@ -657,33 +756,43 @@ async fn subagents_and_ordinary_tools_share_a_batch() {
 /// SUB: the user steers while subagents are in flight. A soft interrupt must
 /// not cost the delegated work — every child still reports, and the steer lands
 /// in the same turn.
+///
+/// ⚠ **Both preconditions are established by a handshake, never by a sleep.**
+/// See [`ParentRendezvous`] for what the wall-clock version measured instead
+/// (scheduler luck) and how often it was wrong. The parent is parked inside its
+/// post-spawn provider call for the whole middle of this test, which is what
+/// makes "the children are in flight" and "the turn's steer window is still
+/// open" simultaneously true rather than merely likely.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn steering_mid_delegation_costs_no_subagent_results() {
-    let h = harness_with_parent_pause(
-        vec![
-            call("left", Call::sub("left", "slow:left:600")),
-            call("right", Call::sub("right", "slow:right:600")),
-        ],
-        Some(Duration::from_millis(250)),
-    )
+    let (h, parked) = harness_with_parked_parent(vec![
+        call("left", Call::sub("left", "slow:left:600")),
+        call("right", Call::sub("right", "slow:right:600")),
+    ])
     .await;
 
     let agent = h.agent.clone();
     let session_id = h.session_id.clone();
     let turn = tokio::spawn(async move { drain(&agent, &session_id).await });
-    tokio::time::timeout(std::time::Duration::from_secs(5), async {
-        loop {
-            if h.ledger.distinct_started().len() == 2 {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+    // 1. The spawn batch has dispatched and the parent is parked, so the loop
+    //    cannot reach the exit check that closes the interrupt queue.
+    parked.rendezvous.await_parked().await;
+    // 2. Both children really are inside the provider. Bounded only as a hung-run
+    //    guard: the parent is parked, so nothing is racing this.
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while h.ledger.distinct_started().len() != 2 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
         }
     })
     .await
-    .expect("both children must be in flight before steering");
+    .expect("both children reach the provider while the parent is parked");
+    // 3. Steer, with the window provably open.
     h.agent
-        .try_queue_soft_interrupt("also summarise what each of them found".to_string(), None)
+        .try_queue_soft_interrupt(STEER.to_string(), None)
         .expect("the parent turn is still accepting a steer while its children run");
+    parked.rendezvous.release();
+
     let messages = turn
         .await
         .expect("turn task joins")
@@ -704,15 +813,24 @@ async fn steering_mid_delegation_costs_no_subagent_results() {
         .filter(|m| m.role == rmcp::model::Role::User)
         .flat_map(|m| m.content.iter())
         .any(|c| match c {
-            biorouter::conversation::message::MessageContent::Text(t) => {
-                t.text.contains("also summarise what each of them found")
-            }
+            biorouter::conversation::message::MessageContent::Text(t) => t.text.contains(STEER),
             _ => false,
         });
     assert!(steer_landed, "the steer reached the conversation");
     assert!(
         !h.agent.has_soft_interrupts(),
         "the queued steer was consumed, not left pending"
+    );
+    // The claim in this test's name that the old timing could not check: the steer
+    // was answered INSIDE this turn. `close_and_drain` finds it at the exit check,
+    // reopens the loop for one more step, and that step puts it in the model's
+    // context. A turn that merely persisted it on the way out — which is what
+    // happens whenever the steer lands after the exit check — would still satisfy
+    // every assertion above, because `settle_soft_interrupts_for_turn` persists
+    // and yields it either way.
+    assert!(
+        parked.saw_steer(),
+        "the steer must reach the model in this turn, not be carried over past its end"
     );
 }
 

--- a/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.test.tsx
+++ b/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.test.tsx
@@ -6,7 +6,11 @@ import { IngestPanel } from './IngestPanel';
 const mocks = vi.hoisted(() => ({
   knowledge: {
     primaryKbId: 'kb-1' as string | null,
-    primaryKb: { id: 'kb-1', name: 'Notes', default_model: null as ModelRef | null },
+    primaryKb: { id: 'kb-1', name: 'Notes', default_model: null as ModelRef | null } as {
+      id: string;
+      name: string;
+      default_model: ModelRef | null;
+    } | null,
     loading: false,
     basesError: null as string | null,
     refresh: vi.fn(),
@@ -481,6 +485,27 @@ describe('IngestPanel paste box visibility', () => {
     render(<IngestPanel />);
     fireEvent.click(screen.getByTestId('knowledge-ingest-paste-text'));
     expect(screen.getByPlaceholderText(/Paste knowledge/i)).toHaveFocus();
+  });
+});
+
+/**
+ * D13: a string nothing can display is worse than none, because it reads as
+ * covered behaviour.
+ *
+ * `IngestPanel` carried a blocked reason for "no primary knowledge base" that no
+ * render could ever reach: `KnowledgeView` swaps its whole body — this panel with
+ * it — for the `No primary knowledge base` EmptyState the moment `primaryKbId` is
+ * null, and that view is the only place this component is mounted. The rung is
+ * gone; `KnowledgeView.test.tsx` holds the other half of the invariant (the view
+ * really does withhold the panel in that state).
+ */
+describe('IngestPanel with no primary knowledge base', () => {
+  it('never claims a missing primary, because it cannot be mounted without one', () => {
+    mocks.knowledge.primaryKbId = null;
+    mocks.knowledge.primaryKb = null;
+    render(<IngestPanel />);
+
+    expect(screen.queryByText(/primary knowledge base/i)).toBeNull();
   });
 });
 

--- a/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.tsx
+++ b/ui/desktop/src/components/knowledge/IngestPanel/IngestPanel.tsx
@@ -467,22 +467,30 @@ export function IngestPanel() {
   // guarded by a cursor + helper line, so it never trains the eye to ignore a
   // permanently half-lit button.
   const nothingToDigest = !dispatchKbId || !model || items.length === 0;
-  const digestBlockedReason = !primaryKbId
-    ? 'Choose or create a primary knowledge base above to enable digestion.'
-    : // Ahead of every model verdict: with no manifest, "which model" has no
-      // answer yet, and "no model is configured" would send the user to fix a
-      // configuration that is not what is broken.
-      kbUnavailable
-      ? basesError
-        ? 'Could not load your knowledge bases, so digestion is on hold.'
-        : 'This knowledge base is unavailable, so digestion is on hold.'
-      : modelPending
-        ? 'Checking which model this knowledge base digests with…'
-        : !model
-          ? 'No model is configured. Choose a model above to enable digestion.'
-          : items.length === 0
-            ? 'Stage a file to digest.'
-            : null;
+  // ⚠ **There is deliberately no "choose a primary knowledge base" rung here.**
+  // This panel cannot be mounted without one: `KnowledgeView` replaces its whole
+  // body — Sources rail included — with the `No primary knowledge base`
+  // `EmptyState` whenever `primaryKbId` is null, and that state is the only route
+  // to this component. A rung for it read as covered behaviour while being
+  // unreachable, and it was the weaker of the two answers anyway: the EmptyState
+  // carries the action (Choose a base), where a blocked-reason line can only
+  // describe the absence. `KnowledgeView.test.tsx` pins the view side of this.
+  //
+  // The ladder therefore opens on `kbUnavailable`, ahead of every model verdict:
+  // with no manifest, "which model" has no answer yet, and "no model is
+  // configured" would send the user to fix a configuration that is not what is
+  // broken.
+  const digestBlockedReason = kbUnavailable
+    ? basesError
+      ? 'Could not load your knowledge bases, so digestion is on hold.'
+      : 'This knowledge base is unavailable, so digestion is on hold.'
+    : modelPending
+      ? 'Checking which model this knowledge base digests with…'
+      : !model
+        ? 'No model is configured. Choose a model above to enable digestion.'
+        : items.length === 0
+          ? 'Stage a file to digest.'
+          : null;
   const digestLabel =
     digestState === 'checking'
       ? 'Checking model…'

--- a/ui/desktop/src/components/knowledge/KnowledgeView.test.tsx
+++ b/ui/desktop/src/components/knowledge/KnowledgeView.test.tsx
@@ -213,6 +213,11 @@ describe('KnowledgeView empty states', () => {
     // The subject band names the same absence, so scope to the EmptyState's own
     // heading rather than to the words.
     expect(screen.getByRole('heading', { name: 'No primary knowledge base' })).toBeInTheDocument();
+    // D13: the EmptyState replaces the WHOLE body, the Sources rail and its
+    // ingest panel included. That is why `IngestPanel` carries no blocked reason
+    // for a missing primary — it can never be mounted in that state, and this
+    // EmptyState is the better answer anyway, because it carries the action.
+    expect(screen.queryByText('Digest workspace')).toBeNull();
     await userEvent.click(screen.getByRole('button', { name: 'Choose a base' }));
     expect(screen.getByRole('dialog', { name: 'Knowledge bases' })).toBeInTheDocument();
   });


### PR DESCRIPTION
Track B — the four smaller live findings, each with a test that fails on `origin/main` and passes here.

| Finding | Fix | Fail-before test |
|---|---|---|
| **D8** an approval card understates its blast radius | the card names every operation | `an_execute_code_card_names_every_directory_the_script_clears` |
| **D9** the 📋 stop-check notice is not persisted | persisted as a transcript row | `the_stop_check_notices_are_in_the_durable_transcript` |
| **D13** an unreachable message | deleted, with the reason recorded | `never claims a missing primary, because it cannot be mounted without one` |
| **D11** a load-sensitive test | the sleep becomes a handshake | the test itself (`steering_mid_delegation_costs_no_subagent_results`) |

None of the four should be left alone. D13 was the one that could have gone either way, and the reasoning is below.

---

## D8 — the card names every operation, not the first

`SensitiveOpsInspector` composed its Auto-mode card as `"This tool call {reason}"`, where `reason` was whichever finding the classifier reached first: every function on the path (`command_writes_sensitively`, `mutating_path_write`, `command_deletes_established_directory`, `code_is_sensitive`) returned `Option<String>` and stopped. For an `execute_code` body that clears several established directories that is one of them.

**Measured on `origin/main` (a16a0cbb).** A script clearing three populated directories produced exactly this card:

```
🔒 Sensitive system operation in Fully-Automatic mode.
This tool call recursively deletes …/sensitive-ops-tests/<id>/first — an existing
directory this session did not create (2 files).
Approve it to continue, or deny it. Ordinary file changes run without a prompt in this mode.
```

`second` and `third` are not in it. A user who read that card and approved it approved two deletions it never mentioned.

Each classifier now accumulates into a `Findings` value instead of returning early, and three decisions live on that type rather than at the call site:

- **Order and de-duplication.** The order is the order the call performs the operations, so the first entry is still exactly what the old card named — no existing expectation about *which* operation is reported changes, and all 75 pre-existing `sensitive_ops` tests pass untouched. De-duplication is not cosmetic: an `execute_code` body is scanned twice (string literals as command lines, then inner tool calls), so one write is reachable down both paths and would otherwise be counted twice in a number the user is asked to trust.
- **A work budget, not a display limit.** Criterion 5 spends a bounded directory walk per target, so grading stops at 32 findings; at the cap the card says "affects **at least** 32 places", because a count that stopped counting must not be presented as a total.
- **Readability, because a card the user cannot read is not consent either.** One finding still reads as the sentence it always was — a one-item bullet list is worse prose than a clause. Several lead with the count, then six entries, then `…and N more, not listed here.`

**Cost.** Only calls that already escalate pay more. A clean `execute_code` body already had every literal extracted and every path iterated — the early return only fired on a *hit*. A script that does escalate now scans the remainder of itself (bounded parsing) and probes up to 32 targets (bounded walks) before parking on a prompt a human will take seconds to answer.

Tests: the end-to-end one above through the real inspector, plus `a_script_deleting_many_directories_names_all_of_them`, `one_delete_command_with_several_operands_names_all_of_them` (which also checks the per-target "contains a git repository" clause is not flattened into a count), `a_very_long_list_is_counted_and_truncated_rather_than_dumped`, and three `Findings` unit tests for de-duplication, the single-finding sentence and the capped count.

Measured: `cargo test -p biorouter --lib -- security::sensitive_ops` — **82 passed, 0 failed** (75 before).

## D9 — the stop-check notice survives a reload

The 📋 notices were yielded on the live stream and written nowhere. The feedback they accompany is model-only, so a turn sent back to finish its checklist left **no** trace after a reload, in History, or in a shared session — only a turn with an extra unexplained round-trip.

Ported verbatim onto `origin/main`, the new test compiles and fails there:

```
assertion `left == right` failed: every 📋 notice the stream showed must also be in the stored transcript
  left: []
 right: ["📋 The checklist still has 2 unfinished item(s) (#1, #2); asking the agent to
          finish them or say why not.", …6 in total]
```

`TurnStop` now carries `Message` rows rather than strings, so `decide_turn_stop` decides per notice whether it is durable and the generator just yields what it is handed. `Agent::durable_notice` persists with `add_message_adopting_uid`, so the yielded copy carries the uid it was stored under (#41) instead of being a second copy of the row.

**Deliberately narrow — the checklist's two notices are the only ones made durable.** Every other inline notice in that loop narrates something the user is watching happen ("Compacting to continue the chat…", "Retrying (2/3)…", "Hook denied permission for X"); replaying those on each reload is noise about a moment that has passed. A turn-level *verdict* is not narration. A failed write degrades to the live-only notice rather than failing the turn over a notice.

This also raises the finding's value: the live drive measured the gate's **redirect** half never firing against real models (16 turns armed, 0 redirected, across eight prompt shapes on two models) while the **stop check** does fire — so this notice is in practice the gate's only visible output.

Measured: `cargo test -p biorouter --lib` — **4039 passed, 0 failed, 2 ignored**; `--test agent` (17), `--test hooks_agent_loop_tests` (10), `--test output_recovery_agent_loop` (9), `--test subagent_delegation` (8) all green; `cargo test -p biorouter-server --lib` — 667 passed.

## D13 — deleted, and why that rather than made reachable

`IngestPanel`'s *"Choose or create a primary knowledge base above to enable digestion."* can never render. `KnowledgeView` is the only place the panel is mounted (`KnowledgeView` → `SourcesRail` → `IngestPanel`, verified by grep — there is no second mount site), and it replaces its whole body with the `No primary knowledge base` `EmptyState` the moment `primaryKbId` is null.

**Deleted.** Reaching it would mean dropping the EmptyState, and the EmptyState is the better of the two answers: it carries the action — a `Choose a base` button that opens the manager — where a blocked-reason line can only describe the absence to someone who then has to go and find the control. The reason the ladder now opens on `kbUnavailable` is recorded where the rung used to be, so it is not re-added by someone reading the ladder and noticing a gap.

Both halves of the invariant are pinned. `IngestPanel.test.tsx` renders the panel with no primary and asserts it never claims one is missing — on `origin/main` that fails with `AssertionError: expected <p …(1)></p> to be null`. `KnowledgeView.test.tsx` gains the other half: in the no-primary state the view really does withhold the digest workspace, which is *why* the panel cannot be in that state.

Measured: `npx vitest run src/components/knowledge` — 258 passed; full suite `npx vitest run --exclude 'src/utils/artifactCdnAssets.browser.test.ts'` — **473 files, 5327 passed, 1 skipped, 0 failed**; `npm run lint:check` clean; `prettier --check` clean on the three touched files.

## D11 — the flake, and that it is not ours

**Confirmed pre-existing.** Built and ran the binary at `1b199445` — the last commit before today's merges — under the same load: **7 failures in 18 runs**, every one the same assertion. On today's `origin/main`: **10 failures in 42 runs**. The test file itself was last touched 2026-08-25.

Every failure is `try_queue_soft_interrupt` answering `TurnEnded` at `subagent_delegation.rs:686`.

**The source.** The test needs two things true at the same instant: the children are in flight, and the parent's soft-interrupt queue is still open. The loop closes that queue in `close_and_drain` the moment it commits to exiting — which is **before** it waits for its children. The harness bought that overlap by sleeping 250 ms inside the parent's post-spawn provider call, i.e. by out-running the loop. Under load the two detached child tasks are not scheduled inside 250 ms, the parent reaches the exit check first, and the queue is shut before the test ever steers. Nothing about the product is wrong; the test was measuring scheduler luck.

No sleep was lengthened and nothing was `#[ignore]`d. `PausedParentProvider` becomes `ParkedParentProvider`: the parent's first post-spawn call announces itself and **parks** until the test releases it. The test awaits that park, awaits both children entering the provider (bounded only as a hung-run guard — nothing is racing it now), steers, releases. The remaining timeouts decide nothing.

That also lets the test finally check the claim in its own name. Every pre-existing assertion passes whether the steer was answered *in* the turn or merely persisted on the way out, because `settle_soft_interrupts_for_turn` persists and yields a carried-over steer either way. The provider now records whether a parent call was **shown** the steer in its context — which is the discriminating question. Counting parent calls is not: native supervision adds one of its own when the children report, so the count is 4, not 3, and is a property of the loop rather than of the steer.

**After:** 30 runs of the binary, six copies at once, load average 55 — **0 failures**.

---

## Gates

- `cargo fmt --check` clean · `./scripts/clippy-lint.sh` clean · `cargo build --workspace --tests` clean
- `cargo test -p biorouter --lib` 4039 passed / 0 failed · `-p biorouter-server --lib` 667 passed / 0 failed
- `npm run lint:check` rc=0 · `npx prettier --check` clean on every touched frontend file
- `npx vitest run` (excluding the known `artifactCdnAssets.browser` teardown hang) 5327 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
