### PR TITLE
refactor(desktop): delete the context that could only ever be null, and guard the class

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -1,13 +1,4 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { SearchView } from './conversation/SearchView';
 import ProgressiveMessageList from './ProgressiveMessageList';
@@ -112,10 +103,6 @@ import { composerSlotMode, subagentComposerKind } from './subagent/subagentReadO
 import { SubagentTabHeader } from './subagent/SubagentTabHeader';
 import { extractKnowledgeBases, useSubagentSession } from './subagent/useSubagentSession';
 import { useChatGroups } from '../contexts/ChatGroupsContext';
-
-// Context for sharing current model info
-const CurrentModelContext = createContext<{ model: string; mode: string } | null>(null);
-export const useCurrentModelInfo = () => useContext(CurrentModelContext);
 
 // How long after the agent last worked a render failure is still treated as part
 // of the current exchange (and worth auto-fixing). A figure the agent just made

--- a/ui/desktop/src/components/ModelAndProviderContext.crossWindow.test.tsx
+++ b/ui/desktop/src/components/ModelAndProviderContext.crossWindow.test.tsx
@@ -83,8 +83,6 @@ vi.mock('./ConfigContext', () => ({
   usePrivacyTiersEnabled: () => true,
 }));
 
-// `BaseChat` is the whole chat surface; the chip imports it for one dead context.
-vi.mock('./BaseChat', () => ({ useCurrentModelInfo: () => null }));
 vi.mock('./settings/models/subcomponents/SwitchModelModal', () => ({
   SwitchModelModal: () => null,
 }));

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.browserSurface.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.browserSurface.test.tsx
@@ -42,8 +42,6 @@ vi.mock('../../../ModelAndProviderContext', () => ({
   }),
 }));
 
-vi.mock('../../../BaseChat', () => ({ useCurrentModelInfo: () => null }));
-
 // Markers rather than `null`: the assertion that matters is whether a click
 // OPENED the dialog, which an empty stub cannot report.
 vi.mock('../subcomponents/SwitchModelModal', () => ({

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.noProvider.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.noProvider.test.tsx
@@ -40,7 +40,6 @@ vi.mock('../../../ModelAndProviderContext', () => ({
     getCurrentProviderDisplayName: async () => '',
   }),
 }));
-vi.mock('../../../BaseChat', () => ({ useCurrentModelInfo: () => null }));
 vi.mock('../subcomponents/SwitchModelModal', () => ({ SwitchModelModal: () => null }));
 vi.mock('../subcomponents/LeadWorkerSettings', () => ({ LeadWorkerSettings: () => null }));
 

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.pinned.test.tsx
@@ -51,7 +51,6 @@ vi.mock('../../../ModelAndProviderContext', () => ({
   }),
 }));
 
-vi.mock('../../../BaseChat', () => ({ useCurrentModelInfo: () => null }));
 vi.mock('../subcomponents/SwitchModelModal', () => ({ SwitchModelModal: () => null }));
 vi.mock('../subcomponents/LeadWorkerSettings', () => ({ LeadWorkerSettings: () => null }));
 

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.privacy.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.privacy.test.tsx
@@ -47,10 +47,6 @@ vi.mock('../../../ModelAndProviderContext', () => ({
   }),
 }));
 
