### PR TITLE
fix(desktop): a rename reaches every tab, not only the active one

### DIFF
--- a/ui/desktop/src/components/chatGroups/ChatGroupsShell.tabTitleSync.test.tsx
+++ b/ui/desktop/src/components/chatGroups/ChatGroupsShell.tabTitleSync.test.tsx
@@ -1,0 +1,225 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '../../api';
+
+/**
+ * A tab that is NOT active must still learn its chat's real name.
+ *
+ * # The bug
+ *
+ * Found by driving the app on 2026-09-12. The daemon renames a chat after each
+ * of its first few turns, with no signal (`SessionManager::maybe_update_name`
+ * runs after the reply stream has closed). A tab title is the one name the
+ * renderer PERSISTS, and only two things could ever correct one: the name
+ * channel, and `handleSessionLoaded` — which comes from BaseChat, and only the
+ * active tab mounts a BaseChat. So the sidebar read "Instruction-following
+ * tests" while the same chat's background tab read "Penguin prompt test", on one
+ * screen, unchanged across three reloads; making that tab active fixed it
+ * instantly.
+ *
+ * `renameTab` already mirrored into every tab of that session — the reducer was
+ * never the problem. What was missing is any path from the server's row to a tab
+ * nobody is looking at. This pins that path: the shell reconciles its titles
+ * against the session list it ALREADY reads and warms for the privacy dots.
+ *
+ * # Why it asserts dispatches, not DOM
+ *
+ * The strip reaches the DOM through BaseChat's `renderSessionTitle` render prop
+ * and BaseChat is unmountable here (~10 providers), exactly as
+ * `ChatGroupsShell.sessionName.test.tsx` and `.privacy.test.tsx` already
+ * document. The dispatch IS the wiring that was absent.
+ */
+
+const dispatch = vi.fn();
+let cachedList: Session[] | null = null;
+let emit: (() => void) | null = null;
+
+vi.mock('../BaseChat', () => ({
+  default: () => <div data-testid="basechat" />,
+}));
+
+vi.mock('../../utils/sessionListCache', () => ({
+  getCachedSessionList: () => cachedList,
+  subscribeSessionList: (listener: () => void) => {
+    emit = listener;
+    return () => {
+      emit = null;
+    };
+  },
+  preloadSessionList: () => {},
+}));
+
+vi.mock('../../hooks/chatStreamStore', () => ({
+  useLiveSessionTiers: () => ({}),
+}));
+
+/**
+ * `t-active` is the group's `activeTabId`; `t-background` and `t-mine` are not.
+ * The background tab is the whole point — on `main` nothing could reach it.
+ */
+let tabs = [
+  {
+    tabId: 't-active',
+    sessionId: 'sess-active',
+    title: 'DELTA instruction test',
+    userSetName: false,
+  },
+  { tabId: 't-background', sessionId: 'sess-bg', title: 'Penguin prompt test', userSetName: false },
+];
+
+vi.mock('../../contexts/ChatGroupsContext', () => ({
+  useChatGroups: () => ({
+    dispatch,
+    state: {
+      activeGroupId: 'g1',
+      layout: { kind: 'leaf', groupId: 'g1' },
+      groups: { g1: { id: 'g1', activeTabId: 't-active', tabs } },
+    },
+  }),
+}));
+
+vi.mock('../ui/sidebar', () => ({ useSidebar: () => ({ state: 'expanded', isMobile: false }) }));
+
+import ChatGroupsShell from './ChatGroupsShell';
+
+function row(id: string, name: string, userSetName = false): Session {
+  return {
+    id,
+    name,
+    user_set_name: userSetName,
+    working_dir: '/tmp',
+    message_count: 2,
+    total_tokens: 0,
+    created_at: '',
+    updated_at: '',
+    extension_data: {},
+  } as unknown as Session;
+}
+
+function renameDispatches() {
+  return dispatch.mock.calls.map((call) => call[0]).filter((a) => a?.type === 'renameTab');
+}
+
+describe('ChatGroupsShell — tab titles are reconciled against the session list', () => {
+  beforeEach(() => {
+    dispatch.mockClear();
+    cachedList = null;
+    emit = null;
+    tabs = [
+      {
+        tabId: 't-active',
+        sessionId: 'sess-active',
+        title: 'DELTA instruction test',
+        userSetName: false,
+      },
+      {
+        tabId: 't-background',
+        sessionId: 'sess-bg',
+        title: 'Penguin prompt test',
+        userSetName: false,
+      },
+    ];
+  });
+
+  it('renames a tab that is not the active one when the row says so', () => {
+    cachedList = [
+      row('sess-active', 'DELTA instruction test'),
+      row('sess-bg', 'Instruction-following tests'),
+    ];
+
+    render(<ChatGroupsShell onChatChange={() => {}} />);
+
+    expect(renameDispatches()).toEqual([
+      {
+        type: 'renameTab',
+        sessionId: 'sess-bg',
+        title: 'Instruction-following tests',
+        userSetName: false,
+      },
+    ]);
+  });
+
+  it('reconciles when the list arrives after the mount, not only on it', () => {
+    // The cold-start order: the strip warms the cache, so the first read is
+    // empty and the correction has to ride the subscription.
+    cachedList = null;
+    render(<ChatGroupsShell onChatChange={() => {}} />);
+    expect(renameDispatches()).toEqual([]);
+
+    cachedList = [row('sess-bg', 'Instruction-following tests')];
+    emit?.();
+
+    expect(renameDispatches()).toEqual([
+      {
+        type: 'renameTab',
+        sessionId: 'sess-bg',
+        title: 'Instruction-following tests',
+        userSetName: false,
+      },
+    ]);
+  });
+
+  /**
+   * Guard 1 — the case the old code was protecting. A user rename sets
+   * `userSetName` on the tab optimistically and `user_set_name` on the row, and
+   * the daemon never auto-renames such a chat again. A user-named tab is skipped
+   * outright, so no late row can snap it back and no keystroke can flicker.
+   */
+  it('never touches a tab the user named', () => {
+    tabs = [{ tabId: 't-mine', sessionId: 'sess-bg', title: 'Penguin notes', userSetName: true }];
+    cachedList = [row('sess-bg', 'Instruction-following tests')];
+
+    render(<ChatGroupsShell onChatChange={() => {}} />);
+
+    expect(renameDispatches()).toEqual([]);
+  });
+
+  /** Guard 2 — the placeholder is a lower bound on a name, never a correction. */
+  it('never downgrades a named tab to the "New chat" placeholder', () => {
+    cachedList = [row('sess-bg', 'New chat')];
+
+    render(<ChatGroupsShell onChatChange={() => {}} />);
+
+    expect(renameDispatches()).toEqual([]);
+  });
+
+  /** …but a tab still ON the placeholder does adopt the row's real name. */
+  it('names a placeholder tab from the row', () => {
+    tabs = [{ tabId: 't-new', sessionId: 'sess-bg', title: 'New chat', userSetName: false }];
+    cachedList = [row('sess-bg', 'Instruction-following tests')];
+
+    render(<ChatGroupsShell onChatChange={() => {}} />);
+
+    expect(renameDispatches()).toEqual([
+      {
+        type: 'renameTab',
+        sessionId: 'sess-bg',
+        title: 'Instruction-following tests',
+        userSetName: false,
+      },
+    ]);
+  });
+
+  /** A row that agrees with the tab must not dispatch — the strip re-renders on
+   *  every streamed token, and a dispatch per emit would be a render loop. */
+  it('dispatches nothing when every title already agrees', () => {
+    cachedList = [
+      row('sess-active', 'DELTA instruction test'),
+      row('sess-bg', 'Penguin prompt test'),
+    ];
+
+    render(<ChatGroupsShell onChatChange={() => {}} />);
+    emit?.();
+
+    expect(renameDispatches()).toEqual([]);
+  });
+
+  /** A chat the list does not carry keeps what it has: silence, not a guess. */
+  it('leaves a tab alone when the list has no row for it', () => {
+    cachedList = [row('sess-active', 'DELTA instruction test')];
+
+    render(<ChatGroupsShell onChatChange={() => {}} />);
+
+    expect(renameDispatches()).toEqual([]);
+  });
+});

