### PR TITLE
test(agents): the script gate's fixture states its working directory

### DIFF
--- a/crates/biorouter/src/agents/script_call_gate.rs
+++ b/crates/biorouter/src/agents/script_call_gate.rs
@@ -978,6 +978,22 @@ mod tests {
             None,
             mode,
         )));
+        // State the working directory rather than inheriting it. Left unset,
+        // `ExtensionManager::resolve_working_dir` falls back to the PROCESS
+        // working directory, and the developer server it spawns roots its file
+        // jail (and its shell) there — ambient state no test owns
+        // (`docs/testing/process-global-state.md`). `cargo test` happens to set
+        // it to this crate's root, so a script reading a relative path read
+        // this crate's files; the same test binary run any other way — from
+        // `target/debug/deps` at the workspace root, under a debugger, from a
+        // stress harness — read the workspace's instead, and the assertion
+        // about what came back changed under the test. Bound to the fixture's
+        // own scratch directory, every file a script below reads is one this
+        // fixture created.
+        agent
+            .extension_manager
+            .set_working_dir(dir.path().to_path_buf())
+            .await;
         agent
             .add_extension(ExtensionConfig::Builtin {
                 name: "developer".into(),
@@ -1405,15 +1421,22 @@ mod tests {
             .update_user_permission("developer__text_editor", PermissionLevel::AlwaysAllow);
         let marker = f.dir.path().join("never-marker");
         let command = js_string(&format!("touch '{}'", marker.display()));
-        // The developer server's path jail is the process working directory
-        // here, which `cargo test` sets to this crate's root — so the next call
-        // reads a file that is certainly inside it.
+        // A file this test wrote, at an absolute path inside the jail the
+        // fixture bound — NOT a relative `"Cargo.toml"`, which the developer
+        // server resolves against its jail base and so, before the fixture
+        // stated one, against the process working directory: this crate's
+        // manifest under `cargo test` and the WORKSPACE manifest when the same
+        // test binary is run from the workspace root, where the assertion below
+        // then failed on `[workspace]`.
+        let readable = f.dir.path().join("after-the-refusal.txt");
+        std::fs::write(&readable, "AFTER-THE-REFUSAL\n").expect("a file to read back");
+        let readable_path = js_string(&readable.display().to_string());
         let code = format!(
             r#"import {{ shell, text_editor }} from "developer";
                let caught = null;
                try {{ shell({{ command: {command} }}); }}
                catch (e) {{ caught = String(e); }}
-               const after = text_editor({{ command: "view", path: "Cargo.toml" }});
+               const after = text_editor({{ command: "view", path: {readable_path} }});
                record_result({{ caught, after }});"#
         );
         let mut script = run_script(&f, &code, CancellationToken::new()).await;
@@ -1438,7 +1461,7 @@ mod tests {
         assert!(
             result["after"]
                 .as_str()
-                .is_some_and(|text| text.contains("[package]")),
+                .is_some_and(|text| text.contains("AFTER-THE-REFUSAL")),
             "the script's next call must still run: {output}"
         );
         assert!(


### PR DESCRIPTION
## The defect, reproduced on `origin/main` before anything was written

`agents::script_call_gate::tests::always_deny_on_the_inner_tool_refuses_it_and_the_script_continues`
had its embedded script read a **relative** path:

```js
const after = text_editor({ command: "view", path: "Cargo.toml" });
```

The developer server resolves a file path against its jail base, and this
fixture never bound one — so the base fell through
`ExtensionManager::resolve_working_dir` to `std::env::current_dir()`. `cargo
test` happens to set that to the package root, so the script read
`crates/biorouter/Cargo.toml` and the assertion on `[package]` held.

Run the same lib test binary any other way and the cwd is the workspace root.
Measured on a clean worktree of `main` at `5a404ecd`:

```
$ ./target/debug/deps/biorouter-3f7447b259284cd8
test result: FAILED. 4044 passed; 1 failed; 2 ignored; 0 measured

panicked at crates/biorouter/src/agents/script_call_gate.rs:1438:9:
the script's next call must still run: Result: {
  "caught": "Error: Tool error from developer__shell: The user has declined ...",
  "after": "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n\n[workspace.package]\n..."
}
```

The workspace manifest has no literal `[package]` line (`grep -n '\[package\]' Cargo.toml` → no match),
so the test fails on the contents of a directory nobody chose. Same binary,
same code, different cwd.

## The fix

Two changes, in one test file.

1. **The fixture states its working directory.** `fixture_with` calls
   `agent.extension_manager.set_working_dir(dir.path())` before loading the
   `developer` builtin, so the developer server's file jail and shell are
   rooted at the `TempDir` the fixture already owns instead of at whatever
   directory the process happens to be in.
2. **The test reads a file it wrote.** The script views an absolute path to
   `after-the-refusal.txt`, written into that scratch directory by the test,
   and asserts on its contents.

This is the class PR #282 fixed in `routes/session.rs` and
`session/session_manager.rs`. That PR deliberately left this one alone because
the path lives inside a generated script driving the real `text_editor`, so
`include_str!` does not apply. The remedy used here is the one
`docs/testing/process-global-state.md` prescribes: the test names its input
rather than inheriting it.

## What would have to be true for these checks to fail — made true, once each

Both halves are load-bearing, and each was removed to prove it:

| Probe | Result |
|---|---|
| Fixture binding removed, absolute path kept | `FAILED` — `Path '/var/folders/.../after-the-refusal.txt' is outside the working directory` |
| File contents poisoned to `POISONED-CONTENT`, assertion unchanged | `FAILED` — `"after": "POISONED-CONTENT\n"`, so the assertion reads what the script really read |

## After

| Invocation | Before (`main` @ 5a404ecd) | After |
|---|---|---|
| `./target/debug/deps/biorouter-<hash>` from the workspace root | `4044 passed; 1 failed` | **`4045 passed; 0 failed`** |
| the module, binary run from a directory outside the repo | n/a (would be refused either way) | `20 passed; 0 failed` |
| `BIOROUTER_DISABLE_KEYRING=true cargo test -p biorouter --lib` | `4045 passed; 0 failed` | `4045 passed; 0 failed` |

`cargo fmt --check` clean. `./scripts/clippy-lint.sh` → `All baseline clippy checks passed!`

## Deliberately not changed

- No production code. The developer server's cwd fallback is correct for the
  CLI, which genuinely has no session directory; the defect was a test
  inheriting it.
- `env!("CARGO_MANIFEST_DIR")` was the other option the filing suggested. It
  would have fixed *what* the script reads while leaving the jail rooted at the
  ambient cwd, so the test would still fail when run from anywhere that is not
  an ancestor of this crate. Binding the jail removes the dependency instead of
  narrowing it.
- One file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)