-// `BaseChat` is the whole chat surface; importing it for one dead context would
-// pull half the app into this suite.
-vi.mock('../../../BaseChat', () => ({ useCurrentModelInfo: () => null }));
-
 vi.mock('../subcomponents/SwitchModelModal', () => ({ SwitchModelModal: () => null }));
 vi.mock('../subcomponents/LeadWorkerSettings', () => ({ LeadWorkerSettings: () => null }));
 

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -323,9 +323,9 @@ export default function ModelsBottomBar({
   // Determine which model to display. The pair's own answer outranks the app-wide
   // selection; a chat's own binding outranks both.
   //
-  // ⚠ `useCurrentModelInfo()` is NOT consulted: `CurrentModelContext` is created
-  // and read in `BaseChat.tsx` and never provided, so the branch that used to sit
-  // here could not run on any surface. See `leadWorkerLabel.ts`.
+  // ⚠ A branch used to sit here reading the live model from a React context in
+  // `BaseChat.tsx` that nothing ever provided, so it could not run on any
+  // surface. See `leadWorkerLabel.ts`.
   const displayModel =
     effectiveModel?.model ??
     chipPair.model ??

--- a/ui/desktop/src/components/settings/models/bottom_bar/leadWorkerLabel.ts
+++ b/ui/desktop/src/components/settings/models/bottom_bar/leadWorkerLabel.ts
@@ -22,9 +22,11 @@
  * degenerate pair whose two halves name the same model. Every real pair read
  * `worker`, in every chat and on Home.
  *
- * ⚠ The `useCurrentModelInfo()` branch that looked like it rescued this is dead:
- * `CurrentModelContext` in `BaseChat.tsx` is created and read and **never
- * provided**, so the hook returns `null` on every surface. Do not reason from it.
+ * ⚠ A branch in the chip looked like it rescued this by reading the live model
+ * from a React context in `BaseChat.tsx`. That context was never provided, so
+ * the branch read `null` on every surface and could not run; it and the context
+ * are gone. `src/test/contextProviders.test.ts` now fails on the next context
+ * created without a provider.
  *
  * # What the renderer can actually know
  *

--- a/ui/desktop/src/test/contextProviders.test.ts
+++ b/ui/desktop/src/test/contextProviders.test.ts
@@ -1,0 +1,130 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every React context the renderer creates must be provided somewhere.
+ *
+ * A context that is created and read but never wrapped in a `Provider` is not
+ * inert: its hook returns the default forever, so every branch downstream that
+ * waits for a real value is unreachable code that reads like live code. That is
+ * exactly what happened to the composer's model chip. `BaseChat.tsx` created
+ * and exported `CurrentModelContext` / `useCurrentModelInfo`, nothing ever
+ * provided it, and `ModelsBottomBar` picked which model to name in a
+ * lead/worker pair by branching on a value that could never arrive. The label
+ * was decided by the fallback in every case the branch was written to handle.
+ * Five specs then carried a `vi.mock` of that hook returning `null`, which made
+ * the dead value look like a deliberately stubbed one.
+ *
+ * Measured on `main` at 5a404ecd, before this guard existed: of the twelve
+ * contexts created under `src/`, eleven had at least one `Provider` and
+ * `CurrentModelContext` had zero — the only one, and the one whose dead branch
+ * had already cost a defect (D7 in PR #283).
+ *
+ * The rule is deliberately blunt: created means provided, with no exemption for
+ * a context that carries a real default value. Every context here is provided
+ * today, including the one with a non-null default, so such an exemption would
+ * only ever wave through the next dead one. If a genuinely default-only context
+ * is ever wanted, add it to `PROVIDED_ELSEWHERE` with the reason it can never
+ * be provided — that entry is the argument, and it should be arguable.
+ *
+ * Scope: `src/`, production files only. A `Provider` that appears only in a
+ * spec does not rescue a context, because production is where the null arrives.
+ */
+const SRC = join(__dirname, '..');
+
+/**
+ * Trees under `src/` this guard does not read. `api/` is generated from the
+ * OpenAPI spec; `bin/` and `web/` are build outputs.
+ */
+const OUT_OF_SCOPE = ['api/', 'bin/', 'web/'];
+
+/**
+ * Contexts created here that can only ever be provided outside this tree, each
+ * with the reason. Empty on purpose — see the note above before adding one.
+ */
+const PROVIDED_ELSEWHERE: { name: string; because: string }[] = [];
+
+interface SourceFile {
+  rel: string;
+  text: string;
+}
+
+function productionSources(): SourceFile[] {
+  const found: SourceFile[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      const rel = relative(SRC, path);
+      if (statSync(path).isDirectory()) {
+        if (!OUT_OF_SCOPE.some((prefix) => `${rel}/`.startsWith(prefix))) walk(path);
+        continue;
+      }
+      if (!/\.tsx?$/.test(entry)) continue;
+      if (entry.includes('.test.') || entry.includes('.spec.') || entry.endsWith('.d.ts')) continue;
+      if (OUT_OF_SCOPE.some((prefix) => rel.startsWith(prefix))) continue;
+      found.push({ rel, text: readFileSync(path, 'utf8') });
+    }
+  };
+  walk(SRC);
+  return found;
+}
+
+const FILES = productionSources();
+
+/** `const Foo = createContext…` / `const Foo = React.createContext…`, exported or not. */
+const DECLARATION =
+  /(?:^|\n)[ \t]*(?:export[ \t]+)?const[ \t]+([A-Za-z_$][\w$]*)[ \t]*=[ \t]*(?:React\.)?createContext\b/g;
+
+interface CreatedContext {
+  name: string;
+  file: string;
+  line: number;
+}
+
+function createdContexts(): CreatedContext[] {
+  const found: CreatedContext[] = [];
+  for (const { rel, text } of FILES) {
+    for (const match of text.matchAll(DECLARATION)) {
+      found.push({
+        name: match[1],
+        file: rel,
+        // The match may start on the newline that precedes the declaration;
+        // report the line the `const` is actually on.
+        line: text.slice(0, match.index + (match[0].startsWith('\n') ? 1 : 0)).split('\n').length,
+      });
+    }
+  }
+  return found;
+}
+
+/**
+ * Both ways a context can be provided in React 19: the classic
+ * `<Foo.Provider value={…}>`, and the shorthand `<Foo value={…}>` that renders
+ * the context object itself. The shorthand is not used in this tree yet;
+ * accepting it keeps the guard from going red on a correct future refactor.
+ */
+function isProvided(name: string): boolean {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const provider = new RegExp(`\\b${escaped}\\.Provider\\b`);
+  const shorthand = new RegExp(`<${escaped}\\s+value\\s*=`);
+  return FILES.some(({ text }) => provider.test(text) || shorthand.test(text));
+}
+
+describe('React contexts in the renderer', () => {
+  it('finds the contexts to check', () => {
+    // A guard whose scan silently matched nothing would pass forever. This tree
+    // had twelve contexts when the guard was written and will not drop to zero.
+    expect(createdContexts().length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('provides every context it creates', () => {
+    const exempt = new Set(PROVIDED_ELSEWHERE.map(({ name }) => name));
+    const orphans = createdContexts()
+      .filter(({ name }) => !exempt.has(name))
+      .filter(({ name }) => !isProvided(name))
+      .map(({ name, file, line }) => `${file}:${line} ${name}`);
+
+    expect(orphans).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The defect, re-measured on `origin/main` at 5a404ecd

`ui/desktop/src/components/BaseChat.tsx:117-118` created and exported a React context that nothing ever provided:

```ts
const CurrentModelContext = createContext<{ model: string; mode: string } | null>(null);
export const useCurrentModelInfo = () => useContext(CurrentModelContext);
```

Counted every context in the renderer rather than trusting the report — of the **twelve** created under `ui/desktop/src`, eleven have at least one `Provider` and `CurrentModelContext` has **zero**:

| context | `.Provider` sites |
|---|---|
| ChatGroupsContext, ThemeContext, TerminalDockContext, ChatContext, ConfigContext, ChatTabDragContext, KnowledgeContext | 1 each |
| ModelAndProviderContext, SidebarContext, CommandContext, ChatStreamRegistryContext | 2 each |
| **CurrentModelContext** | **0** |

So `useCurrentModelInfo()` returned `null` on every surface. Not harmless: `ModelsBottomBar` chose which half of a lead/worker pair the composer chip names by branching on that value, and the branch could never run — D7 of #283, which removed the branch and left the context behind.

## The fail-before test

`ui/desktop/src/test/contextProviders.test.ts`: every context created under `src/` must be provided somewhere in production source (a `Provider` that exists only in a spec does not count; React 19's `<Ctx value={…}>` shorthand is accepted too).

Before, on unmodified `main` source:

```
 ❯ src/test/contextProviders.test.ts (2 tests | 1 failed)
AssertionError: expected [ Array(1) ] to deeply equal []
+   "components/BaseChat.tsx:117 CurrentModelContext",
 Tests  1 failed | 1 passed (2)
```

After: `Tests  2 passed (2)`.

**Falsified once**, because a guard that cannot fail measures nothing: appending a fresh never-provided context to `leadWorkerLabel.ts` turned it red again, naming `leadWorkerLabel.ts:176 ProbeContext`. Probe reverted; it is not in the diff. A second assertion fails if the scan ever matches fewer than ten contexts, so an empty walk cannot pass silently.

## The five mocks — measured, not assumed

The filed suggestion warned that a mock might be load-bearing (stopping a spec from importing the very large real `BaseChat`). It is not, for any of them: nothing in either spec's module graph imports `BaseChat` any more. Measured by replacing each mock factory with one that **throws** if the module is loaded — `ModelsBottomBar.privacy` 11 passed and `ModelAndProviderContext.crossWindow` 13 passed, the throw never firing. So all five are deleted rather than replaced with empty factories.

## Also in the diff

- The now-unused `createContext` / `useContext` imports in `BaseChat.tsx` (nothing else in the file used them).
- The two ⚠ comments in `leadWorkerLabel.ts` and `ModelsBottomBar.tsx` trimmed to the historical point — the chip used to branch on a value that could never arrive — without pointing at a symbol that no longer exists.

## Gates

- `npx vitest run --exclude "**/artifactCdnAssets.browser*"` — **474 files, 5332 passed / 1 skipped, 0 failed**
- `npm run lint:check` (tsc + eslint `--max-warnings 0` + themes/contrast/tokens) — exit 0
- `npx prettier --check` — clean on all nine touched files (it caught `BaseChat.tsx`, whose React import now fits one line; fixed and re-checked)

Deliberately not changed: `ui/desktop/.artifact-harness`, which has no `createContext` of its own, and the guard's scope stops at `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
