### PR TITLE
fix(workflow): a typed parameter default no longer loses the whole list

### DIFF
--- a/crates/biorouter/src/agents/agent.rs
+++ b/crates/biorouter/src/agents/agent.rs
@@ -12316,20 +12316,21 @@ impl Agent {
 
         // A malformed parameter list must not lose the whole workflow: the
         // instructions and activities are the expensive part and are already
-        // parsed. Drop the parameters, say so, keep the rest.
+        // parsed. Nor must ONE malformed parameter lose the list — this used to
+        // be a single `from_value::<Vec<WorkflowParameter>>`, which is
+        // all-or-nothing, and a `number` parameter's natural default
+        // (`"default": 80`) was enough to take every parameter with it. See
+        // `parse_generated_parameters` for what a single bad element costs now.
         let parameters = json_content
             .as_ref()
             .and_then(|json| json.get("parameters"))
-            .and_then(|value| {
-                serde_json::from_value::<Vec<crate::workflow::WorkflowParameter>>(value.clone())
-                    .map_err(|err| {
-                        tracing::warn!(
-                            "Dropping generated workflow parameters that did not parse: {err}"
-                        );
-                    })
-                    .ok()
-            })
-            .filter(|parameters: &Vec<_>| !parameters.is_empty());
+            .map(crate::workflow::parse_generated_parameters)
+            .and_then(|(parameters, notes)| {
+                for note in notes {
+                    tracing::warn!("Generated workflow parameters: {note}");
+                }
+                (!parameters.is_empty()).then_some(parameters)
+            });
 
         let mut workflow_builder = Workflow::builder()
             .title(title)

--- a/crates/biorouter/src/workflow/mod.rs
+++ b/crates/biorouter/src/workflow/mod.rs
@@ -197,16 +197,178 @@ impl fmt::Display for WorkflowParameterInputType {
     }
 }
 
+/// `Null` is "no default"; a string is itself; every other scalar is its JSON
+/// form, which for a number or a boolean is exactly what it looks like (`80`,
+/// `true`).
+fn scalar_as_string(value: Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(string) => Some(string),
+        other => Some(other.to_string()),
+    }
+}
+
+/// Accept a default of any scalar type and store its string form.
+///
+/// `default` is typed `Option<String>` while `input_type` may be `number`,
+/// `boolean` or `date`, so the natural document for a numeric parameter is
+/// `"default": 80`. This struct has two readers and they disagreed about that:
+/// `serde_yaml` hands a plain YAML scalar to a `String` field as its own source
+/// text, so a `.yaml` on disk always worked, while `serde_json` — every
+/// `Workflow` crossing the HTTP API, `workflow_deeplink::decode`, and the
+/// generated JSON `Agent::create_workflow` parses — refused the whole document
+/// with `invalid type: integer `80`, expected a string`.
+///
+/// Nothing downstream needs a `String` for any reason except this field's
+/// declaration: values are substituted into a minijinja template, which renders
+/// every one of them as text whatever the declared type. So the strict reader is
+/// the one that was wrong, and it is brought into line with the lenient one
+/// rather than the other way round.
+///
+/// In the spirit of `deserialize_value_map_as_string` above, and for the same
+/// reason: what a model — or a person — writes for a typed field should not
+/// have to be quoted to be read.
+fn deserialize_scalar_as_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // ⚠ `deserialize_with` on an `Option` field turns a MISSING key into a
+    // "missing field" error unless `#[serde(default)]` sits beside it — see the
+    // attribute below. Every workflow file without a default goes through here.
+    let raw: Option<Value> = Option::deserialize(deserializer)?;
+    Ok(raw.and_then(scalar_as_string))
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct WorkflowParameter {
     pub key: String,
     pub input_type: WorkflowParameterInputType,
     pub requirement: WorkflowParameterRequirement,
     pub description: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_scalar_as_string"
+    )]
     pub default: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Vec<String>>,
