### PR TITLE
fix(session): the first store keeps the date, every later one gets its own prefix

### DIFF
--- a/crates/biorouter/src/session/session_manager.rs
+++ b/crates/biorouter/src/session/session_manager.rs
@@ -209,15 +209,26 @@ const CLAIM_NEXT_SESSION_N: &str = "INSERT INTO session_id_high_water (prefix, l
 /// ~4000 passing results discarded, and nothing in the log naming a cause. A
 /// panic naming both stores is the difference between five minutes and a week.
 ///
-/// ⚠ **Scoped to this crate's own unit tests, deliberately, and NOT to
-/// `debug_assertions`.** The invariant it checks is only true where
-/// [`SessionStorage::id_prefix`] gives each store its own prefix, which is this
-/// same `cfg(test)`. Built without it the prefix is the date, two stores in one
-/// process both mint `<date>_1`, and the guard would fire on a duplicate that is
-/// real but that nothing in this change fixes — see
-/// `two_stores_in_one_process_never_mint_the_same_id` for the measurement and
-/// the reason that gap is left open rather than half-closed here.
-#[cfg(test)]
+/// ⚠ **`debug_assertions`, not `cfg(test)`.** It was the narrower scope until
+/// [`SessionStorage::id_prefix`] gave every store its own prefix in every build
+/// rather than only under `cfg(test)`. While the prefix was per-store only in
+/// this crate's own unit tests, a guard compiled anywhere else would have fired
+/// on a duplicate that was real and unfixed: every integration binary in the
+/// workspace — `crates/biorouter/tests/*.rs`, and every test in
+/// `biorouter-server`, `biorouter-mcp` and `biorouter-cli` — links this crate
+/// built WITHOUT `cfg(test)`, so two stores in one process both minted
+/// `<date>_1`. Measured on 2026-09-12 with the guard widened and the prefix left
+/// alone: `tests/agent.rs` failed 1 of 17 and
+/// `tests/conversation_writeback_stress.rs` 9 of 9, each naming two TempDir
+/// stores. Now that the mint is safe in all builds the guard follows it, which
+/// is what turns a future regression into a panic at the mint instead of a
+/// 40-minute CI timeout naming nothing.
+///
+/// Release builds are deliberately left out. There the check is dead weight —
+/// one store per process, so nothing can clash — and the failure it would
+/// introduce (a panic inside `create_session`) is worse than the one it guards
+/// against.
+#[cfg(debug_assertions)]
 static MINTED_IDS: LazyLock<std::sync::Mutex<HashMap<String, PathBuf>>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 
@@ -234,7 +245,7 @@ static MINTED_IDS: LazyLock<std::sync::Mutex<HashMap<String, PathBuf>>> =
 /// die with `PoisonError` instead of their own result — one genuine detection
 /// became seven failures, six of them meaningless. Measured, in
 /// `conversation_writeback_stress`.
-#[cfg(test)]
+#[cfg(debug_assertions)]
 fn record_minted_id(id: &str, session_dir: &Path) {
     let mut minted = MINTED_IDS
         .lock()
@@ -260,31 +271,47 @@ fn record_minted_id(id: &str, session_dir: &Path) {
     }
 }
 
-/// The 8-character prefix bound to one store directory, allocated from a
-/// process-wide counter.
+/// Where this store sits in the order the process first minted from each one:
+/// `0` for the first, then 1, 2, … one index per distinct store directory.
+///
+/// Stable for one directory and never reused, so a store's prefix — and with it
+/// its `MAX(N)` counter — cannot move under it mid-process.
+///
+/// ⚠ **Never panics while holding the lock, and never trusts it to be
+/// unpoisoned**, for the reason [`record_minted_id`] gives: this now runs in
+/// every build, so a poisoned mutex here would turn one unrelated panic into a
+/// process that can no longer create a session at all.
+fn store_index(session_dir: &Path) -> u64 {
+    static INDEXES: LazyLock<std::sync::Mutex<HashMap<PathBuf, u64>>> =
+        LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let mut indexes = INDEXES
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(index) = indexes.get(session_dir) {
+        return *index;
+    }
+    let index = NEXT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    indexes.insert(session_dir.to_path_buf(), index);
+    index
+}
+
+/// The 8-character prefix of a store that is not the process's first: `s`
+/// followed by [`store_index`] in seven hex digits.
 ///
 /// Free rather than a method so a test can exercise it over thousands of paths
 /// without standing up a `SessionStorage` for each (the constructor creates the
 /// store directory, so the paths would have to be real). See