--- a/ui/desktop/src/components/chatGroups/ChatGroupsShell.tsx
+++ b/ui/desktop/src/components/chatGroups/ChatGroupsShell.tsx
@@ -21,6 +21,7 @@ import { DropTarget } from './dropZones';
 import { groupCountOf } from './chatGroupsLayout';
 import { GroupLayoutSnapshot, snapshotGroupLayout } from './chatGroupsReducer';
 import { firstLeaf, leafGroupIds, GroupLayout, ChatGroupId } from './chatGroupsTypes';
+import { isDefaultSessionName } from '../../utils/sessionNameSync';
 import { splitSnapshotIsStale, splitYieldAction, splitYieldSample } from '../Layout/yieldLadder';
 import { useIsMobile } from '../../hooks/use-mobile';
 import { useSidebar } from '../ui/sidebar';
@@ -173,10 +174,119 @@ function useSessionPrivacyTiers(): Record<string, SessionClassification> {
   return useMemo(() => mergeSessionTiers(cachedTiers, liveTiers), [cachedTiers, liveTiers]);
 }
 
+/**
+ * Reconcile every tab's title against the session list — INCLUDING the tabs
+ * that are not active.
+ *
+ * # What was broken
+ *
+ * A tab title is the only name in the app that is PERSISTED by the renderer
+ * (`chatGroupsStorage`), and until now only two things could correct one: the
+ * name channel (`subscribeSessionNameChanges`, mirrored into every tab by
+ * `ChatGroupsContext`) and `handleSessionLoaded` below — which fires from
+ * BaseChat, and only the ACTIVE tab mounts a BaseChat. So a name this window
+ * never heard announced stayed wrong on a background tab across reload after
+ * reload, while the sidebar — which re-reads the server on every load — showed
+ * the right one. Measured on 2026-09-12: the sidebar read "Instruction-following
+ * tests" while the same chat's background tab read "Penguin prompt test" — on one
+ * screen, at the same moment, unchanged across three reloads, and correcting
+ * instantly the moment that tab was made active.
+ *
+ * The daemon auto-renames a chat after EVERY one of its first few turns
+ * (`SessionManager::maybe_update_name`), after the reply stream has already
+ * closed, and emits no signal for it — so "a name this window never heard
+ * announced" is the normal case, not an exotic one. The poll in
+ * `chatStreamStore.finishTurn` announces what it catches; this closes the
+ * general hole, including a rename made by the CLI, a schedule, or another
+ * window while this one was shut.
+ *
+ * # Why the session list, and why it cannot go stale again
+ *
+ * This is the SAME cache `useSessionPrivacyTiers` above already reads and warms
+ * — no new request, no polling. It is re-read on mount and on every emit, so a
+ * tab's title is checked against the server's row every time this window loads
+ * and every time that list changes. A title can therefore be wrong only for as
+ * long as this cache is, and never across a load.
+ *
+ * # The two things it must not do
+ *
+ *   1. **Overwrite a name the user typed.** A user rename sets `userSetName` on
+ *      the tab (optimistically, in `BaseChat.handleRename`) and `user_set_name`
+ *      on the row, and the daemon never auto-renames such a session again. A
+ *      user-named tab is therefore skipped outright rather than compared: the
+ *      name channel already carries every user rename to every tab
+ *      synchronously, so there is nothing here for this hook to add, and
+ *      skipping makes the snap-back structurally impossible rather than merely
+ *      unlikely. (`sessionListCache` guards the other half of that race — a list
+ *      response that was issued BEFORE the rename it would undo.)
+ *   2. **Downgrade a named tab to the placeholder.** A row still reading "New
+ *      chat" is a lower bound, never a correction, so it is never adopted over a
+ *      title that already has a real name.
+ */
+function useTabTitlesFromSessionList(groups: ReturnType<typeof useChatGroups>): void {
+  const dispatch = groups?.dispatch;
+  // Read through a ref so the effect depends on the SIGNATURE below and not on
+  // state identity — the shell re-renders on every streamed token, and this
+  // effect resubscribes each time it re-runs.
+  const stateRef = useRef(groups?.state);
+  stateRef.current = groups?.state;
+
+  // The (session, title) pairs this hook compares, and nothing else. A tab
+  // opened, closed, bound or renamed changes it; a reorder, a split or a token
+  // does not.
+  const tabTitleSignature = useMemo(() => {
+    const parts: string[] = [];
+    for (const group of Object.values(groups?.state.groups ?? {})) {
+      for (const tab of group.tabs) {
+        if (!tab.sessionId) continue;
+        parts.push(`${tab.sessionId}\u241F${tab.title}\u241F${tab.userSetName ? 1 : 0}`);
+      }
+    }
+    return parts.sort().join('\u241E');
+  }, [groups?.state]);
+
+  useEffect(() => {
+    if (!dispatch) return;
+    const reconcile = () => {
+      const rows = getCachedSessionList();
+      const state = stateRef.current;
+      if (!rows || !state) return;
+      const rowById = new Map(rows.map((row) => [row.id, row]));
+      // One dispatch per SESSION, not per tab: `renameTab` already mirrors into
+      // every tab bound to that session, so a chat open twice must not dispatch
+      // twice.
+      const dispatched = new Set<string>();
+      for (const group of Object.values(state.groups)) {
+        for (const tab of group.tabs) {
+          if (!tab.sessionId || tab.userSetName || dispatched.has(tab.sessionId)) continue;
+          const row = rowById.get(tab.sessionId);
+          if (!row?.name || row.name === tab.title) continue;
+          // Rule 2: the placeholder is a lower bound, never a correction.
+          if (isDefaultSessionName(row.name) && !isDefaultSessionName(tab.title)) continue;
+          dispatched.add(tab.sessionId);
+          dispatch({
+            type: 'renameTab',
+            sessionId: tab.sessionId,
+            title: row.name,
+            userSetName: row.user_set_name ?? false,
+          });
+        }
+      }
+    };
+    reconcile();
+    // Subscribe BEFORE asking for the fetch, for the reason `useSessionPrivacyTiers`
+    // gives: a cache that resolved in between would emit to nobody.
+    const unsubscribe = subscribeSessionList(reconcile);
+    preloadSessionList();
+    return unsubscribe;
+  }, [dispatch, tabTitleSignature]);
+}
+
 export function ChatGroupsShell({ onChatChange }: ChatGroupsShellProps) {
   const groups = useChatGroups();
   const terminalDock = useTerminalDock();
   const privacyTiers = useSessionPrivacyTiers();
+  useTabTitlesFromSessionList(groups);
 
   const isMobile = useIsMobile();
   const { state: sidebarState } = useSidebar();

--- a/ui/desktop/src/hooks/chatStreamStore.autoRename.test.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.autoRename.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * The daemon renames a chat after EVERY one of its first few turns — and the
+ * renderer has to notice each time, not just the first.
+ *
+ * `SessionManager::maybe_update_name` re-generates a chat's name on each turn
+ * until it holds more than {@link AUTO_RENAME_USER_MESSAGE_LIMIT} user messages
+ * (and forever while it is still on the placeholder). It runs AFTER the reply
+ * stream has closed, in a spawned task, and emits no frame — so this store's
+ * post-turn poll is the only thing in the app that can see it happen.
+ *
+ * That poll was gated on `isDefaultSessionName(session.name)`: it asked "has
+ * this chat been named at all?", not "has it been RENAMED?". So it fired once,
+ * for the first auto-name, and every later one was invisible to the entire
+ * renderer — the tab strip, the sidebar and Home recents all kept the first
+ * name until something re-read the session from the server.
+ *
+ * Measured in the app on 2026-09-12 (session `20260912_1`): turn 1 named it
+ * "BRAVO instruction test", turn 2 renamed it in sqlite to "Penguin prompt
+ * test", and 30 s later both the tab and the sidebar still read "BRAVO
+ * instruction test".
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MessageEvent, Session, TokenState } from '../api';
+
+const USER_ACTION_KEY = 'proof-of-user';
+
+const mocks = vi.hoisted(() => ({
+  reply: vi.fn(),
+  observeSessionEvents: vi.fn(),
+  resumeAgent: vi.fn(),
+  cancelTurn: vi.fn(async () => ({ data: { cancelled: true } })),
+  getSession: vi.fn(async (_options?: unknown) => ({ data: null }) as unknown),
+  interrupt: vi.fn(),
+  listSessions: vi.fn(async () => ({ data: { sessions: [] } })),
+  updateFromSession: vi.fn(async () => ({ data: {} })),
+  updateSessionUserWorkflowValues: vi.fn(async () => ({ data: {} })),
+}));
+
+vi.mock('../api', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, ...mocks };
+});
+
+import { ChatStreamRegistry } from './chatStreamStore';
+import {
+  AUTO_RENAME_USER_MESSAGE_LIMIT,
+  subscribeSessionNameChanges,
+  type SessionNameChange,
+} from '../utils/sessionNameSync';
+
+const tokenState: TokenState = {
+  accumulatedInputTokens: 0,
+  accumulatedOutputTokens: 0,
+  accumulatedTotalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  totalTokens: 0,
+};
+
+const finishFrame = { type: 'Finish', reason: 'stop', token_state: tokenState } as MessageEvent;
+
+async function* streamOf(...frames: MessageEvent[]) {
+  for (const frame of frames) yield frame;
+}
+
+/** `user_set_name: false` — an auto-named chat, which is the only kind the
+ *  daemon will rename again. */
+function autoNamedSession(id: string, name: string, messages: number): Session {
+  return {
+    id,
+    name,
+    working_dir: '/tmp',
+    // The count the gate reads. Role-`user` messages of the stored
+    // conversation, exactly what `maybe_update_name` counts.
+    conversation: Array.from({ length: messages }, (_, i) => ({
+      role: 'user',
+      created: i,
+      content: [{ type: 'text', text: `turn ${i}` }],
+      metadata: {},
+    })),
+    message_count: messages,
+    total_tokens: 0,
+    created_at: '',
+    updated_at: '',
+    extension_data: {},
+    user_set_name: false,
+    privacy_tier: 'public',
+  } as unknown as Session;
+}
+
+/**
+ * Every `GET /sessions/{id}` made for THIS chat.
+ *
+ * ⚠ Filtered by id, never counted globally. A controller from an earlier test
+ * keeps walking its own 800/1200/2000… poll ladder in the background — these
+ * tests run on real timers, because the poll's awaits are interleaved with them
+ * — and those calls land in the same shared mock.
+ */
+function readsOf(sessionId: string) {
+  return mocks.getSession.mock.calls
+    .map(
+      (call) => call[0] as { path?: { session_id?: string }; query?: { metadata_only?: boolean } }
+    )
+    .filter((options) => options?.path?.session_id === sessionId);
+}
+
+/** Announcements about THIS chat, for the same reason {@link readsOf} filters. */
+function announcedFor(sessionId: string) {
+  return announced.filter((change) => change.sessionId === sessionId);
+}
+
+/** The poll's first tick is 800 ms out. */
+const PAST_FIRST_POLL = 1400;
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let sessionSeq = 0;
+let announced: SessionNameChange[] = [];
+let unsubscribe: (() => void) | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSession.mockResolvedValue({ data: null });
+  announced = [];
+  unsubscribe?.();
+  unsubscribe = subscribeSessionNameChanges((change) => announced.push(change));
+  Object.assign(window, {
+    electron: {
+      getUserActionKey: vi.fn(async () => USER_ACTION_KEY),
+      showNotification: vi.fn(),
+      logInfo: vi.fn(),
+    },
+  });
+});
+
+/** One turn, from a session row the daemon is still free to rename. */
+async function runOneTurn(sid: string, name: string, priorUserMessages: number) {
+  mocks.resumeAgent.mockResolvedValue({
+    data: { session: autoNamedSession(sid, name, priorUserMessages) },
+  });
+  mocks.reply.mockResolvedValue({ stream: streamOf(finishFrame) });
+  const controller = new ChatStreamRegistry().getController(sid);
+  await controller.loadSession();
+  await controller.handleSubmit('Name three species of Antarctic penguin.');
+  return controller;
+}
+
+describe('the post-turn auto-rename poll', () => {
+  it('announces a rename of a chat that ALREADY has a real name', async () => {
+    const sid = `rename-later-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({
+      data: autoNamedSession(sid, 'Penguin prompt test', 2),
+    });
+
+    const controller = await runOneTurn(sid, 'BRAVO instruction test', 1);
+    await settle(PAST_FIRST_POLL);
+
+    expect(announcedFor(sid)).toContainEqual({
+      sessionId: sid,
+      name: 'Penguin prompt test',
+      userSetName: false,
+      origin: 'llm',
+    });
+    // …and the store's own copy of the row moves with it, or the composer and
+    // the strip would disagree inside one window.
+    expect(controller.getSnapshot().session?.name).toBe('Penguin prompt test');
+  });
+
+  it('announces nothing when the daemon left the name alone', async () => {
+    const sid = `rename-none-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({
+      data: autoNamedSession(sid, 'BRAVO instruction test', 2),
+    });
+
+    await runOneTurn(sid, 'BRAVO instruction test', 1);
+    await settle(PAST_FIRST_POLL);
+
+    expect(announcedFor(sid)).toEqual([]);
+  });
+
+  /**
+   * The gate mirrors the daemon's own rule rather than inventing one: past the
+   * limit, a named chat is never renamed again, so polling for it would be up to
+   * eight requests per turn asking a question whose answer cannot change.
+   *
+   * `getSession` is called exactly once per turn regardless — that is
+   * `refreshSessionBinding`, which has always run. The poll would be the second
+   * call and every one after it.
+   */
+  it('stops polling once the chat is past the daemon’s rename limit', async () => {
+    const sid = `rename-settled-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({
+      data: autoNamedSession(sid, 'A different name entirely', 9),
+    });
+
+    await runOneTurn(sid, 'BRAVO instruction test', AUTO_RENAME_USER_MESSAGE_LIMIT + 2);
+    await settle(PAST_FIRST_POLL);
+
+    expect(readsOf(sid)).toHaveLength(1);
+    expect(announcedFor(sid)).toEqual([]);
+  });
+
+  /** …but a chat still stuck on the placeholder is polled however long it gets,
+   *  because the daemon keeps trying to name it however long it gets. */
+  it('keeps polling a chat still on the placeholder, whatever its length', async () => {
+    const sid = `rename-stuck-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: autoNamedSession(sid, 'Penguin prompt test', 20) });
+
+    await runOneTurn(sid, 'New chat', AUTO_RENAME_USER_MESSAGE_LIMIT + 6);
+    await settle(PAST_FIRST_POLL);
+
+    expect(announcedFor(sid)).toContainEqual({
+      sessionId: sid,
+      name: 'Penguin prompt test',
+      userSetName: false,
+      origin: 'llm',
+    });
+  });
+
+  /** The poll reads two fields; it must not drag the conversation across for
+   *  them, up to eight times a turn. */
+  it('reads the row metadata-only', async () => {
+    const sid = `rename-metaonly-${++sessionSeq}`;
+    mocks.getSession.mockResolvedValue({ data: autoNamedSession(sid, 'Penguin prompt test', 2) });
+
+    await runOneTurn(sid, 'BRAVO instruction test', 1);
+    await settle(PAST_FIRST_POLL);
+
+    const reads = readsOf(sid);
+    expect(reads.length).toBeGreaterThan(1);
+    for (const read of reads) expect(read.query?.metadata_only).toBe(true);
+  });
+});

