### PR TITLE
fix(baam): the featured skill cards repeat their grid twins, and a rule keeps them there

### DIFF
--- a/landing/baam.html
+++ b/landing/baam.html
@@ -1478,29 +1478,29 @@ extensions: []</pre>
             </div>
             <div class="skill-meta"><h3>Scientific Research</h3><div class="skill-type">User-invocable · /scientific-research</div></div>
           </div>
-          <p class="skill-desc">End-to-end literature research — search, read, and synthesize evidence with adversarial hypothesis verification and cited findings.</p>
+          <p class="skill-desc">End-to-end research: scopes the question, reviews real literature, generates hypotheses, plans and verifies the analysis, then writes a cited draft. Delegates biomedical data queries to whichever data extensions are installed. It never fabricates a citation or result.</p>
           <div class="skill-footer">
-            <div class="skill-tags"><span class="tag">Research</span><span class="tag">Literature</span><span class="tag">Citations</span></div>
+            <div class="skill-tags"><span class="tag">Research</span><span class="tag">Literature</span><span class="tag">Verified</span></div>
             <a href="https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-scientific-research/scientific-research.zip" class="skill-dl-btn"><svg class="icon icon-sm" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> .zip</a>
           </div>
         </div>
 
-        <div class="skill-card is-feat" data-cat="core" data-type="user" data-tags="ggplot-visualization ggplot2 r visualization publication figures plots" data-license="Apache-2.0">
+        <div class="skill-card is-feat" data-cat="core" data-type="auto" data-tags="ggplot-visualization ggplot2 r plotting style theme palette export" data-license="Apache-2.0">
           <div class="feat-eyebrow">Featured</div>
           <div class="skill-card-header">
             <div class="icon-tile icon-tile-sm">
               <svg class="icon" viewBox="0 0 24 24"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>
             </div>
-            <div class="skill-meta"><h3>ggplot2 Visualization</h3><div class="skill-type">User-invocable · /ggplot-visualization</div></div>
+            <div class="skill-meta"><h3>ggplot2 Visualization</h3><div class="skill-type">Auto-applied · R plotting</div></div>
           </div>
-          <p class="skill-desc">Publication-quality ggplot2 figures in R — font sizing, palettes, themes, and export settings tuned for journal submission.</p>
+          <p class="skill-desc">Applies ggplot2 best-practice style when writing R plotting code.</p>
           <div class="skill-footer">
-            <div class="skill-tags"><span class="tag">R</span><span class="tag">ggplot2</span><span class="tag">Figures</span></div>
+            <div class="skill-tags"><span class="tag">R</span><span class="tag">ggplot2</span></div>
             <a href="https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-ggplot-visualization/ggplot-visualization.zip" class="skill-dl-btn"><svg class="icon icon-sm" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> .zip</a>
           </div>
         </div>
 
-        <div class="skill-card is-feat" data-cat="biomedical" data-type="auto" data-tags="single-cell scanpy seurat scvi clustering annotation" data-license="Apache-2.0">
+        <div class="skill-card is-feat" data-cat="biomedical" data-type="auto" data-tags="single-cell scanpy seurat scvi" data-license="Apache-2.0">
           <div class="feat-eyebrow">Featured</div>
           <div class="skill-card-header">
             <div class="icon-tile icon-tile-sm">
@@ -1508,7 +1508,7 @@ extensions: []</pre>
             </div>
             <div class="skill-meta"><h3>Single-cell</h3><div class="skill-type">14 skills · auto-applied</div></div>
           </div>
-          <p class="skill-desc">scRNA-seq analysis — QC, clustering, annotation, trajectory, and integration with Scanpy, Seurat, and scVI.</p>
+          <p class="skill-desc">scRNA-seq clustering, annotation, trajectory, and integration.</p>
           <div class="skill-footer">
             <div class="skill-tags"><span class="tag">Scanpy</span><span class="tag">Seurat</span><span class="tag">scVI</span></div>
             <a href="https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-single-cell/single-cell.zip" class="skill-dl-btn"><svg class="icon icon-sm" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7,10 12,15 17,10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> .zip</a>
@@ -2342,7 +2342,7 @@ extensions: []</pre>
         </div>
       </div>
 