+}
+
+/// Parse a generated `parameters` array one element at a time, repairing what
+/// can be repaired.
+///
+/// `serde_json::from_value::<Vec<WorkflowParameter>>` is all-or-nothing: one
+/// element the schema refuses loses EVERY parameter beside it, and the capture
+/// that produced them is then either unparameterised or — because the generated
+/// `prompt` still says `{{ key }}` — refused outright by
+/// `validate_parameters_in_template`.
+///
+/// The two halves of the decision about a single bad element:
+///
+///   * An element that still names a `key` is REPAIRED rather than dropped.
+///     The document may refer to `{{ key }}`, and dropping it alone leaves that
+///     reference dangling — "Missing definitions for parameters in the workflow
+///     file", the exact mirror of the unsavable capture
+///     `service::drop_unreferenced_parameters` exists to prevent. A repaired
+///     parameter nothing refers to costs nothing: that same pruner removes it.
+///   * An element with no readable `key` is dropped. There is nothing a
+///     template could refer to, so there is no reference to leave dangling.
+///
+/// Returns the parameters to keep, and one human-readable note per element that
+/// was repaired or dropped for the caller to log.
+pub fn parse_generated_parameters(value: &Value) -> (Vec<WorkflowParameter>, Vec<String>) {
+    let Some(elements) = value.as_array() else {
+        return (
+            Vec::new(),
+            vec!["dropped `parameters`: it is not an array".to_string()],
+        );
+    };
+
+    let mut kept = Vec::new();
+    let mut notes = Vec::new();
+    for (index, element) in elements.iter().enumerate() {
+        match serde_json::from_value::<WorkflowParameter>(element.clone()) {
+            Ok(parameter) => kept.push(parameter),
+            Err(err) => match repair_generated_parameter(element) {
+                Some(parameter) => {
+                    notes.push(format!("repaired parameter `{}`: {err}", parameter.key));
+                    kept.push(parameter);
+                }
+                None => notes.push(format!("dropped parameter #{index}: {err}")),
+            },
+        }
+    }
+    (kept, notes)
+}
+
+/// Rebuild one refused parameter as the most permissive definition that is
+/// still valid, keeping only what can be read off the raw value.
+///
+/// `None` when there is no usable `key` — the one field a repair cannot invent,
+/// because it is the name the template refers to.
+fn repair_generated_parameter(raw: &Value) -> Option<WorkflowParameter> {
+    let object = raw.as_object()?;
+    let key = object.get("key")?.as_str()?.trim().to_string();
+    if key.is_empty() {
+        return None;
+    }
+
+    // An `input_type` the enum does not have (`integer`, `text`, `enum`, …)
+    // becomes `string`: minijinja renders every value as text anyway, so this
+    // costs the input widget's hint and nothing else.
+    let input_type = object
+        .get("input_type")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or(WorkflowParameterInputType::String);
+
+    let mut default = object.get("default").cloned().and_then(scalar_as_string);
+    // `validate_optional_parameters` refuses a file parameter that carries a
+    // default, to keep a shared workflow from importing somebody else's file. A
+    // repair must not manufacture the one shape the validator rejects.
+    if matches!(input_type, WorkflowParameterInputType::File) {
+        default = None;
+    }
+
+    // An unreadable `requirement` follows the default: `optional` is refused
+    // without one, so a parameter that has no default has to be asked for.
+    let requirement = object
+        .get("requirement")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or(if default.is_some() {
+            WorkflowParameterRequirement::Optional
+        } else {
+            WorkflowParameterRequirement::UserPrompt
+        });
+
+    // Not invented when it is missing: an empty description reads as "nobody
+    // wrote one", which is true, where a synthesised one reads as the model's.
+    let description = object
+        .get("description")
+        .cloned()
+        .and_then(scalar_as_string)
+        .unwrap_or_default();
+
+    let options = object
+        .get("options")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .cloned()
+                .filter_map(scalar_as_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|options| !options.is_empty());
+
+    Some(WorkflowParameter {
+        key,
+        input_type,
+        requirement,
+        description,
+        default,
+        options,
+    })
 }
 
 /// Builder for creating Workflow instances

--- a/crates/biorouter/tests/workflow_capture_parity.rs
+++ b/crates/biorouter/tests/workflow_capture_parity.rs
@@ -519,3 +519,348 @@ parameters:
         "the other half of the pair, unchanged: {message}"
     );
 }