-/// [`SessionStorage::id_prefix`] for why it is allocated rather than hashed.
-#[cfg(test)]
+/// [`SessionStorage::id_prefix`] for why it is allocated rather than hashed, and
+/// why it leads with a letter.
 fn allocate_store_prefix(session_dir: &Path) -> String {
-    static ALLOCATED: LazyLock<std::sync::Mutex<HashMap<PathBuf, String>>> =
-        LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
-    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let mut allocated = ALLOCATED.lock().expect("test id prefixes poisoned");
-    if let Some(prefix) = allocated.get(session_dir) {
-        return prefix.clone();
-    }
-    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let index = store_index(session_dir);
     assert!(
-        n <= u32::MAX as u64,
-        "ran out of 8-character store prefixes ({n}); the prefix must stay 8 \
+        index <= 0x0fff_ffff,
+        "ran out of 8-character store prefixes ({index}); the prefix must stay 8 \
          characters because the counter is read back with SUBSTR(id, 10)"
     );
-    let prefix = format!("{n:08x}");
-    allocated.insert(session_dir.to_path_buf(), prefix.clone());
-    prefix
+    format!("s{index:07x}")
 }
 
 /// Raise every prefix's mark to the largest `N` on disk under it.
@@ -5579,15 +5606,23 @@ impl SessionStorage {
         Ok(())
     }
 
-    /// The 8-character prefix a new session id is built on.
+    /// The 8-character prefix a new session id is built on: today's date for the
+    /// process's FIRST store, `s<index>` for every store after it.
     ///
-    /// Production uses today's date, which is what makes ids sort and read
-    /// sensibly. **Tests must not**, and the reason is worth stating because the
-    /// symptom is nothing like the cause: ids are minted as `PREFIX_N` where `N`
-    /// is `MAX(N) + 1` *within this database*, and every test builds its own
-    /// `TempDir` manager over an EMPTY one. So the first session of every test
-    /// is `20260827_1`, the second `20260827_2`, and so on — ids collide across
-    /// tests by construction.
+    /// The date is what makes ids sort and read sensibly, and **the first store
+    /// is the only store there is in production** — the daemon, a terminal
+    /// `biorouter`, `biorouter acp` and a scheduled job each open one, and
+    /// `SessionManager::instance()` and `biorouter-acp`'s own
+    /// `SessionManager::new(Paths::data_dir())` resolve to the SAME directory, so
+    /// they share one index. Shipped ids are therefore `YYYYMMDD_N` exactly as
+    /// before, `Utc::now()` re-read on every mint so a daemon still rolls over at
+    /// midnight.
+    ///
+    /// A second, DIFFERENT store in one process must not use the date, and the
+    /// reason is worth stating because the symptom is nothing like the cause: ids
+    /// are minted as `PREFIX_N` where `N` is `MAX(N) + 1` *within this database*,
+    /// and a second store opens its own. So both mint `<date>_1`, both mint
+    /// `<date>_2`, and so on — ids collide by construction.
     ///
     /// That matters because `agents::subagent_handle::HANDLES` is process-global
     /// and keyed by session id. A test that leaves a handle behind hands it to
