### PR TITLE
test(cli): sandbox the biorouter-cli test binaries' config root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1132,20 +1132,28 @@ deleted, not kept in step.
 
 Tests: `cargo test -p biorouter --lib -- skill`,
 `cargo test -p biorouter-server --lib -- routes::skills`,
-`cargo test -p biorouter-cli --lib` (**needs an isolated `HOME` — and both `CARGO_HOME`
-and `RUSTUP_HOME` kept pointing at the real ones, as LITERAL paths**: cargo and rustup
-both derive their homes from `$HOME`, so a bare `HOME=$(mktemp -d) cargo test …` loses
-the crate registry and dies with `error[E0463]: can't find crate for \`biorouter\``. That
+`cargo test -p biorouter-cli --lib` (**the isolated `HOME` is no longer needed** — run it
+plain. `crates/biorouter-cli/src/test_sandbox.rs` points `BIOROUTER_PATH_ROOT` at a
+throwaway dir in a `#[ctor]`, before `main`, and freezes `Config::global()` and the session
+store's root there, so the DEFAULT invocation — what a developer types, and what an
+editor's test runner emits — reaches nothing real. Measured on this machine: a plain
+`cargo test -p biorouter-cli` is 503 passed in 35s with `~/.config/biorouter` and
+`~/.local/share/biorouter` byte-for-byte unchanged, where the same command on `main` at
+5a404ecd wrote `<HOME>/.config/biorouter/config.yaml`.
+
+⚠ If you prefix ANY cargo command with `HOME=$(mktemp -d)` for some other reason, keep both
+`CARGO_HOME` and `RUSTUP_HOME` pointing at the real ones as LITERAL paths. Cargo and rustup
+both derive their homes from `$HOME`, so a bare `HOME=$(mktemp -d) cargo test …` loses the
+crate registry and dies with `error[E0463]: can't find crate for \`biorouter\``. That
 surfaces as **rc=101 with zero failing tests**, which reads as a flake rather than as
 nothing having compiled — and a harness that greps for `test result:` reports the
-PREVIOUS build's count.
-
-⚠ **Do not write `CARGO_HOME="$HOME/.cargo"` in the same command.** This line said exactly
-that until 2026-09-01 and it is wrong in zsh: the assignments are applied left to right,
-so `$HOME` expands to the **new temp dir**, not the real one. The failure is not an error
-— it silently redirects `RUSTUP_HOME` as well, so cargo re-downloads the whole toolchain
-and every target recompiles from scratch (measured: `installing component 'rustc'` mid-run,
-and 11m38s for a single crate that normally takes seconds). Use literals:
+PREVIOUS build's count. And **do not write `CARGO_HOME="$HOME/.cargo"` in the same
+command**: this line said exactly that until 2026-09-01 and it is wrong in zsh, because the
+assignments are applied left to right, so `$HOME` expands to the **new temp dir**, not the
+real one. The failure is not an error — it silently redirects `RUSTUP_HOME` as well, so
+cargo re-downloads the whole toolchain and every target recompiles from scratch (measured:
+`installing component 'rustc'` mid-run, and 11m38s for a single crate that normally takes
+seconds). Use literals:
 
 ```bash
 HOME=$(mktemp -d) CARGO_HOME=/Users/wgu/.cargo RUSTUP_HOME=/Users/wgu/.rustup cargo test -p biorouter-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "cliclack",
  "console 0.16.2",
  "crossterm",
+ "ctor",
  "dotenvy",
  "dunce",
  "env-lock",

--- a/crates/biorouter-cli/Cargo.toml
+++ b/crates/biorouter-cli/Cargo.toml
@@ -92,6 +92,10 @@ jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 
 [dev-dependencies]
 tempfile = "3"
+# `src/test_sandbox.rs` runs before `main`, which is the only placement that can
+# win the race against the one-shot cells (`GLOBAL_CONFIG`, `SHARED_STORE_ROOT`)
+# a test would otherwise pin at the developer's real config and session store.
+ctor = "0.2"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 test-case = "3.3"
 tokio = { workspace = true }

--- a/crates/biorouter-cli/src/commands/session.rs
+++ b/crates/biorouter-cli/src/commands/session.rs
@@ -1427,11 +1427,16 @@ mod tests {
     /// routes, with the same reasoning.
     ///
     /// A source scan because `handle_session_export` is bound to the
-    /// `SessionManager::instance()` singleton — it opens the developer's REAL
-    /// session database — so it cannot be driven from a unit test at all. What
-    /// *is* driven for real is the decision itself, over in
-    /// `session_manager.rs`'s `export_gate` module; this holds the wiring and
-    /// the order, which that module cannot see.
+    /// `SessionManager::instance()` singleton — one process-wide store that a
+    /// unit test cannot point at a fixture of its own — so it cannot be driven
+    /// from a unit test at all. (Until `src/test_sandbox.rs` that singleton
+    /// opened the developer's REAL session database, which is why this comment
+    /// stood while the sweep corrected 24 stale copies of the claim elsewhere.
+    /// The `#[ctor]` now pins it inside a throwaway root: that changes *where*
+    /// it writes, not that it is a singleton, so the reason this is a source
+    /// scan is unchanged.) What *is* driven for real is the decision itself,
+    /// over in `session_manager.rs`'s `export_gate` module; this holds the
+    /// wiring and the order, which that module cannot see.
     #[test]
     fn the_export_gate_is_called_before_the_transcript_is_read() {
         let src = include_str!("session.rs");

--- a/crates/biorouter-cli/src/lib.rs
+++ b/crates/biorouter-cli/src/lib.rs
@@ -5,6 +5,13 @@ pub mod project_tracker;
 pub mod scenario_tests;
 pub mod session;
 pub mod signal;
+// Redirects this test binary's config/data root at a throwaway directory
+// before `main`. `#[cfg(test)]`, so it is compiled out of the shipped
+// `biorouter` binary and out of every integration binary — each `tests/*.rs`
+// declares its own copy, and `tests/cli_test_binaries_are_sandboxed.rs` is what
+// notices when one does not.
+#[cfg(test)]
+mod test_sandbox;
 pub mod workflows;
 
 // Re-export commonly used types

--- a/crates/biorouter-cli/src/test_sandbox.rs
+++ b/crates/biorouter-cli/src/test_sandbox.rs
@@ -1,0 +1,216 @@
+//! Points this test binary's Biorouter config/data/state dirs at a throwaway
+//! directory before the first line of test code runs, and freezes the
+//! process-global cells there so no later test can move them.
+//!
+//! `crates/biorouter` and `crates/biorouter-server` have had this since issue
+//! #54 and BR-71 respectively. This crate was the last one without it, and it is
+//! the crate with the most exposure: 27 `SessionManager::instance()` sites
+//! (`commands/session.rs` 9, `cli.rs` 7, `commands/term.rs` 4,
+//! `commands/schedule.rs` 3, `commands/knowledge.rs` 2, `commands/usage.rs` and
+//! `commands/session_watch.rs` 1 each) and 42 `Config::global()` sites, all of
+//! which resolved against the developer's real root. Measured on `main`
+//! (5a404ecd) by running the two guard tests below with the ctor absent:
+//!
+//! ```text
+//! the_config_file_is_not_the_developers:
+//!     expected the per-process sandbox, got /Users/…/.config/biorouter/config.yaml
+//! the_session_store_is_pinned_inside_the_sandbox:
+//!     the process session store is pinned at /Users/…/.local/share/biorouter
+//! ```
+//!
+//! That is not a theoretical reach. A plain `cargo test -p biorouter-cli --lib`
+//! run against an empty `HOME` (475 passed, `main`) left one file behind:
+//! `<HOME>/.config/biorouter/config.yaml`. On a real machine that same write
+//! targets the developer's live config, and every `set_param` a test reaches
+//! lands in it. `commands/session.rs` says so in its own words — "it opens the
+//! developer's REAL session database" — which is why that comment survived the
+//! sweep that corrected 24 stale copies of it elsewhere.
+//!
+//! Documenting a workaround is not a fix. `CLAUDE.md` tells contributors to run
+//! this crate's tests under `HOME=$(mktemp -d)`, but the damage happens on the
+//! DEFAULT invocation — what a developer types, and what an editor's test runner
+//! emits, neither of which reads CLAUDE.md.
+//!
+//! An externally supplied `BIOROUTER_PATH_ROOT` still wins, so a harness that
+//! already sandboxes the process keeps its own root. `tests/non_interactive.rs`,
+//! `tests/serve_lifecycle.rs` and `tests/apps_serve_lifecycle.rs` pass their own
+//! root to each child `Command`, which overrides the inherited one either way.
+//!
+//! ## Setting the variable is not enough — the cells have to be PINNED
+//!
+//! `BIOROUTER_PATH_ROOT` is process-global, and seven files here legitimately
+//! relocate it under a `TempDir` of their own with `env_lock::lock_env`
+//! (`cli.rs`, `logging.rs`, `commands/{serve,knowledge,skill,schedule,
+//! extension}.rs`). `SHARED_STORE_ROOT` and `GLOBAL_CONFIG` are one-shot cells
+//! that resolve their path the first time anything touches them, and the tests
+//! run in parallel — so whichever test gets there first decides for the whole
+//! binary, and that test may be one holding such a lock. Its `TempDir` then
+//! drops, the directory is unlinked, and the cell points at a path that no
+//! longer exists.
+//!
+//! For the session store that is the Windows CI flake PR #282 fixed in the other
+//! two crates, and its symptom looks nothing like its cause: the connection the
+//! pool already opened keeps answering, because SQLite on POSIX does not care
+//! that its inode lost its name, so serial queries still succeed. It is the
+//! first moment two tasks want the pool at once, forcing a **second**
+//! connection, that fails with `(code: 14) unable to open database file` — in
+//! whatever test happened to query next.
+//!
+//! So the ctor freezes both cells here, at a root this module owns. Each costs
+//! one environment read and some path arithmetic — `SessionManager::
+//! shared_store_root()` resolves a `PathBuf`, and `Config::default()` joins two
+//! paths and builds mutexes. No pool, no disk, no async runtime, which is what
+//! makes them safe to run before `main`.
+//!
+//! ⚠ Pinning `Config::global()` also freezes its secret backend, because
+//! `Config::default()` reads `BIOROUTER_DISABLE_KEYRING` at that moment. That
+//! choice was already frozen by whichever of the 42 call sites ran first, so
+//! this makes an existing coin-flip deterministic rather than introducing one —
+//! and it constructs no keyring, it only records the service name, so nothing
+//! here touches the OS keychain. Every documented invocation of this suite sets
+//! `BIOROUTER_DISABLE_KEYRING=true`, including `rust.yml`.
+
+/// This binary's sandbox root, recorded before any test could move it.
+///
+/// ⚠ **`std::env::var("BIOROUTER_PATH_ROOT")` is NOT a way to ask what the
+/// sandbox root is, at any point after `main` starts.** The seven files listed
+/// above point that variable at a `TempDir` of their own and put it back, so a
+/// read taken at test time answers "whichever test is relocating it at this
+/// instant" — a different directory on every run, deleted moments later. This
+/// cell is the only stable answer, and that is why it exists rather than the
+/// assertions re-deriving the root themselves.
+static SANDBOX_ROOT: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+/// Run before `main`, because the placement is the whole point: a guard
+/// installed inside whichever test module "owns" the hazard fixes nothing
+/// whenever another test got to the singleton first.
+#[ctor::ctor]
+fn sandbox_config_root_for_this_test_binary() {
+    if std::env::var_os("BIOROUTER_PATH_ROOT").is_none_or(|v| v.is_empty()) {
+        let root = tempfile::TempDir::new().expect("scratch config root for the cli test binary");
+        std::env::set_var("BIOROUTER_PATH_ROOT", root.path());
+        // Leaked deliberately: a `static` is never dropped, which is exactly the
+        // lifetime the sandbox needs — it must outlive the last test in the
+        // binary, including anything a `#[dtor]` elsewhere runs.
+        static ROOT: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+        let _ = ROOT.set(root);
+    }
+    // Both branches, and after the set: an outer root is recorded as-is, and one
+    // we minted is recorded as the value we just installed.
+    if let Some(root) = std::env::var_os("BIOROUTER_PATH_ROOT") {
+        record_sandbox_root(&root);
+    }
+    // Freeze both process-global cells at whatever root is now in force, before
+    // any test can relocate the variable under a `TempDir` it later unlinks.
+    // Unconditional: an externally supplied root needs the same protection.
+    let _ = biorouter::session::session_manager::SessionManager::shared_store_root();
+    let _ = biorouter::config::Config::global();
+}
+
+fn record_sandbox_root(root: &std::ffi::OsStr) {
+    // A root that is not valid UTF-8 is left unrecorded rather than recorded
+    // lossily — a mangled root would name a *different* directory, and
+    // `sandbox_path_root` saying so beats an assertion quietly comparing against
+    // the wrong path.
+    if let Some(root) = root.to_str() {
+        let _ = SANDBOX_ROOT.set(root.to_owned());
+    }
+}
+
+/// The config/data root every test in this binary resolves under, unless a test
+/// is deliberately relocating it.
+#[cfg(test)]
+fn sandbox_path_root() -> &'static str {
+    SANDBOX_ROOT
+        .get()
+        .expect(
+            "the sandbox root was recorded before main; an absent value means either the ctor \
+             did not run or BIOROUTER_PATH_ROOT is not valid UTF-8 and cannot be recorded",
+        )
+        .as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use biorouter::config::Config;
+    use biorouter::session::session_manager::SessionManager;
+
+    /// Nothing in this binary may resolve to the developer's live configuration.
+    ///
+    /// Asserting on `Config::global()` rather than on `Paths::config_dir()` is
+    /// what makes this meaningful, and the distinction is not pedantic:
+    /// `Paths::config_dir()` re-reads `BIOROUTER_PATH_ROOT` on every call, so it
+    /// would answer "sandboxed" even in a binary where something had already
+    /// frozen `GLOBAL_CONFIG` at the developer's real `config.yaml`.
+    /// `Config::global().path()` is the file a write actually follows.
+    ///
+    /// It fails if a future edit drops the pin from the ctor and a relocating
+    /// test wins the race to `GLOBAL_CONFIG`.
+    #[test]
+    fn the_config_file_is_not_the_developers() {
+        // The recorded root, not `std::env::var` — a read taken here answers
+        // "whichever test is relocating the variable right now", and this
+        // assertion would then blame the sandbox for a sibling's `TempDir`.
+        let root = super::sandbox_path_root();
+        let path = Config::global().path();
+        assert!(
+            path.starts_with(root),
+            "Config::global() resolved to {path}, outside the sandbox at {root}. \
+             Something reached Config::global() before the sandbox was installed, so \
+             config writes from this binary land in the developer's real config."
+        );
+    }
+
+    /// Both assertions above compare two values the ctor derived from the same
+    /// root, so they answer "is the process consistent with itself" and would
+    /// stay green if the ctor had recorded the developer's real root without
+    /// installing a sandbox at all. This is the one that notices that, and it is
+    /// the only check here that names an outside reference point.
+    ///
+    /// ⚠ The home directory is read under **both** names. `HOME` is POSIX;
+    /// Windows calls it `USERPROFILE` and does not define `HOME` outside a Git
+    /// Bash session. Falling back to an empty string keeps the assertion
+    /// meaningful when neither is set, because `starts_with("")` is true for
+    /// every path — a missing home makes this check STRICTER, not vacuous.
+    ///
+    /// ⚠ The `temp_dir()` arm is not a loophole, it is Windows. `TempDir` lands
+    /// under `%LOCALAPPDATA%\Temp`, which IS inside `USERPROFILE`, so a bare
+    /// "outside the home directory" rule is red on every Windows runner while
+    /// the sandbox is working perfectly.
+    #[test]
+    fn the_sandbox_root_is_not_the_developers_home() {
+        let root = std::path::Path::new(super::sandbox_path_root());
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_default();
+        assert!(
+            !root.starts_with(&home) || root.starts_with(std::env::temp_dir()),
+            "the sandbox root is {}, inside the developer's home at {home} and outside \
+             the temp dir. The ctor recorded a root it did not create, so every \
+             assertion in this module is comparing the real config against itself.",
+            root.display()
+        );
+    }
+
+    /// The same claim for the session database, and the stricter of the two.
+    ///
+    /// ⚠ Assert the **pinned** value, never `Paths::data_dir()`. That function
+    /// re-reads the environment on every call and would pass while the store was
+    /// pinned somewhere else entirely — the exact hole this module exists to
+    /// close. `shared_store_root()` is the directory a query follows, frozen for
+    /// the life of the process.
+    #[test]
+    fn the_session_store_is_pinned_inside_the_sandbox() {
+        let root = super::sandbox_path_root();
+        let pinned = SessionManager::shared_store_root();
+        assert!(
+            pinned.starts_with(root),
+            "the process session store is pinned at {}, outside the sandbox at {root}. \
+             Something resolved it before the ctor did, so a test that relocates \
+             BIOROUTER_PATH_ROOT can move this binary's sessions.db into a TempDir \
+             it then deletes — and the failure surfaces as (code: 14) in whatever \
+             test queried next.",
+            pinned.display()
+        );
+    }
+}

--- a/crates/biorouter-cli/tests/apps_serve_lifecycle.rs
+++ b/crates/biorouter-cli/tests/apps_serve_lifecycle.rs
@@ -25,6 +25,14 @@
 //! no SIGTERM to send on Windows.
 #![cfg(unix)]
 
+// Each `tests/*.rs` is its own crate, so the lib's `#[cfg(test)] mod
+// test_sandbox;` is not compiled into this binary. Declare its own copy, so
+// anything here that reaches a process-global cell resolves under a throwaway
+// root rather than the developer's real config and session store. The children
+// this file spawns pass their own `BIOROUTER_PATH_ROOT`, which still wins.
+#[path = "../src/test_sandbox.rs"]
+mod test_sandbox;
+
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;

--- a/crates/biorouter-cli/tests/cli_test_binaries_are_sandboxed.rs
+++ b/crates/biorouter-cli/tests/cli_test_binaries_are_sandboxed.rs
@@ -1,0 +1,74 @@
+//! The guard behind the per-binary test sandbox.
+//!
+//! `src/test_sandbox.rs` redirects this crate's config/data dirs at a throwaway
+//! root before `main`, so a test can never open the developer's real
+//! `config.yaml` or `sessions.db`. The lib declares it `#[cfg(test)]`, which
+//! means it is **not** compiled into integration test binaries — each
+//! `tests/*.rs` is its own crate and must declare its own copy.
+//!
+//! That makes the protection opt-in, and opt-in protection is only as good as
+//! the thing that notices when someone forgets. In `biorouter-server` nothing
+//! did: one branch enumerated the integration files that existed when it was
+//! written, another added a tenth afterwards, and the merge produced a binary
+//! with no sandbox. Neither branch was wrong on its own — the seam between them
+//! was. So the rule is enforced here rather than remembered, before this crate
+//! has the chance to repeat it.
+//!
+//! ⚠ The name is `cli_test_binaries_are_sandboxed`, not the `biorouter-server`
+//! sibling's `every_test_binary_is_sandboxed`, because `rust.yml`'s "integration
+//! binaries" step selects targets with `--test <name>`, which matches across the
+//! whole workspace. It refuses to run at all when two packages share an
+//! integration target name (`::error::two packages have an integration target
+//! named: …`), so the obvious name is a red CI run, not a duplicate test.
+
+// This file opens no database, but it takes the rule it enforces — an exception
+// here would be the first crack in it.
+#[path = "../src/test_sandbox.rs"]
+mod test_sandbox;
+
+/// Every top-level file in `tests/` is a separate binary, so every one needs its
+/// own `mod test_sandbox;`. Subdirectories are shared helper modules, not
+/// binaries, and are correctly skipped.
+#[test]
+fn every_integration_test_binary_declares_the_sandbox() {
+    let tests_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+
+    let mut checked = Vec::new();
+    let mut missing = Vec::new();
+
+    for entry in std::fs::read_dir(&tests_dir).expect("crates/biorouter-cli/tests is readable") {
+        let path = entry.expect("a readable directory entry").path();
+        // Only top-level `.rs` files become test binaries.
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .expect("a file has a name")
+            .to_string_lossy()
+            .into_owned();
+        let source = std::fs::read_to_string(&path).expect("a test file is readable");
+
+        checked.push(name.clone());
+        if !source.contains("mod test_sandbox;") {
+            missing.push(name);
+        }
+    }
+
+    assert!(
+        !checked.is_empty(),
+        "found no test binaries to check: this guard has stopped guarding anything, \
+         which is worse than the defect it exists to catch"
+    );
+
+    missing.sort();
+    assert!(
+        missing.is_empty(),
+        "these integration test binaries do not declare the test sandbox, so anything \
+         in them that reaches Config::global() or SessionManager::instance() resolves \
+         the DEVELOPER'S REAL config and sessions.db: {missing:?}\n\nAdd these two \
+         lines below the file's inner attributes:\n\n    \
+         #[path = \"../src/test_sandbox.rs\"]\n    mod test_sandbox;\n\n\
+         (The lib's copy is #[cfg(test)] and is not compiled into integration binaries.)"
+    );
+}

--- a/crates/biorouter-cli/tests/non_interactive.rs
+++ b/crates/biorouter-cli/tests/non_interactive.rs
@@ -11,6 +11,14 @@
 //! `BIOROUTER_PATH_ROOT`, so nothing here can reach the developer's real
 //! configuration or session store, whatever the parent process was started with.
 
+// Each `tests/*.rs` is its own crate, so the lib's `#[cfg(test)] mod
+// test_sandbox;` is not compiled into this binary. Declare its own copy, so
+// anything here that reaches a process-global cell resolves under a throwaway
+// root rather than the developer's real config and session store. The children
+// this file spawns pass their own `BIOROUTER_PATH_ROOT`, which still wins.
+#[path = "../src/test_sandbox.rs"]
+mod test_sandbox;
+
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};

--- a/crates/biorouter-cli/tests/serve_lifecycle.rs
+++ b/crates/biorouter-cli/tests/serve_lifecycle.rs
@@ -25,6 +25,14 @@
 //! is no SIGTERM to send on Windows.
 #![cfg(unix)]
 
+// Each `tests/*.rs` is its own crate, so the lib's `#[cfg(test)] mod
+// test_sandbox;` is not compiled into this binary. Declare its own copy, so
+// anything here that reaches a process-global cell resolves under a throwaway
+// root rather than the developer's real config and session store. The children
+// this file spawns pass their own `BIOROUTER_PATH_ROOT`, which still wins.
+#[path = "../src/test_sandbox.rs"]
+mod test_sandbox;
+
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::PathBuf;


### PR DESCRIPTION
`crates/biorouter` and `crates/biorouter-server` each have a `src/test_sandbox.rs` whose `#[ctor]` points `BIOROUTER_PATH_ROOT` at a throwaway directory before `main`. `biorouter-cli` was the last crate without one, and it is the crate with the most exposure: **27 `SessionManager::instance()` sites** (`commands/session.rs` 9, `cli.rs` 7, `commands/term.rs` 4, `commands/schedule.rs` 3, `commands/knowledge.rs` 2, `commands/{usage,session_watch}.rs` 1 each) and **42 `Config::global()` sites**, all resolving against the developer's real root.

## The measurement

The two consistency guards, run on `main` (5a404ecd) with the ctor absent:

```
the_config_file_is_not_the_developers ... FAILED
    expected the per-process sandbox, got /Users/…/.config/biorouter/config.yaml
the_session_store_is_pinned_inside_the_sandbox ... FAILED
    the process session store is pinned at /Users/…/.local/share/biorouter
```

That is not a theoretical reach. A full `cargo test -p biorouter-cli` on `main` against an empty `HOME` (487 passed) leaves one file behind: `<HOME>/.config/biorouter/config.yaml`. On a real machine that write targets the developer's live config, and every `set_param` a test reaches lands in it.

| | `main` (5a404ecd) | this branch |
|---|---|---|
| files written into the developer's `HOME` by a default `cargo test -p biorouter-cli` | 1 (`.config/biorouter/config.yaml`) | **0** |
| the same run against the **real** `HOME` | not attempted — it writes there | 503 passed in 35s, `~/.config/biorouter` and `~/.local/share/biorouter` **byte-for-byte unchanged** |
| tests | 487 | 503 |

## Setting the variable is only half of it

Seven files here relocate `BIOROUTER_PATH_ROOT` under a `TempDir` with `env_lock` (`cli.rs`, `logging.rs`, `commands/{serve,knowledge,skill,schedule,extension}.rs`). `SHARED_STORE_ROOT` and `GLOBAL_CONFIG` are one-shot cells, so whichever test touches one first decides for the whole binary — and if that was a relocating test, the cell is pinned inside a directory unlinked moments later. That is the Windows flake PR #282 fixed for the other two crates, and its symptom looks nothing like its cause: the already-open SQLite connection keeps answering, and it surfaces as `(code: 14) unable to open database file` only when the pool must open a **second** one, in whatever test queried next.

So the ctor freezes both cells, and the assertions compare against a **recorded** root rather than re-reading an environment variable a sibling test may be holding at that instant.

## Each check falsified once

- **The two consistency guards** go red with the ctor absent — the output above.
- **`the_sandbox_root_is_not_the_developers_home`** is the only guard with an outside reference point, and it earns its place: with `BIOROUTER_PATH_ROOT` pointed at a directory inside `$HOME`, the other two stayed **green** (they compare two values the ctor derived from the same root) and it alone failed. That is exactly what a ctor recording a root it did not create would look like. Its `temp_dir()` arm is not a loophole — it is Windows, where `TempDir` lands inside `%USERPROFILE%`.
- **`cli_test_binaries_are_sandboxed`** named a probe file added without the declaration (`["zz_falsify_probe.rs"]`), then went green when it was removed.

An externally supplied root still wins — verified by the falsification run above, where the ctor honoured the root it was given instead of minting its own. The three existing integration files pass their own `BIOROUTER_PATH_ROOT` to each child `Command` regardless.

⚠ The meta-guard is deliberately **not** named `every_test_binary_is_sandboxed` like its `biorouter-server` sibling. `rust.yml`'s "integration binaries" step selects targets with `--test <name>`, which matches workspace-wide, and hard-fails when two packages share an integration target name. The obvious name reproduced locally as `::error::two packages have an integration target named: every_test_binary_is_sandboxed`; the rename clears it, checked with the same `cargo metadata | uniq -d` the workflow runs.

## Two comments that were true and no longer are

- **CLAUDE.md** told contributors to run this crate's tests under `HOME=$(mktemp -d)`. That workaround is obsolete — the damage happened on the *default* invocation, which is what a developer types and what an editor's test runner emits, neither of which reads CLAUDE.md. The zsh `CARGO_HOME="$HOME/.cargo"` warning beside it is **kept**, since it applies to any `HOME=`-prefixed cargo command.
- **`commands/session.rs`** said `handle_session_export` "opens the developer's REAL session database" — true until this commit, which is why it survived the sweep that corrected 24 stale copies of the claim. Corrected rather than left standing; the reason it is a source scan (a process-wide singleton) is unchanged.

Deliberately left alone: the "could land on the developer's real skills/config directory" comments in `commands/{skill,extension}.rs` and `session/tui/mod.rs`. They motivate those tests' own env pinning, which is still needed to avoid racing a test that moved the root.

## Gates

`cargo fmt --check` rc=0 · `./scripts/clippy-lint.sh` rc=0 (`--all-targets`, so the new test code is covered) · `cargo test -p biorouter-cli` 503 passed / 0 failed across lib + all four integration binaries · `cargo metadata --locked` rc=0. `BIOROUTER_DISABLE_KEYRING=true` throughout. The `Cargo.lock` change is one line — `ctor` was already in the graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)