+
+/// A generation whose parameters carry the natural JSON for their own
+/// `input_type`.
+///
+/// `WorkflowParameter.default` is `Option<String>`, but `input_type` may be
+/// `number`, `boolean` or `date` — and a model asked for a number writes
+/// `"default": 80`, not `"default": "80"`. That is not a malformed generation;
+/// it is the only shape a `number` parameter's default can sensibly take.
+const GENERATED_JSON_WITH_TYPED_DEFAULTS: &str = r#"{
+  "title": "Gene association summary",
+  "description": "Looks a gene up and summarises its disease associations.",
+  "instructions": "Query the graph and report the strongest associations first.",
+  "activities": ["Summarise APOE"],
+  "prompt": "Summarise at most {{ max_results }} disease associations for {{ gene_symbol }}, preclinical ones included: {{ include_preclinical }}.",
+  "parameters": [
+    {
+      "key": "gene_symbol",
+      "input_type": "string",
+      "requirement": "user_prompt",
+      "description": "HGNC gene symbol"
+    },
+    {
+      "key": "max_results",
+      "input_type": "number",
+      "requirement": "optional",
+      "description": "How many associations to report",
+      "default": 80
+    },
+    {
+      "key": "include_preclinical",
+      "input_type": "boolean",
+      "requirement": "optional",
+      "description": "Whether to include preclinical associations",
+      "default": true
+    }
+  ],
+  "skills": []
+}"#;
+
+/// A `number` or `boolean` default must not take the whole parameter list down.
+///
+/// `Agent::create_workflow` deserialized `parameters` with a single
+/// `serde_json::from_value::<Vec<WorkflowParameter>>`, which is all-or-nothing:
+/// the first scalar the `Option<String>` field refused lost EVERY parameter,
+/// including the well-formed ones beside it. Measured live on 2026-09-12 the
+/// daemon logged `invalid type: integer 80, expected a string` and saved a
+/// workflow with no parameters at all — and, because the prompt still said
+/// `{{ gene_symbol }}`, one that `POST /workflows/save` then refused.
+///
+/// Values render into the minijinja template as strings whatever their declared
+/// type, so a scalar default is accepted and stored in its string form.
+#[tokio::test]
+async fn a_number_or_boolean_default_survives_instead_of_losing_every_parameter() {
+    let h = harness_generating(GENERATED_JSON_WITH_TYPED_DEFAULTS).await;
+    let session = h
+        .agent
+        .config
+        .session_manager
+        .get_session(&h.session_id, true)
+        .await
+        .unwrap();
+
+    let workflow = h
+        .agent
+        .create_workflow(session.conversation.clone().unwrap())
+        .await
+        .expect("the capture");
+
+    let parameters = workflow.parameters.clone().unwrap_or_default();
+    let keys: Vec<&str> = parameters.iter().map(|p| p.key.as_str()).collect();
+    assert_eq!(
+        keys,
+        vec!["gene_symbol", "max_results", "include_preclinical"],
+        "one typed default must not drop the parameters beside it"
+    );
+
+    let default_of = |key: &str| {
+        parameters
+            .iter()
+            .find(|p| p.key == key)
+            .unwrap_or_else(|| panic!("{key} survives"))
+            .default
+            .clone()
+    };
+    assert_eq!(
+        default_of("max_results"),
+        Some("80".to_string()),
+        "a numeric default is kept in its string form, not discarded"
+    );
+    assert_eq!(
+        default_of("include_preclinical"),
+        Some("true".to_string()),
+        "a boolean default is kept in its string form, not discarded"
+    );
+
+    // And the capture is SAVABLE. Losing the list is not merely lossy: the
+    // prompt still refers to all three keys, so a parameterless document is
+    // refused by the same validator `POST /workflows/save` runs.
+    service::validate(&workflow).unwrap_or_else(|err| {
+        panic!(
+            "a workflow captured from a chat must save: {err}\n\n{}",
+            workflow.to_yaml().unwrap_or_default()
+        )
+    });
+}
+
+/// A generation with exactly one parameter the schema cannot accept.
+///
+/// `integer` is not a `WorkflowParameterInputType` (the enum has `number`), and
+/// the third entry has no `key` at all.
+const GENERATED_JSON_WITH_ONE_UNPARSABLE_PARAMETER: &str = r#"{
+  "title": "Gene association summary",
+  "description": "Looks a gene up and summarises its disease associations.",
+  "instructions": "Query the graph and report the strongest associations first.",
+  "activities": ["Summarise APOE"],
+  "prompt": "Summarise the disease associations for {{ gene_symbol }} scoring above {{ score_cutoff }}.",
+  "parameters": [
+    {
+      "key": "gene_symbol",
+      "input_type": "string",
+      "requirement": "user_prompt",
+      "description": "HGNC gene symbol"
+    },
+    {
+      "key": "score_cutoff",
+      "input_type": "integer",
+      "requirement": "optional",
+      "description": "Minimum association score",
+      "default": 0.5
+    },
+    {
+      "input_type": "string",
+      "requirement": "user_prompt",
+      "description": "no key at all, so nothing in the document can refer to it"
+    }
+  ],
+  "skills": []
+}"#;
+
+/// One parameter the schema refuses must cost one parameter, not all of them.
+///
+/// The two halves of the decision, which is the whole point of parsing the
+/// array element by element:
+///
+///   * An element that still names a `key` is REPAIRED, not dropped, to the
+///     most permissive definition that is still valid — because the document
+///     may refer to `{{ key }}`, and dropping it alone would leave that
+///     reference dangling and trip `validate_parameters_in_template`'s "Missing
+///     definitions for parameters in the workflow file" arm. That is the exact
+///     mirror of the unsavable-capture bug `drop_unreferenced_parameters` was
+///     added for, and it would be a strictly worse outcome than today's.
+///     A repaired parameter nothing refers to costs nothing: the existing
+///     `drop_unreferenced_parameters` at the end of `create_workflow` prunes it.
+///   * An element with no readable `key` is dropped outright — there is nothing
+///     a template could refer to, so there is no reference to leave dangling.
+#[tokio::test]
+async fn one_unparsable_parameter_costs_one_parameter_and_not_the_list() {
+    let h = harness_generating(GENERATED_JSON_WITH_ONE_UNPARSABLE_PARAMETER).await;
+    let session = h
+        .agent
+        .config
+        .session_manager
+        .get_session(&h.session_id, true)
+        .await
+        .unwrap();
+
+    let workflow = h
+        .agent
+        .create_workflow(session.conversation.clone().unwrap())
+        .await
+        .expect("the capture");
+
+    let parameters = workflow.parameters.clone().unwrap_or_default();
+    let keys: Vec<&str> = parameters.iter().map(|p| p.key.as_str()).collect();
+    assert_eq!(
+        keys,
+        vec!["gene_symbol", "score_cutoff"],
+        "the well-formed parameter beside the bad one survives, the keyless \
+         entry does not"
+    );
+
+    let repaired = parameters
+        .iter()
+        .find(|p| p.key == "score_cutoff")
+        .expect("the referenced parameter is repaired rather than dropped");
+    assert_eq!(
+        repaired.input_type.to_string(),
+        "string",
+        "an `input_type` the enum does not have degrades to `string`, which is \
+         what minijinja renders every value as anyway"
+    );
+    assert_eq!(
+        repaired.default,
+        Some("0.5".to_string()),
+        "its default is kept in string form"
+    );
+
+    service::validate(&workflow).unwrap_or_else(|err| {
+        panic!(
+            "a workflow captured from a chat must save: {err}\n\n{}",
+            workflow.to_yaml().unwrap_or_default()
+        )
+    });
+}
+
+/// The same typed default, arriving as JSON rather than as a generation.
+///
+/// `Agent::create_workflow` is not the only strict reader of `default`: every
+/// `Workflow` that crosses the HTTP API is `serde_json`-deserialized — the
+/// `Json<…>` body of `POST /workflows/save`, `/workflows/encode` and
+/// `/workflows/scan` — and `workflow_deeplink::decode` is a
+/// `serde_json::from_str::<Workflow>` over the base64 in a pasted
+/// `biorouter://workflow?config=…` link. `"default": 80` failed all of them,
+/// and failed the whole DOCUMENT rather than one parameter.
+///
+/// So the fix belongs on the field and not only in the generator's element-wise
+/// parse: repairing a refused element at capture time would leave every other
+/// reader of the very same document still refusing it.
+///
+/// ⚠ This test is what makes the field's `deserialize_with` load-bearing.
+/// `parse_generated_parameters` repairs a refused element by itself, so the two
+/// capture tests above pass with the field left exactly as it was — measured by
+/// deleting the attribute and re-running the binary: 7 passed, and this was the
+/// only failure, `invalid type: integer `80`, expected a string`, which is
+/// word for word what the live daemon logged on 2026-09-12.
+///
+/// The YAML half is deliberately asserted too, and deliberately NOT claimed as
+/// a fix: `serde_yaml` hands a plain scalar to a `String` field as its own
+/// source text, so `default: 80` in a `.yaml` always worked. That asymmetry
+/// between the two readers of one struct is the thing worth pinning.
+#[test]
+fn a_typed_default_is_read_from_json_as_well_as_yaml() {
+    const JSON: &str = r#"{
+  "version": "1.0.0",
+  "title": "Association report",
+  "description": "Reports associations.",
+  "instructions": "Report at most {{ max_results }} associations, preclinical included: {{ include_preclinical }}.",
+  "parameters": [
+    {
+      "key": "max_results",
+      "input_type": "number",
+      "requirement": "optional",
+      "description": "How many associations to report",
+      "default": 80
+    },
+    {
+      "key": "include_preclinical",
+      "input_type": "boolean",
+      "requirement": "optional",
+      "description": "Whether to include preclinical associations",
+      "default": true
+    }
+  ]
+}"#;
+
+    let defaults = |workflow: &biorouter::workflow::Workflow| -> Vec<Option<String>> {
+        workflow
+            .parameters
+            .iter()
+            .flatten()
+            .map(|parameter| parameter.default.clone())
+            .collect()
+    };
+
+    // What `POST /workflows/save` and a pasted deeplink both run.
+    let from_json = serde_json::from_str::<biorouter::workflow::Workflow>(JSON)
+        .expect("a number or a boolean default is a default, not a type error");
+    assert_eq!(
+        defaults(&from_json),
+        vec![Some("80".to_string()), Some("true".to_string())],
+        "a typed default is read and kept in the string form the template \
+         renders it as"
+    );
+    service::validate(&from_json).expect("and the document is savable");
+
+    // A deeplink is that same JSON round-tripped, so the fix has to survive
+    // being re-serialized: the string form is what goes back out.
+    let link = biorouter::workflow_deeplink::encode(&from_json).expect("encode");
+    let round_tripped = biorouter::workflow_deeplink::decode(&link).expect("decode");
+    assert_eq!(defaults(&round_tripped), defaults(&from_json));
+
+    // And the YAML reader, which never had the defect, still agrees.
+    const YAML: &str = r#"
+version: 1.0.0
+title: Association report
+description: Reports associations.
+instructions: >-
+  Report at most {{ max_results }} associations, preclinical included:
+  {{ include_preclinical }}.
+parameters:
+  - key: max_results
+    input_type: number
+    requirement: optional
+    description: How many associations to report
+    default: 80
+  - key: include_preclinical
+    input_type: boolean
+    requirement: optional
+    description: Whether to include preclinical associations
+    default: true
+"#;
+    let from_yaml = biorouter::workflow::Workflow::from_content(YAML).expect("the YAML reader");
+    assert_eq!(
+        defaults(&from_yaml),
+        defaults(&from_json),
+        "the two readers of one struct must agree about a typed default"
+    );
+}
+
+/// A parameter with no `default` at all still parses.
+///
+/// ⚠ The guard for the trap in the fix above: `deserialize_with` on an `Option`
+/// field makes a MISSING key a hard error unless `#[serde(default)]` sits
+/// beside it — which would break every workflow document in existence, none of
+/// which is required to declare a default. Removing that one attribute and
+/// re-running the binary was measured: 5 of the 8 tests here fail, this one
+/// with `Failed to parse workflow: parameters[0]: missing field `default` at
+/// line 7 column 5`.
+#[test]
+fn a_parameter_without_a_default_still_parses() {
+    let content = r#"
+version: 1.0.0
+title: Association report
+description: Reports associations.
+instructions: Report the associations for {{ gene_symbol }}.
+parameters:
+  - key: gene_symbol
+    input_type: string
+    requirement: user_prompt
+    description: HGNC gene symbol
+"#;
+
+    let workflow = biorouter::workflow::Workflow::from_content(content)
+        .expect("a parameter is not required to declare a default");
+    assert_eq!(
+        workflow
+            .parameters
+            .iter()
+            .flatten()
+            .map(|parameter| parameter.default.clone())
+            .collect::<Vec<_>>(),
+        vec![None],
+        "an absent default reads as absent, not as an error"
+    );
+}