--- a/ui/desktop/src/hooks/chatStreamStore.test.ts
+++ b/ui/desktop/src/hooks/chatStreamStore.test.ts
@@ -276,6 +276,9 @@ describe('ChatStreamRegistry', () => {
       path: { session_id: '20260716_27' },
       // Issue #56 Task 58: reading a private chat's transcript needs this.
       headers: { 'X-User-Action': 'test-key' },
+      // The poll reads a name and a flag, up to eight times per turn, and must
+      // not drag the conversation across with them.
+      query: { metadata_only: true },
       throwOnError: true,
     });
     // …and so does running a turn in one. `/reply` is the route that dominates

--- a/ui/desktop/src/hooks/chatStreamStore.tsx
+++ b/ui/desktop/src/hooks/chatStreamStore.tsx
@@ -20,6 +20,7 @@ import {
 } from '../api';
 import {
   announceSessionName,
+  AUTO_RENAME_USER_MESSAGE_LIMIT,
   cacheGet,
   cacheSet,
   isDefaultSessionName,
@@ -2407,11 +2408,32 @@ class ChatStreamController {
     // touched. Not awaited — the turn is over and nothing on screen waits on it.
     void this.refreshSessionBinding();
 
+    // ⚠ **The name this window believes, captured BEFORE the poll below.** The
+    // poll's question is "did the daemon rename this chat?", and the only way to
+    // answer it is to compare against what we already show. Comparing against
+    // the PLACEHOLDER instead — which is what this did — answers a narrower
+    // question ("has it been named at all?") and so noticed only the FIRST
+    // auto-name. Every later one was invisible to the whole renderer.
+    const knownName = this.snapshot.session?.name ?? '';
+    // The daemon's own rule, mirrored: `SessionManager::maybe_update_name` skips
+    // a user-named session, and otherwise renames while the chat is still on the
+    // placeholder OR has at most {@link AUTO_RENAME_USER_MESSAGE_LIMIT} (3,
+    // mirrored from the daemon) user-role messages. So those are exactly the
+    // turns after which a rename can arrive, and polling past them would ask a
+    // question whose answer can no longer change. Counted the same
+    // way the daemon counts it — user-role messages of the stored conversation,
+    // tool responses included. A disagreement costs one wasted metadata read in
+    // one direction and one missed poll in the other; the two counts are of the
+    // same objects, so it is the same number.
+    const userMessageCount = this.snapshot.messages.filter((m) => m.role === 'user').length;
+    const daemonMayStillRename =
+      isDefaultSessionName(knownName) || userMessageCount <= AUTO_RENAME_USER_MESSAGE_LIMIT;
+
     if (
       this.sessionId &&
       this.snapshot.session &&
       !this.snapshot.session.user_set_name &&
-      isDefaultSessionName(this.snapshot.session.name)
+      daemonMayStillRename
     ) {
       const pollDelays = [800, 1200, 2000, 3000, 4000, 6000, 8000, 10000];
       void (async () => {
@@ -2420,6 +2442,10 @@ class ChatStreamController {
           try {
             const response = await getSession({
               path: { session_id: this.sessionId },
+              // The name and the flag are all this reads, and it reads them up
+              // to eight times per turn — so it must not drag the whole
+              // conversation across with them.
+              query: { metadata_only: true },
               // Issue #56 Task 58: reading a private chat needs the
               // proof-of-user.
               headers: await userActionHeaders(),
@@ -2429,7 +2455,7 @@ class ChatStreamController {
             if (!data) continue;
             const proposedName = data.name;
             if (data.user_set_name) break;
-            if (proposedName && !isDefaultSessionName(proposedName)) {
+            if (proposedName && proposedName !== knownName && !isDefaultSessionName(proposedName)) {
               const uniqueName = await disambiguateSessionName(proposedName, this.sessionId);
               if (uniqueName !== proposedName) {
                 try {

--- a/ui/desktop/src/utils/sessionListCache.test.ts
+++ b/ui/desktop/src/utils/sessionListCache.test.ts
@@ -75,6 +75,76 @@ describe('sessionListCache', () => {
     expect(getCachedSessionList()?.[0]).toMatchObject({ name: 'New name', user_set_name: true });
   });
 
+  /**
+   * A list response describes the moment it was ISSUED. A rename announced after
+   * that is the LATER fact, and replacing the whole array would undo it — the
+   * snap-back `sessionNameSync`'s header describes.
+   *
+   * It stopped being cosmetic when the tab strip started reconciling its titles
+   * against this cache: a clobbered name is written onto a tab and persisted
+   * there. And the window is the common one — a new chat's first turn issues a
+   * list refresh (`refreshSessionBinding` → `notifySessionListChanged`) and,
+   * ~800 ms later, announces the name the daemon generated.
+   */
+  it('keeps a rename announced while the list request was still in flight', async () => {
+    let finishRequest: ((value: { data: { sessions: unknown[] } }) => void) | undefined;
+    mocks.listSessions.mockReturnValue(
+      new Promise((resolve) => {
+        finishRequest = resolve;
+      })
+    );
+
+    const inFlight = refreshSessionList();
+    await vi.waitFor(() => expect(mocks.listSessions).toHaveBeenCalledTimes(1));
+
+    // The daemon's auto-name lands while the (slow) list read is still open.
+    announceSessionName({
+      sessionId: 's1',
+      name: 'Penguin prompt test',
+      userSetName: false,
+      origin: 'llm',
+    });
+
+    // …and the response, which was issued before it, still says the old name.
+    finishRequest?.({
+      data: {
+        sessions: [{ id: 's1', name: 'New chat', user_set_name: false, working_dir: '/x' }],
+      },
+    });
+    await inFlight;
+
+    expect(getCachedSessionList()?.[0]).toMatchObject({
+      name: 'Penguin prompt test',
+      user_set_name: false,
+    });
+  });
+
+  /** Only for the request it raced. The NEXT read is the later fact and wins. */
+  it('lets a later list read overwrite a name it raced once', async () => {
+    let finishRequest: ((value: { data: { sessions: unknown[] } }) => void) | undefined;
+    mocks.listSessions.mockReturnValue(
+      new Promise((resolve) => {
+        finishRequest = resolve;
+      })
+    );
+    const inFlight = refreshSessionList();
+    await vi.waitFor(() => expect(mocks.listSessions).toHaveBeenCalledTimes(1));
+    announceSessionName({ sessionId: 's1', name: 'Raced', userSetName: false, origin: 'llm' });
+    finishRequest?.({
+      data: { sessions: [{ id: 's1', name: 'Stale', user_set_name: false, working_dir: '/x' }] },
+    });
+    await inFlight;
+
+    mocks.listSessions.mockResolvedValue({
+      data: {
+        sessions: [{ id: 's1', name: 'Renamed elsewhere', user_set_name: true, working_dir: '/x' }],
+      },
+    });
+    await refreshSessionList();
+
+    expect(getCachedSessionList()?.[0]).toMatchObject({ name: 'Renamed elsewhere' });
+  });
+
   it('a keyless refresh keeps the flagged identity instead of clobbering it', async () => {
     mocks.listSessions.mockResolvedValue({ data: { sessions: [] } });
     await refreshSessionList(true);

--- a/ui/desktop/src/utils/sessionListCache.ts
+++ b/ui/desktop/src/utils/sessionListCache.ts
@@ -20,12 +20,35 @@ function emitChange(): void {
   for (const listener of listeners) listener();
 }
 
+/**
+ * Names the name channel published WHILE a list request was in flight.
+ *
+ * A list response describes the moment it was ISSUED, so a rename that landed
+ * after that is the LATER fact — but `refreshSessionList` replaces the whole
+ * array, which would undo it. That is the snap-back `sessionNameSync`'s header
+ * describes, and until now it only cost Home recents and See-all a wrong name
+ * until their next refresh. It costs more now: the tab strip reconciles its
+ * titles against this cache (`ChatGroupsShell.useTabTitlesFromSessionList`), so
+ * a clobbered name would be written onto a tab AND persisted there.
+ *
+ * The window is not hypothetical. A brand-new chat's first turn opens both
+ * halves of it: `refreshSessionBinding` finds the chat missing from a fetched
+ * list and calls `notifySessionListChanged` (→ a full `GET /sessions`), and
+ * ~800 ms later the auto-name poll announces the generated name. On a machine
+ * with thousands of chats the list is easily the slower of the two.
+ *
+ * Recorded only while a request is outstanding, and cleared by the request that
+ * consumes them, so the map cannot grow.
+ */
+const namesPublishedDuringFetch = new Map<string, { name: string; userSetName: boolean }>();
+
 // A session rename rides the name channel, not the list channel — but the
 // See-all view and Home recents read THIS cache, so patch the cached name when
 // one arrives. Without this a rename made in the tab pill or the sidebar never
 // reached those two surfaces until they remounted, and the same session showed
 // two different names in two panels at once.
 subscribeSessionNameChanges(({ sessionId, name, userSetName }) => {
+  if (inFlightRequest) namesPublishedDuringFetch.set(sessionId, { name, userSetName });
   if (!cachedSessions) return;
   const idx = cachedSessions.findIndex((s) => s.id === sessionId);
   if (idx === -1) return;
@@ -125,6 +148,17 @@ export function notifySessionListChanged(change: SessionListChange = {}): void {
   getListChannel()?.postMessage({ at: Date.now(), ...change });
 }
 
+/** Re-apply the renames that outran this response. See {@link namesPublishedDuringFetch}. */
+function applyNamesPublishedDuringFetch(sessions: Session[]): Session[] {
+  if (namesPublishedDuringFetch.size === 0) return sessions;
+  const next = sessions.map((session) => {
+    const later = namesPublishedDuringFetch.get(session.id);
+    return later ? { ...session, name: later.name, user_set_name: later.userSetName } : session;
+  });
+  namesPublishedDuringFetch.clear();
+  return next;
+}
+
 export function getCachedSessionList(): Session[] | null {
   return cachedSessions;
 }
@@ -167,6 +201,9 @@ export async function refreshSessionList(includeSubagents?: boolean): Promise<Se
   // proof's async hop: a flag change in that gap orphans this request, and
   // an orphan must still ask for the list it was issued for.
   const issuedFor = cachedIncludeSubagents;
+  // This request's answer supersedes every name it is about to carry — except
+  // the ones announced from HERE on. See {@link namesPublishedDuringFetch}.
+  namesPublishedDuringFetch.clear();
   inFlightRequest = userActionHeaders()
     .then((headers) =>
       listSessions<true>({
@@ -180,7 +217,7 @@ export async function refreshSessionList(includeSubagents?: boolean): Promise<Se
       // this exact call, but publish nothing — the cache and its subscribers
       // belong to the request that replaced it.
       if (generation !== requestGeneration) return response.data.sessions;
-      cachedSessions = response.data.sessions;
+      cachedSessions = applyNamesPublishedDuringFetch(response.data.sessions);
       emitChange();
       return cachedSessions;
     })

--- a/ui/desktop/src/utils/sessionNameSync.ts
+++ b/ui/desktop/src/utils/sessionNameSync.ts
@@ -32,6 +32,20 @@ import { userActionHeaders } from './userAction';
 
 export const DEFAULT_SESSION_NAME = 'New chat';
 
+/**
+ * How many user-role messages a chat may hold and still be auto-renamed —
+ * `MSG_COUNT_FOR_SESSION_NAME_GENERATION` in
+ * `crates/biorouter/src/providers/base.rs`, mirrored.
+ *
+ * The daemon re-generates a chat's name after EVERY turn until this many user
+ * messages have accumulated, and keeps trying forever while the chat is still on
+ * the placeholder (`SessionManager::maybe_update_name`). It does so after the
+ * reply stream has closed and announces nothing, so the renderer's post-turn
+ * poll is the only thing that can notice — and this is the bound on how long
+ * that poll is worth running.
+ */
+export const AUTO_RENAME_USER_MESSAGE_LIMIT = 3;
+
 const DEFAULT_NAME_PATTERNS: RegExp[] = [
   /^New chat$/i,
   /^New Session$/i,


### PR DESCRIPTION
## The defect

A chat is auto-named after its first turn and **renamed again** by the daemon after each of its next few turns. The renderer never followed the later renames, and a tab that was not active never followed any of them.

Reproduced myself on `origin/main` (0e03b794) in the real app before touching anything, sandbox `fx-tabname`:

**A — live staleness.** Session `20260912_1`.

| step | sqlite `sessions.name` | tab strip | sidebar Recents |
|---|---|---|---|
| after turn 1 | `BRAVO instruction test` | `BRAVO instruction test` | `BRAVO instruction test` |
| after turn 2, +10 s | **`Penguin prompt test`** | `BRAVO instruction test` | `BRAVO instruction test` |
| +20 s | `Penguin prompt test` | `BRAVO instruction test` | `BRAVO instruction test` |
| +30 s | `Penguin prompt test` | `BRAVO instruction test` | `BRAVO instruction test` |

**B — the worse half.** Same chat, third turn → renamed to `Instruction-following tests`. Made a *second* chat the active tab, then reloaded:

```
sidebar : ["Instruction-following tests", "DELTA instruction test", …]
tabs    : [{id:"tab-2", t:"Penguin prompt test",  aria:"Close Penguin prompt test"},
           {id:"tab-4", t:"DELTA instruction test"}]
```

Two names for one chat on one screen, unchanged across two further reloads, correcting the instant that tab was clicked.

## Where each surface gets its name

* **`sessionNameSync`'s BroadcastChannel is the only channel.** The sidebar (`useSidebarSessions`), the See-all/Home cache (`sessionListCache`), each chat store, and — via `ChatGroupsContext` → `renameTab` — every tab, all subscribe to it. The reducer's `renameTab` already mirrors into **every** tab of a session, active or not; the reducer was never the bug.
* **The daemon emits no rename signal.** `SessionManager::maybe_update_name` runs from `spawn_session_rename`, a `tokio::spawn` *after* the reply loop ends, so the `/reply` SSE stream is already closed; no `SessionBusEvent` variant carries a name. The renderer can only learn by reading the row.
* **The only thing that ever announced an auto-rename** was the poll in `chatStreamStore.finishTurn` — gated on `isDefaultSessionName(session.name)`. That asks "has this chat been named at all?", not "has it been *renamed*?". So it fired once and never again, and nothing in the renderer heard turn 2's rename. That is A.
* **A tab title is the one name the renderer persists** (`chatGroupsStorage`). Only two things could correct one: that channel, or `handleSessionLoaded` — which comes from BaseChat, and only the **active** tab mounts a BaseChat. So a name this window never heard stayed wrong on a background tab forever, while the sidebar re-read the server on every load. That is B.

## The fix

**1. `chatStreamStore.finishTurn` — ask the right question.** Capture the name this window shows before polling, and gate on the daemon's own rule (`maybe_update_name`: still on the placeholder, **or** at most `AUTO_RENAME_USER_MESSAGE_LIMIT` = 3 user messages, mirroring `MSG_COUNT_FOR_SESSION_NAME_GENERATION`). Past that bound a named chat is never auto-renamed again, so the poll stops exactly where the rename can. The poll now also reads `metadata_only` — it wants a name and a flag, up to eight times per turn, and was pulling the whole conversation across for them.

**2. `ChatGroupsShell.useTabTitlesFromSessionList` — reconcile tabs that nobody is looking at.** Follows the daemon's signal where one exists (1 above is that path); for everything else — a rename by the CLI, a schedule, another window while this one was shut, a poll that missed — it compares each tab's title against the **session list the shell already reads and warms for the privacy dots**. No new request, no polling, no timer. It runs on mount and on every list emit, so a title is checked against the server's row every time the window loads; it cannot survive a load as a lie.

**3. `sessionListCache` — the race that reconcile would otherwise import.** A list response describes the moment it was *issued*; `refreshSessionList` replaced the whole array, so a rename announced mid-flight was clobbered (the snap-back `sessionNameSync`'s header describes — until now only Home recents and See-all paid for it). Renames announced while a request is outstanding are re-applied over its answer. The window is the common one: a new chat's first turn issues a list refresh (`refreshSessionBinding` → `notifySessionListChanged`) and ~800 ms later announces the generated name.

## Not breaking what the old gate protected

* **A manual rename is never overwritten.** A user rename sets `userSetName` on the tab (optimistically, `BaseChat.handleRename`) and `user_set_name` on the row, and the daemon never auto-renames such a chat again — so a user-named tab is **skipped outright** rather than compared. Snap-back is structurally impossible, not merely unlikely, and there is no keystroke window to flicker in.
* **A named tab is never downgraded** to a row still reading `New chat`; the placeholder is a lower bound on a name, never a correction.
* Checked three ways: the two guards have their own tests; each guard was **falsified once** (drop the `userSetName` skip → "never touches a tab the user named" goes red; drop the placeholder rule → "never downgrades" goes red; drop the message-count bound → "stops polling once past the limit" goes red); and at runtime a background tab planted with `title:"My own name for this", userSetName:true` against a row reading `Penguin naming prompts` kept the user's name across a reload and 24 s, with the tab-title DOM in exactly one state over an 8 s sample (no flicker).

## Fail-before

All on `origin/main` @ 0e03b794:

```
ChatGroupsShell.tabTitleSync.test.tsx      3 failed | 4 passed   (the 4 are the guards)
chatStreamStore.autoRename.test.tsx        2 failed | 3 passed
sessionListCache.test.ts                   1 failed | 8 passed
```

The headline one is `renames a tab that is not the active one when the row says so` — the level the bug lives at.

With the change: `120 passed` across those files plus `chatStreamStore.test.ts`, and `476 files / 5354 tests passed` for the whole suite (`--exclude artifactCdnAssets`, whose teardown exceeds 30 s on pristine `main` too).

## Live verification, after

Restarted the app on this branch (vite caches transformed modules, so a reload is not enough — verified the served module contains the fix before measuring).

**A, after.** New chat → turn 1 → `CHARLIE instruction test`. Turn 2 → daemon wrote `Penguin naming prompts`:

```
DB  t+6s : Penguin naming prompts
UI  t+5s : tabs ["Penguin naming prompts"]   recents[0] Penguin naming prompts
UI  t+10s … t+40s: unchanged, correct
```

(Before: 30 s on the old name and counting.)

**B, after.** Planted the exact persisted state `main` left behind — the background tab's title frozen at `CHARLIE instruction test`, the row already `Penguin naming prompts`, a different chat active — then reloaded:

```
active  : tab-3  (20260912_2, DELTA instruction test)
tabs    : [{id:"tab-2", t:"Penguin naming prompts", aria:"Close Penguin naming prompts"}, …]
sidebar : ["DELTA instruction test", "Penguin naming prompts", …]
```

The background tab corrected itself without being touched, and the two surfaces agree.

## Gates

`npm run lint:check` (typecheck + eslint `--max-warnings 0` + themes + 332 contrast assertions + token mirrors) clean; `npx prettier --check` matched all eight touched files and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