@@ -5612,14 +5647,36 @@ impl SessionStorage {
     /// candidates, and one lib-test run allocates thousands of stores. A counter
     /// cannot collide at all, costs a map lookup, and removes the only place
     /// where whether CI hangs was a question of luck.
+    ///
+    /// ⚠ **The allocated prefix leads with `s`, and that letter is the whole
+    /// point.** A date is eight digits, so a bare hex counter could in principle
+    /// reach `20260912` and hand a later store the prefix the first one is
+    /// using — 539,760,402 distinct stores in one process, which is absurd, but
+    /// "absurd" is the same kind of answer the truncated hash gave. A leading
+    /// letter makes it impossible instead of unlikely, and it also says at a
+    /// glance, in a database or a log, that an id did not come from the store
+    /// this process was built around.
+    ///
+    /// ⚠ **Both branches give every store its own prefix.** That is the
+    /// invariant [`MINTED_IDS`] checks, and it is why that guard can now be
+    /// compiled for every `debug_assertions` build rather than only for this
+    /// crate's own unit tests.
     #[cfg(test)]
     fn id_prefix(&self) -> String {
+        // Never the date, not even for the first store: which store is first in a
+        // test binary depends on the order the harness happens to schedule its
+        // threads, so a date branch here would make one arbitrary store's ids
+        // change shape from run to run. Uniqueness does not need it.
         allocate_store_prefix(&self.session_dir)
     }
 
     #[cfg(not(test))]
     fn id_prefix(&self) -> String {
-        chrono::Utc::now().format("%Y%m%d").to_string()
+        if store_index(&self.session_dir) == 0 {
+            chrono::Utc::now().format("%Y%m%d").to_string()
+        } else {
+            allocate_store_prefix(&self.session_dir)
+        }
     }
 
     async fn create_session(
@@ -5646,7 +5703,7 @@ impl SessionStorage {
             .await?;
 
         let id = format!("{today}_{next_n}");
-        #[cfg(test)]
+        #[cfg(debug_assertions)]
         record_minted_id(&id, &self.session_dir);
 
         let session = sqlx::query_as(
@@ -19110,33 +19167,76 @@ mod session_id_uniqueness_tests {
         );
     }
 
+    /// An allocated prefix can never be mistaken for a date, by shape.
+    ///
+    /// The exactness the allocator buys is only worth anything if the two
+    /// prefix *kinds* cannot meet: production's first store takes today's date,
+    /// every later one takes an allocated prefix, and if a counter could ever
+    /// render as eight digits it could render as today's. `s` makes that a
+    /// property of the alphabet instead of a property of how many stores a
+    /// process happens to open.
+    #[test]
+    fn an_allocated_prefix_can_never_be_a_date() {
+        let today = chrono::Utc::now().format("%Y%m%d").to_string();
+        assert!(
+            today.len() == 8 && today.chars().all(|c| c.is_ascii_digit()),
+            "the date prefix stopped being eight digits ({today}); this test \
+             compares the two prefix kinds by shape and no longer knows one"
+        );
+        // Four fresh stores, so four consecutive indices — whatever the counter
+        // happens to stand at when this test runs. That is all the coverage the
+        // property needs: the leading character comes from the format string and
+        // not from the value, so no index can lose it.
+        for path in ["/kind/a", "/kind/b", "/kind/c", "/kind/d"] {
+            let prefix = allocate_store_prefix(&PathBuf::from(path).join(SESSIONS_FOLDER));
+            assert_eq!(
+                prefix.len(),
+                8,
+                "the prefix must stay 8 characters: {prefix}"
+            );
+            assert_ne!(
+                prefix, today,
+                "an allocated prefix rendered as today's date"
+            );
+            assert!(
+                !prefix.starts_with(|c: char| c.is_ascii_digit()),
+                "an allocated prefix starting with a digit can collide with a \
+                 date once the counter is large enough: {prefix}"
+            );
+        }
+    }
+
     /// End to end: two stores in one process never mint the same id.
     ///
     /// The property the two tests above are components of, asserted through
     /// `create_session` itself so a future change that keeps the allocator and
     /// breaks the mint still goes red.
     ///
-    /// ⚠ **This holds in THIS binary and not in every one.**
-    /// [`SessionStorage::id_prefix`]'s per-store branch is `#[cfg(test)]`, so it
-    /// is compiled only for this crate's own unit tests. Every integration
-    /// binary in the workspace — `crates/biorouter/tests/*.rs`, and every test in
-    /// `biorouter-server`, `biorouter-mcp` and `biorouter-cli` — links this crate
-    /// built WITHOUT `cfg(test)`, prefixes ids with the date, and mints
-    /// `<date>_1` from every store. That is not a theory: building with
-    /// [`MINTED_IDS`] active outside `cfg(test)` makes `tests/agent.rs` fail four
-    /// tests and `tests/conversation_writeback_stress.rs` eight, each reporting
-    /// `session id 20260912_1 was minted twice in one process` between two named
-    /// TempDir stores. CI runs those binaries.
+    /// ⚠ **This used to hold in THIS binary and in no other one**, and the
+    /// companion that proves it now holds everywhere is
+    /// `crates/biorouter/tests/session_id_cross_store.rs` — the same property,
+    /// asserted from an integration binary, which is a build of this crate
+    /// WITHOUT `cfg(test)`. Keep both: this one covers the `cfg(test)` branch of
+    /// [`SessionStorage::id_prefix`], that one covers the shipped branch, and
+    /// neither can see the other's.
     ///
-    /// That gap is deliberately NOT closed here. The two ways to close it are to
-    /// give later stores a non-date prefix in non-test builds — which changes
-    /// user-visible ids on a real production path (`biorouter-acp`'s server
-    /// constructs its own manager) — or to floor the numeric part
-    /// process-wide, which was written, measured and removed: it breaks every
-    /// fixture that replays id reuse, because
-    /// `a_rewrite_basis_cannot_cross_a_wipe_that_recycled_the_session_id`
-    /// asserts the wipe hands *the same id* back. Both are a maintainer's call,
-    /// not a bug fix's.
+    /// The gap was real and measured. While the per-store prefix was
+    /// `#[cfg(test)]`-only, every integration binary in the workspace —
+    /// `crates/biorouter/tests/*.rs`, and every test in `biorouter-server`,
+    /// `biorouter-mcp` and `biorouter-cli`, all of which CI runs — prefixed ids
+    /// with the date and minted `<date>_1` from every store. Building
+    /// [`MINTED_IDS`] outside `cfg(test)` on top of that, on 2026-09-12, made
+    /// `tests/agent.rs` fail 1 of 17 and `tests/conversation_writeback_stress.rs`
+    /// 9 of 9, each reporting `session id 20260912_1 was minted twice in one
+    /// process` between two named TempDir stores.
+    ///
+    /// It was closed by giving stores *after the first* a non-date prefix in
+    /// every build, so a single-store process — which is every production one —
+    /// keeps `YYYYMMDD_N` unchanged. The alternative, flooring the numeric part
+    /// process-wide, was written, measured and removed: it breaks every fixture
+    /// that replays id reuse, because
+    /// `a_rewrite_basis_cannot_cross_a_wipe_that_recycled_the_session_id` asserts
+    /// the wipe hands *the same id* back, and a process floor cannot allow that.
     #[tokio::test]
     async fn two_stores_in_one_process_never_mint_the_same_id() {
         let a = tempfile::TempDir::new().unwrap();

--- a/crates/biorouter/tests/session_id_cross_store.rs
+++ b/crates/biorouter/tests/session_id_cross_store.rs
@@ -1,0 +1,146 @@
+//! Two DIFFERENT session stores in one process never mint the same session id —
+//! in a build of `biorouter` without `cfg(test)`.
+//!
+//! `session_manager.rs`'s own `two_stores_in_one_process_never_mint_the_same_id`
+//! asserts this property too, and could not see the defect this file was written
+//! for: a lib unit test is compiled WITH `cfg(test)`, and until 2026-09-12 that
+//! was the only configuration in which `SessionStorage::id_prefix` gave each
+//! store its own prefix. Every integration binary in the workspace — this one,
+//! the rest of `crates/biorouter/tests/`, and every test in `biorouter-server`,
+//! `biorouter-mcp` and `biorouter-cli`, all of which CI runs — links the crate
+//! built without it, prefixed ids with the date, and minted `<date>_1` from
+//! every store.
+//!
+//! Why that is worth a binary of its own rather than a line in an existing one:
+//! a session id is the key of several PROCESS-GLOBAL registries
+//! (`agents::subagent_handle::HANDLES`, `session_events`' bus, `AgentManager`'s
+//! pin), so the second store's chat silently inherits the first's entries and a
+//! turn waits forever on work that has already finished. The symptom is a hang
+//! in a test that has nothing to do with session ids, tens of minutes later, with
+//! nothing in the log naming a cause — the shape that cost this repository whole
+//! CI jobs (commit acae89ea, and ~4000 discarded results on #273).
+//!
+//! Measured on this file, 2026-09-12:
+//!   * before the fix: `the_second_store_in_this_process_mints_ids_of_its_own`
+//!     fails with `both stores minted "20260912_1"`.
+//!   * after: the second store mints `s0000001_1` and the first still mints
+//!     `20260912_1`.
+//!
+//! ⚠ **One `#[test]`, deliberately.** The date prefix belongs to the FIRST store
+//! this process mints from, and "first" is decided by whichever thread the
+//! harness schedules first. Split across several test functions, the assertion
+//! that production's id shape is intact would pass or fail by luck. One function
+//! owns the order.
+
+use biorouter::session::session_manager::SessionType;
+use biorouter::session::SessionManager;
+use tempfile::TempDir;
+
+/// The `N` of a `PREFIX_N` id.
+fn suffix(id: &str) -> i64 {
+    id.rsplit('_')
+        .next()
+        .unwrap_or_else(|| panic!("`{id}` is not a PREFIX_N session id"))
+        .parse()
+        .unwrap_or_else(|e| panic!("`{id}` has an unparseable counter: {e}"))
+}
+
+/// The `PREFIX` of a `PREFIX_N` id.
+fn prefix(id: &str) -> &str {
+    let (head, _) = id
+        .rsplit_once('_')
+        .unwrap_or_else(|| panic!("`{id}` is not a PREFIX_N session id"));
+    head
+}
+
+async fn mint(sm: &SessionManager, dir: &TempDir, n: usize) -> Vec<String> {
+    let mut ids = Vec::with_capacity(n);
+    for _ in 0..n {
+        ids.push(
+            sm.create_session(dir.path().to_path_buf(), "c".into(), SessionType::User)
+                .await
+                .unwrap()
+                .id,
+        );
+    }
+    ids
+}
+
+#[tokio::test]
+async fn the_second_store_in_this_process_mints_ids_of_its_own() {
+    // ── The first store: production's only one, and its ids must not move. ──
+    let first_dir = TempDir::new().unwrap();
+    let first = SessionManager::new(first_dir.path().to_path_buf());
+    let first_ids = mint(&first, &first_dir, 3).await;
+
+    let today = chrono::Utc::now().format("%Y%m%d").to_string();
+    assert_eq!(
+        first_ids.iter().map(|id| prefix(id)).collect::<Vec<_>>(),
+        vec![today.as_str(); 3],
+        "the process's first store must still mint YYYYMMDD_N — that is every \
+         shipped id, and `{today}` is today. Got {first_ids:?}"
+    );
+    assert_eq!(
+        first_ids.iter().map(|id| suffix(id)).collect::<Vec<_>>(),
+        vec![1, 2, 3],
+        "one store must still number 1..n with no gaps; got {first_ids:?}"
+    );
+
+    // ── A second, DIFFERENT store. This is the whole defect. ──
+    let second_dir = TempDir::new().unwrap();
+    let second = SessionManager::new(second_dir.path().to_path_buf());
+    let second_ids = mint(&second, &second_dir, 3).await;
+
+    for id in &second_ids {
+        assert!(
+            !first_ids.contains(id),
+            "both stores minted `{id}` (first store {first_ids:?}, second \
+             {second_ids:?}). A session id keys process-global registries — \
+             subagent_handle::HANDLES, session_events, AgentManager's pin — so \
+             the second store's chat inherits the first's entries and a turn \
+             that waits on one of them never returns.",
+        );
+    }
+    assert_ne!(
+        prefix(&second_ids[0]),
+        today,
+        "the second store took the date prefix, so it restarts the same counter \
+         over its own empty database and collides id for id: {second_ids:?}"
+    );
+
+    // ── A third one, so the rule is a rule and not a two-store special case. ──
+    let third_dir = TempDir::new().unwrap();
+    let third = SessionManager::new(third_dir.path().to_path_buf());
+    let third_ids = mint(&third, &third_dir, 3).await;
+
+    let minted: Vec<&String> = first_ids
+        .iter()
+        .chain(second_ids.iter())
+        .chain(third_ids.iter())
+        .collect();
+    let distinct: std::collections::HashSet<&&String> = minted.iter().collect();
+    assert_eq!(
+        distinct.len(),
+        minted.len(),
+        "three stores in one process minted a duplicate id: {minted:?}"
+    );
+
+    // ── Re-opening a store keeps its prefix, so its counter cannot restart. ──
+    //
+    // A prefix bound to the manager rather than to the directory would hand this
+    // reopened store a fresh one, and it would then mint `<new>_1` over a
+    // database whose ids are all `<old>_N` — a collision with its own future.
+    let reopened = SessionManager::new(second_dir.path().to_path_buf());
+    let reopened_ids = mint(&reopened, &second_dir, 2).await;
+    assert_eq!(
+        reopened_ids.iter().map(|id| prefix(id)).collect::<Vec<_>>(),
+        vec![prefix(&second_ids[0]); 2],
+        "re-opening a store changed its prefix: it minted {reopened_ids:?} over \
+         a database already holding {second_ids:?}"
+    );
+    assert_eq!(
+        reopened_ids.iter().map(|id| suffix(id)).collect::<Vec<_>>(),
+        vec![4, 5],
+        "a re-opened store must carry on counting, not restart; got {reopened_ids:?}"
+    );
+}


### PR DESCRIPTION
Closes the cross-store session-id collision that was still live in **every**
integration test binary in the workspace.

## The defect, re-measured on `origin/main` at `5a404ecd`

A session id is the key of several process-global registries
(`agents::subagent_handle::HANDLES`, `session_events`' bus, `AgentManager`'s
pin). Two stores in one process minting the same id hands the second owner the
first's entries, and a turn then waits forever on work that already finished —
a hang in a test that has nothing to do with session ids, tens of minutes later,
with nothing in the log naming a cause.

`SessionStorage::id_prefix` already gave each store its own prefix, but its
per-store branch is `#[cfg(test)]`, so it exists only for `biorouter`'s own unit
tests. Every integration binary in the workspace — `crates/biorouter/tests/*.rs`
and every test in `biorouter-server`, `biorouter-mcp` and `biorouter-cli` — links
the crate built **without** `cfg(test)`, prefixes ids with the date, and mints
`<date>_1` from every store. CI runs all of them.

Reproduced exactly as the filing described (widen `MINTED_IDS`/`record_minted_id`
to `debug_assertions`, leave the prefix alone), on this tree today:

| command | before |
|---|---|
| `cargo test -p biorouter --test agent` | **1 of 17 failed** |
| `cargo test -p biorouter --test conversation_writeback_stress` | **9 of 9 failed** |

each with `session id 20260912_1 was minted twice in one process: first by the
store at …/.tmpGKivYo/sessions, now by the store at …/.tmpRxhrzN/data/sessions`.

(The filing predicted 4 and 8; the numbers above are what this machine measured.
The count is scheduling-dependent — whichever store mints second panics — so it
is the *reproduction*, not the tally, that matters.)

## Option A, chosen — and how the ACP concern is answered

The filing left two options to a maintainer. **(A) is implemented.** Stores
*after the first* get a non-date prefix, in every build rather than only in test
ones.

The stated objection to A was that `biorouter-acp/src/server.rs:346` builds its
own `SessionManager` over `config.data_dir`, so an ACP session might carry an id
like `00000001_1`. It cannot, because the index is bound to the store
**directory**, not to the manager: `config.data_dir` is `Paths::data_dir()`,
which is the same directory `SHARED_STORE_ROOT` (and therefore
`SessionManager::instance()`) resolves, so both share index 0 and both mint
`YYYYMMDD_N`. An ACP process that opens only that store — which is every one —
is unchanged. `Utc::now()` is still re-read on every mint, so a daemon still
rolls over at midnight.

The prefix for later stores is `s<index>` in seven hex digits, not a bare hex
counter. A date is eight digits, so a bare counter could in principle render as
`20260912` and take the first store's prefix. That needs 539,760,402 distinct
stores in one process — absurd, but "absurd" is the same kind of answer the
truncated hash this file already replaced was giving. A leading letter makes it
a property of the alphabet. It also reads, in a database or a log, as "this id
did not come from the store the process was built around".

**Option B stays rejected**, for the reason the filing recorded: a process-wide
floor on the numeric part breaks every fixture that replays id reuse, because
`a_rewrite_basis_cannot_cross_a_wipe_that_recycled_the_session_id` asserts the
wipe hands the *same* id back.

## The guard now covers what the mint made safe

`MINTED_IDS` and `record_minted_id` move from `cfg(test)` to
`debug_assertions`, so a regression panics at the mint naming both stores
instead of hanging a CI job 35 minutes later. Release builds are deliberately
left out: there the check is dead weight (one store per process) and a panic
inside `create_session` is worse than the collision it guards.

**Verified live rather than assumed.** Regressing `id_prefix` back to "always the
date" makes `tests/agent.rs` — a build of the crate *without* `cfg(test)` — fail
with the guard's own message, so the guard is genuinely compiled into those
binaries and is not silently absent:

```
session id 20260912_1 was minted twice in one process: first by the store at
…/.tmpnMO61w/sessions, now by the store at …/.tmpPprnsE/data/sessions.
```

## Fail-before / pass-after

`crates/biorouter/tests/session_id_cross_store.rs` is new, and is the property
asserted from an integration binary — the configuration the lib test cannot see.
Against **pristine `origin/main` source** (fix reverted, test kept):

```
FAILED. 0 passed; 1 failed
both stores minted `20260912_1` (first store ["20260912_1", "20260912_2",
"20260912_3"], second ["20260912_1", "20260912_2", "20260912_3"])
```

With the fix: `ok. 1 passed; 0 failed`. It also pins what must NOT change — the
first store still mints `20260912_1..3` with no gaps, and re-opening a store
keeps its prefix and carries on at `_4`.

One `#[test]`, deliberately: "first store" is decided by whichever thread the
harness schedules first, so split across several test functions the assertion
about production's id shape would pass or fail by luck.

## After

| command | after |
|---|---|
| `cargo test -p biorouter --test agent` | 17 passed, 0 failed |
| `cargo test -p biorouter --test conversation_writeback_stress` | 9 passed, 0 failed |
| `cargo test -p biorouter --test session_id_cross_store` | 1 passed, 0 failed |
| `cargo test -p biorouter --lib` (from `crates/biorouter`) | 4046 passed, 0 failed |
| `cargo fmt --check` | clean |
| `./scripts/clippy-lint.sh` | clean (exit 0) |

CI picks the new binary up with no registration — the integration step
enumerates targets from `cargo metadata`, and `session_id_cross_store` is unique
across the workspace's 128 test targets (that step errors on a duplicate name).

## Deliberately not changed

* The `cfg(test)` branch of `id_prefix` still never uses the date, even for the
  first store. Uniqueness does not need it, and a date branch there would make
  one arbitrary store's ids change shape from run to run.
* `subagent_handler.rs` and `workspace_extension.rs` carry doc comments citing
  `id_prefix`; each already says "unique in the process", which this makes more
  true, not less. Left untouched to keep the diff to two files.
* No `serial_test` key, spacer band or other hand-rolled defence was
  reintroduced — the mint is the one place this is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