### PR DESCRIPTION
## The defect, re-measured on `origin/main` (5a404ecd)

`WorkflowParameter.default` is `Option<String>` while `input_type` may be `number`, `boolean` or `date`, so a model asked for a numeric parameter writes the only sensible thing: `"default": 80`.

Capturing a chat whose generation carries `"default": 80` and `"default": true`, on pristine `origin/main`:

```
SCRATCH parameters = None
SCRATCH validate   = Err("Missing definitions for parameters in the workflow file: gene_symbol, include_preclinical, max_results.")
```

All three parameters were lost — not just the one with the typed default — and the document that resulted was then **refused by the same validator `POST /workflows/save` runs**, because the generated `prompt` still said `{{ gene_symbol }}`. Both fail-before tests failed with `left: []`.

## Two faults, two fixes

**1. The field.** This struct has two readers and they disagreed. `serde_yaml` hands a plain scalar to a `String` field as its own source text, so a `.yaml` on disk always worked. `serde_json` refused with `` invalid type: integer `80`, expected a string `` — and serde_json is what reads every `Workflow` crossing the HTTP API (`POST /workflows/save`, `/encode`, `/scan`), what `workflow_deeplink::decode` runs over a pasted share link, and what `Agent::create_workflow` runs over the generation. `default` now accepts any scalar and keeps its string form, which is what minijinja renders it as regardless of the declared type. The strict reader was the wrong one.