-      <div class="skill-card" data-license="Apache-2.0">
+      <div class="skill-card" data-tags="ggplot-visualization ggplot2 r plotting style theme palette export" data-license="Apache-2.0">
         <div class="skill-card-header">
           <div class="icon-tile icon-tile-sm">
             <svg class="icon" viewBox="0 0 24 24"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>

--- a/landing/registry.json
+++ b/landing/registry.json
@@ -2040,7 +2040,16 @@
         "R",
         "ggplot2"
       ],
-      "keywords": [],
+      "keywords": [
+        "ggplot-visualization",
+        "ggplot2",
+        "r",
+        "plotting",
+        "style",
+        "theme",
+        "palette",
+        "export"
+      ],
       "download": "https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-ggplot-visualization/ggplot-visualization.zip",
       "filename": "ggplot-visualization.zip",
       "license": "Apache-2.0"

--- a/landing/scripts/baam-search.test.mjs
+++ b/landing/scripts/baam-search.test.mjs
@@ -469,14 +469,19 @@ if (!existsSync(PLAYWRIGHT)) {
    * ⚠ The skills comparison reads the three GRIDS, not the whole shelf.
    * `build-registry.mjs` derives every registry row from `#core-skill-grid`,
    * `#dev-skill-grid` and `#bio-skill-grid`, so those cards stand one-to-one
-   * against the rows. The `#skills-featured` strip above them repeats three of
-   * those skills as hand-written cards, and the copies have DRIFTED — measured on
-   * the live page, the featured `ggplot2 Visualization` reads "Publication-quality
-   * ggplot2 figures in R — font sizing, palettes, themes" where its grid twin
-   * reads "Applies ggplot2 best-practice style", and carries a `Figures` tag and
-   * seven `data-tags` the grid card has none of. That is prose the registry does
-   * not describe, so a differential against the registry cannot speak about it: it
-   * is a content divergence on the page, not a matcher one.
+   * against the rows. The `#skills-featured` strip above them REPEATS three of
+   * those skills, so `#skills-section .skill-card` draws 132 cards against 129
+   * rows and the identity this comparison uses — the download link — collides on
+   * three of them. That is what keeps the selector on the grids: a repeat is not
+   * a second catalog entry, and counting it as one breaks the row-for-row
+   * comparison below before it can say anything.
+   *
+   * What the copies SAY is no longer a reason. They had drifted — 8 fields across
+   * the three, measured 2026-09-12 — so a query could reach a featured card
+   * through words its registry row did not carry. They are now held identical to
+   * their twins by a real-run rule in `build-registry.mjs`
+   * (`assertFeaturedRepeatsItsGridTwin`) that `--check` enforces in CI and on the
+   * landing deploy, so the strip answers exactly the queries its twins do.
    */
   for (const [label, shelf, selector, key, fields, noise] of [
     ['extensions', 'extensions', '#extensions-section .ext-card', 'extensions', extensionFields, Search.EXTENSION_NOISE],

--- a/landing/scripts/build-registry.mjs
+++ b/landing/scripts/build-registry.mjs
@@ -1185,29 +1185,42 @@ function parseSkillGrid(id, category) {
   if (IS_REAL_RUN && cards.length === 0) {
     fail(`the element with id="${id}" holds no skill-card elements`);
   }
-  return cards.map(({ attrs, inner: card }) => {
-    const name = stripTags(first(/<h3>([\s\S]*?)<\/h3>/, card));
-    const type = stripTags(first(/<div class="skill-type">([\s\S]*?)<\/div>/, card));
-    const description = stripTags(first(/<p class="skill-desc">([\s\S]*?)<\/p>/, card));
-    const download = first(/<a href="([^"]+)"[^>]*class="skill-dl-btn"/, card);
-    const tags = allTags(/<div class="skill-tags">([\s\S]*?)<\/div>/, card);
-    const license = attrs['data-license'] || 'Apache-2.0';
-    const dataTags = String(attrs['data-tags'] ?? '')
-      .split(/\s+/)
-      .filter(Boolean);
-    return {
-      id: slugFromUrl(download),
-      name,
-      category,
-      type,
-      description,
-      tags,
-      keywords: dataTags,
-      download: absolutize(download),
-      filename: download.split('/').pop(),
-      license,
-    };
-  });
+  return cards.map((card) => readSkillCard(card, category));
+}
+
+/**
+ * One skill card, read as the registry row it becomes.
+ *
+ * Split out of `parseSkillGrid` so the featured strip below is read by the SAME
+ * code that builds the row, rather than by a second parser that could disagree
+ * with this one about what a card says — a differential whose two sides are
+ * measured differently reports its own skew as drift.
+ *
+ * `category` is not on the card: a grid card inherits it from the grid it sits
+ * in, and a featured card declares its own `data-cat`.
+ */
+function readSkillCard({ attrs, inner: card }, category) {
+  const name = stripTags(first(/<h3>([\s\S]*?)<\/h3>/, card));
+  const type = stripTags(first(/<div class="skill-type">([\s\S]*?)<\/div>/, card));
+  const description = stripTags(first(/<p class="skill-desc">([\s\S]*?)<\/p>/, card));
+  const download = first(/<a href="([^"]+)"[^>]*class="skill-dl-btn"/, card);
+  const tags = allTags(/<div class="skill-tags">([\s\S]*?)<\/div>/, card);
+  const license = attrs['data-license'] || 'Apache-2.0';
+  const dataTags = String(attrs['data-tags'] ?? '')
+    .split(/\s+/)
+    .filter(Boolean);
+  return {
+    id: slugFromUrl(download),
+    name,
+    category,
+    type,
+    description,
+    tags,
+    keywords: dataTags,
+    download: absolutize(download),
+    filename: download.split('/').pop(),
+    license,
+  };
 }
 
 const skills = [
@@ -1215,6 +1228,63 @@ const skills = [
   ...parseSkillGrid('dev-skill-grid', 'Developer'),
   ...parseSkillGrid('bio-skill-grid', 'Biomedical'),
 ];
+
+// ---- The featured strip repeats grid cards, so it must repeat them exactly --
+// `#skills-featured` is three hand-written copies of cards that also live in the
+// grids, and ONLY the grids reach the registry. A divergence is therefore
+// invisible to every other gate in this file while being the first thing a
+// visitor reads: the strip promises one thing, and the catalog the app installs
+// from — and the model searches — describes another.
+//
+// Measured on 2026-09-12, before this check existed, the three copies differed
+// from their twins in 8 fields. The worst was not prose. The featured `ggplot2
+// Visualization` advertised "User-invocable · /ggplot-visualization" for a skill
+// whose SKILL.md declares `user-invocable: false` — a slash command that does not
+// exist — and the shelf derives the type facet from that very text, so one skill
+// answered the "User-invocable" chip as a featured card and the "Auto-applied"
+// chip as a grid card.
+//
+// Real-run only, for the reason the grids above are: the fixtures beside this
+// script carry extension cards and no skills shelf at all.
+function assertFeaturedRepeatsItsGridTwin(rows) {
+  const section = elementById(html, 'skills-featured');
+  if (!section || section.inner === null) {
+    fail('no usable element with id="skills-featured" — the catalog lost its featured strip');
+    return;
+  }
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  for (const card of pickCards(section.inner, 'skill-card')) {
+    const featured = readSkillCard(card, String(card.attrs['data-cat'] ?? ''));
+    const twin = byId.get(featured.id);
+    if (!twin) {
+      fail(
+        `featured card "${featured.name || featured.id}" repeats no grid card: nothing in ` +
+          `the three grids downloads "${featured.filename || featured.id}". Every card in ` +
+          '#skills-featured must be a copy of one in the grids.'
+      );
+      continue;
+    }
+    for (const field of ['name', 'type', 'description', 'tags', 'keywords']) {
+      if (JSON.stringify(featured[field]) === JSON.stringify(twin[field])) continue;
+      fail(
+        `featured "${twin.id}" and its grid card disagree on ${field}: the strip says ` +
+          `${JSON.stringify(featured[field])}, the grid says ${JSON.stringify(twin[field])}. ` +
+          'The grid card is the one registry.json publishes, so it is the one to copy FROM.'
+      );
+    }
+    // Compared case-insensitively on purpose: the grid supplies the display name
+    // the registry row carries ("Core") and the strip its own chip slug ("core").
+    // Same axis, two spellings — and a copy filed under the wrong one is reachable
+    // from a category chip its twin is not.
+    if (featured.category.toLowerCase() !== twin.category.toLowerCase()) {
+      fail(
+        `featured "${twin.id}" declares data-cat="${featured.category}", but its grid card ` +
+          `sits in the ${twin.category} grid`
+      );
+    }
+  }
+}
+if (IS_REAL_RUN) assertFeaturedRepeatsItsGridTwin(skills);
 
 const registry = {
   version: 2,

--- a/landing/scripts/build-registry.test.mjs
+++ b/landing/scripts/build-registry.test.mjs
@@ -801,3 +801,133 @@ test('a held generation lock is refused by name', () => {
     rmSync(lock, { force: true });
   }
 });
+
+// ---- The featured strip repeats grid cards -------------------------------
+// Driven by mutating the real catalog, for the reason the closed-private-set and
+// orphaned-institution tests above are: the fixtures carry extension cards and no
+// skills shelf, so the rule is only reachable on a real run. `--check` writes
+// nothing and exits on the violation drain before any comparison; the page is
+// restored in a `finally` and the restoration asserted afterwards.
+
+const FEATURED_PAGE = join(LANDING, 'baam.html');
+
+/**
+ * `original` with `from` → `to`, applied inside the `#skills-featured` strip ONLY.
+ *
+ * Every field in that strip now equals its grid twin's — that is the whole point
+ * of the rule — so a whole-page `replace` would edit whichever copy came first
+ * and prove nothing about the other. Windowing on the strip is what makes
+ * "mutated the featured card" a true statement rather than a hopeful one.
+ */
+function mutateFeatured(original, from, to) {
+  const start = original.indexOf('id="skills-featured"');
+  const end = original.indexOf('id="core-skill-grid"');
+  assert.ok(start !== -1 && end > start, 'the featured strip and the core grid must both be found');
+  const strip = original.slice(start, end);
+  assert.equal(
+    strip.split(from).length - 1,
+    1,
+    `the mutation anchor must be unique in the strip: ${from}`
+  );
+  const mutated = original.slice(0, start) + strip.replace(from, to) + original.slice(end);
+  assert.notEqual(mutated, original, 'the mutation must actually apply, or this proves nothing');
+  return mutated;
+}
+
+/** Run `--check` over a mutated page, restoring the page whatever happens. */
+function checkWithFeatured(mutate) {
+  const original = readFileSync(FEATURED_PAGE, 'utf8');
+  let r;
+  protectingArtifacts(() => {
+    try {
+      writeFileSync(FEATURED_PAGE, mutate(original));
+      r = run({ args: ['--check'] });
+    } finally {
+      writeFileSync(FEATURED_PAGE, original);
+    }
+  });
+  assert.equal(readFileSync(FEATURED_PAGE, 'utf8'), original, 'the real catalog must be restored');
+  return r;
+}
+
+test('the committed featured strip says exactly what its grid twins say', () => {
+  // The green half: the four mutations below all assert a REFUSAL, and a refusal
+  // means nothing if the unmutated page was already being refused for some
+  // unrelated reason.
+  //
+  // Stated plainly, because it is the kind of assertion that reads stronger than
+  // it is: this test is also green on a tree where the rule does not exist at all
+  // — no rule, no complaint, no "featured" in stderr. It is the four mutations
+  // that prove the rule fires; measured on origin/main, where the rule was
+  // missing, two of them failed on `--check` exiting 0 where 1 was required and
+  // two on the drifted copy no longer carrying the twin's text.
+  const r = run({ args: ['--check'] });
+  assert.equal(r.code, 0, r.both);
+  assert.doesNotMatch(r.stderr, /featured/, r.both);
+});
+
+test('a featured card that reworded its grid twin is refused, naming the field', () => {
+  // The defect this rule was written for: on 2026-09-12 the three copies differed
+  // from their twins in 8 fields, and nothing in this file or in CI could see it,
+  // because only the GRIDS reach registry.json. The strip is the first thing a
+  // visitor reads and the one thing no gate was reading.
+  const r = checkWithFeatured((original) =>
+    mutateFeatured(
+      original,
+      'scRNA-seq clustering, annotation, trajectory, and integration.',
+      'scRNA-seq analysis — QC, clustering, annotation, trajectory, and integration.'
+    )
+  );
+  assert.equal(r.code, 1, `a reworded featured card must be refused\n${r.both}`);
+  assert.match(r.stderr, /featured "single-cell" and its grid card disagree on description/);
+  // The repair is part of the rule: which of the two copies is canonical is the
+  // question a person hitting this has, and "they differ" does not answer it.
+  assert.match(r.stderr, /the one registry\.json publishes, so it is the one to copy FROM/);
+});
+
+test('a featured card whose keywords drifted is refused, not only its prose', () => {
+  // `data-tags` is the half a reader cannot see. It is what the card matches on
+  // in the shelf's own text search, so a strip-only keyword answers queries the
+  // registry row — and therefore the app's catalog and the model-facing search —
+  // does not, for the very same download.
+  const r = checkWithFeatured((original) =>
+    mutateFeatured(
+      original,
+      'data-tags="single-cell scanpy seurat scvi"',
+      'data-tags="single-cell scanpy seurat scvi clustering annotation"'
+    )
+  );
+  assert.equal(r.code, 1, `drifted featured keywords must be refused\n${r.both}`);
+  assert.match(r.stderr, /featured "single-cell" and its grid card disagree on keywords/);
+});
+
+test('a featured card filed under the wrong category chip is refused', () => {
+  // `data-cat` has no twin to compare against on the card itself — a grid card
+  // inherits its category from the grid — so this is the one field the rule has
+  // to reach for deliberately. Wrong, the copy answers a category chip its twin
+  // does not, which is the same skill appearing in two places and missing from one.
+  const r = checkWithFeatured((original) =>
+    mutateFeatured(original, 'data-cat="biomedical"', 'data-cat="core"')
+  );
+  assert.equal(r.code, 1, `a miscategorised featured card must be refused\n${r.both}`);
+  assert.match(
+    r.stderr,
+    /featured "single-cell" declares data-cat="core", but its grid card sits in the Biomedical grid/
+  );
+});
+
+test('a featured card that repeats nothing in the grids is refused by name', () => {
+  // The strip is defined as repeats. A card only there is a download the registry
+  // never publishes: the app's catalog cannot install it and the page's own search
+  // is the only place it exists.
+  const r = checkWithFeatured((original) =>
+    mutateFeatured(
+      original,
+      'skill-single-cell/single-cell.zip',
+      'skill-single-cell/not-a-published-skill.zip'
+    )
+  );
+  assert.equal(r.code, 1, `a featured card with no twin must be refused\n${r.both}`);
+  assert.match(r.stderr, /repeats no grid card/);
+  assert.match(r.stderr, /not-a-published-skill\.zip/);
+});

--- a/ui/desktop/src/components/baam/registry.fallback.json
+++ b/ui/desktop/src/components/baam/registry.fallback.json
@@ -2040,7 +2040,16 @@
         "R",
         "ggplot2"
       ],
-      "keywords": [],
+      "keywords": [
+        "ggplot-visualization",
+        "ggplot2",
+        "r",
+        "plotting",
+        "style",
+        "theme",
+        "palette",
+        "export"
+      ],
       "download": "https://github.com/BaranziniLab/biorouter-skills/releases/download/skill-ggplot-visualization/ggplot-visualization.zip",
       "filename": "ggplot-visualization.zip",
       "license": "Apache-2.0"


### PR DESCRIPTION
The `#skills-featured` strip on the BAAM page repeats three skills that also live in the three skill grids, as hand-written copies. Only the **grids** reach `registry.json`, so the copies could say anything and no gate would notice. They had drifted.

## What I measured on `origin/main` (5a404ecd)

Parsing `landing/baam.html` and matching each featured card to its grid twin by download link: **8 divergent fields across the 3 cards** (129 grid cards = the 129 registry rows; 132 `.skill-card` in the shelf = 129 + 3 repeats).

The worst divergence was not prose. The featured `ggplot2 Visualization` advertised `User-invocable · /ggplot-visualization` — a slash command that does not exist, because that skill's own `SKILL.md` declares `user-invocable: false` and describes itself as style rules applied when writing R plotting code. The shelf derives the invocation-mode facet from that very text (`card._type` is read out of `.skill-type`), so the same skill answered **both** chips depending on which copy you looked at.

Measured in a real browser (playwright, same server the search harness uses), `main` → this branch:

| | before | after |
|---|---|---|
| chip **Auto-applied** → ggplot copies | featured hidden, grid shown | both shown |
| chip **User-invocable** → ggplot copies | featured shown, grid hidden | both hidden |
| query `journal` | reached the **featured** ggplot card | reaches no ggplot card |
| query `theme` | only the **featured** copy | both copies |
| query `export` | only the **featured** copy (+ Stata) | both copies (+ Stata) |

`journal`, `theme` and `export` were words only the hand-written copy carried, so a visitor's query reached a card whose registry row — the thing the desktop catalog and `skills__searchMarketplaceSkills` describe — said something else.

## What changed

**The grid card is canonical.** It is what `registry.json` publishes, and for ggplot it is also what the skill actually is. The three featured copies were re-synced from their twins (`.skill-type`, `.skill-desc`, `.skill-tags`, `data-tags`; ggplot's dead `data-type="user"` corrected to `auto` rather than left as a second copy of the same wrong claim).

**`ggplot-visualization`'s grid card had an EMPTY `data-tags`**, which is why its registry row published `keywords: []` — the row was reachable only by id, name, description and two tags. Filled from the skill's own `SKILL.md` (`theme_minimal`/`theme_classic`, RColorBrewer palettes, `## Export`/`ggsave`), **not** from the drifted card's "publication figures / journal submission" prose, which the skill never claims. That is the only change to `registry.json`; `registry.fallback.json` was regenerated with it, and the compiled-in Rust private set is byte-identical, as skills are not extensions.

**So it cannot drift again**, `build-registry.mjs` grows a real-run rule, `assertFeaturedRepeatsItsGridTwin`, that refuses any featured card whose `name`, `type`, `description`, `tags`, `keywords` or category differ from its twin's — or that repeats no grid card at all. Both sides are read by the same `readSkillCard` (split out of `parseSkillGrid`) so the rule cannot report its own parser skew as drift. `--check` already runs in `frontend.yml` and `deploy-landing.yml`, so it is enforced pre-merge and on deploy.

## Fail-before

With the new rule and `main`'s untouched page, `--check` exits **1** and names all 8:

```
registry: featured "ggplot-visualization" and its grid card disagree on type: the strip says
  "User-invocable · /ggplot-visualization", the grid says "Auto-applied · R plotting". ...
registry: featured "ggplot-visualization" and its grid card disagree on keywords: the strip says
  ["ggplot-visualization","ggplot2","r","visualization","publication","figures","plots"], the grid says []. ...
registry: 8 validation failure(s); nothing written
```

Of the five tests added to `build-registry.test.mjs`, **four fail on `origin/main`** — two because `--check` exits 0 where 1 is required (the rule does not exist: `actual: 0, expected: 1`), two because main's copy no longer carries the text the mutation anchors on. The fifth asserts the committed tree is clean; its comment states plainly that it is also green on a tree with no rule at all, so nobody mistakes it for the gate.

## Gates

- `node landing/scripts/build-registry.mjs --check` clean
- `node landing/scripts/check-consistency.mjs --check` clean
- all four landing suites: build-registry 61/61, check-docs-privacy 21/21, baam-privacy-facet 16/16, baam-search 23/23
- `npm run lint:check` in `ui/desktop` passes end to end

## Deliberately not changed

- **The harness's grid-only selector.** The stale comment in `baam-search.test.mjs` justified the scoping by the drift, so it is updated — but the scoping stays. `#skills-section .skill-card` draws 132 cards against 129 rows, and that test identifies a card by its download link, so three links would collide. Relaxing it needs the repeats folded, not a selector swap.
- **`single-cell`'s grid `data-tags`.** Its featured copy carried two extra keywords (`clustering`, `annotation`), but both words are already in the grid description, which is a searched field — so promoting them would change ranking, not reachability. The copy adopted the grid's list instead.
- **Reformatting `landing/scripts/**`.** Prettier under `ui/desktop/.prettierrc.json` flags all four landing scripts on `main` and no workflow runs it there, so it is not a gate for that directory. My added lines follow the files' existing style and stay under 100 columns.
- **`baam-search.test.mjs` is in no CI workflow.** Noted, not fixed here — wiring it is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)