**2. The array.** `Agent::create_workflow` used a single all-or-nothing `from_value::<Vec<WorkflowParameter>>`, so the first refused element lost every well-formed parameter beside it. It now parses element by element.

## The trap the suggestion flagged, decided deliberately

A dropped-but-referenced parameter leaves `{{ key }}` dangling and trips `validate_parameters_in_template`'s "Missing definitions for parameters in the workflow file" — the exact mirror of the unsavable capture `drop_unreferenced_parameters` was added to prevent, and strictly worse than today's behaviour. So:

- An element that still names a `key` is **repaired**, not dropped: to the most permissive definition that is still valid (`input_type` the enum lacks → `string`; unreadable `requirement` → `optional` if it has a default, else `user_prompt`; a `file` parameter's default is stripped, since `validate_optional_parameters` refuses that pairing). A repaired parameter nothing refers to costs nothing — the existing `drop_unreferenced_parameters` at the end of `create_workflow` prunes it.
- An element with **no readable `key`** is dropped. Nothing in a template could refer to it, so there is no reference to leave dangling.

## After

All three parameters survive, `80` and `true` keep their string form, and `service::validate` accepts the document. 8 passed, 0 failed in `workflow_capture_parity`.

## Each half pinned against its own removal — measured once, each

| experiment | result |
|---|---|
| delete the field's `deserialize_with` | the two capture tests stay **green** (the element-wise repair covers them alone); only `a_typed_default_is_read_from_json_as_well_as_yaml` fails, with `` invalid type: integer `80`, expected a string `` — word for word what the live daemon logged |
| delete the `#[serde(default)]` beside it | **5 of 8** fail with ``missing field `default` `` — i.e. every document that declares no default, which is most of them |

The second is the real trap in this fix: `deserialize_with` on an `Option` field makes a *missing* key a hard error without `#[serde(default)]`.

One claim of my own was falsified along the way and the test rewritten because of it: I first wrote the field-level test against YAML, and it passed with the fix removed — `serde_yaml` never had the defect. The test reads JSON (and round-trips a deeplink) precisely because that is the reader that was strict.

## Gates

`cargo fmt --check`; `./scripts/clippy-lint.sh`; `cargo test -p biorouter --lib` (4045 passed); `-p biorouter-server --lib` (667 passed); the `workflow_capture_parity` (8), `self_test_workflow_isolation` (4), `privacy_capability` (4) and `subagent_tool_tests` (4) binaries. `cargo run -p biorouter-server --bin generate_schema` leaves `ui/desktop/openapi.json` byte-identical, so the generated TypeScript client does not move.

## Deliberately not changed

- **`requirement: optional` with no `default` is still refused**, including on a strictly-parsed parameter. It is a pre-existing validator rule that applies equally to documents this PR never touches; silently rewriting it only in the repair path would make two identical-looking parameters behave differently.
- **`WorkflowParameter.default` stays `Option<String>`.** Widening it to a typed value would move the OpenAPI schema and the generated TS client, and every consumer stringifies it anyway.
- Three files touched, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)